### PR TITLE
See group profile from the company page

### DIFF
--- a/assets/js/graphql/Objectives/index.tsx
+++ b/assets/js/graphql/Objectives/index.tsx
@@ -8,6 +8,12 @@ const LIST_OBJECTIVES = gql`
       name
       description
 
+      group {
+        id
+        name
+        mission
+      }
+
       owner {
         id
         fullName

--- a/assets/js/pages/ObjectiveListPage/Group.tsx
+++ b/assets/js/pages/ObjectiveListPage/Group.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+
+import * as Popover from "../../components/Popover";
+import Icon from "../../components/Icon";
+
+function Profile({
+  group,
+  onSeeGroup,
+  onUnassign,
+  onChangeGroup,
+}): JSX.Element {
+  return (
+    <div>
+      <div className="w-56 mb-2 flex flex-col items-center">
+        <div className="w-full">
+          <div className="font-semibold">{group.name}</div>
+          <div className="text-sm text-dark-2">{group.mission}</div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        <Popover.Button children="Go to Group" onClick={onSeeGroup} />
+        <Popover.Button
+          children="Unassign"
+          data-test-id="unassignChampion"
+          onClick={onUnassign}
+        />
+        <Popover.Button children="Change Group" onClick={onChangeGroup} />
+      </div>
+    </div>
+  );
+}
+
+function Group({ group, dataTestID }): JSX.Element {
+  const onSeeGroup = () => {
+    console.log("see group");
+  };
+
+  const onUnassign = () => {
+    console.log("unassign");
+  };
+
+  const onChangeGroup = () => {
+    console.log("change group");
+  };
+
+  let content: JSX.Element = <div>not assigned</div>;
+
+  if (group) {
+    content = (
+      <Profile
+        group={group}
+        onSeeGroup={onSeeGroup}
+        onChangeGroup={onChangeGroup}
+        onUnassign={onUnassign}
+      />
+    );
+  }
+
+  return (
+    <Popover.Root modal={true}>
+      <Popover.Trigger className="outline-0" data-test-id={dataTestID}>
+        <div className="pr-2 flex flex-row-reverse">
+          <div className="text-dark-2 rounded px-1 py-0.5 gap-0.5 flex items-center">
+            <div className="scale-75">
+              <Icon name="groups" size="small" color="dark-2" />
+            </div>
+            {group ? group.name : "not assigned"}
+          </div>
+        </div>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          data-test-id="championSelect"
+          align="start"
+          side="left"
+          sideOffset={10}
+          className="w-60 bg-white p-2 gap-1 card-shadow border border-dark-8% rounded transition"
+          children={content}
+        />
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+export function TargetGroup({ target }): JSX.Element {
+  return <Group group={target.group} dataTestID="targetGroup" />;
+}
+
+export function GoalGroup({ goal }): JSX.Element {
+  return <Group group={goal.group} dataTestID="goalGroup" />;
+}

--- a/assets/js/pages/ObjectiveListPage/index.tsx
+++ b/assets/js/pages/ObjectiveListPage/index.tsx
@@ -13,6 +13,7 @@ import {
 import { Link } from "react-router-dom";
 import Icon from "../../components/Icon";
 import { GoalOwner, TargetOwner } from "./Champion";
+import { GoalGroup, TargetGroup } from "./Group";
 
 export async function ObjectiveListPageLoader(apolloClient: any) {
   await listObjectives(apolloClient, {});
@@ -178,7 +179,7 @@ function KeyResultRow({ kr }) {
       </div>
 
       <div className="flex items-center">
-        <Group name={kr.group} />
+        <TargetGroup target={kr} />
 
         <div className="border-r border-dark-8% pr-2 w-24 flex mr-4">
           <KeyResultStatus keyResult={kr} />
@@ -222,19 +223,6 @@ function KeyResultList({ objective, editing, startEditing }) {
   );
 }
 
-function Group({ name }) {
-  return (
-    <div className="border-r border-dark-8% pr-2 w-48 flex flex-row-reverse">
-      <div className="text-dark-2 rounded px-1 py-0.5 gap-0.5 flex items-center">
-        <div className="scale-75">
-          <Icon name="groups" size="small" color="dark-2" />
-        </div>
-        not assigned
-      </div>
-    </div>
-  );
-}
-
 function ObjectiveCard({ objective, editing, startEditing }) {
   return (
     <div
@@ -251,7 +239,7 @@ function ObjectiveCard({ objective, editing, startEditing }) {
         </Link>
 
         <div className="flex items-center">
-          <Group name="marketing" />
+          <GoalGroup goal={objective} />
 
           <KeyResultStatus keyResult={{ status: "pending" }} />
 

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -63,6 +63,8 @@ defmodule Operately.Groups do
       ** (Ecto.NoResultsError)
 
   """
+  def get_group(nil), do: nil
+  def get_group(id), do: Repo.get(Group, id)
   def get_group!(id), do: Repo.get!(Group, id)
 
   def get_group_by_name(name) do

--- a/lib/operately_web/graphql/types/groups.ex
+++ b/lib/operately_web/graphql/types/groups.ex
@@ -1,0 +1,25 @@
+defmodule OperatelyWeb.GraphQL.Types.Groups do
+  use Absinthe.Schema.Notation
+
+  object :group do
+    field :id, non_null(:id)
+    field :name, non_null(:string)
+    field :mission, :string
+
+    field :members, list_of(non_null(:person)) do
+      resolve fn group, _, _ ->
+        people = Operately.Groups.list_members(group)
+
+        {:ok, people}
+      end
+    end
+
+    field :points_of_contact, list_of(non_null(:group_contact)) do
+      resolve fn group, _, _ ->
+        contacts = Operately.Groups.list_contacts(group)
+
+        {:ok, contacts}
+      end
+    end
+  end
+end

--- a/lib/operately_web/graphql/types/objectives.ex
+++ b/lib/operately_web/graphql/types/objectives.ex
@@ -21,6 +21,14 @@ defmodule OperatelyWeb.GraphQL.Types.Objectives do
         {:ok, key_results}
       end
     end
+
+    field :group, :group do
+      resolve fn objective, _, _ ->
+        group = Operately.Groups.get_group(objective.group_id)
+
+        {:ok, group}
+      end
+    end
   end
 
   input_object :create_objective_input do

--- a/lib/operately_web/schema.ex
+++ b/lib/operately_web/schema.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Schema do
   import_types Types.Objectives
   import_types Types.Person
   import_types Types.KeyResults
+  import_types Types.Groups
 
   # Queries
   import_types Queries.Projects
@@ -77,28 +78,6 @@ defmodule OperatelyWeb.Schema do
     field :name, non_null(:string)
     field :type, non_null(:string)
     field :value, non_null(:string)
-  end
-
-  object :group do
-    field :id, non_null(:id)
-    field :name, non_null(:string)
-    field :mission, :string
-
-    field :members, list_of(non_null(:person)) do
-      resolve fn group, _, _ ->
-        people = Operately.Groups.list_members(group)
-
-        {:ok, people}
-      end
-    end
-
-    field :points_of_contact, list_of(non_null(:group_contact)) do
-      resolve fn group, _, _ ->
-        contacts = Operately.Groups.list_contacts(group)
-
-        {:ok, contacts}
-      end
-    end
   end
 
   input_object :create_kpi_input do

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -76,6 +76,16 @@ defmodule MyApp.Features.CompanyPageTest do
     assert_goal_champion(state, "Unassigned")
   end
 
+  feature "see group details", state do
+    group = create_group("Customer Success")
+    create_goal("Increase retention rate", group: group)
+
+    state
+    |> visit_page()
+    |> click_on_the_goal_group()
+    |> UI.assert_text("Customer Success")
+  end
+
   # ===========================================================================
 
   defp create_goal(name) do
@@ -86,18 +96,26 @@ defmodule MyApp.Features.CompanyPageTest do
     Operately.OkrsFixtures.objective_fixture(%{name: name, owner_id: champion.id})
   end
 
+  defp create_goal(name, group: group) do
+    Operately.OkrsFixtures.objective_fixture(%{name: name, group_id: group.id})
+  end
+
+  defp create_target(name, objective_id) do
+    Operately.OkrsFixtures.key_result_fixture(%{name: name, objective_id: objective_id})
+  end
+
   defp create_goal_with_targets(name, targets) do
     goal = create_goal(name)
-
-    Enum.each(targets, fn target ->
-      Operately.OkrsFixtures.key_result_fixture(%{name: target, objective_id: goal.id})
-    end)
-
+    Enum.each(targets, fn t -> create_target(t, goal.id) end)
     goal
   end
 
   defp create_person(name) do
     Operately.PeopleFixtures.person_fixture(%{full_name: name})
+  end
+
+  defp create_group(name) do
+    Operately.GroupsFixtures.group_fixture(%{name: name})
   end
 
   defp visit_page(state) do
@@ -126,6 +144,10 @@ defmodule MyApp.Features.CompanyPageTest do
 
   defp click_on_the_target_champion(state) do
     state |> UI.click(testid: "targetChampion")
+  end
+
+  defp click_on_the_goal_group(state) do
+    state |> UI.click(testid: "goalGroup")
   end
 
   defp choose_champion(state, name) do


### PR DESCRIPTION
When the user is on the company page and clicks on the group, the group profile is displayed in a popup, consisting of the group's name and mission statement.

Closes https://github.com/operately/operately/issues/47.