### PR TITLE
Introducing Objectives and Key Results

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -32,3 +32,5 @@ config :logger, level: :warning
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
+
+config :wallaby, screenshot_on_failure: true

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -35,7 +35,11 @@ defmodule Operately.Okrs do
       ** (Ecto.NoResultsError)
 
   """
-  def get_objective!(id), do: Repo.get!(Objective, id)
+  def get_objective!(id) do
+    Objective
+    |> Repo.get!(id)
+    |> Repo.preload(:key_results)
+  end
 
   @doc """
   Creates a objective.

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -1,0 +1,104 @@
+defmodule Operately.Okrs do
+  @moduledoc """
+  The Okrs context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Operately.Repo
+
+  alias Operately.Okrs.Objective
+
+  @doc """
+  Returns the list of objectives.
+
+  ## Examples
+
+      iex> list_objectives()
+      [%Objective{}, ...]
+
+  """
+  def list_objectives do
+    Repo.all(Objective)
+  end
+
+  @doc """
+  Gets a single objective.
+
+  Raises `Ecto.NoResultsError` if the Objective does not exist.
+
+  ## Examples
+
+      iex> get_objective!(123)
+      %Objective{}
+
+      iex> get_objective!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_objective!(id), do: Repo.get!(Objective, id)
+
+  @doc """
+  Creates a objective.
+
+  ## Examples
+
+      iex> create_objective(%{field: value})
+      {:ok, %Objective{}}
+
+      iex> create_objective(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_objective(attrs \\ %{}) do
+    %Objective{}
+    |> Objective.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a objective.
+
+  ## Examples
+
+      iex> update_objective(objective, %{field: new_value})
+      {:ok, %Objective{}}
+
+      iex> update_objective(objective, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_objective(%Objective{} = objective, attrs) do
+    objective
+    |> Objective.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a objective.
+
+  ## Examples
+
+      iex> delete_objective(objective)
+      {:ok, %Objective{}}
+
+      iex> delete_objective(objective)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_objective(%Objective{} = objective) do
+    Repo.delete(objective)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking objective changes.
+
+  ## Examples
+
+      iex> change_objective(objective)
+      %Ecto.Changeset{data: %Objective{}}
+
+  """
+  def change_objective(%Objective{} = objective, attrs \\ %{}) do
+    Objective.changeset(objective, attrs)
+  end
+end

--- a/lib/operately/okrs/key_result.ex
+++ b/lib/operately/okrs/key_result.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Okrs.KeyResult do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "key_results" do
+    belongs_to :objective, Operately.Okrs.Objective
+
+    field :name, :string
+    field :target, :integer
+    field :unit, Ecto.Enum, values: [:percentage, :number]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(key_result, attrs) do
+    key_result
+    |> cast(attrs, [:name, :unit, :target])
+    |> validate_required([:name, :unit, :target])
+  end
+end

--- a/lib/operately/okrs/key_result.ex
+++ b/lib/operately/okrs/key_result.ex
@@ -10,6 +10,7 @@ defmodule Operately.Okrs.KeyResult do
     field :name, :string
     field :target, :integer
     field :unit, Ecto.Enum, values: [:percentage, :number]
+    field :direction, Ecto.Enum, values: [:above, :below]
 
     timestamps()
   end
@@ -17,7 +18,7 @@ defmodule Operately.Okrs.KeyResult do
   @doc false
   def changeset(key_result, attrs) do
     key_result
-    |> cast(attrs, [:name, :unit, :target])
-    |> validate_required([:name, :unit, :target])
+    |> cast(attrs, [:name, :unit, :target, :direction])
+    |> validate_required([:name, :unit, :target, :direction])
   end
 end

--- a/lib/operately/okrs/objective.ex
+++ b/lib/operately/okrs/objective.ex
@@ -5,6 +5,8 @@ defmodule Operately.Okrs.Objective do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "objectives" do
+    has_many :key_results, Operately.Okrs.KeyResult, on_delete: :delete_all
+
     field :description, :string
     field :name, :string
 

--- a/lib/operately/okrs/objective.ex
+++ b/lib/operately/okrs/objective.ex
@@ -17,6 +17,7 @@ defmodule Operately.Okrs.Objective do
   def changeset(objective, attrs) do
     objective
     |> cast(attrs, [:name, :description])
+    |> cast_assoc(:key_results)
     |> validate_required([:name, :description])
   end
 end

--- a/lib/operately/okrs/objective.ex
+++ b/lib/operately/okrs/objective.ex
@@ -1,0 +1,20 @@
+defmodule Operately.Okrs.Objective do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "objectives" do
+    field :description, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(objective, attrs) do
+    objective
+    |> cast(attrs, [:name, :description])
+    |> validate_required([:name, :description])
+  end
+end

