### PR TITLE
List projects on the objective page

### DIFF
--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
 
-export default function Avatar({ person_full_name } : { person_full_name : string }) : JSX.Element {
+export enum AvatarSize {
+  Small = 'small',
+  Normal = 'normal',
+  Large = 'large',
+}
+
+export default function Avatar({ person_full_name, size } : { person_full_name : string, size : AvatarSize }) : JSX.Element {
   const initials = person_full_name.split(' ').map((n) => n[0]).join('');
 
+  const sizeClass = size === AvatarSize.Small ? 'w-6 h-6 text-sm' : size === AvatarSize.Large ? 'w-12 h-12 text-2xl' : 'w-10 h-10 text-lg';
+
   return (
-    <div className="flex items-center justify-center w-10 h-10 text-white bg-gray-500 rounded-full">
+    <div className={"flex items-center justify-center text-white bg-gray-500 rounded-full" + " " + sizeClass}>
       {initials}
     </div>
   );
+}
+
+Avatar.defaultProps = {
+  size: AvatarSize.Normal,
 }

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -102,6 +102,15 @@ i18n
               "completed": "Completed",
               "cancelled": "Cancelled",
             }
+          },
+
+          "objectives": {
+            "projects_in_progress_title": "Projects in Progress",
+
+            "project_list_title": "Project Title",
+            "project_list_timeline": "Timeline",
+            "project_list_team": "Team",
+            "project_list_last_updated": "Last Updated",
           }
         },
       },

--- a/assets/js/pages/ObjectivePage/Projects.tsx
+++ b/assets/js/pages/ObjectivePage/Projects.tsx
@@ -80,8 +80,6 @@ export default function Projects({objectiveID} : {objectiveID: string}) : JSX.El
 
   if (data.alignedProjects.length === 0) return <></>;
 
-  console.log(data);
-
   return <div className="mt-4">
     <Title />
 

--- a/assets/js/pages/ObjectivePage/Projects.tsx
+++ b/assets/js/pages/ObjectivePage/Projects.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, gql } from '@apollo/client';
+
+import Avatar, {AvatarSize} from '../../components/Avatar';
+
+const GET_ALIGNED_PROJECTS = gql`
+  query GetAlignedProjects($objectiveID: ID!) {
+    alignedProjects(objectiveID: $objectiveID) {
+      id
+      name
+      updatedAt
+
+      owner {
+        full_name
+        title
+      }
+    }
+  }
+`;
+
+function Title() : JSX.Element {
+  const { t } = useTranslation();
+
+  return <h1 className="uppercase text-sm px-2">{t("objectives.projects_in_progress_title")}</h1>;
+}
+
+function CardListHeader({headers} : {headers: Array<{id: string, label: string}>}) : JSX.Element {
+  return <div className="flex gap-2 mt-4 px-2">
+    {headers.map((header) => <div key={header.id} className="w-1/4 text-sm">{header.label}</div>)}
+  </div>;
+}
+
+interface Owner {
+  full_name: string;
+  title: string;
+}
+
+interface Project {
+  id: string;
+  name: string;
+  updatedAt: string;
+  owner: Owner;
+}
+
+function Card({project} : {project: Project}) : JSX.Element {
+  return <div className="flex gap-2 mt-2 rounded shadow p-2 bg-white">
+    <div className="w-1/4 text-sm">{project.name}</div>
+    <div className="w-1/4 text-sm">---</div>
+    <div className="w-1/4 text-sm"><Champion person={project.owner} /></div>
+    <div className="w-1/4 text-sm">{project.updatedAt}</div>
+  </div>;
+}
+
+function Champion({person} : {person: Owner}) : JSX.Element {
+  return (
+    <div className="flex gap-2 items-center">
+      <Avatar person_full_name={person.full_name} size={AvatarSize.Small} />
+      <div>{person.full_name}</div>
+    </div>
+  );
+}
+
+export default function Projects({objectiveID} : {objectiveID: string}) : JSX.Element {
+  const { t } = useTranslation();
+
+  const { loading, error, data } = useQuery(GET_ALIGNED_PROJECTS, {
+    variables: { objectiveID }
+  });
+
+  const headers = [
+    {id: "title", label: t("objectives.project_list_title")},
+    {id: "timeline", label: t("objectives.project_list_timeline")},
+    {id: "team", label: t("objectives.project_list_team")},
+    {id: "lastUpdate", label: t("objectives.project_list_last_updated")}
+  ];
+
+  if (loading) return <p>{t("loading.loading")}</p>;
+  if (error) return <p>{t("error.error")}: {error.message}</p>;
+
+  if (data.alignedProjects.length === 0) return <></>;
+
+  console.log(data);
+
+  return <div className="mt-4">
+    <Title />
+
+    <CardListHeader headers={headers} />
+
+    {data.alignedProjects.map((project : Project) => <Card key={project.id} project={project} />)}
+  </div>;
+}

