### PR TITLE
List projects on the group page

### DIFF
--- a/assets/js/graphql/Projects/index.tsx
+++ b/assets/js/graphql/Projects/index.tsx
@@ -1,8 +1,8 @@
 import { gql, useQuery } from '@apollo/client';
 
 const LIST_PROJECTS = gql`
-  query ListProjects($groupId: ID) {
-    projects(groupId: $groupId) {
+  query ListProjects($groupId: ID, $objectiveId: ID) {
+    projects(groupId: $groupId, objectiveId: $objectiveId) {
       id
       name
       updatedAt

--- a/assets/js/graphql/Projects/index.tsx
+++ b/assets/js/graphql/Projects/index.tsx
@@ -1,0 +1,25 @@
+import { gql, useQuery } from '@apollo/client';
+
+const LIST_PROJECTS = gql`
+  query ListProjects($groupId: ID) {
+    projects(groupId: $groupId) {
+      id
+      name
+      updatedAt
+
+      owner {
+        fullName
+        title
+      }
+    }
+  }
+`;
+
+interface ListProjectsVariables {
+  groupId?: string;
+  objectiveId?: string;
+}
+
+export function useProjects(variables : ListProjectsVariables) {
+  return useQuery(LIST_PROJECTS, { variables });
+}

--- a/assets/js/pages/GroupPage/Projects.tsx
+++ b/assets/js/pages/GroupPage/Projects.tsx
@@ -41,7 +41,7 @@ interface Project {
   id: string;
   name: string;
   updatedAt: string;
-  owner: Owner;
+  owner?: Owner;
 }
 
 function Card({project} : {project: Project}) : JSX.Element {
@@ -56,8 +56,13 @@ function Card({project} : {project: Project}) : JSX.Element {
     </div>
 
     <div className="w-2/6">
-      <Champion person={project.owner} />
-      <div className="text-dark-2 text-xs ml-8">with 2 colaborators</div>
+      {project.owner
+        ? <>
+            <Champion person={project.owner} />
+            <div className="text-dark-2 text-xs ml-8">with 2 colaborators</div>
+          </>
+        : <div className="text-dark-2 text-xs">No owner</div>
+      }
     </div>
     <div className="w-2/6 text-dark-2">
       <RelativeTime date={project.updatedAt} />
@@ -89,13 +94,13 @@ export default function Projects({groupId} : {groupId: string}) : JSX.Element {
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
-  if (data.alignedProjects.length === 0) return <></>;
+  if (data.projects.length === 0) return <></>;
 
   return <div className="mt-4">
-    <h2>{t("objectives.projects_in_progress_title")}</h2>
+    <h2 className="text-lg font-semibold">{t("objectives.projects_in_progress_title")}</h2>
 
     <CardListHeader headers={headers} />
 
-    {data.alignedProjects.map((project : Project) => <Card key={project.id} project={project} />)}
+    {data.projects.map((project : Project) => <Card key={project.id} project={project} />)}
   </div>;
 }

--- a/assets/js/pages/GroupPage/Projects.tsx
+++ b/assets/js/pages/GroupPage/Projects.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useTranslation } from 'react-i18next';
 import { useProjects } from '../../graphql/Projects';
 
@@ -6,7 +7,6 @@ import RelativeTime from '../../components/RelativeTime';
 import Avatar, {AvatarSize} from '../../components/Avatar';
 
 import { Link } from "react-router-dom";
-import SectionHeader from './SectionHeader';
 
 function CardListHeader({headers} : {headers: Array<{id: string, label: string}>}) : JSX.Element {
   return <div className="flex gap-14 mt-4 px-2">
@@ -74,10 +74,10 @@ function Champion({person} : {person: Owner}) : JSX.Element {
   );
 }
 
-export default function Projects({objectiveID} : {objectiveID: string}) : JSX.Element {
+export default function Projects({groupId} : {groupId: string}) : JSX.Element {
   const { t } = useTranslation();
 
-  const { loading, error, data } = useProjects({objectiveId: objectiveID});
+  const { loading, error, data } = useProjects({groupId});
 
   const headers = [
     {id: "title", label: t("objectives.project_list_title")},
@@ -92,7 +92,7 @@ export default function Projects({objectiveID} : {objectiveID: string}) : JSX.El
   if (data.alignedProjects.length === 0) return <></>;
 
   return <div className="mt-4">
-    <SectionHeader>{t("objectives.projects_in_progress_title")}</SectionHeader>
+    <h2>{t("objectives.projects_in_progress_title")}</h2>
 
     <CardListHeader headers={headers} />
 

--- a/assets/js/pages/GroupPage/index.tsx
+++ b/assets/js/pages/GroupPage/index.tsx
@@ -7,6 +7,7 @@ import AddMembersModal from './AddMembersModal';
 import Avatar from '../../components/Avatar';
 import GroupMission from './GroupMission';
 import PointsOfContact from './PointsOfContact';
+import Projects from './Projects';
 
 const GET_GROUP = gql`
   query GetGroup($id: ID!) {
@@ -96,6 +97,8 @@ export function GroupPage() {
         pointsOfContact={data.group.pointsOfContact}
         onAddContact={refetch}
       />
+
+      <Projects groupId={id} />
     </div>
   )
 }