--- a/lib/operately_web/controllers/objective_controller.ex
+++ b/lib/operately_web/controllers/objective_controller.ex
@@ -1,0 +1,62 @@
+defmodule OperatelyWeb.ObjectiveController do
+  use OperatelyWeb, :controller
+
+  alias Operately.Okrs
+  alias Operately.Okrs.Objective
+
+  def index(conn, _params) do
+    objectives = Okrs.list_objectives()
+    render(conn, :index, objectives: objectives)
+  end
+
+  def new(conn, _params) do
+    changeset = Okrs.change_objective(%Objective{})
+    render(conn, :new, changeset: changeset)
+  end
+
+  def create(conn, %{"objective" => objective_params}) do
+    case Okrs.create_objective(objective_params) do
+      {:ok, objective} ->
+        conn
+        |> put_flash(:info, "Objective created successfully.")
+        |> redirect(to: ~p"/objectives/#{objective}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :new, changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    objective = Okrs.get_objective!(id)
+    render(conn, :show, objective: objective)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    objective = Okrs.get_objective!(id)
+    changeset = Okrs.change_objective(objective)
+    render(conn, :edit, objective: objective, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "objective" => objective_params}) do
+    objective = Okrs.get_objective!(id)
+
+    case Okrs.update_objective(objective, objective_params) do
+      {:ok, objective} ->
+        conn
+        |> put_flash(:info, "Objective updated successfully.")
+        |> redirect(to: ~p"/objectives/#{objective}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :edit, objective: objective, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    objective = Okrs.get_objective!(id)
+    {:ok, _objective} = Okrs.delete_objective(objective)
+
+    conn
+    |> put_flash(:info, "Objective deleted successfully.")
+    |> redirect(to: ~p"/objectives")
+  end
+end

--- a/lib/operately_web/controllers/objective_controller.ex
+++ b/lib/operately_web/controllers/objective_controller.ex
@@ -14,7 +14,9 @@ defmodule OperatelyWeb.ObjectiveController do
     render(conn, :new, changeset: changeset)
   end
 
-  def create(conn, %{"objective" => objective_params}) do
+  def create(conn, %{"objective" => objective_params, "key_results" => key_results_params}) do
+    IO.inspect(objective_params)
+    IO.inspect(key_results_params)
     case Okrs.create_objective(objective_params) do
       {:ok, objective} ->
         conn

--- a/lib/operately_web/controllers/objective_controller.ex
+++ b/lib/operately_web/controllers/objective_controller.ex
@@ -15,9 +15,9 @@ defmodule OperatelyWeb.ObjectiveController do
   end
 
   def create(conn, %{"objective" => objective_params, "key_results" => key_results_params}) do
-    IO.inspect(objective_params)
-    IO.inspect(key_results_params)
-    case Okrs.create_objective(objective_params) do
+    params = Map.merge(objective_params, %{"key_results" => Map.values(key_results_params)})
+
+    case Okrs.create_objective(params) do
       {:ok, objective} ->
         conn
         |> put_flash(:info, "Objective created successfully.")

--- a/lib/operately_web/controllers/objective_html.ex
+++ b/lib/operately_web/controllers/objective_html.ex
@@ -1,0 +1,5 @@
+defmodule OperatelyWeb.ObjectiveHTML do
+  use OperatelyWeb, :html
+
+  embed_templates "objective_html/*"
+end

--- a/lib/operately_web/controllers/objective_html/edit.html.heex
+++ b/lib/operately_web/controllers/objective_html/edit.html.heex
@@ -1,0 +1,17 @@
+<.header>
+  Edit Objective <%= @objective.id %>
+  <:subtitle>Use this form to manage objective records in your database.</:subtitle>
+</.header>
+
+<.simple_form :let={f} for={@changeset} method="put" action={~p"/objectives/#{@objective}"}>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+  <.input field={f[:name]} type="text" label="Name" />
+  <.input field={f[:description]} type="text" label="Description" />
+  <:actions>
+    <.button>Save Objective</.button>
+  </:actions>
+</.simple_form>
+
+<.back navigate={~p"/objectives"}>Back to objectives</.back>

--- a/lib/operately_web/controllers/objective_html/index.html.heex
+++ b/lib/operately_web/controllers/objective_html/index.html.heex
@@ -1,0 +1,24 @@
+<.header>
+  Listing Objectives
+  <:actions>
+    <.link href={~p"/objectives/new"}>
+      <.button>New Objective</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table id="objectives" rows={@objectives} row_click={&JS.navigate(~p"/objectives/#{&1}")}>
+  <:col :let={objective} label="Name"><%= objective.name %></:col>
+  <:col :let={objective} label="Description"><%= objective.description %></:col>
+  <:action :let={objective}>
+    <div class="sr-only">
+      <.link navigate={~p"/objectives/#{objective}"}>Show</.link>
+    </div>
+    <.link navigate={~p"/objectives/#{objective}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={objective}>
+    <.link href={~p"/objectives/#{objective}"} method="delete" data-confirm="Are you sure?">
+      Delete
+    </.link>
+  </:action>
+</.table>

--- a/lib/operately_web/controllers/objective_html/index.html.heex
+++ b/lib/operately_web/controllers/objective_html/index.html.heex
@@ -8,7 +8,7 @@
 </.header>
 
 <.table id="objectives" rows={@objectives} row_click={&JS.navigate(~p"/objectives/#{&1}")}>
-  <:col :let={objective} label="Name"><%= objective.name %></:col>
+<:col :let={objective} label="Name"><.link navigate={~p"/objectives/#{objective}"}><%= objective.name %></.link></:col>
   <:col :let={objective} label="Description"><%= objective.description %></:col>
   <:action :let={objective}>
     <div class="sr-only">

--- a/lib/operately_web/controllers/objective_html/index.html.heex
+++ b/lib/operately_web/controllers/objective_html/index.html.heex
@@ -8,7 +8,7 @@
 </.header>
 
 <.table id="objectives" rows={@objectives} row_click={&JS.navigate(~p"/objectives/#{&1}")}>
-<:col :let={objective} label="Name"><.link navigate={~p"/objectives/#{objective}"}><%= objective.name %></.link></:col>
+  <:col :let={objective} label="Name"><.link navigate={~p"/objectives/#{objective}"}><%= objective.name %></.link></:col>
   <:col :let={objective} label="Description"><%= objective.description %></:col>
   <:action :let={objective}>
     <div class="sr-only">

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -3,17 +3,6 @@
   <:subtitle>Use this form to manage objective records in your database.</:subtitle>
 </.header>
 
-<div id="key-result-template" style="display: none;">
-  <div data-key-result class="mt-2 px-2 py-2 block w-full rounded-lg border border-zinc-300">
-    <.input id="key_results[][name]" name="key_results[][name]" type="text" label="Name" value="" />
-
-    <.input class="mt-1" id="key_results[][unit]" name="key_results[][unit]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
-    <.input class="mt-1" id="key_results[][direction]" name="key_results[][direction]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
-
-    <.input class="mt-1" id="key_results[][target]" name="key_results[][target]" type="text" label="Target" value="" />
-  </div>
-</div>
-
 <.simple_form :let={f} for={@changeset} action={~p"/objectives"}>
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
@@ -30,21 +19,40 @@
 
   <.button type="button" class="btn btn-primary" id="add-key-result">Add Key Result</.button>
 
-  <script>
-    document.addEventListener("DOMContentLoaded", function(event) {
-      var addKeyResultButton = document.getElementById("add-key-result");
-      var keyResultContainer = document.getElementById("key-results-container");
-      var keyResultTemplate = document.getElementById("key-result-template");
-
-      addKeyResultButton.addEventListener("click", function() {
-        keyResultContainer.innerHTML += keyResultTemplate.innerHTML;
-      });
-    });
-  </script>
-
   <:actions>
     <.button>Save Objective</.button>
   </:actions>
 </.simple_form>
 
 <.back navigate={~p"/objectives"}>Back to objectives</.back>
+
+<!-- This is the part of the form that is responsible for a single key result -->
+<!-- First, you have a template that is hidden by default -->
+<!-- Then, you have a script that clones the template and appends it to the key results container -->
+
+<div id="key-result-template" style="display: none;">
+  <div data-key-result class="mt-2 px-2 py-2 block w-full rounded-lg border border-zinc-300">
+    <.input id="key_results[__INDEX__][name]" name="key_results[__INDEX__][name]" type="text" label="Name" value="" />
+
+    <.input class="mt-1" id="key_results[__INDEX__][unit]" name="key_results[__INDEX__][unit]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
+    <.input class="mt-1" id="key_results[__INDEX__][direction]" name="key_results[__INDEX__][direction]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
+
+    <.input class="mt-1" id="key_results[__INDEX__][target]" name="key_results[__INDEX__][target]" type="text" label="Target" value="" />
+  </div>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function(event) {
+    var addKeyResultButton = document.getElementById("add-key-result");
+    var keyResultContainer = document.getElementById("key-results-container");
+    var keyResultTemplate = document.querySelector("#key-result-template [data-key-result]");
+
+    addKeyResultButton.addEventListener("click", function() {
+      var keyResult = keyResultTemplate.cloneNode(true);
+      keyResult.style.display = "block";
+      keyResult.innerHTML = keyResult.innerHTML.replace(/__INDEX__/g, keyResultContainer.children.length);
+
+      keyResultContainer.appendChild(keyResult);
+    });
+  });
+</script>

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -14,15 +14,15 @@
 
   <p>How will you measure success?</p>
 
-  <%= inputs_for f, :key_results, fn v -> %>
-    <div class="flex flex-wrap -mx-1 overflow-hidden">
-      <div class="form-group px-1 w-3/6">
-        <.input field={v[:name]} type="text" label="Name" />
-        <.input field={v[:target]} type="select" label="Unit" options={["Percentage", "Number"]} />
-        <.input field={v[:target]} type="text" label="Target" />
-      </div>
-    </div>
-  <% end %>
+  <%# <%= inputs_for f, :key_results, fn v -> %1> %>
+  <%#   <div class="flex flex-wrap -mx-1 overflow-hidden"> %>
+  <%#     <div class="form-group px-1 w-3/6"> %>
+  <%#       <.input field={v[:name]} type="text" label="Name" /> %>
+  <%#       <.input field={v[:target]} type="select" label="Unit" options={["Percentage", "Number"]} /> %>
+  <%#       <.input field={v[:target]} type="text" label="Target" /> %>
+  <%#     </div> %>
+  <%#   </div> %>
+  <%# <% end %1> %>
 
   <:actions>
     <.button>Save Objective</.button>

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -12,6 +12,18 @@
 
   <.input type="select" label="Timeframe" field={f[:timeframe]} options={["Current quarter"]} />
 
+  <p>How will you measure success?</p>
+
+  <%= inputs_for f, :key_results, fn v -> %>
+    <div class="flex flex-wrap -mx-1 overflow-hidden">
+      <div class="form-group px-1 w-3/6">
+        <.input field={v[:name]} type="text" label="Name" />
+        <.input field={v[:target]} type="select" label="Unit" options={["Percentage", "Number"]} />
+        <.input field={v[:target]} type="text" label="Target" />
+      </div>
+    </div>
+  <% end %>
+
   <:actions>
     <.button>Save Objective</.button>
   </:actions>

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -3,6 +3,17 @@
   <:subtitle>Use this form to manage objective records in your database.</:subtitle>
 </.header>
 
+<div id="key-result-template" style="display: none;">
+  <div data-key-result class="mt-2 px-2 py-2 block w-full rounded-lg border border-zinc-300">
+    <.input id="key_result[name][]" name="key_result[name][]" type="text" label="Name" value="" />
+
+    <.input class="mt-1" id="key_result[unit][]" name="key_result[unit][]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
+    <.input class="mt-1" id="key_result[direction][]" name="key_result[direction][]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
+
+    <.input class="mt-1" id="key_result[target][]" name="key_result[target][]" type="text" label="Target" value="" />
+  </div>
+</div>
+
 <.simple_form :let={f} for={@changeset} action={~p"/objectives"}>
   <.error :if={@changeset.action}>
     Oops, something went wrong! Please check the errors below.
@@ -14,15 +25,22 @@
 
   <p>How will you measure success?</p>
 
-  <%# <%= inputs_for f, :key_results, fn v -> %1> %>
-  <%#   <div class="flex flex-wrap -mx-1 overflow-hidden"> %>
-  <%#     <div class="form-group px-1 w-3/6"> %>
-  <%#       <.input field={v[:name]} type="text" label="Name" /> %>
-  <%#       <.input field={v[:target]} type="select" label="Unit" options={["Percentage", "Number"]} /> %>
-  <%#       <.input field={v[:target]} type="text" label="Target" /> %>
-  <%#     </div> %>
-  <%#   </div> %>
-  <%# <% end %1> %>
+  <div id="key-results-container">
+  </div>
+
+  <.button type="button" class="btn btn-primary" id="add-key-result">Add Key Result</.button>
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function(event) {
+      var addKeyResultButton = document.getElementById("add-key-result");
+      var keyResultContainer = document.getElementById("key-results-container");
+      var keyResultTemplate = document.getElementById("key-result-template");
+
+      addKeyResultButton.addEventListener("click", function() {
+        keyResultContainer.innerHTML += keyResultTemplate.innerHTML;
+      });
+    });
+  </script>
 
   <:actions>
     <.button>Save Objective</.button>

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -5,12 +5,12 @@
 
 <div id="key-result-template" style="display: none;">
   <div data-key-result class="mt-2 px-2 py-2 block w-full rounded-lg border border-zinc-300">
