### PR TITLE
Show key results on objective screen

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -371,7 +371,7 @@ i18n
       }
     },
     returnNull: false,
-    lng: "jp",
+    lng: "en",
     fallbackLng: "en",
   });
 

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -7,6 +7,8 @@ i18n
     resources: {
       "en": {
         translation: {
+          "intlDateTime": "{{val, datetime}}",
+
           "Objectives": "Objectives",
           "Tenets": "Tenets",
           "Projects": "Projects",

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -84,6 +84,17 @@ i18n
             "add_group_members_title": "Add Group Members",
             "add_group_members_search_placeholder": "Search for a person...",
             "add_group_members_button": "Add Members",
+          },
+
+          "keyResults": {
+            "status": "Status",
+            "completion": "Completion",
+            "lastUpdated": "Last Updated",
+            "keyResult": "Key Result",
+
+            "statuses": {
+              "pending": "Pending",
+            }
           }
         },
       },
@@ -158,6 +169,17 @@ i18n
             "add_group_members_title": "Додај чланове групе",
             "add_group_members_search_placeholder": "Прonaђи човека...",
             "add_group_members_button": "Додај чланове",
+          },
+
+          "keyResults": {
+            "status": "Cтатус",
+            "completion": "Cтепен завршетка",
+            "lastUpdated": "Последња ажурирања",
+            "keyResult": "Кључни резултат",
+
+            "statuses": {
+              "pending": "Почетак",
+            }
           }
         },
       },
@@ -240,6 +262,17 @@ i18n
             "add_group_members_title": "Csoport tagjainak hozzáadása",
             "add_group_members_search_placeholder": "Keresés személyek között...",
             "add_group_members_button": "Csoport tagjainak hozzáadása",
+          },
+
+          "keyResults": {
+            "status": "Státusz",
+            "completion": "Teljesítés",
+            "lastUpdated": "Utolsó frissítés",
+            "keyResult": "Kulcs eredmény",
+
+            "statuses": {
+              "pending": "Indítás",
+            }
           }
         },
       },
@@ -322,12 +355,23 @@ i18n
             "add_group_members_title": "グループメンバーの追加",
             "add_group_members_search_placeholder": "人々を検索...",
             "add_group_members_button": "グループメンバーを追加",
+          },
+
+          "keyResults": {
+            "status": "スターテス",
+            "completion": "完了",
+            "lastUpdated": "最終更新",
+            "keyResult": "キーリザルト",
+
+            "statuses": {
+              "pending": "開始",
+            }
           }
         },
       }
     },
     returnNull: false,
-    lng: "en",
+    lng: "jp",
     fallbackLng: "en",
   });
 

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -94,6 +94,11 @@ i18n
 
             "statuses": {
               "pending": "Pending",
+              "on_track": "On Track",
+              "at_risk": "At Risk",
+              "off_track": "Off Track",
+              "completed": "Completed",
+              "cancelled": "Cancelled",
             }
           }
         },

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -5,6 +5,7 @@ import { useQuery, gql } from '@apollo/client';
 
 import Table from './Table';
 import StatusBadge from './StatusBadge';
