### PR TITLE
Introducing company tenets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,14 @@ WORKDIR $APP_HOME
 
 RUN echo "export PS1='\w $ '" >> /home/dev/.bashrc
 
+# Wallaby tests are printing out an error message without this folder.
+# The error message is harmless, but it is annoying.
+# This is a workaround for the error message.
+#
+# The message is:
+# find: ‘/home/dev/.config/chromium/Crash Reports/pending/’: No such file or directory.
+RUN mkdir -p "/home/dev/.config/chromium/Crash Reports/pending"
+
 # Set the default command to run when the container starts.
 # Start the phoenix server.
 

--- a/lib/operately/tenets.ex
+++ b/lib/operately/tenets.ex
@@ -1,0 +1,104 @@
+defmodule Operately.Tenets do
+  @moduledoc """
+  The Tenets context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Operately.Repo
+
+  alias Operately.Tenets.Tenet
+
+  @doc """
+  Returns the list of tenets.
+
+  ## Examples
+
+      iex> list_tenets()
+      [%Tenet{}, ...]
+
+  """
+  def list_tenets do
+    Repo.all(Tenet)
+  end
+
+  @doc """
+  Gets a single tenet.
+
+  Raises `Ecto.NoResultsError` if the Tenet does not exist.
+
+  ## Examples
+
+      iex> get_tenet!(123)
+      %Tenet{}
+
+      iex> get_tenet!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_tenet!(id), do: Repo.get!(Tenet, id)
+
+  @doc """
+  Creates a tenet.
+
+  ## Examples
+
+      iex> create_tenet(%{field: value})
+      {:ok, %Tenet{}}
+
+      iex> create_tenet(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_tenet(attrs \\ %{}) do
+    %Tenet{}
+    |> Tenet.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a tenet.
+
+  ## Examples
+
+      iex> update_tenet(tenet, %{field: new_value})
+      {:ok, %Tenet{}}
+
+      iex> update_tenet(tenet, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_tenet(%Tenet{} = tenet, attrs) do
+    tenet
+    |> Tenet.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a tenet.
+
+  ## Examples
+
+      iex> delete_tenet(tenet)
+      {:ok, %Tenet{}}
+
+      iex> delete_tenet(tenet)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_tenet(%Tenet{} = tenet) do
+    Repo.delete(tenet)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking tenet changes.
+
+  ## Examples
+
+      iex> change_tenet(tenet)
+      %Ecto.Changeset{data: %Tenet{}}
+
+  """
+  def change_tenet(%Tenet{} = tenet, attrs \\ %{}) do
+    Tenet.changeset(tenet, attrs)
+  end
+end

--- a/lib/operately/tenets/tenet.ex
+++ b/lib/operately/tenets/tenet.ex
@@ -1,0 +1,20 @@
+defmodule Operately.Tenets.Tenet do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "tenets" do
+    field :description, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(tenet, attrs) do
+    tenet
+    |> cast(attrs, [:name, :description])
+    |> validate_required([:name, :description])
+  end
+end