-    <.input id="key_result[name][]" name="key_result[name][]" type="text" label="Name" value="" />
+    <.input id="key_results[][name]" name="key_results[][name]" type="text" label="Name" value="" />
 
-    <.input class="mt-1" id="key_result[unit][]" name="key_result[unit][]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
-    <.input class="mt-1" id="key_result[direction][]" name="key_result[direction][]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
+    <.input class="mt-1" id="key_results[][unit]" name="key_results[][unit]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
+    <.input class="mt-1" id="key_results[][direction]" name="key_results[][direction]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
 
-    <.input class="mt-1" id="key_result[target][]" name="key_result[target][]" type="text" label="Target" value="" />
+    <.input class="mt-1" id="key_results[][target]" name="key_results[][target]" type="text" label="Target" value="" />
   </div>
 </div>
 

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -12,12 +12,16 @@
 
   <.input type="select" label="Timeframe" field={f[:timeframe]} options={["Current quarter"]} />
 
+  <hr>
+
   <p>How will you measure success?</p>
 
   <div id="key-results-container">
   </div>
 
   <.button type="button" class="btn btn-primary" id="add-key-result">Add Key Result</.button>
+
+  <hr>
 
   <:actions>
     <.button>Save Objective</.button>
@@ -34,8 +38,8 @@
   <div data-key-result class="mt-2 px-2 py-2 block w-full rounded-lg border border-zinc-300">
     <.input id="key_results[__INDEX__][name]" name="key_results[__INDEX__][name]" type="text" label="Name" value="" />
 
