### PR TITLE
Add ability to leave comments on status updates

### DIFF
--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -25,7 +25,7 @@ interface OnSaveData {
 
 interface EditorProps {
   placeholder: string,
-  title: string,
+  title?: string,
   peopleSearch: EditorMentionSearchFunc,
   onSave?: (data: OnSaveData) => void;
 }
@@ -64,7 +64,7 @@ export default function Editor({placeholder, title, peopleSearch, onSave} : Edit
     ],
   })
 
-  const header = <div className="p-4 py-2 border-b border-stone-200 text-sm">{title}</div>;
+  const header = title ? <div className="p-4 py-2 border-b border-stone-200 text-sm">{title}</div> : null;
 
   const handleSave = () => {
     if(!editor) return;
@@ -76,12 +76,20 @@ export default function Editor({placeholder, title, peopleSearch, onSave} : Edit
     });
   };
 
-  return (
-    <div className="mt-4 rounded bg-white shadow-sm border border-stone-200">
-      {header}
-      <MenuBar editor={editor} />
-      <EditorContent editor={editor} />
-      <Footer onSave={handleSave} />
-    </div>
-  );
+  React.useEffect(() => {
+    console.log("Focusing1")
+
+    if(!editor) return;
+
+    console.log("Focusing2")
+
+    editor.commands.focus();
+  }, [editor]);
+
+  return <>
+    {header}
+    <MenuBar editor={editor} />
+    <EditorContent editor={editor} />
+    <Footer onSave={handleSave} />
+  </>
 }

--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -77,11 +77,7 @@ export default function Editor({placeholder, title, peopleSearch, onSave} : Edit
   };
 
   React.useEffect(() => {
-    console.log("Focusing1")
-
     if(!editor) return;
-
-    console.log("Focusing2")
 
     editor.commands.focus();
   }, [editor]);

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -116,6 +116,10 @@ i18n
             "write_an_update": {
               "title": "POST AN UPDATE",
               "placeholder": "Write an update…",
+            },
+
+            "leave_comment": {
+              "placeholder": "Leave a comment…",
             }
           }
         },

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -138,7 +138,7 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
   ]);
 
   return (
-    <div className="rounded bg-white shadow-sm border border-stone-200 rounded">
+    <div className="rounded-lg bg-white shadow-sm border border-stone-200 overflow-hidden">
       <div className="p-4 py-2 border-b border-stone-200">
         <div className="flex gap-1 items-center">
           <Avatar person_full_name={update.author.fullName} size={AvatarSize.Small} />
@@ -147,9 +147,50 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
         </div>
       </div>
       <div className="prose p-4" dangerouslySetInnerHTML={{__html: html}} />
+
+      <CommentEditor />
     </div>
   );
 }