--- a/assets/js/pages/ObjectivePage/Projects.tsx
+++ b/assets/js/pages/ObjectivePage/Projects.tsx
@@ -89,13 +89,13 @@ export default function Projects({objectiveID} : {objectiveID: string}) : JSX.El
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;
 
-  if (data.alignedProjects.length === 0) return <></>;
+  if (data.projects.length === 0) return <></>;
 
   return <div className="mt-4">
     <SectionHeader>{t("objectives.projects_in_progress_title")}</SectionHeader>
 
     <CardListHeader headers={headers} />
 
-    {data.alignedProjects.map((project : Project) => <Card key={project.id} project={project} />)}
+    {data.projects.map((project : Project) => <Card key={project.id} project={project} />)}
   </div>;
 }

--- a/assets/js/pages/ProjectListPage/index.tsx
+++ b/assets/js/pages/ProjectListPage/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery, gql } from '@apollo/client';
 import { Link } from 'react-router-dom';
 
 import ButtonLink from '../../components/ButtonLink';
@@ -8,57 +7,24 @@ import PageTitle from '../../components/PageTitle';
 import Card from '../../components/Card';
 import CardList from '../../components/CardList';
 
-const GET_PROJECTS = gql`
-  query GetProjects {
-    projects {
-      id
-      name
-      description
-    }
-  }
-`;
-
-const PROJECT_SUBSCRIPTION = gql`
-  subscription OnProjectAdded {
-    projectAdded {
-      id
-    }
-  }
-`;
+import { listProjects, useProjects } from '../../graphql/Projects';
 
 export async function ProjectListPageLoader(apolloClient : any) {
-  await apolloClient.query({
-    query: GET_PROJECTS,
-    fetchPolicy: 'network-only'
-  });
-
+  await listProjects(apolloClient, {});
   return {};
 }
 
 function ListOfProjects({projects}) {
-  return (
-      <CardList>
-        {projects.map(({id, name, description}: any) => (
-          <Link key={name} to={`/projects/${id}`}><Card>{name} - {description}</Card></Link>
-        ))}
-    </CardList>
-  );
+  return <CardList>
+    {projects.map(({id, name, description}: any) => (
+      <Link key={name} to={`/projects/${id}`}><Card>{name} {description ? " - " + description : ""}</Card></Link>
+    ))}
+  </CardList>;
 }
 
 export function ProjectListPage() {
   const { t } = useTranslation();
-  const { loading, error, data, subscribeToMore, refetch } = useQuery(GET_PROJECTS);
-
-  React.useEffect(() => {
-    subscribeToMore({
-      document: PROJECT_SUBSCRIPTION,
-      updateQuery: (prev, { subscriptionData }) => {
-        if (!subscriptionData.data) return prev;
-        refetch();
-        return prev;
-      }
-    })
-  }, [])
+  const { loading, error, data } = useProjects({});
 
   if (loading) return <p>{t("loading.loading")}</p>;
   if (error) return <p>{t("error.error")}: {error.message}</p>;

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -65,6 +65,10 @@ defmodule Operately.Groups do
   """
   def get_group!(id), do: Repo.get!(Group, id)
 
+  def get_group_by_name(name) do
+    Repo.one(from g in Group, where: g.name == ^name)
+  end
+
   @doc """
   Creates a group.
 

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -17,8 +17,16 @@ defmodule Operately.Projects do
       [%Project{}, ...]
 
   """
-  def list_projects do
-    Repo.all(Project)
+  def list_projects(filters = %{}) do
+    query = Project
+
+    query = if filters.group_id do
+      query |> join(:inner, [p], g in assoc(p, :group), on: g.id == ^filters.group_id)
+    else
+      query |> join(:inner, [p], o in assoc(p, :objective), on: o.id == ^filters.objective_id)
+    end
+
+    Repo.all(query)
   end
 
   @doc """

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -8,7 +8,7 @@ defmodule Operately.Projects do
 
   alias Operately.Projects.Project
 
-  def list_projects(filters = %{}) do
+  def list_projects(filters \\ %{}) do
     Operately.Projects.ListQuery.build(filters) |> Repo.all()
   end
 

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -8,25 +8,8 @@ defmodule Operately.Projects do
 
   alias Operately.Projects.Project
 
-  @doc """
-  Returns the list of projects.
-
-  ## Examples
-
-      iex> list_projects()
-      [%Project{}, ...]
-
-  """
   def list_projects(filters = %{}) do
-    query = Project
-
-    query = if filters.group_id do
-      query |> join(:inner, [p], g in assoc(p, :group), on: g.id == ^filters.group_id)
-    else
-      query |> join(:inner, [p], o in assoc(p, :objective), on: o.id == ^filters.objective_id)
-    end
-
-    Repo.all(query)
+    Operately.Projects.ListQuery.build(filters) |> Repo.all()
   end
 
   @doc """

--- a/lib/operately/projects/list_query.ex
+++ b/lib/operately/projects/list_query.ex
@@ -1,0 +1,37 @@
+defmodule Operately.Projects.ListQuery do
+  import Ecto.Query, warn: false
+
+  alias Operately.Projects.Project
+
+  def build(filters) do
+    query = from p in Project
+
+    query = apply_group_filter(query, filters.group_id)
+    query = apply_objective_filter(query, filters.objective_id)
+
+    query
+  end
+
+  #
+  # Filter by group if the filter is present
+  #
+  defp apply_group_filter(query, nil) do
+    query
+  end
+
+  defp apply_group_filter(query, group_id) do
+    from p in query, where: p.group_id == ^group_id
+  end
+
+  #
+  # Filter by objective if the filter is present
+  #
+  defp apply_objective_filter(query, nil) do
+    query
+  end
+
+  defp apply_objective_filter(query, objective_id) do
+    from p in query, where: p.objective_id == ^objective_id
+  end
+
+end

--- a/lib/operately/projects/list_query.ex
+++ b/lib/operately/projects/list_query.ex
@@ -6,8 +6,8 @@ defmodule Operately.Projects.ListQuery do
   def build(filters) do
     query = from p in Project
 
-    query = apply_group_filter(query, filters.group_id)
-    query = apply_objective_filter(query, filters.objective_id)
+    query = apply_group_filter(query, filters[:group_id])
+    query = apply_objective_filter(query, filters[:objective_id])
 
     query
   end

--- a/lib/operately/projects/list_query.ex
+++ b/lib/operately/projects/list_query.ex
@@ -2,6 +2,7 @@ defmodule Operately.Projects.ListQuery do
   import Ecto.Query, warn: false
 
   alias Operately.Projects.Project
+  alias Operately.Alignments.Alignment
 
   def build(filters) do
     query = from p in Project
@@ -31,7 +32,9 @@ defmodule Operately.Projects.ListQuery do
   end
 
   defp apply_objective_filter(query, objective_id) do
-    from p in query, where: p.objective_id == ^objective_id
+    from p in query,
+      join: a in Alignment, on: p.id == a.child and a.child_type == :project,
+      where: a.parent == ^objective_id and a.parent_type == :objective
   end
 
 end

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -5,6 +5,8 @@ defmodule Operately.Projects.Project do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "projects" do
+    belongs_to :group, Operately.Groups.Group, foreign_key: :group_id
+
     field :description, :string
     field :name, :string
 
@@ -17,7 +19,7 @@ defmodule Operately.Projects.Project do
   @doc false
   def changeset(project, attrs) do
     project
-    |> cast(attrs, [:name, :description])
+    |> cast(attrs, [:name, :description, :group_id])
     |> cast_assoc(:ownership)
     |> validate_required([:name, :description])
   end

--- a/lib/operately_web/graphql/queries/projects.ex
+++ b/lib/operately_web/graphql/queries/projects.ex
@@ -1,0 +1,29 @@
+defmodule OperatelyWeb.GraphQL.Queries.Projects do
+  use Absinthe.Schema.Notation
+
+  object :project_queries do
+    field :projects, list_of(:project) do
+      arg :group_id, :id
+      arg :objective_id, :id
+
+      resolve fn _, args, _ ->
+        projects = Operately.Projects.list_projects(%{
+          group_id: args[:group_id],
+          objective_id: args[:objective_id]
+        })
+
+        {:ok, projects}
+      end
+    end
+
+    field :project, :project do
+      arg :id, non_null(:id)
+
+      resolve fn args, _ ->
+        project = Operately.Projects.get_project!(args.id)
+
+        {:ok, project}
+      end
+    end
+  end
+end

--- a/lib/operately_web/graphql/types/person.ex
+++ b/lib/operately_web/graphql/types/person.ex
@@ -1,0 +1,10 @@
+defmodule OperatelyWeb.GraphQL.Types.Person do
+  use Absinthe.Schema.Notation
+
+  object :person do
+    field :id, non_null(:id)
+    field :full_name, non_null(:string)
+    field :title, :string
+    field :avatar_url, :string
+  end
+end

--- a/lib/operately_web/graphql/types/projects.ex
+++ b/lib/operately_web/graphql/types/projects.ex
@@ -1,0 +1,18 @@
+defmodule OperatelyWeb.GraphQL.Types.Projects do
+  use Absinthe.Schema.Notation
+
+  object :project do
+    field :id, non_null(:id)
+    field :name, non_null(:string)
+    field :description, :string
+    field :updated_at, non_null(:date)
+
+    field :owner, :person do
+      resolve fn objective, _, _ ->
+        person = Operately.Projects.get_owner!(objective)
+
+        {:ok, person}
+      end
+    end
+  end
+end

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -240,8 +240,14 @@ defmodule OperatelyWeb.Schema do
     end
 
     field :projects, list_of(:project) do
+      arg :group_id, :id
+      arg :objective_id, :id
+
       resolve fn _, _, _ ->
-        projects = Operately.Projects.list_projects()
+        projects = Operately.Projects.list_projects(${
+          group_id: args.group_id,
+          objective_id: args.objective_id
+        })
 
         {:ok, projects}
       end
@@ -293,17 +299,6 @@ defmodule OperatelyWeb.Schema do
         key_results = Operately.Okrs.list_key_results!(objective_id)
 
         {:ok, key_results}
-      end
-    end
-
-    field :aligned_projects, list_of(:project) do
-      arg :objective_id, non_null(:id)
-
-      resolve fn args, _ ->
-        objective_id = args.objective_id
-        projects = Operately.Okrs.list_aligned_projects!(objective_id)
-
-        {:ok, projects}
       end
     end
 

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -1,7 +1,17 @@
 defmodule OperatelyWeb.Schema do
   use Absinthe.Schema
 
+  alias OperatelyWeb.GraphQL.Types
+  alias OperatelyWeb.GraphQL.Queries
+
   import_types Absinthe.Type.Custom
+
+  # Types
+  import_types Types.Projects
+  import_types Types.Person
+
+  # Queries
+  import_types Queries.Projects
 
   object :update do
     field :id, non_null(:id)
@@ -66,27 +76,6 @@ defmodule OperatelyWeb.Schema do
     field :description, :string
   end
 
-  object :person do
-    field :id, non_null(:id)
-    field :full_name, non_null(:string)
-    field :title, :string
-    field :avatar_url, :string
-  end
-
-  object :project do
-    field :id, non_null(:id)
-    field :name, non_null(:string)
-    field :description, :string
-    field :updated_at, non_null(:date)
-
-    field :owner, :person do
-      resolve fn objective, _, _ ->
-        person = Operately.Projects.get_owner!(objective)
-
-        {:ok, person}
-      end
-    end
-  end
 
   object :group_contact do
     field :id, non_null(:id)
@@ -161,6 +150,8 @@ defmodule OperatelyWeb.Schema do
   end
 
   query do
+    import_fields :project_queries
+
     field :me, :person do
       resolve fn _, _, %{context: context} ->
         {:ok, context.current_account.person}
@@ -239,29 +230,6 @@ defmodule OperatelyWeb.Schema do
       end
     end
 
-    field :projects, list_of(:project) do
-      arg :group_id, :id
-      arg :objective_id, :id
-
-      resolve fn _, _, _ ->
-        projects = Operately.Projects.list_projects(${
-          group_id: args.group_id,
-          objective_id: args.objective_id
-        })
-
-        {:ok, projects}
-      end
-    end
-
-    field :project, :project do
-      arg :id, non_null(:id)
-
-      resolve fn args, _ ->
-        project = Operately.Projects.get_project!(args.id)
-
-        {:ok, project}
-      end
-    end
 
     field :search_people, list_of(:person) do
       arg :query, non_null(:string)

--- a/priv/repo/migrations/20230425114123_add_group_id_to_projects.exs
+++ b/priv/repo/migrations/20230425114123_add_group_id_to_projects.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddGroupIdToProjects do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :group_id, references(:groups, on_delete: :nothing, type: :binary_id)
+    end
+
+    create index(:projects, [:group_id])
+  end
+end

--- a/test/features/groups.feature
+++ b/test/features/groups.feature
@@ -33,3 +33,9 @@ Feature: Groups
     And I add a point of contact "Slack" with the value "#marketing-hq"
     Then the point of contact "#marketing-hq" is visible on the group "Marketing" page
 
+  Scenario: Listing projects in a group
+    Given I am logged in as a user
+    Given that a group with the name "Marketing" exists
+    Given that a project with the name "Marketing Website" exists in the group "Marketing"
+    When I visit the group "Marketing" page
+    Then I should see "Marketing Website" in the list of projects

--- a/test/features/groups_test.exs
+++ b/test/features/groups_test.exs
@@ -3,6 +3,7 @@ defmodule Operately.Features.GroupsTest do
 
   alias Operately.Groups
   alias Operately.PeopleFixtures
+  alias Operately.ProjectsFixtures
 
   import_steps(Operately.Features.SharedSteps.Login)
   import_steps(Operately.Features.SharedSteps.SimpleInteractions)
@@ -124,6 +125,20 @@ defmodule Operately.Features.GroupsTest do
   defthen ~r/^the point of contact "(?<name>[^"]+)" is visible on the group "(?<group>[^"]+)" page$/, %{name: name}, state do
     state.session
     |> assert_has(Query.text(name))
+  end
+
+  defgiven ~r/^that a project with the name "(?<name>[^"]+)" exists in the group "(?<group>[^"]+)"$/, %{name: name, group: group}, state do
+    group = Groups.get_group_by_name(group)
+
+    project = ProjectsFixtures.project_fixture(%{
+      name: name,
+      group_id: group.id
+    })
+  end
+
+  defthen ~r/^I should see "(?<project>[^"]+)" in the list of projects$/, %{project: project}, state do
+    state.session
+    |> assert_has(Query.text(project))
   end
 
 end


### PR DESCRIPTION
In this pull-request I'm adding support for listing projects on the group page.

A small scale refactoring was also executed during the implementation: 
- Project related queries were extracted from components and pages and moved to `graphql/Projects`
- Project queries and types in the Absinth server were extracted and moved to a dedicated file inside of the `operately_web/graphql/` directory.