-    <.input class="mt-1" id="key_results[__INDEX__][unit]" name="key_results[__INDEX__][unit]" type="select" label="Unit" options={["Percentage", "Number"]} value="Percentage" />
-    <.input class="mt-1" id="key_results[__INDEX__][direction]" name="key_results[__INDEX__][direction]" type="select" label="Direction" options={["Above", "Below"]} value="Percentage" />
+    <.input class="mt-1" id="key_results[__INDEX__][unit]" name="key_results[__INDEX__][unit]" type="select" label="Unit" options={["percentage", "number"]} value="Percentage" />
+    <.input class="mt-1" id="key_results[__INDEX__][direction]" name="key_results[__INDEX__][direction]" type="select" label="Direction" options={["above", "below"]} value="Percentage" />
 
     <.input class="mt-1" id="key_results[__INDEX__][target]" name="key_results[__INDEX__][target]" type="text" label="Target" value="" />
   </div>

--- a/lib/operately_web/controllers/objective_html/new.html.heex
+++ b/lib/operately_web/controllers/objective_html/new.html.heex
@@ -1,0 +1,20 @@
+<.header>
+  New Objective
+  <:subtitle>Use this form to manage objective records in your database.</:subtitle>
+</.header>
+
+<.simple_form :let={f} for={@changeset} action={~p"/objectives"}>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+  <.input field={f[:name]} type="text" label="Name" />
+  <.input field={f[:description]} type="text" label="Description" />
+
+  <.input type="select" label="Timeframe" field={f[:timeframe]} options={["Current quarter"]} />
+
+  <:actions>
+    <.button>Save Objective</.button>
+  </:actions>
+</.simple_form>
+
+<.back navigate={~p"/objectives"}>Back to objectives</.back>

--- a/lib/operately_web/controllers/objective_html/show.html.heex
+++ b/lib/operately_web/controllers/objective_html/show.html.heex
@@ -1,12 +1,23 @@
 <.header>
-  Objective <%= @objective.id %>
-  <:subtitle>This is a objective record from your database.</:subtitle>
+  Objective <%= @objective.name %>
+  <:subtitle><%= @objective.description %></:subtitle>
   <:actions>
     <.link href={~p"/objectives/#{@objective}/edit"}>
       <.button>Edit objective</.button>
     </.link>
   </:actions>
 </.header>
+
+<div>
+  <%= for key_result <- @objective.key_results do %>
+    <div>
+      <%= key_result.name %>
+      <%= key_result.direction %>
+      <%= key_result.target %>
+      <%= key_result.unit %>
+    </div>
+  <% end %>
+</div>
 
 <.list>
   <:item title="Name"><%= @objective.name %></:item>

--- a/lib/operately_web/controllers/objective_html/show.html.heex
+++ b/lib/operately_web/controllers/objective_html/show.html.heex
@@ -8,20 +8,20 @@
   </:actions>
 </.header>
 