+
+function CommentEditor() : JSX.Element {
+  const [active, setActive] = React.useState(false);
+
+  const { t } = useTranslation();
+  const client = useApolloClient();
+  const peopleSearch = PeopleSuggestions(client);
+
+  const handleAddComment = async ({json}) => {
+    console.log(json)
+    // await client.mutate({
+    //   mutation: CREATE_UPDATE,
+    //   variables: {
+    //     input: {
+    //       updatableId: id,
+    //       updatableType: "objective",
+    //       content: JSON.stringify(json),
+    //     }
+    //   }
+    // })
+  }
+
+
+  if (!active) {
+    return (
+      <div className="p-4 text-gray-500 cursor-pointer bg-light-1 flex items-center gap-2" onClick={() => setActive(true)}>
+        <Avatar person_full_name="IS" size={AvatarSize.Small} />
+        <span>{t("objectives.leave_comment.placeholder")}</span>
+      </div>
+    );
+  } else {
+    return <Editor
+      placeholder={t("objectives.leave_comment.placeholder")}
+      peopleSearch={peopleSearch}
+      onSave={handleAddComment}
+    />;
+  }
+}
+
 
 function Feed({objectiveID} : {objectiveID: string}) : JSX.Element {
   const { t } = useTranslation();
@@ -228,12 +269,14 @@ export function ObjectivePage() {
       <KeyResults objectiveID={id} />
       <Projects objectiveID={id} />
 
-      <Editor
-        title={t("objectives.write_an_update.title")}
-        placeholder={t("objectives.write_an_update.placeholder")}
-        peopleSearch={peopleSearch}
-        onSave={handleAddUpdate}
-      />
+      <div className="mt-4 rounded bg-white shadow-sm border border-stone-200">
+        <Editor
+          title={t("objectives.write_an_update.title")}
+          placeholder={t("objectives.write_an_update.placeholder")}
+          peopleSearch={peopleSearch}
+          onSave={handleAddUpdate}
+        />
+      </div>
 
       <Feed objectiveID={id} />
     </div>

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -126,17 +126,11 @@ defmodule Operately.Updates do
 
   alias Operately.Updates.Comment
 
-  @doc """
-  Returns the list of comments.
+  def list_comments(update_id) do
+    query = from c in Comment,
+      where: c.update_id == ^update_id
 
-  ## Examples
-
-      iex> list_comments()
-      [%Comment{}, ...]
-
-  """
-  def list_comments do
-    Repo.all(Comment)
+    Repo.all(query)
   end
 
   @doc """
@@ -171,6 +165,20 @@ defmodule Operately.Updates do
     %Comment{}
     |> Comment.changeset(attrs)
     |> Repo.insert()
+    |> publish_comment_added()
+  end
+
+  def publish_comment_added({:ok, comment}) do
+    Absinthe.Subscription.publish(
+      OperatelyWeb.Endpoint,
+      comment,
+      comment_added: "*")
+
+    {:ok, comment}
+  end
+
+  def publish_comment_added(e) do
+    e
   end
 
   @doc """

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -123,4 +123,100 @@ defmodule Operately.Updates do
   def change_update(%Update{} = update, attrs \\ %{}) do
     Update.changeset(update, attrs)
   end
+
+  alias Operately.Updates.Comment
+
+  @doc """
+  Returns the list of comments.
+
+  ## Examples
+
+      iex> list_comments()
+      [%Comment{}, ...]
+
+  """
+  def list_comments do
+    Repo.all(Comment)
+  end
+
+  @doc """
+  Gets a single comment.
+
+  Raises `Ecto.NoResultsError` if the Comment does not exist.
+
+  ## Examples
+
+      iex> get_comment!(123)
+      %Comment{}
+
+      iex> get_comment!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_comment!(id), do: Repo.get!(Comment, id)
+
+  @doc """
+  Creates a comment.
+
+  ## Examples
+
+      iex> create_comment(%{field: value})
+      {:ok, %Comment{}}
+
+      iex> create_comment(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_comment(attrs \\ %{}) do
+    %Comment{}
+    |> Comment.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a comment.
+
+  ## Examples
+
+      iex> update_comment(comment, %{field: new_value})
+      {:ok, %Comment{}}
+
+      iex> update_comment(comment, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_comment(%Comment{} = comment, attrs) do
+    comment
+    |> Comment.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a comment.
+
+  ## Examples
+
+      iex> delete_comment(comment)
+      {:ok, %Comment{}}
+
+      iex> delete_comment(comment)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_comment(%Comment{} = comment) do
+    Repo.delete(comment)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking comment changes.
+
+  ## Examples
+
+      iex> change_comment(comment)
+      %Ecto.Changeset{data: %Comment{}}
+
+  """
+  def change_comment(%Comment{} = comment, attrs \\ %{}) do
+    Comment.changeset(comment, attrs)
+  end
 end

--- a/lib/operately/updates/comment.ex
+++ b/lib/operately/updates/comment.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Updates.Comment do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "comments" do
+    field :content, :string
+    field :update_id, :binary_id
+    field :author_id, :binary_id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(comment, attrs) do
+    comment
+    |> cast(attrs, [:content])
+    |> validate_required([:content])
+  end
+end

--- a/lib/operately/updates/comment.ex
+++ b/lib/operately/updates/comment.ex
@@ -15,7 +15,7 @@ defmodule Operately.Updates.Comment do
   @doc false
   def changeset(comment, attrs) do
     comment
-    |> cast(attrs, [:content])
-    |> validate_required([:content])
+    |> cast(attrs, [:content, :update_id, :author_id])
+    |> validate_required([:content, :update_id, :author_id])
   end
 end

--- a/priv/repo/migrations/20230417173349_create_comments.exs
+++ b/priv/repo/migrations/20230417173349_create_comments.exs
@@ -1,0 +1,17 @@
+defmodule Operately.Repo.Migrations.CreateComments do
+  use Ecto.Migration
+
+  def change do
+    create table(:comments, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :content, :text
+      add :update_id, references(:updates, on_delete: :nothing, type: :binary_id)
+      add :author_id, references(:people, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create index(:comments, [:update_id])
+    create index(:comments, [:author_id])
+  end
+end

--- a/test/operately/updates_test.exs
+++ b/test/operately/updates_test.exs
@@ -79,17 +79,23 @@ defmodule Operately.UpdatesTest do
     @invalid_attrs %{content: nil}
 
     test "list_comments/0 returns all comments" do
-      comment = comment_fixture()
-      assert Updates.list_comments() == [comment]
+      {comment, update, _} = comment_fixture(:with_update, :with_author, %{})
+      assert Updates.list_comments(update.id) == [comment]
     end
 
     test "get_comment!/1 returns the comment with given id" do
-      comment = comment_fixture()
+      {comment, _, _} = comment_fixture(:with_update, :with_author, %{})
       assert Updates.get_comment!(comment.id) == comment
     end
 
     test "create_comment/1 with valid data creates a comment" do
-      valid_attrs = %{content: "some content"}
+      {update, author} = update_fixture(:with_author, %{})
+
+      valid_attrs = %{
+        content: "some content",
+        author_id: author.id,
+        update_id: update.id
+      }
 
       assert {:ok, %Comment{} = comment} = Updates.create_comment(valid_attrs)
       assert comment.content == "some content"
@@ -100,7 +106,7 @@ defmodule Operately.UpdatesTest do
     end
 
     test "update_comment/2 with valid data updates the comment" do
-      comment = comment_fixture()
+      {comment, _, _} = comment_fixture(:with_update, :with_author, %{})
       update_attrs = %{content: "some updated content"}
 
       assert {:ok, %Comment{} = comment} = Updates.update_comment(comment, update_attrs)
@@ -108,19 +114,19 @@ defmodule Operately.UpdatesTest do
     end
 
     test "update_comment/2 with invalid data returns error changeset" do
-      comment = comment_fixture()
+      {comment, _, _} = comment_fixture(:with_update, :with_author, %{})
       assert {:error, %Ecto.Changeset{}} = Updates.update_comment(comment, @invalid_attrs)
       assert comment == Updates.get_comment!(comment.id)
     end
 
     test "delete_comment/1 deletes the comment" do
-      comment = comment_fixture()
+      {comment, _, _} = comment_fixture(:with_update, :with_author, %{})
       assert {:ok, %Comment{}} = Updates.delete_comment(comment)
       assert_raise Ecto.NoResultsError, fn -> Updates.get_comment!(comment.id) end
     end
 
     test "change_comment/1 returns a comment changeset" do
-      comment = comment_fixture()
+      {comment, _, _} = comment_fixture(:with_update, :with_author, %{})
       assert %Ecto.Changeset{} = Updates.change_comment(comment)
     end
   end

--- a/test/operately/updates_test.exs
+++ b/test/operately/updates_test.exs
@@ -70,4 +70,58 @@ defmodule Operately.UpdatesTest do
       assert %Ecto.Changeset{} = Updates.change_update(update)
     end
   end
+
+  describe "comments" do
+    alias Operately.Updates.Comment
+
+    import Operately.UpdatesFixtures
+
+    @invalid_attrs %{content: nil}
+
+    test "list_comments/0 returns all comments" do
+      comment = comment_fixture()
+      assert Updates.list_comments() == [comment]
+    end
+
+    test "get_comment!/1 returns the comment with given id" do
+      comment = comment_fixture()
+      assert Updates.get_comment!(comment.id) == comment
+    end
+
+    test "create_comment/1 with valid data creates a comment" do
+      valid_attrs = %{content: "some content"}
+
+      assert {:ok, %Comment{} = comment} = Updates.create_comment(valid_attrs)
+      assert comment.content == "some content"
+    end
+
+    test "create_comment/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Updates.create_comment(@invalid_attrs)
+    end
+
+    test "update_comment/2 with valid data updates the comment" do
+      comment = comment_fixture()
+      update_attrs = %{content: "some updated content"}
+
+      assert {:ok, %Comment{} = comment} = Updates.update_comment(comment, update_attrs)
+      assert comment.content == "some updated content"
+    end
+
+    test "update_comment/2 with invalid data returns error changeset" do
+      comment = comment_fixture()
+      assert {:error, %Ecto.Changeset{}} = Updates.update_comment(comment, @invalid_attrs)
+      assert comment == Updates.get_comment!(comment.id)
+    end
+
+    test "delete_comment/1 deletes the comment" do
+      comment = comment_fixture()
+      assert {:ok, %Comment{}} = Updates.delete_comment(comment)
+      assert_raise Ecto.NoResultsError, fn -> Updates.get_comment!(comment.id) end
+    end
+
+    test "change_comment/1 returns a comment changeset" do
+      comment = comment_fixture()
+      assert %Ecto.Changeset{} = Updates.change_comment(comment)
+    end
+  end
 end

--- a/test/support/fixtures/updates_fixtures.ex
+++ b/test/support/fixtures/updates_fixtures.ex
@@ -23,4 +23,18 @@ defmodule Operately.UpdatesFixtures do
 
     update
   end
+
+  @doc """
+  Generate a comment.
+  """
+  def comment_fixture(attrs \\ %{}) do
+    {:ok, comment} =
+      attrs
+      |> Enum.into(%{
+        content: "some content"
+      })
+      |> Operately.Updates.create_comment()
+
+    comment
+  end
 end

--- a/test/support/fixtures/updates_fixtures.ex
+++ b/test/support/fixtures/updates_fixtures.ex
@@ -24,9 +24,17 @@ defmodule Operately.UpdatesFixtures do
     update
   end
 
-  @doc """
-  Generate a comment.
-  """
+  def comment_fixture(:with_update, :with_author, attrs) do
+    {update, author} = update_fixture(:with_author, %{})
+
+    comment = comment_fixture(Map.merge(attrs, %{
+      update_id: update.id,
+      author_id: author.id
+    }))
+
+    {comment, update, author}
+  end
+
   def comment_fixture(attrs \\ %{}) do
     {:ok, comment} =
       attrs


### PR DESCRIPTION
In this pull-request, I'm introducing the support for leaving comments on status updates.
Screenshot:

<img width="1248" alt="Screen Shot 2023-04-17 at 9 49 09 PM" src="https://user-images.githubusercontent.com/1779493/232595151-64e33327-4863-4494-a67e-2cbc0d505b59.png">