--- a/lib/operately_web/controllers/tenet_controller.ex
+++ b/lib/operately_web/controllers/tenet_controller.ex
@@ -1,0 +1,62 @@
+defmodule OperatelyWeb.TenetController do
+  use OperatelyWeb, :controller
+
+  alias Operately.Tenets
+  alias Operately.Tenets.Tenet
+
+  def index(conn, _params) do
+    tenets = Tenets.list_tenets()
+    render(conn, :index, tenets: tenets)
+  end
+
+  def new(conn, _params) do
+    changeset = Tenets.change_tenet(%Tenet{})
+    render(conn, :new, changeset: changeset)
+  end
+
+  def create(conn, %{"tenet" => tenet_params}) do
+    case Tenets.create_tenet(tenet_params) do
+      {:ok, tenet} ->
+        conn
+        |> put_flash(:info, "Tenet created successfully.")
+        |> redirect(to: ~p"/tenets/#{tenet}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :new, changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    tenet = Tenets.get_tenet!(id)
+    render(conn, :show, tenet: tenet)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    tenet = Tenets.get_tenet!(id)
+    changeset = Tenets.change_tenet(tenet)
+    render(conn, :edit, tenet: tenet, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "tenet" => tenet_params}) do
+    tenet = Tenets.get_tenet!(id)
+
+    case Tenets.update_tenet(tenet, tenet_params) do
+      {:ok, tenet} ->
+        conn
+        |> put_flash(:info, "Tenet updated successfully.")
+        |> redirect(to: ~p"/tenets/#{tenet}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :edit, tenet: tenet, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    tenet = Tenets.get_tenet!(id)
+    {:ok, _tenet} = Tenets.delete_tenet(tenet)
+
+    conn
+    |> put_flash(:info, "Tenet deleted successfully.")
+    |> redirect(to: ~p"/tenets")
+  end
+end

--- a/lib/operately_web/controllers/tenet_html.ex
+++ b/lib/operately_web/controllers/tenet_html.ex
@@ -1,0 +1,5 @@
+defmodule OperatelyWeb.TenetHTML do
+  use OperatelyWeb, :html
+
+  embed_templates "tenet_html/*"
+end

--- a/lib/operately_web/controllers/tenet_html/edit.html.heex
+++ b/lib/operately_web/controllers/tenet_html/edit.html.heex
@@ -1,0 +1,17 @@
+<.header>
+  Edit Tenet <%= @tenet.id %>
+  <:subtitle>Use this form to manage tenet records in your database.</:subtitle>
+</.header>
+
+<.simple_form :let={f} for={@changeset} method="put" action={~p"/tenets/#{@tenet}"}>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+  <.input field={f[:name]} type="text" label="Name" />
+  <.input field={f[:description]} type="text" label="Description" />
+  <:actions>
+    <.button>Save Tenet</.button>
+  </:actions>
+</.simple_form>
+
+<.back navigate={~p"/tenets"}>Back to tenets</.back>

--- a/lib/operately_web/controllers/tenet_html/index.html.heex
+++ b/lib/operately_web/controllers/tenet_html/index.html.heex
@@ -1,0 +1,24 @@
+<.header>
+  Listing Tenets
+  <:actions>
+    <.link href={~p"/tenets/new"}>
+      <.button>New Tenet</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.table id="tenets" rows={@tenets} row_click={&JS.navigate(~p"/tenets/#{&1}")}>
+  <:col :let={tenet} label="Name"><%= tenet.name %></:col>
+  <:col :let={tenet} label="Description"><%= tenet.description %></:col>
+  <:action :let={tenet}>
+    <div class="sr-only">
+      <.link navigate={~p"/tenets/#{tenet}"}>Show</.link>
+    </div>
+    <.link navigate={~p"/tenets/#{tenet}/edit"}>Edit</.link>
+  </:action>
+  <:action :let={tenet}>
+    <.link href={~p"/tenets/#{tenet}"} method="delete" data-confirm="Are you sure?">
+      Delete
+    </.link>
+  </:action>
+</.table>

--- a/lib/operately_web/controllers/tenet_html/new.html.heex
+++ b/lib/operately_web/controllers/tenet_html/new.html.heex
@@ -1,0 +1,17 @@
+<.header>
+  New Tenet
+  <:subtitle>Use this form to manage tenet records in your database.</:subtitle>
+</.header>
+
+<.simple_form :let={f} for={@changeset} action={~p"/tenets"}>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+  <.input field={f[:name]} type="text" label="Name" />
+  <.input field={f[:description]} type="text" label="Description" />
+  <:actions>
+    <.button>Save Tenet</.button>
+  </:actions>
+</.simple_form>
+
+<.back navigate={~p"/tenets"}>Back to tenets</.back>

--- a/lib/operately_web/controllers/tenet_html/show.html.heex
+++ b/lib/operately_web/controllers/tenet_html/show.html.heex
@@ -1,0 +1,16 @@
+<.header>
+  Tenet <%= @tenet.id %>
+  <:subtitle>This is a tenet record from your database.</:subtitle>
+  <:actions>
+    <.link href={~p"/tenets/#{@tenet}/edit"}>
+      <.button>Edit tenet</.button>
+    </.link>
+  </:actions>
+</.header>
+
+<.list>
+  <:item title="Name"><%= @tenet.name %></:item>
+  <:item title="Description"><%= @tenet.description %></:item>
+</.list>
+
+<.back navigate={~p"/tenets"}>Back to tenets</.back>

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -21,6 +21,7 @@ defmodule OperatelyWeb.Router do
 
     resources "/groups", GroupController
     resources "/objectives", ObjectiveController
+    resources "/tenets", TenetController
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20230308141139_create_tenets.exs
+++ b/priv/repo/migrations/20230308141139_create_tenets.exs
@@ -1,0 +1,13 @@
+defmodule Operately.Repo.Migrations.CreateTenets do
+  use Ecto.Migration
+
+  def change do
+    create table(:tenets, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string
+      add :description, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/features/tenets.feature
+++ b/test/features/tenets.feature
@@ -1,0 +1,11 @@
+Feature: Tenets
+
+  Scenario: Creating a company tenet
+    Given I am logged in as a user
+    And I am on the Tenets page
+    When I click the "Create Tenet" button
+    And I fill in "Name" with "Customer obsession rather than competitor focus"
+    And I fill in "Description" with "We are committed to earning the trust of our customers by putting their needs first."
+    And I click the "Create" button
+    Then I should see "Customer obsession rather than competitor focus" on the Tenets page
+

--- a/test/features/tenets.feature
+++ b/test/features/tenets.feature
@@ -3,9 +3,9 @@ Feature: Tenets
   Scenario: Creating a company tenet
     Given I am logged in as a user
     And I am on the Tenets page
-    When I click the "Create Tenet" button
+    When I click the "New Tenet" button
     And I fill in "Name" with "Customer obsession rather than competitor focus"
     And I fill in "Description" with "We are committed to earning the trust of our customers by putting their needs first."
-    And I click the "Create" button
+    And I click the "Save Tenet" button
     Then I should see "Customer obsession rather than competitor focus" on the Tenets page
 

--- a/test/features/tenets_test.exs
+++ b/test/features/tenets_test.exs
@@ -1,0 +1,23 @@
+defmodule MyApp.Features.TenetsTest do
+  use Operately.FeatureCase, file: "tenets.feature"
+
+  defgiven ~r/^I am logged in as a user$/, _vars, state do
+  end
+
+  defand ~r/^I am on the Tenets page$/, _vars, state do
+    state.session |> visit("/tenets")
+  end
+
+  defwhen ~r/^I click the "(?<button_name>[^"]+)" button$/, %{button_name: button_name}, state do
+    state.session |> click(Query.button(button_name))
+  end
+
+  defand ~r/^I fill in "(?<field>[^"]+)" with "(?<value>[^"]+)"$/, %{field: field, value: value}, state do
+    state.session |> fill_in(Query.text_field(field), with: value)
+  end
+
+  defthen ~r/^I should see "(?<tenet>[^"]+)" on the Tenets page$/, %{tenet: tenet}, state do
+    state.session |> assert_has(Query.text(tenet))
+  end
+
+end