-<div>
-  <%= for key_result <- @objective.key_results do %>
-    <div>
-      <%= key_result.name %>
-      <%= key_result.direction %>
-      <%= key_result.target %>
-      <%= key_result.unit %>
-    </div>
-  <% end %>
-</div>
-
 <.list>
   <:item title="Name"><%= @objective.name %></:item>
   <:item title="Description"><%= @objective.description %></:item>
 </.list>
+
+<h2 class="mt-8">Key Results</h2>
+
+<div>
+  <%= for key_result <- @objective.key_results do %>
+    <div class="mt1">
+      <h3><%= key_result.name %></h3>
+      <%= key_result.direction%> <%= key_result.target%> <%= key_result.unit %>
+    </div>
+  <% end %>
+</div>
 
 <.back navigate={~p"/objectives"}>Back to objectives</.back>

--- a/lib/operately_web/controllers/objective_html/show.html.heex
+++ b/lib/operately_web/controllers/objective_html/show.html.heex
@@ -1,0 +1,16 @@
+<.header>
+  Objective <%= @objective.id %>
+  <:subtitle>This is a objective record from your database.</:subtitle>
+  <:actions>
+    <.link href={~p"/objectives/#{@objective}/edit"}>
+      <.button>Edit objective</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @objective.name %></:item>
+  <:item title="Description"><%= @objective.description %></:item>
+</.list>
+
+<.back navigate={~p"/objectives"}>Back to objectives</.back>

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -20,6 +20,7 @@ defmodule OperatelyWeb.Router do
     get "/", PageController, :home
 
     resources "/groups", GroupController
+    resources "/objectives", ObjectiveController
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20230307123238_create_objectives.exs
+++ b/priv/repo/migrations/20230307123238_create_objectives.exs
@@ -1,0 +1,13 @@
+defmodule Operately.Repo.Migrations.CreateObjectives do
+  use Ecto.Migration
+
+  def change do
+    create table(:objectives, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :description, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20230307135121_create_key_results.exs
+++ b/priv/repo/migrations/20230307135121_create_key_results.exs
@@ -1,0 +1,17 @@
+defmodule Operately.Repo.Migrations.CreateKeyResults do
+  use Ecto.Migration
+
+  def change do
+    create table(:key_results, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :unit, :string
+      add :target, :integer
+      add :objective_id, references(:objectives, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:key_results, [:objective_id])
+  end
+end

--- a/priv/repo/migrations/20230307154049_add_direction_to_key_results_table.exs
+++ b/priv/repo/migrations/20230307154049_add_direction_to_key_results_table.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddDirectionToKeyResultsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:key_results) do
+      add :direction, :string
+    end
+  end
+end

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -7,10 +7,17 @@ Feature: Objectives and Key Results
     And I fill in the Objective Name field with "Maintain support happiness"
     And I fill in the Objective Description field with "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
     And I choose "Current quarter" from the Timeframe dropdown
+    And I add a Key Result with the name "Happiness score increased from 95 to 97" as "Percentage" and the target value "Above" "97"
+    And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" as "Number" and the target value "Below" "1 hour"
     And I click on the Create Objective and results button
-    And I add a Key Result with the name "Happiness score increased from 95 to 97" and the target value "above" "97"
-    And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" and the target value "below" "1 hour"
     Then I should see "Maintain support happiness" in the list of Objectives
+    When I click on the "Maintain support happiness Objective"
+    Then I should see "Maintain support happiness" in the Objective title
+    And I should see "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers." in the Objective description
+    And I should see "Current quarter" in the Objective timeframe
+    And I should see "Happiness score increased from 95 to 97" in the list of Key Results
+    And I should see "First response time dropped from 2 hours to 1 hour" in the list of Key Results
+
 
   # Scenario: Viewing Objectives and Key Results
   #   Given I am logged in as a user

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -1,0 +1,20 @@
+Feature: Objectives and Key Results
+
+  Scenario: Creating an Objective
+    Given I am logged in as a user
+    And I am on the Objectives page
+    When I click on the Create Objective button
+    And I fill in the Objective Name field with "Maintain support happiness"
+    And I fill in the Objective Description field with "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
+    And I choose "Current quarter" from the Timeframe dropdown
+    And I click on the Create Objective and results button
+    And I add a Key Result with the name "Happiness score increased from 95 to 97" and the target value "above" "97"
+    And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" and the target value "below" "1 hour"
+    Then I should see "Maintain support happiness" in the list of Objectives
+
+  # Scenario: Viewing Objectives and Key Results
+  #   Given I am logged in as a user
+  #   And I am on the Objectives page
+  #   When I view the list of Objectives and Key Results
+  #   Then I should see a list of all Objectives and their associated Key Results
+  #   And I should be able to click on an Objective to view its details

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -11,10 +11,10 @@ Feature: Objectives and Key Results
     And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" as "Number" and the target value "Below" "1 hour"
     And I click on the Create Objective and results button
     Then I should see "Maintain support happiness" in the list of Objectives
-    When I click on the "Maintain support happiness Objective"
+    When I click on the "Maintain support happiness" objective
     Then I should see "Maintain support happiness" in the Objective title
     And I should see "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers." in the Objective description
-    And I should see "Current quarter" in the Objective timeframe
+    # And I should see "Current quarter" in the Objective timeframe
     And I should see "Happiness score increased from 95 to 97" in the list of Key Results
     And I should see "First response time dropped from 2 hours to 1 hour" in the list of Key Results
 

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -14,14 +14,5 @@ Feature: Objectives and Key Results
     When I click on the "Maintain support happiness" objective
     Then I should see "Maintain support happiness" in the Objective title
     And I should see "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers." in the Objective description
-    # And I should see "Current quarter" in the Objective timeframe
     And I should see "Happiness score increased from 95 to 97" in the list of Key Results
     And I should see "First response time dropped from 2 hours to 1 hour" in the list of Key Results
-
-
-  # Scenario: Viewing Objectives and Key Results
-  #   Given I am logged in as a user
-  #   And I am on the Objectives page
-  #   When I view the list of Objectives and Key Results
-  #   Then I should see a list of all Objectives and their associated Key Results
-  #   And I should be able to click on an Objective to view its details

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -7,8 +7,8 @@ Feature: Objectives and Key Results
     And I fill in the Objective Name field with "Maintain support happiness"
     And I fill in the Objective Description field with "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
     And I choose "Current quarter" from the Timeframe dropdown
-    And I add a Key Result with the name "Happiness score increased from 95 to 97" as "Percentage" and the target value "Above" "97"
-    And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" as "Number" and the target value "Below" "1 hour"
+    And I add a Key Result with the name "Happiness score increased from 95 to 97" as "percentage" and the target value "above" "97"
+    And I add a Key Result with the name "First response time dropped from 2 hours to 1 hour" as "number" and the target value "below" "1"
     And I click on the Create Objective and results button
     Then I should see "Maintain support happiness" in the list of Objectives
     When I click on the "Maintain support happiness" objective

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -47,10 +47,11 @@ defmodule MyApp.Features.OkrsTest do
   end
 
   defwhen ~r/^I click on the "(?<name>[^"]+)" objective$/, %{name: name}, state do