+import DateTime from './DateTime';
 
 const GET_KEY_RESULTS = gql`
   query GetKeyResults($objectiveID: ID!) {
@@ -52,7 +53,12 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
       status: <StatusBadge status={keyResult.status} />,
       completion: "---",
       keyResult: keyResult.name,
-      lastUpdated: keyResult.updatedAt,
+      lastUpdated: t('intlDateTime', {
+        val: Date.parse(keyResult.updatedAt),
+        formatParams: {
+          val: {month: 'long', day: 'numeric'},
+        }
+      }),
     }
   })
 

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -11,6 +11,7 @@ const GET_KEY_RESULTS = gql`
     keyResults(objectiveID: $objectiveID) {
       id
       name
+      status
     }
   }
 `;
@@ -18,6 +19,7 @@ const GET_KEY_RESULTS = gql`
 interface KeyResult {
   id: string;
   name: string;
+  status: string;
 }
 
 export default function KeyResults({objectiveID} : {objectiveID: string}) {
@@ -45,7 +47,7 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
 
   const rows = data.keyResults.map((keyResult: KeyResult) => {
     return {
-      status: <StatusBadge status="pending" />,
+      status: <StatusBadge status={keyResult.status} />,
       completion: "---",
       keyResult: keyResult.name,
       lastUpdated: "---",

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -12,6 +12,7 @@ const GET_KEY_RESULTS = gql`
       id
       name
       status
+      updatedAt
     }
   }
 `;
@@ -20,6 +21,7 @@ interface KeyResult {
   id: string;
   name: string;
   status: string;
+  updatedAt: string;
 }
 
 export default function KeyResults({objectiveID} : {objectiveID: string}) {
@@ -50,7 +52,7 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
       status: <StatusBadge status={keyResult.status} />,
       completion: "---",
       keyResult: keyResult.name,
-      lastUpdated: "---",
+      lastUpdated: keyResult.updatedAt,
     }
   })
 

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { useTranslation } from 'react-i18next';
+import { useQuery, gql } from '@apollo/client';
+
+const GET_KEY_RESULTS = gql`
+  query GetKeyResults($objectiveID: ID!) {
+    keyResults(objectiveID: $objectiveID) {
+      id
+      name
+    }
+  }
+`;
+
+interface KeyResult {
+  id: string;
+  name: string;
+}
+
+function KeyResult({keyResult} : {keyResult: KeyResult}) : JSX.Element {
+  return (
+    <div className="mt-4 flex gap-2 items-center">
+      <div>
+        <div className="font-bold">{keyResult.name}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function KeyResults({objectiveID} : {objectiveID: string}) {
+  const { t } = useTranslation();
+  const { loading, error, data } = useQuery(GET_KEY_RESULTS, {
+    variables: { objectiveID: objectiveID },
+  });
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error : {error.message}</p>;
+
+  return (
+    <div>
+      <h1>{t("KeyResults")}</h1>
+
+      {data.keyResults.map((keyResult: KeyResult, index: number) => (
+        <KeyResult key={index} keyResult={keyResult} />
+      ))}
+    </div>
+  );
+}

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery, gql } from '@apollo/client';
 
+import Table from './Table';
+
 const GET_KEY_RESULTS = gql`
   query GetKeyResults($objectiveID: ID!) {
     keyResults(objectiveID: $objectiveID) {
@@ -15,45 +17,6 @@ const GET_KEY_RESULTS = gql`
 interface KeyResult {
   id: string;
   name: string;
-}
-
-function KeyResult({keyResult} : {keyResult: KeyResult}) : JSX.Element {
-  return (
-    <div className="mt-4 flex gap-2 items-center">
-      <div>
-        <div className="font-bold">{keyResult.name}</div>
-      </div>
-    </div>
-  );
-}
-
-interface Header {
-  id: string;
-  label: string;
-}
-
-interface Row {
-  [key: string]: string;
-}
-
-function Table({headers, columnClasses, rows}) : JSX.Element {
-  return (
-    <div className="mt-4 flex flex-col gap-2 items-center rounded border border-stone-200">
-      <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
-        {headers.map((header: Header, index: number) => (
-          <div key={index} className={columnClasses[header.id]}>{header.label}</div>
-        ))}
-      </div>
-
-      {rows.map((row: Row, index: number) => {
-        return <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
-          {headers.map((header: Header) => (
-            <div key={index} className={columnClasses[header.id]}>{row[header.id]}</div>
-          ))}
-        </div>;
-      })}
-    </div>
-  );
 }
 
 export default function KeyResults({objectiveID} : {objectiveID: string}) {

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -25,14 +25,14 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
     variables: { objectiveID: objectiveID },
   });
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error : {error.message}</p>;
+  if (loading) return <p>{t("loading.loading")}</p>;
+  if (error) return <p>{t("error.error")}: {error.message}</p>;
 
   const headers = [
-    { id: "status", label: "Status" },
-    { id: "completion", label: "Completion" },
-    { id: "keyResult", label: "Key Result" },
-    { id: "lastUpdated", label: "Last Updated" },
+    { id: "status", label: t("keyResults.status") },
+    { id: "completion", label: t("keyResults.completion") },
+    { id: "keyResult", label: t("keyResults.keyResult") },
+    { id: "lastUpdated", label: t("keyResults.lastUpdated") },
   ]
 
   const columnClasses = {
@@ -44,7 +44,7 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
 
   const rows = data.keyResults.map((keyResult: KeyResult) => {
     return {
-      status: "Pending",
+      status: t("keyResults.statuses.pending"),
       completion: "---",
       keyResult: keyResult.name,
       lastUpdated: "---",

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -27,6 +27,35 @@ function KeyResult({keyResult} : {keyResult: KeyResult}) : JSX.Element {
   );
 }
 
+interface Header {
+  id: string;
+  label: string;
+}
+
+interface Row {
+  [key: string]: string;
+}
+
+function Table({headers, columnClasses, rows}) : JSX.Element {
+  return (
+    <div className="mt-4 flex flex-col gap-2 items-center rounded border border-stone-200">
+      <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+        {headers.map((header: Header, index: number) => (
+          <div key={index} className={columnClasses[header.id]}>{header.label}</div>
+        ))}
+      </div>
+
+      {rows.map((row: Row, index: number) => {
+        return <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+          {headers.map((header: Header) => (
+            <div key={index} className={columnClasses[header.id]}>{row[header.id]}</div>
+          ))}
+        </div>;
+      })}
+    </div>
+  );
+}
+
 export default function KeyResults({objectiveID} : {objectiveID: string}) {
   const { t } = useTranslation();
   const { loading, error, data } = useQuery(GET_KEY_RESULTS, {
@@ -36,13 +65,32 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error : {error.message}</p>;
 
+  const headers = [
+    { id: "status", label: "Status" },
+    { id: "completion", label: "Completion" },
+    { id: "keyResult", label: "Key Result" },
+    { id: "lastUpdated", label: "Last Updated" },
+  ]
+
+  const columnClasses = {
+    status: "w-32",
+    completion: "w-32",
+    keyResult: "flex-1",
+    lastUpdated: "w-32 text-right",
+  };
+
+  const rows = data.keyResults.map((keyResult: KeyResult) => {
+    return {
+      status: "Pending",
+      completion: "---",
+      keyResult: keyResult.name,
+      lastUpdated: "---",
+    }
+  })
+
   return (
     <div>
-      <h1>{t("KeyResults")}</h1>
-
-      {data.keyResults.map((keyResult: KeyResult, index: number) => (
-        <KeyResult key={index} keyResult={keyResult} />
-      ))}
+      <Table headers={headers} columnClasses={columnClasses} rows={rows} />
     </div>
   );
 }

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, gql } from '@apollo/client';
 
 import Table from './Table';
+import StatusBadge from './StatusBadge';
 
 const GET_KEY_RESULTS = gql`
   query GetKeyResults($objectiveID: ID!) {
@@ -44,7 +45,7 @@ export default function KeyResults({objectiveID} : {objectiveID: string}) {
 
   const rows = data.keyResults.map((keyResult: KeyResult) => {
     return {
-      status: t("keyResults.statuses.pending"),
+      status: <StatusBadge status="pending" />,
       completion: "---",
       keyResult: keyResult.name,
       lastUpdated: "---",

--- a/assets/js/pages/ObjectivePage/StatusBadge.tsx
+++ b/assets/js/pages/ObjectivePage/StatusBadge.tsx
@@ -1,11 +1,25 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+const StatusBadgeClasses = {
+  "pending": "bg-gray-200 text-gray-800",
+  "on_track": "bg-green-200 text-green-800",
+  "at_risk": "bg-yellow-200 text-yellow-800",
+  "off_track": "bg-red-200 text-red-800",
+  "completed": "bg-green-200 text-green-800",
+  "cancelled": "bg-gray-200 text-gray-800",
+}
+
 export default function StatusBadge({status}: {status: string}) {
   const { t } = useTranslation();
 
+  const colorClasses = StatusBadgeClasses[status]
+  if(colorClasses === undefined) {
+    throw new Error("Invalid status: " + status);
+  }
+
   return (
-    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm bg-stone-200 text-stone-800">
+    <span className={"inline-flex items-center px-2.5 py-0.5 rounded-full text-sm " + colorClasses}>
       {t("keyResults.statuses." + status)}
     </span>
   );

--- a/assets/js/pages/ObjectivePage/StatusBadge.tsx
+++ b/assets/js/pages/ObjectivePage/StatusBadge.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+export default function StatusBadge({status}: {status: string}) {
+  const { t } = useTranslation();
+
+  return (
+    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm bg-stone-200 text-stone-800">
+      {t("keyResults.statuses." + status)}
+    </span>
+  );
+}

--- a/assets/js/pages/ObjectivePage/Table.tsx
+++ b/assets/js/pages/ObjectivePage/Table.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+interface Header {
+  id: string;
+  label: string;
+}
+
+interface Row {
+  [key: string]: string;
+}
+
+interface TableHeaderRowProps {
+  headers: Header[];
+  columnClasses: {[key: string]: string};
+}
+
+function TableHeaderRow({headers, columnClasses} : TableHeaderRowProps) : JSX.Element {
+  return (
+    <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+      {headers.map((header: Header, index: number) => (
+        <div key={index} className={columnClasses[header.id]}>{header.label}</div>
+      ))}
+    </div>
+  );
+}
+
+interface TableRowProps {
+  headers: Header[];
+  row: Row;
+  columnClasses: {[key: string]: string};
+}
+
+function TableRow({headers, row, columnClasses} : TableRowProps) : JSX.Element {
+  return (
+    <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+      {headers.map((header: Header) => (
+        <div className={columnClasses[header.id]}>{row[header.id]}</div>
+      ))}
+    </div>
+  );
+}
+
+interface TableProps {
+  headers: Header[];
+  columnClasses: {[key: string]: string};
+  rows: Row[];
+}
+
+export default function Table({headers, columnClasses, rows} : TableProps) : JSX.Element {
+  return (
+    <div className="mt-4 flex flex-col gap-2 items-center rounded border border-stone-200">
+      <TableHeaderRow headers={headers} columnClasses={columnClasses} />
+
+      {rows.map((row: Row, index: number) => {
+        return <TableRow key={index} headers={headers} row={row} columnClasses={columnClasses} />
+      })}
+    </div>
+  );
+}

--- a/assets/js/pages/ObjectivePage/Table.tsx
+++ b/assets/js/pages/ObjectivePage/Table.tsx
@@ -6,7 +6,7 @@ interface Header {
 }
 
 interface Row {
-  [key: string]: string;
+  [key: string]: string | JSX.Element;
 }
 
 interface TableHeaderRowProps {
@@ -16,7 +16,7 @@ interface TableHeaderRowProps {
 
 function TableHeaderRow({headers, columnClasses} : TableHeaderRowProps) : JSX.Element {
   return (
-    <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+    <div className="w-full flex gap-2 justify-between text-sm px-4 py-2">
       {headers.map((header: Header, index: number) => (
         <div key={index} className={columnClasses[header.id]}>{header.label}</div>
       ))}
@@ -32,7 +32,7 @@ interface TableRowProps {
 
 function TableRow({headers, row, columnClasses} : TableRowProps) : JSX.Element {
   return (
-    <div className="w-full flex gap-2 justify-between px-4 py-1 border-b border-stone-200">
+    <div className="w-full flex gap-2 justify-between px-4 py-2 border-t border-stone-200 hover:bg-stone-100">
       {headers.map((header: Header) => (
         <div className={columnClasses[header.id]}>{row[header.id]}</div>
       ))}
@@ -48,7 +48,7 @@ interface TableProps {
 
 export default function Table({headers, columnClasses, rows} : TableProps) : JSX.Element {
   return (
-    <div className="mt-4 flex flex-col gap-2 items-center rounded border border-stone-200">
+    <div className="mt-4 flex flex-col items-center rounded border border-stone-200">
       <TableHeaderRow headers={headers} columnClasses={columnClasses} />
 
       {rows.map((row: Row, index: number) => {

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import Avatar from '../../components/Avatar';
 import PageTitle from '../../components/PageTitle';
+import KeyResults from './KeyResults';
 
 const GET_OBJECTIVE = gql`
   query GetObjective($id: ID!) {
@@ -67,6 +68,8 @@ export function ObjectivePage() {
       <p className="max-w-lg">{data.objective.description}</p>
 
       <Champion person={data.objective.owner as Person} />
+
+      <KeyResults objectiveID={id} />
     </div>
   )
 }

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -26,6 +26,16 @@ defmodule Operately.Okrs do
     Repo.all(Objective) |> Repo.preload(associations)
   end
 
+  def list_key_results!(objective_id) do
+    query = (
+      from kr in KeyResult,
+      where: kr.objective_id == ^objective_id
+    )
+
+    Repo.all(query)
+  end
+
+
   @doc """
   Gets a single objective.
 

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -54,6 +54,10 @@ defmodule Operately.Okrs do
     objective.owner
   end
 
+  def get_objective_by_name!(name) do
+    Objective |> Repo.get_by!(name: name)
+  end
+
   @doc """
   Creates a objective.
 

--- a/lib/operately/okrs/key_result.ex
+++ b/lib/operately/okrs/key_result.ex
@@ -20,7 +20,7 @@ defmodule Operately.Okrs.KeyResult do
   @doc false
   def changeset(key_result, attrs) do
     key_result
-    |> cast(attrs, [:name, :unit, :target, :direction, :objective_id])
-    |> validate_required([:name, :unit, :target, :direction, :objective_id])
+    |> cast(attrs, [:name, :unit, :target, :direction, :objective_id, :status])
+    |> validate_required([:name, :unit, :target, :direction, :objective_id, :status])
   end
 end

--- a/lib/operately/okrs/key_result.ex
+++ b/lib/operately/okrs/key_result.ex
@@ -8,6 +8,8 @@ defmodule Operately.Okrs.KeyResult do
     belongs_to :objective, Operately.Okrs.Objective
 
     field :name, :string
+    field :status, Ecto.Enum, values: [:pending, :on_track, :at_risk, :off_track, :completed, :cancelled], default: :pending
+
     field :target, :integer
     field :unit, Ecto.Enum, values: [:percentage, :number]
     field :direction, Ecto.Enum, values: [:above, :below]

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -1,6 +1,8 @@
 defmodule OperatelyWeb.Schema do
   use Absinthe.Schema
 
+  import_types Absinthe.Type.Custom
+
   object :tenet do
     field :id, non_null(:id)
     field :name, non_null(:string)
@@ -57,6 +59,7 @@ defmodule OperatelyWeb.Schema do
     field :id, non_null(:id)
     field :name, non_null(:string)
     field :status, non_null(:string)
+    field :updated_at, non_null(:date)
   end
 
   input_object :create_kpi_input do

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -53,6 +53,12 @@ defmodule OperatelyWeb.Schema do
     end
   end
 
+  object :key_result do
+    field :id, non_null(:id)
+    field :name, non_null(:string)
+    field :status, non_null(:string)
+  end
+
   input_object :create_kpi_input do
     field :name, non_null(:string)
     field :description, :string
@@ -170,6 +176,17 @@ defmodule OperatelyWeb.Schema do
         people = Operately.People.search_people(args.query)
 
         {:ok, people}
+      end
+    end
+
+    field :key_results, list_of(:key_result) do
+      arg :objective_id, non_null(:id)
+
+      resolve fn args, _ ->
+        objective_id = args.objective_id
+        key_results = Operately.Okrs.list_key_results!(objective_id)
+
+        {:ok, key_results}
       end
     end
   end

--- a/priv/repo/migrations/20230413142030_add_status_field_to_key_results.exs
+++ b/priv/repo/migrations/20230413142030_add_status_field_to_key_results.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddStatusFieldToKeyResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:key_results) do
+      add :status, :string
+    end
+  end
+end

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -21,3 +21,12 @@ Feature: Objectives and Key Results
     Then I should see "Maintain support happiness" in the Objective title
     And I should see "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers." in the Objective description
     And I should see "John Johnson" as the Objective owner
+
+  Scenario: Viewing key results on an Objective
+    Given I am logged in as a user
+    And I have "John Johnson" in my organization as the "Head of Support"
+    And I have an objective called "Maintain support happiness" owned by "John Johnson" with a description of "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
+    And I have a key result called "Increase happiness score by 10% in Q2" for the "Maintain support happiness" objective
+    And I am on the "Maintain support happiness" Objective page
+    Then I should see "Increase happiness score by 10% in Q2" in the "Maintain support happiness" Objective key results
+    And I should see that "Increase happiness score by 10% in Q2" has status "pending"

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -29,4 +29,4 @@ Feature: Objectives and Key Results
     And I have a key result called "Increase happiness score by 10% in Q2" for the "Maintain support happiness" objective
     And I am on the "Maintain support happiness" Objective page
     Then I should see "Increase happiness score by 10% in Q2" in the "Maintain support happiness" Objective key results
-    And I should see that "Increase happiness score by 10% in Q2" has status "pending"
+    And I should see that "Increase happiness score by 10% in Q2" has status "Pending"

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -115,4 +115,30 @@ defmodule MyApp.Features.OkrsTest do
     state.session |> assert_text(name)
   end
 
+  defand ~r/^I have a key result called "(?<name>[^"]+)" for the "(?<objective>[^"]+)" objective$/, %{name: name, objective: objecive}, state do
+    # objective = Operately.Okrs.get_objective_by_name!(objecive)
+
+    # OkrsFixtures.key_result_fixture(%{
+    #   name: name,
+    #   objective_id: objective.id
+    # })
+  end
+
+  defand ~r/^I am on the "(?<name>[^"]+)" Objective page$/, %{name: name}, state do
+    objective = Operately.Okrs.get_objective_by_name!(name)
+
+    state.session
+    |> visit("/objectives/#{objective.id}")
+    |> wait_for_page_to_load("/objectives/#{objective.id}")
+  end
+
+  defthen ~r/^I should see "(?<name>[^"]+)" in the "(?<objective>[^"]+)" Objective key results$/, %{name: name, objective: objective}, state do
+    state.session |> take_screenshot()
+    state.session |> assert_text(name)
+  end
+
+  defand ~r/^I should see that "(?<name>[^"]+)" has status "(?<status>[^"]+)"$/, %{name: name, status: status}, state do
+    state.session |> assert_text(status)
+  end
+
 end

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -116,12 +116,12 @@ defmodule MyApp.Features.OkrsTest do
   end
 
   defand ~r/^I have a key result called "(?<name>[^"]+)" for the "(?<objective>[^"]+)" objective$/, %{name: name, objective: objecive}, state do
-    # objective = Operately.Okrs.get_objective_by_name!(objecive)
+    objective = Operately.Okrs.get_objective_by_name!(objecive)
 
-    # OkrsFixtures.key_result_fixture(%{
-    #   name: name,
-    #   objective_id: objective.id
-    # })
+    OkrsFixtures.key_result_fixture(%{
+      name: name,
+      objective_id: objective.id
+    })
   end
 
   defand ~r/^I am on the "(?<name>[^"]+)" Objective page$/, %{name: name}, state do


### PR DESCRIPTION
In this pull-request, I'm introducing support for listing key results on the objectives page.
Every key result has a name, status, progress, and the last update time.

The code was written during live coding sessions:
- https://www.youtube.com/watch?v=xPc6byVqtsk
- https://www.youtube.com/watch?v=lew8vKYcLXQ

Screenshot:

![Screenshot 2023-04-13 at 20 13 31](https://user-images.githubusercontent.com/1779493/231847673-ccb859e7-1b43-456d-9a3b-4d56902dbedf.png)