--- a/test/operately/tenets_test.exs
+++ b/test/operately/tenets_test.exs
@@ -1,0 +1,61 @@
+defmodule Operately.TenetsTest do
+  use Operately.DataCase
+
+  alias Operately.Tenets
+
+  describe "tenets" do
+    alias Operately.Tenets.Tenet
+
+    import Operately.TenetsFixtures
+
+    @invalid_attrs %{description: nil, name: nil}
+
+    test "list_tenets/0 returns all tenets" do
+      tenet = tenet_fixture()
+      assert Tenets.list_tenets() == [tenet]
+    end
+
+    test "get_tenet!/1 returns the tenet with given id" do
+      tenet = tenet_fixture()
+      assert Tenets.get_tenet!(tenet.id) == tenet
+    end
+
+    test "create_tenet/1 with valid data creates a tenet" do
+      valid_attrs = %{description: "some description", name: "some name"}
+
+      assert {:ok, %Tenet{} = tenet} = Tenets.create_tenet(valid_attrs)
+      assert tenet.description == "some description"
+      assert tenet.name == "some name"
+    end
+
+    test "create_tenet/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Tenets.create_tenet(@invalid_attrs)
+    end
+
+    test "update_tenet/2 with valid data updates the tenet" do
+      tenet = tenet_fixture()
+      update_attrs = %{description: "some updated description", name: "some updated name"}
+
+      assert {:ok, %Tenet{} = tenet} = Tenets.update_tenet(tenet, update_attrs)
+      assert tenet.description == "some updated description"
+      assert tenet.name == "some updated name"
+    end
+
+    test "update_tenet/2 with invalid data returns error changeset" do
+      tenet = tenet_fixture()
+      assert {:error, %Ecto.Changeset{}} = Tenets.update_tenet(tenet, @invalid_attrs)
+      assert tenet == Tenets.get_tenet!(tenet.id)
+    end
+
+    test "delete_tenet/1 deletes the tenet" do
+      tenet = tenet_fixture()
+      assert {:ok, %Tenet{}} = Tenets.delete_tenet(tenet)
+      assert_raise Ecto.NoResultsError, fn -> Tenets.get_tenet!(tenet.id) end
+    end
+
+    test "change_tenet/1 returns a tenet changeset" do
+      tenet = tenet_fixture()
+      assert %Ecto.Changeset{} = Tenets.change_tenet(tenet)
+    end
+  end
+end