-    # Your implementation here
+    state.session |> click(Query.link(name))
   end
 
   defthen ~r/^I should see "(?<name>[^"]+)" in the Objective title$/, %{name: name}, state do
+    state.session |> ts()
     state.session |> assert_text(name)
   end
 

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -45,4 +45,25 @@ defmodule MyApp.Features.OkrsTest do
   defthen ~r/^I should see "(?<name>[^"]+)" in the list of Objectives$/, %{name: name}, state do
     state.session |> visit("/objectives") |> assert_text(name)
   end
+
+  defwhen ~r/^I click on the "(?<name>[^"]+)" objective$/, %{name: name}, state do
+    # Your implementation here
+  end
+
+  defthen ~r/^I should see "(?<name>[^"]+)" in the Objective title$/, %{name: name}, state do
+    state.session |> assert_text(name)
+  end
+
+  defand ~r/^I should see "(?<description>[^"]+)" in the Objective description$/, %{description: description}, state do
+    state.session |> assert_text(description)
+  end
+
+  defand ~r/^I should see "(?<name>[^"]+)" in the list of Key Results$/, %{timeframe: timeframe}, state do
+    state.session |> assert_text(timeframe)
+  end
+
+  defand ~r/^I should see "(?<name>[^"]+)" in the list of Key Results$/, %{name: name}, state do
+    state.session |> assert_text(name)
+  end
+
 end

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -1,0 +1,39 @@
+defmodule MyApp.Features.OkrsTest do
+  use Operately.FeatureCase, file: "okrs.feature"
+
+  defgiven ~r/^I am logged in as a user$/, _vars, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I am on the Objectives page$/, _vars, state do
+    # Your implementation here
+  end
+
+  defwhen ~r/^I click on the Create Objective button$/, _vars, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I fill in the Objective Name field with "(?<name>[^"]+)"$/, %{name: name}, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I fill in the Objective Description field with "(?<description>[^"]+)"$/, %{description: description}, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I choose "(?<timeframe>[^"]+)" from the Timeframe dropdown$/, %{timeframe: timeframe}, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I click on the Create Objective and results button$/, _vars, state do
+    # Your implementation here
+  end
+
+  defand ~r/^I add a Key Result with the name "(?<kr_name>[^"]+)" and the target value "(?<direction>[^"]+)" "(?<value>[^"]+)"$/, %{kr_name: name, direction: direction, value: value}, state do
+    # Your implementation here
+  end
+
+  defthen ~r/^I should see "(?<name>[^"]+)" in the list of Objectives$/, %{name: name}, state do
+    # Your implementation here
+  end
+end

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -9,15 +9,15 @@ defmodule MyApp.Features.OkrsTest do
   end
 
   defwhen ~r/^I click on the Create Objective button$/, _vars, state do
-    state.session |> click("Create Objective")
+    state.session |> click(Query.button("New Objective"))
   end
 
   defand ~r/^I fill in the Objective Name field with "(?<name>[^"]+)"$/, %{name: name}, state do
-    state.session |> fill_in("Name", with: name)
+    state.session |> fill_in(Query.text_field("Name"), with: name)
   end
 
   defand ~r/^I fill in the Objective Description field with "(?<description>[^"]+)"$/, %{description: description}, state do
-    state.session |> fill_in("Description", with: description)
+    state.session |> fill_in(Query.text_field("Description"), with: description)
   end
 
   defand ~r/^I choose "(?<timeframe>[^"]+)" from the Timeframe dropdown$/, %{timeframe: timeframe}, state do
@@ -25,7 +25,7 @@ defmodule MyApp.Features.OkrsTest do
   end
 
   defand ~r/^I click on the Create Objective and results button$/, _vars, state do
-    state.session |> click("Create Objective with results")
+    state.session |> click(Query.button("Save Objective"))
   end
 
   defand ~r/^I add a Key Result with the name "(?<kr_name>[^"]+)" and the target value "(?<direction>[^"]+)" "(?<value>[^"]+)"$/, %{kr_name: name, direction: direction, value: value}, state do

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -28,11 +28,18 @@ defmodule MyApp.Features.OkrsTest do
     state.session |> click(Query.button("Save Objective"))
   end
 
