### PR TITLE
Go to the Group Page from the company page

### DIFF
--- a/assets/js/pages/ObjectiveListPage/Group.tsx
+++ b/assets/js/pages/ObjectiveListPage/Group.tsx
@@ -1,14 +1,13 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 import * as Popover from "../../components/Popover";
 import Icon from "../../components/Icon";
 
-function Profile({
-  group,
-  onSeeGroup,
-  onUnassign,
-  onChangeGroup,
-}): JSX.Element {
+function Profile({ group, onUnassign, onChangeGroup }): JSX.Element {
+  const navigate = useNavigate();
+  const handleGoToGroup = () => navigate(`/groups/${group.id}`);
+
   return (
     <div>
       <div className="w-56 mb-2 flex flex-col items-center">
@@ -19,23 +18,27 @@ function Profile({
       </div>
 
       <div className="flex flex-col gap-1">
-        <Popover.Button children="Go to Group" onClick={onSeeGroup} />
+        <Popover.Button
+          data-test-id="goToGroup"
+          children="Go to Group"
+          onClick={handleGoToGroup}
+        />
         <Popover.Button
           children="Unassign"
-          data-test-id="unassignChampion"
+          data-test-id="unassignGroup"
           onClick={onUnassign}
         />
-        <Popover.Button children="Change Group" onClick={onChangeGroup} />
+        <Popover.Button
+          data-test-id="changeGroup"
+          children="Change Group"
+          onClick={onChangeGroup}
+        />
       </div>
     </div>
   );
 }
 
 function Group({ group, dataTestID }): JSX.Element {
-  const onSeeGroup = () => {
-    console.log("see group");
-  };
-
   const onUnassign = () => {
     console.log("unassign");
   };
@@ -50,7 +53,6 @@ function Group({ group, dataTestID }): JSX.Element {
     content = (
       <Profile
         group={group}
-        onSeeGroup={onSeeGroup}
         onChangeGroup={onChangeGroup}
         onUnassign={onUnassign}
       />

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -84,6 +84,8 @@ defmodule MyApp.Features.CompanyPageTest do
     |> visit_page()
     |> click_on_the_goal_group()
     |> UI.assert_text("Customer Success")
+    |> click_on_go_to_group()
+    |> UI.assert_page("/groups/#{group.id}")
   end
 
   # ===========================================================================
@@ -148,6 +150,10 @@ defmodule MyApp.Features.CompanyPageTest do
 
   defp click_on_the_goal_group(state) do
     state |> UI.click(testid: "goalGroup")
+  end
+
+  defp click_on_go_to_group(state) do
+    state |> UI.click(testid: "goToGroup")
   end
 
   defp choose_champion(state, name) do

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -117,7 +117,13 @@ defmodule Operately.FeatureCase do
     end
 
     def assert_page(state, path) do
-      session(state) |> Browser.assert_path(path)
+      require ExUnit.Assertions
+
+      wait_for_page_to_load(state, path)
+
+      ExUnit.Assertions.assert Browser.current_path(session(state)) == path
+
+      state
     end
 
     def visit(state, path) do

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -116,6 +116,10 @@ defmodule Operately.FeatureCase do
       end)
     end
 
+    def assert_page(state, path) do
+      session(state) |> Browser.assert_path(path)
+    end
+
     def visit(state, path) do
       session(state) |> Browser.visit(path)
     end


### PR DESCRIPTION
When a user clicks on a group on the company page, a mini group profile appears. In that mini profile, there is a "Go to Group" button that leads to the group page. This PR implements this functionality.

Closes https://github.com/operately/operately/issues/49.