### PR TITLE
Persist updates in the database and display the updates in the Objective Feed

### DIFF
--- a/assets/js/components/Button/index.tsx
+++ b/assets/js/components/Button/index.tsx
@@ -1,7 +1,32 @@
 import React from 'react';
 
-export default function Button(props : any) {
+export enum ButtonSize {
+  Small = 'small',
+  Normal = 'normal',
+  Large = 'large',
+}
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  size: ButtonSize;
+}
+
+function textSize(size : ButtonSize) : string {
+  switch (size) {
+    case ButtonSize.Small:
+      return "text-sm";
+    case ButtonSize.Large:
+      return "text-lg";
+    default:
+      return "text-base";
+  }
+}
+
+export default function Button(props : ButtonProps) {
   return (
-    <button {...props} className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" />
+    <button {...props} className={"bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded " + textSize(props.size)} />
   );
 }
+
+Button.defaultProps = {
+  size: ButtonSize.Normal,
+};

--- a/assets/js/components/Editor/Footer.tsx
+++ b/assets/js/components/Editor/Footer.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import Button, {ButtonSize} from '../../components/Button';
+
+export default function Footer() : JSX.Element {
+  return <div className="bg-light-1 p-2 border-t border-stone-200 flex justify-between">
+    <div></div>
+    <Button size={ButtonSize.Small} >Post</Button>
+  </div>;
+}

--- a/assets/js/components/Editor/Footer.tsx
+++ b/assets/js/components/Editor/Footer.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 
 import Button, {ButtonSize} from '../../components/Button';
 
