### PR TITLE
Fix macOS development environment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 # We will call this user 'dev' inside of the development container.
 # The name might differ from your host machine, but the UID and GID will be the same.
 
-RUN groupadd --gid ${GROUP_ID} dev \
+RUN groupadd --force --gid ${GROUP_ID} dev \
  && useradd --uid ${USER_ID} --gid dev --shell /bin/bash --create-home dev
 
 # Switch to the 'dev' user.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ USER_CONTEXT = export GROUP_ID=$$(id -g) && export USER_ID=$$(id -u)
 # Most importantly, it is able to seemlesly use ARM images on ARM machines, and
 # AMD64 images on AMD64 machines.
 #
-DOCKER_COMPOSE = docker compose run --rm -v /vagrant/screenshots:/tmp/screenshots
+DOCKER_COMPOSE = docker compose run --rm -v $(PWD)/screenshots:/tmp/screenshots
 
 #
 # Prepare commands to run the containers in various modes.


### PR DESCRIPTION
In this pull request I'm fixing problem with setup development environment on macOS.
- Fix `groupadd` problem when group already exists
- Use project root directory as default for screenshots