--- a/test/operately_web/controllers/tenet_controller_test.exs
+++ b/test/operately_web/controllers/tenet_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule OperatelyWeb.TenetControllerTest do
+  use OperatelyWeb.ConnCase
+
+  import Operately.TenetsFixtures
+
+  @create_attrs %{description: "some description", name: "some name"}
+  @update_attrs %{description: "some updated description", name: "some updated name"}
+  @invalid_attrs %{description: nil, name: nil}
+
+  describe "index" do
+    test "lists all tenets", %{conn: conn} do
+      conn = get(conn, ~p"/tenets")
+      assert html_response(conn, 200) =~ "Listing Tenets"
+    end
+  end
+
+  describe "new tenet" do
+    test "renders form", %{conn: conn} do
+      conn = get(conn, ~p"/tenets/new")
+      assert html_response(conn, 200) =~ "New Tenet"
+    end
+  end
+
+  describe "create tenet" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post(conn, ~p"/tenets", tenet: @create_attrs)
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == ~p"/tenets/#{id}"
+
+      conn = get(conn, ~p"/tenets/#{id}")
+      assert html_response(conn, 200) =~ "Tenet #{id}"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post(conn, ~p"/tenets", tenet: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New Tenet"
+    end
+  end
+
+  describe "edit tenet" do
+    setup [:create_tenet]
+
+    test "renders form for editing chosen tenet", %{conn: conn, tenet: tenet} do
+      conn = get(conn, ~p"/tenets/#{tenet}/edit")
+      assert html_response(conn, 200) =~ "Edit Tenet"
+    end
+  end
+
+  describe "update tenet" do
+    setup [:create_tenet]
+
+    test "redirects when data is valid", %{conn: conn, tenet: tenet} do
+      conn = put(conn, ~p"/tenets/#{tenet}", tenet: @update_attrs)
+      assert redirected_to(conn) == ~p"/tenets/#{tenet}"
+
+      conn = get(conn, ~p"/tenets/#{tenet}")
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, tenet: tenet} do
+      conn = put(conn, ~p"/tenets/#{tenet}", tenet: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit Tenet"
+    end
+  end
+
+  describe "delete tenet" do
+    setup [:create_tenet]
+
+    test "deletes chosen tenet", %{conn: conn, tenet: tenet} do
+      conn = delete(conn, ~p"/tenets/#{tenet}")
+      assert redirected_to(conn) == ~p"/tenets"
+
+      assert_error_sent 404, fn ->
+        get(conn, ~p"/tenets/#{tenet}")
+      end
+    end
+  end
+
+  defp create_tenet(_) do
+    tenet = tenet_fixture()
+    %{tenet: tenet}
+  end
+end

--- a/test/support/fixtures/tenets_fixtures.ex
+++ b/test/support/fixtures/tenets_fixtures.ex
@@ -1,0 +1,21 @@
+defmodule Operately.TenetsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Operately.Tenets` context.
+  """
+
+  @doc """
+  Generate a tenet.
+  """
+  def tenet_fixture(attrs \\ %{}) do
+    {:ok, tenet} =
+      attrs
+      |> Enum.into(%{
+        description: "some description",
+        name: "some name"
+      })
+      |> Operately.Tenets.create_tenet()
+
+    tenet
+  end
+end


### PR DESCRIPTION
In this Pull Request, I'm introducing the concept of company tenets. 

### What are company tenets?
Company tenets are a set of guiding principles or values that define an organization's culture and guide its decision-making processes. These tenets should be established by the company's leadership and are intended to shape the behaviors and attitudes of all team members.

When a company has well-defined tenets, teams make faster decisions in several ways:

1. Clarity on what is most important to the organization. Teams prioritize decisions and reduces the time spent debating options that do not align with the company's values.
2. Alignment: When team members understand and share the same company tenets, they are more likely to be aligned in their decision-making. This alignment helps teams to work towards the same goals, and they reduce the likelihood of conflicting decisions and delays.
3. Empowerment: Teams should make decisions without needing to seek approval from higher-ups for every little decision. This speeds up decision-making, and reduces bottlenecks.
4. Accountability: Tenets also establish clear accountability within the organization. When teams understand the company's values, they are more likely to take ownership of their decisions and be accountable for the outcomes.

What are some example of company tenets:

- From Basecamp: "We make money by making a product people want to buy".
- From Amazon: "Customer Obsession in contrast to Competitor obsession"
- From Google: "Focus on the user and all else will follow".

Operately aims to help every startup become 10x more productive without needing to learn and invent everything from scratch. Company tenets are a great example that have industry level proven track record.

### How to review this Pull-Request?

Start from the `test/features/tenets.feature` that describes what is added in this pull request. The steps outlined in `test/features/tenets_tests.exs` will help you to find the main entry points and where to look further.

### New testing infrastructure

Wallaby tests were reporting a problem with `/home/dev/.config/chromioum` folder. The error message was harmeless, but it was annoying and distracting to see it on every test run.

The new addition to the `Dockerfile` introduces a fix that successfully eliminates this problem. 