### PR TITLE
Fix overriding default environment variables on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@
 #
 # See https://docs.docker.com/engine/security/userns-remap/
 # for more information.
-USER_CONTEXT = export GID=$$(id -g) && export UID=$$(id -u)
+USER_CONTEXT = export GROUP_ID=$$(id -g) && export USER_ID=$$(id -u)
 
 #
 # Prepare a command to run the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
     build:
       context: .
       args:
-        - USER_ID=${UID}
-        - GROUP_ID=${GID}
-    user: ${UID}:${GID}
+        - USER_ID
+        - GROUP_ID
+    user: ${USER_ID}:${GROUP_ID}
     volumes:
       - ./:/home/dev/app
     ports:


### PR DESCRIPTION
This pull requests fix the issue with overriding default `UID` and `GID` environment variables on  macOS #8 