### PR TITLE
Fetch user avatars from Google on signup, comment and share updates with the current logged in person

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ test:
 	mkdir -p $(SCREENSHOTS_DIR)
 	$(TEST_CONTAINER) mix test $(FILE)
 
+test.db.migrate:
+	$(DEV_CONTAINER) mix ecto.migrate
+
 test.watch:
 	$(TEST_CONTAINER) mix test.watch $(FILE)
 

--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -6,16 +6,69 @@ export enum AvatarSize {
   Large = 'large',
 }
 
-export default function Avatar({ person_full_name, size } : { person_full_name : string, size : AvatarSize }) : JSX.Element {
-  const initials = person_full_name.split(' ').map((n) => n[0]).join('');
+interface Person {
+  avatarUrl?: string;
+  fullName: string;
+  title?: string;
+  id: string;
+}
 
-  const sizeClass = size === AvatarSize.Small ? 'w-6 h-6 text-sm' : size === AvatarSize.Large ? 'w-12 h-12 text-2xl' : 'w-10 h-10 text-lg';
+interface AvatarProps {
+  person: Person;
+  size: AvatarSize;
+}
+
+function SizeClasses({size} : {size: AvatarSize}) : string {
+  switch (size) {
+    case AvatarSize.Small:
+      return 'w-6 h-6 text-sm';
+    case AvatarSize.Large:
+      return 'w-12 h-12 text-2xl';
+    case AvatarSize.Normal:
+      return 'w-10 h-10 text-lg';
+  }
+}
+
+function TextClasses({size} : {size: AvatarSize}) : string {
+  switch (size) {
+    case AvatarSize.Small:
+      return 'text-sm';
+    case AvatarSize.Large:
+      return 'text-2xl';
+    case AvatarSize.Normal:
+      return 'text-lg';
+  }
+}
+
+function BackupAvatar({person, size} : AvatarProps) : JSX.Element {
+  const initials = person.fullName.split(' ').map((n) => n[0]).join('');
+
+  const baseClass = "flex items-center justify-center text-white rounded-full bg-brand-base";
+  const sizeClass = SizeClasses({size});
+  const textClass = TextClasses({size});
+  const className = baseClass + " " + sizeClass + " " + textClass;
 
   return (
-    <div className={"flex items-center justify-center text-white bg-gray-500 rounded-full" + " " + sizeClass}>
+    <div className={className}>
       {initials}
     </div>
   );
+}
+
+function ImageAvatar({person, size} : AvatarProps) : JSX.Element {
+  const baseClass = "rounded-full overflow-hidden bg-brand-base";
+  const sizeClass = SizeClasses({size});
+  const className = baseClass + " " + sizeClass;
+
+  return (
+    <div className={className}>
+      <img src={person.avatarUrl} alt={person.fullName} />
+    </div>
+  );
+}
+
+export default function Avatar(props : AvatarProps) : JSX.Element {
+  return props.person.avatarUrl ? ImageAvatar(props) : BackupAvatar(props);
 }
 
 Avatar.defaultProps = {

--- a/assets/js/components/Card/index.tsx
+++ b/assets/js/components/Card/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default function Card({children}) {
   return (
-    <div className="py-2 px-4 bg-white rounded shadow-sm hover:shadow hover:cursor-pointer">
+    <div className="py-4 px-4 bg-white rounded-lg card-shadow hover:card-shadow-blue hover:cursor-pointer">
       {children}
     </div>
   );

--- a/assets/js/components/CardList/index.tsx
+++ b/assets/js/components/CardList/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default function CardList({children}) {
-  return <div className="flex flex-col gap-2">{
+  return <div className="flex flex-col gap-4">{
     children.map((child: JSX.Element) => child)
   }</div>;
 }

--- a/assets/js/components/Editor/MentionList.tsx
+++ b/assets/js/components/Editor/MentionList.tsx
@@ -52,11 +52,11 @@ const MentionList = forwardRef((props : MentionListProps, ref) => {
   }
 
   const upHandler = () => {
-    setSelectedIndex(nextIndex(selectedIndex))
+    setSelectedIndex(prevIndex(selectedIndex))
   }
 
   const downHandler = () => {
-    setSelectedIndex(prevIndex(selectedIndex))
+    setSelectedIndex(nextIndex(selectedIndex))
   }
 
   const enterHandler = () => {

--- a/assets/js/components/PageTitle/index.tsx
+++ b/assets/js/components/PageTitle/index.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 export default function PageTitle({ title, buttons }: { title: string, buttons: [JSX.Element] }) {
   return (
-    <div className="flex items-center justify-between mb-4">
+    <div className="mb-4">
       <h1 className="text-2xl font-bold">{title}</h1>
-      <div className="flex gap-2">
+
+      <div className="flex gap-2 mt-4">
         {buttons.map((button: JSX.Element) => button)}
       </div>
     </div>

--- a/assets/js/components/SideNavigation/Link.tsx
+++ b/assets/js/components/SideNavigation/Link.tsx
@@ -13,8 +13,8 @@ export default function Link({to, title, icon}: LinkProps) : JSX.Element {
   const baseClass = "block rounded px-2 py-1.5 text-[16px] flex gap-1.5 items-center font-semibold";
 
   const classNameHandler = ({isActive, isPending}) => {
-    if(isActive) return baseClass + ' text-dark-1 bg-light-base';
-    if(isPending) return baseClass + ' text-dark-1 bg-light-base';
+    if(isActive) return baseClass + ' text-dark-base bg-light-base';
+    if(isPending) return baseClass + ' text-dark-base bg-light-base';
 
     return baseClass + ' text-dark-1 hover:bg-light-gray';
   };

--- a/assets/js/graphql/Me/index.tsx
+++ b/assets/js/graphql/Me/index.tsx
@@ -1,0 +1,16 @@
+import { useQuery, gql } from '@apollo/client';
+
+const GET_ME = gql`
+  query GetMe {
+    me {
+      id
+      fullName
+      avatarUrl
+      title
+    }
+  }
+`;
+
+export function useMe() {
+  return useQuery(GET_ME);
+}

--- a/assets/js/layouts/DefaultLayout/User.tsx
+++ b/assets/js/layouts/DefaultLayout/User.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 
 import Avatar, {AvatarSize} from '../../components/Avatar';
 import Icon from '../../components/Icon';
+import { useMe } from '../../graphql/Me';
 
 export default function User() {
+  const { data, loading, error } = useMe();
+
+  if (loading) return <div></div>;
+  if (error) return <div></div>;
+
   return (
     <div className="fixed top-2 right-2 p-[18px] flex gap-10 items-center justify-between bg-light-2 rounded-lg w-[300px]">
       <div className="flex gap-2 items-center">
-        <Avatar size={AvatarSize.Small} person_full_name="Igor Sarcevic" />
-        <span className="font-semibold">Igor Sarcevic</span>
+        <Avatar size={AvatarSize.Small} person={data.me} />
+        <span className="font-semibold">{data.me.fullName}</span>
       </div>
 
       <div className="hover:cursor-pointer flex items-center gap-2">

--- a/assets/js/layouts/DefaultLayout/User.tsx
+++ b/assets/js/layouts/DefaultLayout/User.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import Avatar, {AvatarSize} from '../../components/Avatar';
+
+export default function User() {
+  return (
+    <div className="fixed top-2 right-2 p-[18px] flex gap-10 items-center justify-between bg-light-2 rounded-lg">
+      <div className="flex gap-2 items-center">
+        <Avatar size={AvatarSize.Small} person_full_name="Igor Sarcevic" />
+        <span>Igor Sarcevic</span>
+      </div>
+    </div>
+  );
+}

--- a/assets/js/layouts/DefaultLayout/User.tsx
+++ b/assets/js/layouts/DefaultLayout/User.tsx
@@ -1,13 +1,19 @@
 import React from 'react';
 
 import Avatar, {AvatarSize} from '../../components/Avatar';
+import Icon from '../../components/Icon';
 
 export default function User() {
   return (
-    <div className="fixed top-2 right-2 p-[18px] flex gap-10 items-center justify-between bg-light-2 rounded-lg">
+    <div className="fixed top-2 right-2 p-[18px] flex gap-10 items-center justify-between bg-light-2 rounded-lg w-[300px]">
       <div className="flex gap-2 items-center">
         <Avatar size={AvatarSize.Small} person_full_name="Igor Sarcevic" />
-        <span>Igor Sarcevic</span>
+        <span className="font-semibold">Igor Sarcevic</span>
+      </div>
+
+      <div className="hover:cursor-pointer flex items-center gap-2">
+        <Icon name="settings" color="dark-2" hoverColor="dark" />
+        <Icon name="chevron down" color="dark-2" hoverColor="dark" />
       </div>
     </div>
   );

--- a/assets/js/layouts/DefaultLayout/index.tsx
+++ b/assets/js/layouts/DefaultLayout/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import SideNavigation from '../../components/SideNavigation';
 import { Outlet } from 'react-router-dom';
+
+import SideNavigation from '../../components/SideNavigation';
+import User from './User';
 
 export default function DefaultLayout() {
   return (
@@ -12,6 +14,8 @@ export default function DefaultLayout() {
           <Outlet />
         </div>
       </div>
+
+      <User />
     </div>
   );
 }

--- a/assets/js/pages/GroupPage/index.tsx
+++ b/assets/js/pages/GroupPage/index.tsx
@@ -16,7 +16,8 @@ const GET_GROUP = gql`
 
       members {
         id
-        full_name
+        fullName
+        avatarUrl
       }
     }
   }
@@ -35,14 +36,15 @@ export async function GroupPageLoader(apolloClient : any, {params}) {
 
 interface Person {
   id: string;
-  full_name: string;
+  fullName: string;
+  avatarUrl?: string;
 }
 
 function MemberList({ members } : { members: Person[] }) {
   return (
     <div className="flex gap-2">
       {members.map((m : Person) => (
-        <Avatar key={m.id} person_full_name={m.full_name} />
+        <Avatar key={m.id} person={m} />
       ))}
     </div>
   );

--- a/assets/js/pages/ObjectiveListPage/index.tsx
+++ b/assets/js/pages/ObjectiveListPage/index.tsx
@@ -8,6 +8,7 @@ import ButtonLink from '../../components/ButtonLink';
 import PageTitle from '../../components/PageTitle';
 import Card from '../../components/Card';
 import CardList from '../../components/CardList';
+import Avatar, {AvatarSize} from '../../components/Avatar';
 
 const GET_OBJECTIVES = gql`
   query GetObjectives {
@@ -15,6 +16,13 @@ const GET_OBJECTIVES = gql`
       id
       name
       description
+
+      owner {
+        id
+        fullName
+        avatarUrl
+        title
+      }
     }
   }
 `;
@@ -38,10 +46,28 @@ export async function ObjectiveListPageLoader(apolloClient : any) {
 
 function ListOfObjectives({objectives}) {
   return (
-      <CardList>
-        {objectives.map(({id, name, description}: any) => (
-          <Link key={name} to={`/objectives/${id}`}><Card>{name} - {description}</Card></Link>
-        ))}
+    <CardList>
+      {objectives.map((objective: any) => (
+        <Link key={objective.name} to={`/objectives/${objective.id}`}>
+          <Card>
+            <div className="flex items-center gap-2 justify-between">
+              <div className="max-w-2xl">
+                <div className="text-brand-base font-bold">{objective.name}</div>
+                <div className="text-dark-1 truncate">{objective.description}</div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Avatar person={objective.owner} size={AvatarSize.Normal} />
+
+                <div>
+                  <div className="font-medium">{objective.owner.fullName}</div>
+                  <div className="text-xs">{objective.owner.title}</div>
+                </div>
+              </div>
+            </div>
+          </Card>
+        </Link>
+      ))}
     </CardList>
   );
 }

--- a/assets/js/pages/ObjectivePage/Champion.tsx
+++ b/assets/js/pages/ObjectivePage/Champion.tsx
@@ -3,6 +3,7 @@ import Avatar from '../../components/Avatar';
 
 interface Person {
   fullName: string;
+  avatarUrl?: string;
   title: string;
   id: string;
 }
@@ -10,7 +11,7 @@ interface Person {
 export default function Champion({person} : {person: Person}) : JSX.Element {
   return (
     <div className="mt-4 flex gap-2 items-center">
-      <Avatar person_full_name={person.fullName} />
+      <Avatar person={person} />
       <div>
         <div className="font-bold">{person.fullName}</div>
         <div className="text-dark-1">{person.title}</div>

--- a/assets/js/pages/ObjectivePage/Feed.tsx
+++ b/assets/js/pages/ObjectivePage/Feed.tsx
@@ -85,7 +85,7 @@ const GET_UPDATES = gql`
 function ShortName({fullName} : {fullName: string}) : JSX.Element {
   const [firstName, lastName] = fullName.split(" ");
 
-  return <>{firstName} {lastName[0]}.</>;
+  return <>{firstName} {lastName ? lastName[0] : ""}.</>;
 }
 
 function FeedItem({update} : {update: Update}) : JSX.Element {

--- a/assets/js/pages/ObjectivePage/Feed.tsx
+++ b/assets/js/pages/ObjectivePage/Feed.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useQuery, gql, useApolloClient } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
+import { useMe } from '../../graphql/Me';
 
 import Avatar, {AvatarSize} from '../../components/Avatar';
 import Editor from '../../components/Editor';
@@ -93,7 +94,7 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
       <div className="p-4">
         <div className="pb-4 border-b border-dark-8%">
           <div className="flex gap-1.5 items-center">
-            <Avatar person_full_name={update.author.fullName} size={AvatarSize.Small} />
+            <Avatar person={update.author} />
             <span className="text-dark-1 ml-1"><ShortName fullName={update.author.fullName}></ShortName></span>
             <span className="text-dark-2 text-xs">posted an update <RelativeTime date={update.insertedAt} /></span>
           </div>
@@ -110,7 +111,7 @@ function FeedItem({update} : {update: Update}) : JSX.Element {
 function Comment({comment}) : JSX.Element {
   return <div>
     <div className="flex gap-1.5 items-center mt-4 pt-4 border-t border-dark-8%">
-      <Avatar person_full_name={comment.author.fullName} size={AvatarSize.Small} />
+      <Avatar person={comment.author} size={AvatarSize.Small} />
       <span className="text-dark-1"><ShortName fullName={comment.author.fullName}></ShortName></span>
       <span className="text-dark-2 text-xs"><RelativeTime date={comment.insertedAt} /></span>
     </div>
@@ -150,10 +151,12 @@ function CommentEditor({updateId}) : JSX.Element {
     }
   }
 
+  const {data} = useMe();
+
   if (!active) {
     return (
       <div className="p-4 text-dark-2 cursor-pointer bg-light-1 flex items-center gap-2" onClick={() => setActive(true)}>
-        <Avatar person_full_name="IS" size={AvatarSize.Small} />
+        {data ? <Avatar person={data.me} size={AvatarSize.Small} /> : null}
         <span>{t("objectives.leave_comment.placeholder")}</span>
       </div>
     );

--- a/assets/js/pages/ObjectivePage/PeopleSuggestions.tsx
+++ b/assets/js/pages/ObjectivePage/PeopleSuggestions.tsx
@@ -3,7 +3,7 @@ import { gql, ApolloClient } from '@apollo/client';
 
 interface Person {
   fullName: string;
-  title: string;
+  title?: string;
   id: string;
 }
 

--- a/assets/js/pages/ObjectivePage/Projects.tsx
+++ b/assets/js/pages/ObjectivePage/Projects.tsx
@@ -16,7 +16,7 @@ const GET_ALIGNED_PROJECTS = gql`
       updatedAt
 
       owner {
-        full_name
+        fullName
         title
       }
     }
@@ -46,7 +46,9 @@ function Timeline({percentage, startDate, endDate}) : JSX.Element {
 }
 
 interface Owner {
-  full_name: string;
+  id: string;
+  fullName: string;
+  avatarUrl?: string;
   title: string;
 }
 
@@ -81,8 +83,8 @@ function Card({project} : {project: Project}) : JSX.Element {
 function Champion({person} : {person: Owner}) : JSX.Element {
   return (
     <div className="flex gap-2 items-center">
-      <Avatar person_full_name={person.full_name} size={AvatarSize.Small} />
-      <div>{person.full_name}</div>
+      <Avatar person={person} size={AvatarSize.Small} />
+      <div>{person.fullName}</div>
     </div>
   );
 }

--- a/assets/js/pages/ObjectivePage/index.tsx
+++ b/assets/js/pages/ObjectivePage/index.tsx
@@ -54,7 +54,7 @@ export function ObjectivePage() {
 
   return (
     <div>
-      <div className="flex items-start justify-between text-dark-1 mb-10">
+      <div className="flex items-end justify-between text-dark-1 mb-10">
         <div>
           <PageTitle title={data.objective.name} />
           <p className="max-w-lg">{data.objective.description}</p>

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -350,7 +350,7 @@ defmodule Operately.People do
       %Account{} = account ->
         Repo.preload(account, [:person])
       nil ->
-        {:error, :not_found}
+        nil
     end
   end
 

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -345,7 +345,13 @@ defmodule Operately.People do
   """
   def get_account_by_session_token(token) do
     {:ok, query} = AccountToken.verify_session_token_query(token)
-    Repo.one(query)
+
+    case Repo.one(query) do
+      %Account{} = account ->
+        Repo.preload(account, [:person])
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   @doc """

--- a/lib/operately/people/account.ex
+++ b/lib/operately/people/account.ex
@@ -4,6 +4,8 @@ defmodule Operately.People.Account do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "accounts" do
+    has_one(:person, Operately.People.Person, foreign_key: :account_id)
+
     field :email, :string
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -20,7 +20,7 @@ defmodule Operately.People.Person do
   @doc false
   def changeset(person, attrs) do
     person
-    |> cast(attrs, [:full_name, :handle, :title, :avatar_url, :email])
+    |> cast(attrs, [:full_name, :handle, :title, :avatar_url, :email, :account_id])
     |> validate_required([:full_name, :handle])
     |> unique_constraint(:handle)
   end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -4,11 +4,15 @@ defmodule Operately.People.Person do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
-  @derive {Jason.Encoder, only: [:id, :full_name , :inserted_at, :handle, :title]}
+
   schema "people" do
+    belongs_to(:account, Operately.Accounts.Account)
+
     field :full_name, :string
     field :handle, :string
     field :title, :string
+    field :avatar_url, :string
+    field :email, :string
 
     timestamps()
   end
@@ -16,7 +20,7 @@ defmodule Operately.People.Person do
   @doc false
   def changeset(person, attrs) do
     person
-    |> cast(attrs, [:full_name, :handle, :title])
+    |> cast(attrs, [:full_name, :handle, :title, :avatar_url, :email])
     |> validate_required([:full_name, :handle, :title])
     |> unique_constraint(:handle)
   end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -21,7 +21,7 @@ defmodule Operately.People.Person do
   def changeset(person, attrs) do
     person
     |> cast(attrs, [:full_name, :handle, :title, :avatar_url, :email])
-    |> validate_required([:full_name, :handle, :title])
+    |> validate_required([:full_name, :handle])
     |> unique_constraint(:handle)
   end
 end

--- a/lib/operately_web/components/layouts/root.html.heex
+++ b/lib/operately_web/components/layouts/root.html.heex
@@ -24,6 +24,7 @@
 
     <style>
       @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&display=swap');
+      @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
       body {
         font-family: 'Inter', sans-serif;

--- a/lib/operately_web/controllers/account_oauth_controller.ex
+++ b/lib/operately_web/controllers/account_oauth_controller.ex
@@ -54,7 +54,13 @@ defmodule OperatelyWeb.AccountOauthController do
     def test_login(conn, params) do
       account_params = %{
         email: params["email"],
-        password: random_password()
+        password: random_password(),
+        person: %{
+          email: params["email"],
+          full_name: params["email"],
+          handle: params["email"],
+          avatar_url: "https://www.gravatar.com/avatar/#{:crypto.strong_rand_bytes(16) |> Base.encode16()}"
+        }
       }
 
       case People.fetch_or_create_account(account_params) do

--- a/lib/operately_web/controllers/account_oauth_controller.ex
+++ b/lib/operately_web/controllers/account_oauth_controller.ex
@@ -9,6 +9,8 @@ defmodule OperatelyWeb.AccountOauthController do
   @rand_pass_length 32
 
   def callback(%{assigns: %{ueberauth_auth: %{info: account_info}}} = conn, %{"provider" => "google"}) do
+    IO.inspect(account_info)
+
     account_params = %{email: account_info.email, password: random_password()}
 
     case People.fetch_or_create_account(account_params) do

--- a/lib/operately_web/graphql/context.ex
+++ b/lib/operately_web/graphql/context.ex
@@ -1,0 +1,10 @@
+defmodule OperatelyWeb.GraphQL.Context do
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    current_account = conn.assigns[:current_account]
+    context = %{current_account: current_account}
+
+    Absinthe.Plug.put_options(conn, context: context)
+  end
+end

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -19,6 +19,10 @@ defmodule OperatelyWeb.Router do
     plug :fetch_current_account
   end
 
+  pipeline :graphql do
+    plug OperatelyWeb.GraphQL.Context
+  end
+
   #
   # Account authentication and creation routes
   #
@@ -59,7 +63,7 @@ defmodule OperatelyWeb.Router do
   end
 
   scope "/api" do
-    pipe_through [:api, :require_authenticated_account]
+    pipe_through [:api, :require_authenticated_account, :graphql]
 
     forward "/gql", Absinthe.Plug, schema: OperatelyWeb.Schema
   end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -69,7 +69,8 @@ defmodule OperatelyWeb.Schema do
   object :person do
     field :id, non_null(:id)
     field :full_name, non_null(:string)
-    field :title, non_null(:string)
+    field :title, :string
+    field :avatar_url, :string
   end
 
   object :project do

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -140,6 +140,12 @@ defmodule OperatelyWeb.Schema do
   end
 
   query do
+    field :me, :person do
+      resolve fn _, _, _ ->
+        {:ok, Operately.People.list_people() |> List.last()}
+      end
+    end
+
     field :kpis, list_of(:kpi) do
       resolve fn _, _, _ ->
         kpis = Operately.Kpis.list_kpis()

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -141,8 +141,8 @@ defmodule OperatelyWeb.Schema do
 
   query do
     field :me, :person do
-      resolve fn _, _, _ ->
-        {:ok, Operately.People.list_people() |> List.last()}
+      resolve fn _, _, %{context: context} ->
+        {:ok, context.current_account.person}
       end
     end
 
@@ -352,9 +352,9 @@ defmodule OperatelyWeb.Schema do
     field :create_update, :update do
       arg :input, non_null(:create_update_input)
 
-      resolve fn args, _ ->
+      resolve fn args, %{context: context} ->
         Operately.Updates.create_update(%{
-          author_id: hd(Operately.People.list_people()).id,
+          author_id: context.current_account.person.id,
           updatable_type: args.input.updatable_type,
           updatable_id: args.input.updatable_id,
           content: args.input.content
@@ -365,9 +365,9 @@ defmodule OperatelyWeb.Schema do
     field :create_comment, :comment do
       arg :input, non_null(:create_comment_input)
 
-      resolve fn args, _ ->
+      resolve fn args, %{context: context} ->
         Operately.Updates.create_comment(%{
-          author_id: hd(Operately.People.list_people()).id,
+          author_id: context.current_account.person.id,
           update_id: args.input.update_id,
           content: args.input.content
         })

--- a/priv/repo/migrations/20230420073647_connect_people_with_accounts.exs
+++ b/priv/repo/migrations/20230420073647_connect_people_with_accounts.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.ConnectPeopleWithAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:people) do
+      add :account_id, references(:accounts, on_delete: :delete_all, type: :binary_id)
+      add :avatar_url, :string
+      add :email, :string
+    end
+  end
+end

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -14,7 +14,7 @@ Feature: Groups
   Scenario: Adding Group Members
     Given I am logged in as a user
     Given that a group with the name "Marketing" exists
-    Given I have "John Johnson" in my organization as the "Head of Support"
+    Given I have "Peter Swalowski" in my organization as the "Head of Support"
     When I visit the group "Marketing" page
-    And I add the user "John Johnson" to the group
-    Then the user "JJ" is visible on the group "Marketing" page
+    And I add the user "Peter Swalowski" to the group
+    Then the user "PS" is visible on the group "Marketing" page

--- a/test/features/groups_test.exs
+++ b/test/features/groups_test.exs
@@ -82,8 +82,8 @@ defmodule Operately.Features.GroupsTest do
   defand ~r/^I add the user "(?<name>[^"]+)" to the group$/, %{name: name}, state do
     state.session
     |> click(Query.button("Add Members"))
-    |> fill_in(Query.css("#peopleSearch"), with: "John")
-    |> assert_text("John Johnson")
+    |> fill_in(Query.css("#peopleSearch"), with: String.split(name, " ") |> List.first)
+    |> assert_text(name)
     |> send_keys([:enter])
     |> find(Query.css(".ReactModalPortal"), fn modal ->
       click(modal, Query.button("Add Members"))


### PR DESCRIPTION
In this pull-request I'm adding support for avatars and paying the debt of hardcoded user profiles. Now, the currently signed in user will leave the comments and updates, instead of a hardcoded one.

Additionally, I'm introducing a notch on the top of the screen that shows the currently signed in account.

---

Screenshot:
![Screenshot 2023-04-20 at 11 08 01](https://user-images.githubusercontent.com/1779493/233317627-878b6f1b-9ada-4757-81e1-e4b3fcf7735b.png)