-export default function Footer() : JSX.Element {
+interface FooterProps {
+  onSave: () => void;
+}
+
+export default function Footer({onSave} : FooterProps) : JSX.Element {
   return <div className="bg-light-1 p-2 border-t border-stone-200 flex justify-between">
     <div></div>
-    <Button size={ButtonSize.Small} >Post</Button>
+    <Button onClick={onSave} size={ButtonSize.Small} >Post</Button>
   </div>;
 }

--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -18,13 +18,19 @@ interface Person {
   fullName: string;
 }
 
+interface OnSaveData {
+  json: any;
+  html: string;
+}
+
 interface EditorProps {
   placeholder: string,
   title: string,
-  peopleSearch: EditorMentionSearchFunc
+  peopleSearch: EditorMentionSearchFunc,
+  onSave?: (data: OnSaveData) => void;
 }
 
-export default function Editor({placeholder, title, peopleSearch} : EditorProps) : JSX.Element {
+export default function Editor({placeholder, title, peopleSearch, onSave} : EditorProps) : JSX.Element {
   const editor = useEditor({
     editorProps: {
       attributes: {
@@ -60,12 +66,22 @@ export default function Editor({placeholder, title, peopleSearch} : EditorProps)
 
   const header = <div className="p-4 py-2 border-b border-stone-200 text-sm">{title}</div>;
 
+  const handleSave = () => {
+    if(!editor) return;
+    if(!onSave) return;
+
+    onSave({
+      json: editor.getJSON(),
+      html: editor.getHTML(),
+    });
+  };
+
   return (
     <div className="mt-4 rounded bg-white shadow-sm border border-stone-200">
       {header}
       <MenuBar editor={editor} />
       <EditorContent editor={editor} />
-      <Footer />
+      <Footer onSave={handleSave} />
     </div>
   );
 }

--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -9,6 +9,7 @@ import Mention from '@tiptap/extension-mention';
 
 import MenuBar from './MenuBar';
 import MentionPopup from './MentionPopup';
+import Footer from './Footer';
 
 export type EditorMentionSearchFunc = ({query} : {query : string}) => Promise<Person[]> | any[];
 
@@ -64,6 +65,7 @@ export default function Editor({placeholder, title, peopleSearch} : EditorProps)
       {header}
       <MenuBar editor={editor} />
       <EditorContent editor={editor} />
+      <Footer />
     </div>
   );
 }

--- a/assets/js/components/RelativeTime/index.tsx
+++ b/assets/js/components/RelativeTime/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+function utcDate() : number {
+  var now = new Date();
+
+  return +(new Date(now.getTime() + now.getTimezoneOffset() * 60000));
+}
+
+interface Props {
+  date: string;
+}
+
+export default function RelativeTime({date} : Props) : JSX.Element {
+  const { t } = useTranslation();
+
+  const diff = utcDate() - Date.parse(date);
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  if (seconds < 60) {
+    return <>{t("intlRelativeDateTime", {val: -seconds, range: "second"})}</>;
+  }
+
+  if (minutes < 60) {
+    return <>{t("intlRelativeDateTime", {val: -minutes, range: "minute"})}</>;
+  }
+
+  if (hours < 24) {
+    return <>{t("intlRelativeDateTime", {val: -hours, range: "hour"})}</>;
+  }
+
+  if (days < 7) {
+    return <>{t("intlRelativeDateTime", {val: -days, range: "day"})}</>;
+  }
+
+  if (weeks < 4) {
+    return <>{t("intlRelativeDateTime", {val: -weeks, range: "week"})}</>;
+  }
+
+  if (months < 12) {
+    return <>{t("intlRelativeDateTime", {val: -months, range: "month"})}</>;
+  }
+
+  return <>{t("intlRelativeDateTime", {val: -years, range: "year"})}</>;
+}

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -8,6 +8,7 @@ i18n
       "en": {
         translation: {
           "intlDateTime": "{{val, datetime}}",
+          "intlRelativeDateTime": "{{val, relativetime}}",
 
           "Objectives": "Objectives",
           "Tenets": "Tenets",

--- a/assets/js/pages/ObjectivePage/KeyResults.tsx
+++ b/assets/js/pages/ObjectivePage/KeyResults.tsx
@@ -5,7 +5,6 @@ import { useQuery, gql } from '@apollo/client';
 
 import Table from './Table';
 import StatusBadge from './StatusBadge';
-import DateTime from './DateTime';
 
 const GET_KEY_RESULTS = gql`
   query GetKeyResults($objectiveID: ID!) {

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -34,6 +34,15 @@ const SEARCH_PEOPLE = gql`
   }
 `;
 
+const CREATE_UPDATE = gql`
+  mutation CreateUpdate($input: CreateUpdateInput!) {
+    createUpdate(input: $input) {
+      id
+    }
+  }
+`;
+
+
 interface Person {
   fullName: string;
   title: string;
@@ -98,6 +107,21 @@ export function ObjectivePage() {
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
+  const handleAddUpdate = async ({json}) => {
+    console.log("Saving update", JSON.stringify(json));
+
+    await client.mutate({
+      mutation: CREATE_UPDATE,
+      variables: {
+        input: {
+          updatableId: id,
+          updatableType: "objective",
+          content: JSON.stringify(json),
+        }
+      }
+    })
+  }
+
   return (
     <div>
       <PageTitle title={data.objective.name} />
@@ -112,9 +136,7 @@ export function ObjectivePage() {
         title={t("objectives.write_an_update.title")}
         placeholder={t("objectives.write_an_update.placeholder")}
         peopleSearch={peopleSearch}
-        onSave={(data) => {
-          console.log(data.json);
-        }}
+        onSave={handleAddUpdate}
       />
     </div>
   )

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -180,7 +180,7 @@ function Feed({objectiveID} : {objectiveID: string}) : JSX.Element {
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
-  return <div className="mt-4">
+  return <div className="mt-4" data-test="feed">
     <div className="text-sm uppercase">FEED</div>
 
     <div className="mt-4 flex flex-col gap-2">
@@ -206,8 +206,6 @@ export function ObjectivePage() {
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
   const handleAddUpdate = async ({json}) => {
-    console.log("Saving update", JSON.stringify(json));
-
     await client.mutate({
       mutation: CREATE_UPDATE,
       variables: {

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -112,7 +112,10 @@ export function ObjectivePage() {
         title={t("objectives.write_an_update.title")}
         placeholder={t("objectives.write_an_update.placeholder")}
         peopleSearch={peopleSearch}
-        />
+        onSave={(data) => {
+          console.log(data.json);
+        }}
+      />
     </div>
   )
 }

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -8,6 +8,7 @@ import PageTitle from '../../components/PageTitle';
 import KeyResults from './KeyResults';
 import Projects from './Projects';
 import Editor, { EditorMentionSearchFunc } from '../../components/Editor';
+import RelativeTime from '../../components/RelativeTime';
 
 import Bold from '@tiptap/extension-bold'
 import Document from '@tiptap/extension-document'
@@ -54,6 +55,11 @@ const GET_UPDATES = gql`
     updates(updatableId: $updatableId, updatableType: $updatableType) {
       id
       content
+      author {
+        id
+        fullName
+      }
+      insertedAt
     }
   }
 `;
@@ -75,6 +81,8 @@ interface Person {
 interface Update {
   id: string;
   content: string;
+  author: Person;
+  insertedAt: string;
 }
 
 function Champion({person} : {person: Person}) : JSX.Element {
@@ -133,9 +141,9 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
     <div className="rounded bg-white shadow-sm border border-stone-200 rounded">
       <div className="p-4 py-2 border-b border-stone-200">
         <div className="flex gap-1 items-center">
-          <Avatar person_full_name="John Doe" size={AvatarSize.Small} />
-          <span className="ml-1">John Doe</span>
-          <span className="text-gray-400">posted an update 2 hours ago</span>
+          <Avatar person_full_name={update.author.fullName} size={AvatarSize.Small} />
+          <span className="ml-1">{update.author.fullName}</span>
+          <span className="text-gray-400">posted an update <RelativeTime date={update.insertedAt} /></span>
         </div>
       </div>
       <div className="prose p-4" dangerouslySetInnerHTML={{__html: html}} />

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, gql, useApolloClient, ApolloClient } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 
-import Avatar from '../../components/Avatar';
+import Avatar, {AvatarSize} from '../../components/Avatar';
 import PageTitle from '../../components/PageTitle';
 import KeyResults from './KeyResults';
 import Projects from './Projects';
@@ -130,7 +130,16 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
   ]);
 
   return (
-    <div className="prose" dangerouslySetInnerHTML={{__html: html}} />
+    <div className="rounded bg-white shadow-sm border border-stone-200 rounded">
+      <div className="p-4 py-2 border-b border-stone-200">
+        <div className="flex gap-1 items-center">
+          <Avatar person_full_name="John Doe" size={AvatarSize.Small} />
+          <span className="ml-1">John Doe</span>
+          <span className="text-gray-400">posted an update 2 hours ago</span>
+        </div>
+      </div>
+      <div className="prose p-4" dangerouslySetInnerHTML={{__html: html}} />
+    </div>
   );
 }
 
@@ -163,11 +172,13 @@ function Feed({objectiveID} : {objectiveID: string}) : JSX.Element {
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
-  return (
-    <div>
+  return <div className="mt-4">
+    <div className="text-sm uppercase">FEED</div>
+
+    <div className="mt-4 flex flex-col gap-2">
       {data.updates.slice(0).reverse().map((update : Update) => <FeedItem key={update.id} update={update} />)}
     </div>
-  );
+  </div>;
 }
 
 export function ObjectivePage() {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@apollo/client": "^3.7.11",
+        "@formatjs/intl-relativetimeformat": "^11.1.10",
         "@tiptap/extension-bullet-list": "^2.0.3",
         "@tiptap/extension-list-item": "^2.0.3",
         "@tiptap/extension-mention": "^2.0.3",
@@ -419,6 +420,33 @@
       "integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
       "dependencies": {
         "@floating-ui/core": "^1.2.4"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz",
+      "integrity": "sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+      "integrity": "sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@formatjs/intl-relativetimeformat": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-11.1.10.tgz",
+      "integrity": "sha512-4KTqW0mq3MR4cUAaSxiccNdurTT+ZwqrccpwsDuMLsz8Fw7i6krt4rgdT4y7cu1jpKtBMffwTBvWMBLMudxNsQ==",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -2746,6 +2774,33 @@
       "integrity": "sha512-+sAUfpQ3Frz+VCbPCqj+cZzvEESy3fjSeT/pDWkYCWOBXYNNKZfuVsHuv8/JO2zze8+Eb/Q7a6hZVgzS81fLbQ==",
       "requires": {
         "@floating-ui/core": "^1.2.4"
+      }
+    },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz",
+      "integrity": "sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==",
+      "requires": {
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-localematcher": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz",
+      "integrity": "sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@formatjs/intl-relativetimeformat": {
+      "version": "11.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-11.1.10.tgz",
+      "integrity": "sha512-4KTqW0mq3MR4cUAaSxiccNdurTT+ZwqrccpwsDuMLsz8Fw7i6krt4rgdT4y7cu1jpKtBMffwTBvWMBLMudxNsQ==",
+      "requires": {
+        "@formatjs/ecma402-abstract": "1.14.3",
+        "@formatjs/intl-localematcher": "0.2.32",
+        "tslib": "^2.4.0"
       }
     },
     "@graphql-typed-document-node/core": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -11,6 +11,7 @@
         "@tiptap/extension-mention": "^2.0.3",
         "@tiptap/extension-placeholder": "^2.0.3",
         "@tiptap/extension-text-style": "^2.0.3",
+        "@tiptap/html": "^2.0.3",
         "@tiptap/pm": "^2.0.3",
         "@tiptap/react": "^2.0.3",
         "@tiptap/starter-kit": "^2.0.3",
@@ -858,6 +859,22 @@
         "@tiptap/core": "^2.0.0"
       }
     },
+    "node_modules/@tiptap/html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.0.3.tgz",
+      "integrity": "sha512-F0mihUTJ+mqqczHl7du9kBmani3pkwYeEuc/xls+DlYobdTzhSqIaF/ce8utHwRxTvDUPwSEM7+ITr93e2PqQA==",
+      "dependencies": {
+        "zeed-dom": "^0.9.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0"
+      }
+    },
     "node_modules/@tiptap/pm": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.0.3.tgz",
@@ -1231,6 +1248,17 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
       "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
     "node_modules/csstype": {
       "version": "3.1.1",
@@ -2374,6 +2402,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/zeed-dom": {
+      "version": "0.9.26",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.9.26.tgz",
+      "integrity": "sha512-HWjX8rA3Y/RI32zby3KIN1D+mgskce+She4K7kRyyx62OiVxJ5FnYm8vWq0YVAja3Tf2S1M0XAc6O2lRFcMgcQ==",
+      "dependencies": {
+        "css-what": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/holtwick"
+      }
+    },
     "node_modules/zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
@@ -2981,6 +3024,14 @@
       "integrity": "sha512-yHIYtZVewSwfBfI6TffnsDRiOuXzytppcCsaDlsZFm8OtLG8v9ioH0ItMoOstmZZBiWJOm8iOy2yWSc4rNQEJw==",
       "requires": {}
     },
+    "@tiptap/html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.0.3.tgz",
+      "integrity": "sha512-F0mihUTJ+mqqczHl7du9kBmani3pkwYeEuc/xls+DlYobdTzhSqIaF/ce8utHwRxTvDUPwSEM7+ITr93e2PqQA==",
+      "requires": {
+        "zeed-dom": "^0.9.19"
+      }
+    },
     "@tiptap/pm": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.0.3.tgz",
@@ -3294,6 +3345,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
       "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
     },
     "csstype": {
       "version": "3.1.1",
@@ -4177,6 +4233,14 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+    },
+    "zeed-dom": {
+      "version": "0.9.26",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.9.26.tgz",
+      "integrity": "sha512-HWjX8rA3Y/RI32zby3KIN1D+mgskce+She4K7kRyyx62OiVxJ5FnYm8vWq0YVAja3Tf2S1M0XAc6O2lRFcMgcQ==",
+      "requires": {
+        "css-what": "^6.1.0"
+      }
     },
     "zen-observable": {
       "version": "0.8.15",

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,6 +6,7 @@
     "@tiptap/extension-mention": "^2.0.3",
     "@tiptap/extension-placeholder": "^2.0.3",
     "@tiptap/extension-text-style": "^2.0.3",
+    "@tiptap/html": "^2.0.3",
     "@tiptap/pm": "^2.0.3",
     "@tiptap/react": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@apollo/client": "^3.7.11",
+    "@formatjs/intl-relativetimeformat": "^11.1.10",
     "@tiptap/extension-bullet-list": "^2.0.3",
     "@tiptap/extension-list-item": "^2.0.3",
     "@tiptap/extension-mention": "^2.0.3",

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -1,0 +1,104 @@
+defmodule Operately.Updates do
+  @moduledoc """
+  The Updates context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Operately.Repo
+
+  alias Operately.Updates.Update
+
+  @doc """
+  Returns the list of updates.
+
+  ## Examples
+
+      iex> list_updates()
+      [%Update{}, ...]
+
+  """
+  def list_updates do
+    Repo.all(Update)
+  end
+
+  @doc """
+  Gets a single update.
+
+  Raises `Ecto.NoResultsError` if the Update does not exist.
+
+  ## Examples
+
+      iex> get_update!(123)
+      %Update{}
+
+      iex> get_update!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_update!(id), do: Repo.get!(Update, id)
+
+  @doc """
+  Creates a update.
+
+  ## Examples
+
+      iex> create_update(%{field: value})
+      {:ok, %Update{}}
+
+      iex> create_update(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_update(attrs \\ %{}) do
+    %Update{}
+    |> Update.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a update.
+
+  ## Examples
+
+      iex> update_update(update, %{field: new_value})
+      {:ok, %Update{}}
+
+      iex> update_update(update, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_update(%Update{} = update, attrs) do
+    update
+    |> Update.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a update.
+
+  ## Examples
+
+      iex> delete_update(update)
+      {:ok, %Update{}}
+
+      iex> delete_update(update)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_update(%Update{} = update) do
+    Repo.delete(update)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking update changes.
+
+  ## Examples
+
+      iex> change_update(update)
+      %Ecto.Changeset{data: %Update{}}
+
+  """
+  def change_update(%Update{} = update, attrs \\ %{}) do
+    Update.changeset(update, attrs)
+  end
+end

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -21,6 +21,15 @@ defmodule Operately.Updates do
     Repo.all(Update)
   end
 
+  def list_updates(updatable_id, updatable_type) do
+    query = from u in Update,
+      where: u.updatable_id == ^updatable_id,
+      where: u.updatable_type == ^updatable_type,
+      limit: 10
+
+    Repo.all(query)
+  end
+
   @doc """
   Gets a single update.
 

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -73,6 +73,10 @@ defmodule Operately.Updates do
     {:ok, update}
   end
 
+  def publish_update_added(e) do
+    e
+  end
+
   @doc """
   Updates a update.
 

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -24,8 +24,7 @@ defmodule Operately.Updates do
   def list_updates(updatable_id, updatable_type) do
     query = from u in Update,
       where: u.updatable_id == ^updatable_id,
-      where: u.updatable_type == ^updatable_type,
-      limit: 10
+      where: u.updatable_type == ^updatable_type
 
     Repo.all(query)
   end
@@ -62,6 +61,16 @@ defmodule Operately.Updates do
     %Update{}
     |> Update.changeset(attrs)
     |> Repo.insert()
+    |> publish_update_added()
+  end
+
+  def publish_update_added({:ok, update}) do
+    Absinthe.Subscription.publish(
+      OperatelyWeb.Endpoint,
+      update,
+      update_added: "*")
+
+    {:ok, update}
   end
 
   @doc """

--- a/lib/operately/updates/update.ex
+++ b/lib/operately/updates/update.ex
@@ -1,0 +1,22 @@
+defmodule Operately.Updates.Update do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "updates" do
+    field :content, :string
+    field :updatable_id, Ecto.UUID
+    field :updatable_type, Ecto.Enum, values: [:objective, :project]
+    field :author_id, :binary_id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(update, attrs) do
+    update
+    |> cast(attrs, [:content, :updatable_id, :updatable_type])
+    |> validate_required([:content, :updatable_id, :updatable_type])
+  end
+end

--- a/lib/operately/updates/update.ex
+++ b/lib/operately/updates/update.ex
@@ -16,7 +16,7 @@ defmodule Operately.Updates.Update do
   @doc false
   def changeset(update, attrs) do
     update
-    |> cast(attrs, [:content, :updatable_id, :updatable_type])
-    |> validate_required([:content, :updatable_id, :updatable_type])
+    |> cast(attrs, [:content, :updatable_id, :updatable_type, :author_id])
+    |> validate_required([:content, :updatable_id, :updatable_type, :author_id])
   end
 end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -3,6 +3,14 @@ defmodule OperatelyWeb.Schema do
 
   import_types Absinthe.Type.Custom
 
+  object :update do
+    field :id, non_null(:id)
+    # field :content, non_null(:string)
+    # field :author, non_null(:person)
+    # field :updateable_id, non_null(:id)
+    # field :created_at, non_null(:date)
+  end
+
   object :tenet do
     field :id, non_null(:id)
     field :name, non_null(:string)
@@ -88,6 +96,12 @@ defmodule OperatelyWeb.Schema do
     field :description, :string
     field :timeframe, non_null(:string)
     field :owner_id, non_null(:id)
+  end
+
+  input_object :create_update_input do
+    field :content, non_null(:string)
+    field :updatable_id, non_null(:id)
+    field :updatable_type, non_null(:string)
   end
 
   query do
@@ -278,6 +292,14 @@ defmodule OperatelyWeb.Schema do
         {:ok, _} = Operately.Groups.add_members(group, args.person_ids)
 
         {:ok, group}
+      end
+    end
+
+    field :create_update, :update do
+      arg :input, non_null(:create_update_input)
+
+      resolve fn args, _ ->
+        {:ok, %{id: Ecto.UUID.generate()}}
       end
     end
   end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -7,7 +7,7 @@ defmodule OperatelyWeb.Schema do
     field :id, non_null(:id)
     field :content, non_null(:string)
     field :updateable_id, non_null(:id)
-    field :created_at, non_null(:date)
+    field :inserted_at, non_null(:naive_datetime)
 
     field :author, :person do
       resolve fn update, _, _ ->

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -359,5 +359,14 @@ defmodule OperatelyWeb.Schema do
         {:ok, %{topic: "*"}}
       end
     end
+
+    field :update_added, :update do
+      arg :updatable_id, non_null(:id)
+      arg :updatable_type, non_null(:string)
+
+      config fn _, _ ->
+        {:ok, %{topic: "*"}}
+      end
+    end
   end
 end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -5,10 +5,17 @@ defmodule OperatelyWeb.Schema do
 
   object :update do
     field :id, non_null(:id)
-    # field :content, non_null(:string)
-    # field :author, non_null(:person)
-    # field :updateable_id, non_null(:id)
-    # field :created_at, non_null(:date)
+    field :content, non_null(:string)
+    field :updateable_id, non_null(:id)
+    field :created_at, non_null(:date)
+
+    field :author, :person do
+      resolve fn update, _, _ ->
+        person = Operately.People.get_person!(update.author_id)
+
+        {:ok, person}
+      end
+    end
   end
 
   object :tenet do
@@ -299,7 +306,12 @@ defmodule OperatelyWeb.Schema do
       arg :input, non_null(:create_update_input)
 
       resolve fn args, _ ->
-        {:ok, %{id: Ecto.UUID.generate()}}
+        Operately.Updates.create_update(%{
+          author_id: hd(Operately.People.list_people()).id,
+          updatable_type: args.input.updatable_type,
+          updatable_id: args.input.updatable_id,
+          content: args.input.content
+        })
       end
     end
   end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -233,6 +233,19 @@ defmodule OperatelyWeb.Schema do
         {:ok, projects}
       end
     end
+
+    field :updates, list_of(:update) do
+      arg :updatable_id, non_null(:id)
+      arg :updatable_type, non_null(:string)
+
+      resolve fn args, _ ->
+        updatable_id = args.updatable_id
+        updatable_type = args.updatable_type
+        updates = Operately.Updates.list_updates(updatable_id, updatable_type)
+
+        {:ok, updates}
+      end
+    end
   end
 
   mutation do

--- a/priv/repo/migrations/20230416071114_create_updates.exs
+++ b/priv/repo/migrations/20230416071114_create_updates.exs
@@ -1,0 +1,17 @@
+defmodule Operately.Repo.Migrations.CreateUpdates do
+  use Ecto.Migration
+
+  def change do
+    create table(:updates, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :content, :text
+      add :updatable_id, :uuid
+      add :updatable_type, :string
+      add :author_id, references(:people, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:updates, [:author_id])
+  end
+end

--- a/test/features/okrs.feature
+++ b/test/features/okrs.feature
@@ -40,3 +40,13 @@ Feature: Objectives and Key Results
     And I am on the "Maintain support happiness" Objective page
     Then I should see "Live Support Chat" in the "Maintain support happiness" Objective projects
     And I should see that "Asara Utsuhashi" is the champion of "Live Support Chat"
+
+  Scenario: Posting updates
+    Given I am logged in as a user
+    And I have "John Johnson" in my organization as the "Head of Support"
+    And I have "Asara Utsuhashi" in my organization as the "Senior Software Engineer"
+    And I have an objective called "Maintain support happiness" owned by "John Johnson" with a description of "The happiness score is a measure of how happy our customers are with our support. We want to maintain a score of 95% or higher in order to live up to our core tenant which states that we focus on delighting customers."
+    And I am on the "Maintain support happiness" Objective page
+    When I fill in the Update field with "We are currently working on a live support chat feature. We hope to have it ready by the end of the quarter."
+    And I click on Post Update
+    Then I should see "We are currently working on a live support chat feature. We hope to have it ready by the end of the quarter." in the Objective updates

--- a/test/features/okrs_test.exs
+++ b/test/features/okrs_test.exs
@@ -134,7 +134,6 @@ defmodule MyApp.Features.OkrsTest do
   end
 
   defthen ~r/^I should see "(?<name>[^"]+)" in the "(?<objective>[^"]+)" Objective key results$/, %{name: name, objective: objective}, state do
-    state.session |> take_screenshot()
     state.session |> assert_text(name)
   end
 
@@ -168,6 +167,23 @@ defmodule MyApp.Features.OkrsTest do
 
   defand ~r/^I should see that "(?<champion>[^"]+)" is the champion of "(?<project>[^"]+)"$/, %{champion: champion, project: project}, state do
     state.session |> assert_text(champion)
+  end
+
+  defwhen ~r/^I fill in the Update field with "(?<message>[^"]+)"$/, %{message: message}, state do
+    editor = state.session |> find(Query.css(".ProseMirror"))
+    editor |> send_keys(message)
+  end
+
+  defand ~r/^I click on Post Update$/, _vars, state do
+    state.session |> click(Query.button("Post"))
+  end
+
+  defthen ~r/^I should see "(?<message>[^"]+)" in the Objective updates$/, %{message: message}, state do
+    feed = Query.css("[data-test=\"feed\"]")
+
+    find(state.session, feed, fn element ->
+      element |> assert_text(message)
+    end)
   end
 
 end

--- a/test/operately/updates_test.exs
+++ b/test/operately/updates_test.exs
@@ -11,17 +11,26 @@ defmodule Operately.UpdatesTest do
     @invalid_attrs %{content: nil, updatable_id: nil, updatable_type: nil}
 
     test "list_updates/0 returns all updates" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
+
       assert Updates.list_updates() == [update]
     end
 
     test "get_update!/1 returns the update with given id" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
+
       assert Updates.get_update!(update.id) == update
     end
 
     test "create_update/1 with valid data creates a update" do
-      valid_attrs = %{content: "some content", updatable_id: "7488a646-e31f-11e4-aace-600308960662", updatable_type: :objective}
+      person = Operately.PeopleFixtures.person_fixture()
+
+      valid_attrs = %{
+        content: "some content",
+        updatable_id: "7488a646-e31f-11e4-aace-600308960662",
+        updatable_type: :objective,
+        author_id: person.id
+      }
 
       assert {:ok, %Update{} = update} = Updates.create_update(valid_attrs)
       assert update.content == "some content"
@@ -34,7 +43,7 @@ defmodule Operately.UpdatesTest do
     end
 
     test "update_update/2 with valid data updates the update" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
       update_attrs = %{content: "some updated content", updatable_id: "7488a646-e31f-11e4-aace-600308960668", updatable_type: :project}
 
       assert {:ok, %Update{} = update} = Updates.update_update(update, update_attrs)
@@ -44,19 +53,20 @@ defmodule Operately.UpdatesTest do
     end
 
     test "update_update/2 with invalid data returns error changeset" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
+
       assert {:error, %Ecto.Changeset{}} = Updates.update_update(update, @invalid_attrs)
       assert update == Updates.get_update!(update.id)
     end
 
     test "delete_update/1 deletes the update" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
       assert {:ok, %Update{}} = Updates.delete_update(update)
       assert_raise Ecto.NoResultsError, fn -> Updates.get_update!(update.id) end
     end
 
     test "change_update/1 returns a update changeset" do
-      update = update_fixture()
+      {update, _} = update_fixture(:with_author, %{})
       assert %Ecto.Changeset{} = Updates.change_update(update)
     end
   end

--- a/test/operately/updates_test.exs
+++ b/test/operately/updates_test.exs
@@ -1,0 +1,63 @@
+defmodule Operately.UpdatesTest do
+  use Operately.DataCase
+
+  alias Operately.Updates
+
+  describe "updates" do
+    alias Operately.Updates.Update
+
+    import Operately.UpdatesFixtures
+
+    @invalid_attrs %{content: nil, updatable_id: nil, updatable_type: nil}
+
+    test "list_updates/0 returns all updates" do
+      update = update_fixture()
+      assert Updates.list_updates() == [update]
+    end
+
+    test "get_update!/1 returns the update with given id" do
+      update = update_fixture()
+      assert Updates.get_update!(update.id) == update
+    end
+
+    test "create_update/1 with valid data creates a update" do
+      valid_attrs = %{content: "some content", updatable_id: "7488a646-e31f-11e4-aace-600308960662", updatable_type: :objective}
+
+      assert {:ok, %Update{} = update} = Updates.create_update(valid_attrs)
+      assert update.content == "some content"
+      assert update.updatable_id == "7488a646-e31f-11e4-aace-600308960662"
+      assert update.updatable_type == :objective
+    end
+
+    test "create_update/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Updates.create_update(@invalid_attrs)
+    end
+
+    test "update_update/2 with valid data updates the update" do
+      update = update_fixture()
+      update_attrs = %{content: "some updated content", updatable_id: "7488a646-e31f-11e4-aace-600308960668", updatable_type: :project}
+
+      assert {:ok, %Update{} = update} = Updates.update_update(update, update_attrs)
+      assert update.content == "some updated content"
+      assert update.updatable_id == "7488a646-e31f-11e4-aace-600308960668"
+      assert update.updatable_type == :project
+    end
+
+    test "update_update/2 with invalid data returns error changeset" do
+      update = update_fixture()
+      assert {:error, %Ecto.Changeset{}} = Updates.update_update(update, @invalid_attrs)
+      assert update == Updates.get_update!(update.id)
+    end
+
+    test "delete_update/1 deletes the update" do
+      update = update_fixture()
+      assert {:ok, %Update{}} = Updates.delete_update(update)
+      assert_raise Ecto.NoResultsError, fn -> Updates.get_update!(update.id) end
+    end
+
+    test "change_update/1 returns a update changeset" do
+      update = update_fixture()
+      assert %Ecto.Changeset{} = Updates.change_update(update)
+    end
+  end
+end

--- a/test/support/fixtures/updates_fixtures.ex
+++ b/test/support/fixtures/updates_fixtures.ex
@@ -1,0 +1,22 @@
+defmodule Operately.UpdatesFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Operately.Updates` context.
+  """
+
+  @doc """
+  Generate a update.
+  """
+  def update_fixture(attrs \\ %{}) do
+    {:ok, update} =
+      attrs
+      |> Enum.into(%{
+        content: "some content",
+        updatable_id: "7488a646-e31f-11e4-aace-600308960662",
+        updatable_type: :objective
+      })
+      |> Operately.Updates.create_update()
+
+    update
+  end
+end

--- a/test/support/fixtures/updates_fixtures.ex
+++ b/test/support/fixtures/updates_fixtures.ex
@@ -4,16 +4,20 @@ defmodule Operately.UpdatesFixtures do
   entities via the `Operately.Updates` context.
   """
 
-  @doc """
-  Generate a update.
-  """
+  def update_fixture(:with_author, attrs) do
+    person = Operately.PeopleFixtures.person_fixture()
+    update = update_fixture(Map.put(attrs, :author_id, person.id))
+
+    {update, person}
+  end
+
   def update_fixture(attrs \\ %{}) do
     {:ok, update} =
       attrs
       |> Enum.into(%{
         content: "some content",
-        updatable_id: "7488a646-e31f-11e4-aace-600308960662",
-        updatable_type: :objective
+        updatable_id: Ecto.UUID.generate(),
+        updatable_type: :objective,
       })
       |> Operately.Updates.create_update()
 


### PR DESCRIPTION
In this PR I'm implementing taking the content from the TipTap editor and saving it into the database. Once saved, the `update_created` message is broadcasted and the feeds of people is automatically updated.

We are using the `JSON` format to save the content into the database. The raw JSON format preserves user mentions, in contrast to saving directly the HTML content which passes this information to the backend and makes it difficult to further process this data, for example to send out emails to the mentioned people.