-  defand ~r/^I add a Key Result with the name "(?<kr_name>[^"]+)" and the target value "(?<direction>[^"]+)" "(?<value>[^"]+)"$/, %{kr_name: name, direction: direction, value: value}, state do
-    state.session |> click("Add Key Result")
-    state.session |> fill_in("Name", with: name)
-    state.session |> select(direction, from: "Direction")
-    state.session |> fill_in("Target value", with: value)
+  defand ~r/^I add a Key Result with the name "(?<kr_name>[^"]+)" as "(?<unit>[^"]+)" and the target value "(?<direction>[^"]+)" "(?<value>[^"]+)"$/, %{kr_name: name, direction: direction, unit: unit, value: value}, state do
+    state.session
+    |> click(Query.button("Add Key Result"))
+    |> ts()
+    |> scroll_into_view("#key-results-container")
+    |> find(Query.css("#key-results-container [data-key-result]:last-child"), fn container ->
+      container
+      |> fill_in(Query.text_field("Name"), with: name)
+      |> select(unit, from: "Unit")
+      |> select(direction, from: "Direction")
+      |> fill_in(Query.text_field("Target"), with: value)
+    end)
   end
 
   defthen ~r/^I should see "(?<name>[^"]+)" in the list of Objectives$/, %{name: name}, state do

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -2,38 +2,40 @@ defmodule MyApp.Features.OkrsTest do
   use Operately.FeatureCase, file: "okrs.feature"
 
   defgiven ~r/^I am logged in as a user$/, _vars, state do
-    # Your implementation here
   end
 
   defand ~r/^I am on the Objectives page$/, _vars, state do
-    # Your implementation here
+    state.session |> visit("/objectives")
   end
 
   defwhen ~r/^I click on the Create Objective button$/, _vars, state do
-    # Your implementation here
+    state.session |> click("Create Objective")
   end
 
   defand ~r/^I fill in the Objective Name field with "(?<name>[^"]+)"$/, %{name: name}, state do
-    # Your implementation here
+    state.session |> fill_in("Name", with: name)
   end
 
   defand ~r/^I fill in the Objective Description field with "(?<description>[^"]+)"$/, %{description: description}, state do
-    # Your implementation here
+    state.session |> fill_in("Description", with: description)
   end
 
   defand ~r/^I choose "(?<timeframe>[^"]+)" from the Timeframe dropdown$/, %{timeframe: timeframe}, state do
-    # Your implementation here
+    state.session |> select(timeframe, from: "Timeframe")
   end
 
   defand ~r/^I click on the Create Objective and results button$/, _vars, state do
-    # Your implementation here
+    state.session |> click("Create Objective with results")
   end
 
   defand ~r/^I add a Key Result with the name "(?<kr_name>[^"]+)" and the target value "(?<direction>[^"]+)" "(?<value>[^"]+)"$/, %{kr_name: name, direction: direction, value: value}, state do
-    # Your implementation here
+    state.session |> click("Add Key Result")
+    state.session |> fill_in("Name", with: name)
+    state.session |> select(direction, from: "Direction")
+    state.session |> fill_in("Target value", with: value)
   end
 
   defthen ~r/^I should see "(?<name>[^"]+)" in the list of Objectives$/, %{name: name}, state do
-    # Your implementation here
+    state.session |> visit("/objectives") |> assert_text(name)
   end
 end

--- a/test/operately/okrs_test.exs
+++ b/test/operately/okrs_test.exs
@@ -1,0 +1,61 @@
+defmodule Operately.OkrsTest do
+  use Operately.DataCase
+
+  alias Operately.Okrs
+
+  describe "objectives" do
+    alias Operately.Okrs.Objective
+
+    import Operately.OkrsFixtures
+
+    @invalid_attrs %{description: nil, name: nil}
+
+    test "list_objectives/0 returns all objectives" do
+      objective = objective_fixture()
+      assert Okrs.list_objectives() == [objective]
+    end
+
+    test "get_objective!/1 returns the objective with given id" do
+      objective = objective_fixture()
+      assert Okrs.get_objective!(objective.id) == objective
+    end
+
+    test "create_objective/1 with valid data creates a objective" do
+      valid_attrs = %{description: "some description", name: "some name"}
+
+      assert {:ok, %Objective{} = objective} = Okrs.create_objective(valid_attrs)
+      assert objective.description == "some description"
+      assert objective.name == "some name"
+    end
+
+    test "create_objective/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Okrs.create_objective(@invalid_attrs)
+    end
+
+    test "update_objective/2 with valid data updates the objective" do
+      objective = objective_fixture()
+      update_attrs = %{description: "some updated description", name: "some updated name"}
+
+      assert {:ok, %Objective{} = objective} = Okrs.update_objective(objective, update_attrs)
+      assert objective.description == "some updated description"
+      assert objective.name == "some updated name"
+    end
+
+    test "update_objective/2 with invalid data returns error changeset" do
+      objective = objective_fixture()
+      assert {:error, %Ecto.Changeset{}} = Okrs.update_objective(objective, @invalid_attrs)
+      assert objective == Okrs.get_objective!(objective.id)
+    end
+
+    test "delete_objective/1 deletes the objective" do
+      objective = objective_fixture()
+      assert {:ok, %Objective{}} = Okrs.delete_objective(objective)
+      assert_raise Ecto.NoResultsError, fn -> Okrs.get_objective!(objective.id) end
+    end
+
+    test "change_objective/1 returns a objective changeset" do
+      objective = objective_fixture()
+      assert %Ecto.Changeset{} = Okrs.change_objective(objective)
+    end
+  end
+end

