### PR TITLE
Replace 0 seconds ago with just now

### DIFF
--- a/assets/js/components/RelativeTime/index.tsx
+++ b/assets/js/components/RelativeTime/index.tsx
@@ -24,6 +24,10 @@ export default function RelativeTime({date} : Props) : JSX.Element {
   const months = Math.floor(days / 30);
   const years = Math.floor(days / 365);
 
+  if (seconds < 10) {
+    return <>{t("intlRelativeDateTimeJustNow")}</>;
+  }
+
   if (seconds < 60) {
     return <>{t("intlRelativeDateTime", {val: -seconds, range: "second"})}</>;
   }

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -9,6 +9,7 @@ i18n
         translation: {
           "intlDateTime": "{{val, datetime}}",
           "intlRelativeDateTime": "{{val, relativetime}}",
+          "intlRelativeDateTimeJustNow": "just now",
 
           "Objectives": "Objectives",
           "Tenets": "Tenets",

--- a/assets/js/pages/ObjectivePage/Feed.tsx
+++ b/assets/js/pages/ObjectivePage/Feed.tsx
@@ -169,6 +169,10 @@ export default function Feed({objectiveID} : {objectiveID: string}) : JSX.Elemen
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
+  if(data.updates.length == 0) {
+    return <></>;
+  }
+
   return <div className="mt-4" data-test="feed">
     <div className="text-sm uppercase">FEED</div>
 


### PR DESCRIPTION
Displaying `post added 0 seconds ago` is less nice than saying `post added just now`.
The threshold is set to < 10 seconds.