--- a/assets/js/pages/ObjectivePage/Table.tsx
+++ b/assets/js/pages/ObjectivePage/Table.tsx
@@ -48,7 +48,7 @@ interface TableProps {
 
 export default function Table({headers, columnClasses, rows} : TableProps) : JSX.Element {
   return (
-    <div className="mt-4 flex flex-col items-center rounded border border-stone-200">
+    <div className="mt-4 flex flex-col items-center rounded border border-stone-200 bg-white">
       <TableHeaderRow headers={headers} columnClasses={columnClasses} />
 
       {rows.map((row: Row, index: number) => {

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useQuery, gql } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 
 import Avatar from '../../components/Avatar';
 import PageTitle from '../../components/PageTitle';
 import KeyResults from './KeyResults';
+import Projects from './Projects';
 
 const GET_OBJECTIVE = gql`
   query GetObjective($id: ID!) {
@@ -50,6 +52,7 @@ export async function ObjectivePageLoader(apolloClient : any, {params}) {
 }
 
 export function ObjectivePage() {
+  const { t } = useTranslation();
   const { id } = useParams();
 
   if (!id) return <p>Unable to find objective</p>;
@@ -59,8 +62,8 @@ export function ObjectivePage() {
     fetchPolicy: 'cache-only'
   });
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error : {error.message}</p>;
+  if (loading) return <p>{t("loading.loading")}</p>;
+  if (error) return <p>{t("error.error")}: {error.message}</p>;
 
   return (
     <div>
@@ -70,6 +73,7 @@ export function ObjectivePage() {
       <Champion person={data.objective.owner as Person} />
 
       <KeyResults objectiveID={id} />
+      <Projects objectiveID={id} />
     </div>
   )
 }

--- a/lib/operately/alignments/alignment.ex
+++ b/lib/operately/alignments/alignment.ex
@@ -6,7 +6,7 @@ defmodule Operately.Alignments.Alignment do
   @foreign_key_type :binary_id
   schema "alignments" do
     field :child, Ecto.UUID
-    field :child_type, Ecto.Enum, values: [:objective]
+    field :child_type, Ecto.Enum, values: [:objective, :project]
     field :parent, Ecto.UUID
     field :parent_type, Ecto.Enum, values: [:objective]
 

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -35,6 +35,18 @@ defmodule Operately.Okrs do
     Repo.all(query)
   end
 
+  def list_aligned_projects!(objective_id) do
+    alias Operately.Alignments.Alignment
+    alias Operately.Projects.Project
+
+    query = (
+      from p in Project,
+      join: a in Alignment, on: p.id == a.child and a.child_type == :project,
+      where: a.parent == ^objective_id and a.parent_type == :objective
+    )
+
+    Repo.all(query)
+  end
 
   @doc """
   Gets a single objective.

--- a/lib/operately/ownerships/ownership.ex
+++ b/lib/operately/ownerships/ownership.ex
@@ -8,7 +8,7 @@ defmodule Operately.Ownerships.Ownership do
     belongs_to :person, Operately.People.Person
 
     field :target, Ecto.UUID
-    field :target_type, Ecto.Enum, values: [:objective, :tenet]
+    field :target_type, Ecto.Enum, values: [:objective, :tenet, :project]
 
     timestamps()
   end

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -37,6 +37,11 @@ defmodule Operately.Projects do
   """
   def get_project!(id), do: Repo.get!(Project, id)
 
+  def get_owner!(project) do
+    project = Repo.preload(project, [:owner])
+    project.owner
+  end
+
   @doc """
   Creates a project.
 

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -8,6 +8,9 @@ defmodule Operately.Projects.Project do
     field :description, :string
     field :name, :string
 
+    has_one :ownership, Operately.Ownerships.Ownership, foreign_key: :target, on_replace: :update
+    has_one :owner, through: [:ownership, :person]
+
     timestamps()
   end
 
@@ -15,6 +18,7 @@ defmodule Operately.Projects.Project do
   def changeset(project, attrs) do
     project
     |> cast(attrs, [:name, :description])
+    |> cast_assoc(:ownership)
     |> validate_required([:name, :description])
   end
 end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -39,6 +39,15 @@ defmodule OperatelyWeb.Schema do
     field :id, non_null(:id)
     field :name, non_null(:string)
     field :description, :string
+    field :updated_at, non_null(:date)
+
+    field :owner, :person do
+      resolve fn objective, _, _ ->
+        person = Operately.Projects.get_owner!(objective)
+
+        {:ok, person}
+      end
+    end
   end
 
   object :group do
@@ -190,6 +199,17 @@ defmodule OperatelyWeb.Schema do
         key_results = Operately.Okrs.list_key_results!(objective_id)
 
         {:ok, key_results}
+      end
+    end
+
+    field :aligned_projects, list_of(:project) do
+      arg :objective_id, non_null(:id)
+
+      resolve fn args, _ ->
+        objective_id = args.objective_id
+        projects = Operately.Okrs.list_aligned_projects!(objective_id)
+
+        {:ok, projects}
       end
     end
   end

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -30,3 +30,13 @@ Feature: Objectives and Key Results
     And I am on the "Maintain support happiness" Objective page
     Then I should see "Increase happiness score by 10% in Q2" in the "Maintain support happiness" Objective key results
     And I should see that "Increase happiness score by 10% in Q2" has status "Pending"
+
+  Scenario: Viewing ongoing projects on an Objective
+    Given I am logged in as a user
+    And I have "John Johnson" in my organization as the "Head of Support"
+    And I have "Asara Utsuhashi" in my organization as the "Senior Software Engineer"
+    And I have an objective called "Maintain support happiness" owned by "John Johnson" with a description of "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
+    And I have a project called "Live Support Chat" for the "Maintain support happiness" objective championed by "Asara Utsuhashi"
+    And I am on the "Maintain support happiness" Objective page
+    Then I should see "Live Support Chat" in the "Maintain support happiness" Objective projects
+    And I should see that "Asara Utsuhashi" is the champion of "Live Support Chat"

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -3,6 +3,7 @@ defmodule MyApp.Features.OkrsTest do
 
   alias Operately.OkrsFixtures
   alias Operately.PeopleFixtures
+  alias Operately.ProjectsFixtures
 
   import_steps(Operately.Features.SharedSteps.Login)
   import_steps(Operately.Features.SharedSteps.SimpleInteractions)
@@ -139,6 +140,34 @@ defmodule MyApp.Features.OkrsTest do
 
   defand ~r/^I should see that "(?<name>[^"]+)" has status "(?<status>[^"]+)"$/, %{name: name, status: status}, state do
     state.session |> assert_text(status)
+  end
+
+  defand ~r/^I have a project called "(?<name>[^"]+)" for the "(?<objective>[^"]+)" objective championed by "(?<champion>[^"]+)"$/, %{name: name, objective: objective, champion: champion}, state do
+    objective = Operately.Okrs.get_objective_by_name!(objective)
+    champion = Operately.People.get_person_by_name!(champion)
+
+    project = ProjectsFixtures.project_fixture(%{
+      name: name,
+      ownership: %{
+        target_type: :project,
+        person_id: champion.id
+      }
+    })
+
+    Operately.Alignments.create_alignment(%{
+      child: project.id,
+      child_type: :project,
+      parent: objective.id,
+      parant_type: :objective,
+    })
+  end
+
+  defthen ~r/^I should see "(?<project>[^"]+)" in the "(?<objective>[^"]+)" Objective projects$/, %{project: project, objective: objective}, state do
+    state.session |> assert_text(project)
+  end
+
+  defand ~r/^I should see that "(?<champion>[^"]+)" is the champion of "(?<project>[^"]+)"$/, %{champion: champion, project: project}, state do
+    state.session |> assert_text(champion)
   end
 
 end

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -154,11 +154,11 @@ defmodule MyApp.Features.OkrsTest do
       }
     })
 
-    Operately.Alignments.create_alignment(%{
+    {:ok, _} = Operately.Alignments.create_alignment(%{
       child: project.id,
       child_type: :project,
       parent: objective.id,
-      parant_type: :objective,
+      parent_type: :objective,
     })
   end
 

--- a/test/operately/ownerships_test.exs
+++ b/test/operately/ownerships_test.exs
@@ -6,8 +6,6 @@ defmodule Operately.OwnershipsTest do
   describe "ownerships" do
     import Operately.OwnershipsFixtures
 
-    @invalid_attrs %{person_id: nil, target: nil, target_type: nil}
-
     test "list_ownerships/0 returns all ownerships" do
       ownership = ownership_fixture()
       assert Ownerships.list_ownerships() == [ownership]


### PR DESCRIPTION
In this pull-request, I'm adding support for listing ongoing projects on the objective page.
The displayed fields are: Title, Progress, Champion and Last Updated At.