--- a/test/operately_web/controllers/objective_controller_test.exs
+++ b/test/operately_web/controllers/objective_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule OperatelyWeb.ObjectiveControllerTest do
+  use OperatelyWeb.ConnCase
+
+  import Operately.OkrsFixtures
+
+  @create_attrs %{description: "some description", name: "some name"}
+  @update_attrs %{description: "some updated description", name: "some updated name"}
+  @invalid_attrs %{description: nil, name: nil}
+
+  describe "index" do
+    test "lists all objectives", %{conn: conn} do
+      conn = get(conn, ~p"/objectives")
+      assert html_response(conn, 200) =~ "Listing Objectives"
+    end
+  end
+
+  describe "new objective" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, ~p"/objectives/new")
+      assert html_response(conn, 200) =~ "New Objective"
+    end
+  end
+
+  describe "create objective" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/objectives", objective: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == ~p"/objectives/#{id}"
+
+      conn = get(conn, ~p"/objectives/#{id}")
+      assert html_response(conn, 200) =~ "Objective #{id}"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/objectives", objective: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Objective"
+    end
+  end
+
+  describe "edit objective" do
+    setup [:create_objective]
+
+    test "renders form for editing chosen objective", %{conn: conn, objective: objective} do
+      conn = get(conn, ~p"/objectives/#{objective}/edit")
+      assert html_response(conn, 200) =~ "Edit Objective"
+    end
+  end
+
+  describe "update objective" do
+    setup [:create_objective]
+
+    test "redirects when data is valid", %{conn: conn, objective: objective} do
+      conn = put(conn, ~p"/objectives/#{objective}", objective: @update_attrs)
+      assert redirected_to(conn) == ~p"/objectives/#{objective}"
+
+      conn = get(conn, ~p"/objectives/#{objective}")
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, objective: objective} do
+      conn = put(conn, ~p"/objectives/#{objective}", objective: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Objective"
+    end
+  end
+
+  describe "delete objective" do
+    setup [:create_objective]
+
+    test "deletes chosen objective", %{conn: conn, objective: objective} do
+      conn = delete(conn, ~p"/objectives/#{objective}")
+      assert redirected_to(conn) == ~p"/objectives"
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/objectives/#{objective}")
+      end
+    end
+  end
+
+  defp create_objective(_) do
+    objective = objective_fixture()
+    %{objective: objective}
+  end
+end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -23,11 +23,17 @@ defmodule Operately.FeatureCase do
         :ok
       end
 
-      defp select(session, option, from: select) do
+      defp select(session, option_name, from: select_name) do
+        alias Wallaby.Query
+
         session
-        |> find(select, fn select ->
-          click(select, option)
+        |> find(Query.select(select_name), fn select ->
+          click(select, Query.option(option_name))
         end)
+      end
+
+      defp ts(session) do
+        take_screenshot(session)
       end
     end
   end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -12,9 +12,6 @@ defmodule Operately.FeatureCase do
     quote do
       alias Operately.Repo
 
-      import Ecto
-      import Ecto.Changeset
-      import Ecto.Query
       import Operately.DataCase
 
       use Cabbage.Feature, async: false, file: unquote(file)
@@ -24,6 +21,13 @@ defmodule Operately.FeatureCase do
         Operately.DataCase.setup_sandbox(async: false)
 
         :ok
+      end
+
+      defp select(session, option, from: select) do
+        session
+        |> find(select, fn select ->
+          click(select, option)
+        end)
       end
     end
   end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -35,6 +35,10 @@ defmodule Operately.FeatureCase do
       defp ts(session) do
         take_screenshot(session)
       end
+
+      def scroll_into_view(session, css_selector) do
+        session |> execute_script("document.querySelector('#{css_selector}').scrollIntoView()")
+      end
     end
   end
 end

--- a/test/support/fixtures/okrs_fixtures.ex
+++ b/test/support/fixtures/okrs_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Operately.OkrsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Operately.Okrs` context.
+  """
+
+  @doc """
+  Generate a objective.
+  """
+  def objective_fixture(attrs \\ %{}) do
+    {:ok, objective} =
+      attrs
+      |> Enum.into(%{
+        description: "some description",
+        name: "some name"
+      })
+      |> Operately.Okrs.create_objective()
+
+    objective
+  end
+end


### PR DESCRIPTION
This pull request introduces Objectives and Key Results (OKRs) to our product. OKRs are a popular goal-setting framework used to help teams align their efforts and achieve common goals.

Our goal is to improve team alignment and focus on achieving meaningful results. With Operately, we offer an opinionated approach to setting up OKRs, encouraging users to define measurable results using clear and well-understood metrics.

In some organisations, OKRs can become a convoluted to-do list rather than a clear and measurable outcome for the team to focus on. Operately aims to prevent this misuse and ensure that teams set up their OKRs correctly.

## How to review this Pull-Request?

Start from the `test/features/okrs.feature` gherkin specification that outlines how objectives should behave in the system. Following this, you will end up discovering two new entities introduced to the system `Objectives` and `KeyResults`.

Both Objectives and Key Results are nested under the `Operately.Okrs` context, where the relationship between them is expressed with:

- Objectives have_many key_results
- Key Results belong to an Objective

## New Testing Infrastructure

This PullRequest introduces a couple of new testing infrastructure tools:

- The `scroll_into_view` Wallaby helper, that can be used to scroll the page of the browser so that the element becomes visible for the Wallaby selector
- The `ts` utility that is a shorthand for `take_screenshot` which takes a screenshot of the current page that the tests are executing

## Challenges in this Pull Request

Nested forms are quite tricky in Phoenix, or I'm not experienced enough with them.

At one point in the code, the building of the dynamic form that can convert both Objectives and multiple Key Results, is a bit too low level and required me to deal with form naming and parsing manually. I don't like this, nor does it feel like a proper solution.

If you have a feedback how to do this better, I'm happy to hear it.