### PR TITLE
Unassign group from a Goal

### DIFF
--- a/assets/js/graphql/Objectives/index.tsx
+++ b/assets/js/graphql/Objectives/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { gql, useQuery, ApolloClient } from "@apollo/client";
+import { gql, useQuery, ApolloClient, useApolloClient } from "@apollo/client";
 
 const LIST_OBJECTIVES = gql`
   query ListObjectives($groupId: ID) {
@@ -166,4 +166,40 @@ export function setTargetOwner(
     variables,
     refetchQueries: [{ query: LIST_OBJECTIVES }, "ListObjectives"],
   });
+}
+
+export function useSetGoalGroup(goalId: string) {
+  const client = useApolloClient();
+
+  return function (groupId: string) {
+    return client.mutate({
+      mutation: gql`
+        mutation SetGoalGroup($id: ID!, $group_id: ID) {
+          setGoalGroup(id: $id, group_id: $group_id) {
+            id
+          }
+        }
+      `,
+      variables: { id: goalId, group_id: groupId },
+      refetchQueries: [{ query: LIST_OBJECTIVES }, "ListObjectives"],
+    });
+  };
+}
+
+export function useSetTargetGroup(targetId: string) {
+  const client = useApolloClient();
+
+  return function (groupId: string) {
+    return client.mutate({
+      mutation: gql`
+        mutation SetTargetGroup($id: ID!, $group_id: ID) {
+          setTargetGroup(id: $id, group_id: $group_id) {
+            id
+          }
+        }
+      `,
+      variables: { id: targetId, group_id: groupId },
+      refetchQueries: [{ query: LIST_OBJECTIVES }, "ListObjectives"],
+    });
+  };
 }

--- a/assets/js/pages/ObjectiveListPage/Group.tsx
+++ b/assets/js/pages/ObjectiveListPage/Group.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from "react-router-dom";
 import * as Popover from "../../components/Popover";
 import Icon from "../../components/Icon";
 
+import { useSetGoalGroup, useSetTargetGroup } from "../../graphql/Objectives";
+
 function Profile({ group, onUnassign, onChangeGroup }): JSX.Element {
   const navigate = useNavigate();
   const handleGoToGroup = () => navigate(`/groups/${group.id}`);
@@ -38,9 +40,9 @@ function Profile({ group, onUnassign, onChangeGroup }): JSX.Element {
   );
 }
 
-function Group({ group, dataTestID }): JSX.Element {
-  const onUnassign = () => {
-    console.log("unassign");
+function Group({ group, dataTestID, setGroup }): JSX.Element {
+  const onUnassign = async () => {
+    await setGroup(null);
   };
 
   const onChangeGroup = () => {
@@ -59,11 +61,16 @@ function Group({ group, dataTestID }): JSX.Element {
     );
   }
 
+  const title = group ? group.name : "Unassigned";
+
   return (
     <Popover.Root modal={true}>
       <Popover.Trigger className="outline-0" data-test-id={dataTestID}>
         <div className="pr-2 flex flex-row-reverse">
-          <div className="text-dark-2 rounded px-1 py-0.5 gap-0.5 flex items-center">
+          <div
+            className="text-dark-2 rounded px-1 py-0.5 gap-0.5 flex items-center"
+            title={title}
+          >
             <div className="scale-75">
               <Icon name="groups" size="small" color="dark-2" />
             </div>
@@ -87,9 +94,21 @@ function Group({ group, dataTestID }): JSX.Element {
 }
 
 export function TargetGroup({ target }): JSX.Element {
-  return <Group group={target.group} dataTestID="targetGroup" />;
+  const setTargetGroup = useSetTargetGroup(target.id);
+
+  return (
+    <Group
+      group={target.group}
+      dataTestID="targetGroup"
+      setGroup={setTargetGroup}
+    />
+  );
 }
 
 export function GoalGroup({ goal }): JSX.Element {
-  return <Group group={goal.group} dataTestID="goalGroup" />;
+  const setGoalGroup = useSetGoalGroup(goal.id);
+
+  return (
+    <Group group={goal.group} dataTestID="goalGroup" setGroup={setGoalGroup} />
+  );
 }

--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -141,6 +141,14 @@ defmodule Operately.Okrs do
     |> Repo.update()
   end
 
+  def set_goal_group(id, group_id \\ nil) do
+    objective = get_objective!(id)
+
+    objective
+    |> Objective.changeset(%{group_id: group_id})
+    |> Repo.update()
+  end
+
   @doc """
   Deletes a objective.
 

--- a/lib/operately_web/graphql/mutations/objectives.ex
+++ b/lib/operately_web/graphql/mutations/objectives.ex
@@ -18,5 +18,14 @@ defmodule OperatelyWeb.GraphQL.Mutations.Objectives do
         Operately.Okrs.set_objective_owner(args.id, args.owner_id)
       end
     end
+
+    field :set_goal_group, :objective do
+      arg :id, non_null(:id)
+      arg :group_id, :id
+
+      resolve fn args, _ ->
+        Operately.Okrs.set_goal_group(args.id, args.group_id)
+      end
+    end
   end
 end

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -71,7 +71,7 @@ defmodule MyApp.Features.CompanyPageTest do
     state
     |> visit_page()
     |> click_on_the_goal_champion()
-    |> click_unassign()
+    |> click_unassign_champion()
 
     assert_goal_champion(state, "Unassigned")
   end
@@ -86,6 +86,18 @@ defmodule MyApp.Features.CompanyPageTest do
     |> UI.assert_text("Customer Success")
     |> click_on_go_to_group()
     |> UI.assert_page("/groups/#{group.id}")
+  end
+
+  feature "unassigning groups", state do
+    group = create_group("Customer Success")
+    create_goal("Increase retention rate", group: group)
+
+    state
+    |> visit_page()
+    |> click_on_the_goal_group()
+    |> click_unassign_group()
+
+    assert_goal_group(state, "Unassigned")
   end
 
   # ===========================================================================
@@ -164,6 +176,10 @@ defmodule MyApp.Features.CompanyPageTest do
     UI.assert_has(state, title: name, in: UI.find(state, testid: "goalChampion"))
   end
 
+  defp assert_goal_group(state, name) do
+    UI.assert_has(state, title: name, in: UI.find(state, testid: "goalGroup"))
+  end
+
   defp assert_target_champion(state, name) do
     UI.assert_has(state, title: name, in: UI.find(state, testid: "targetChampion"))
   end
@@ -182,7 +198,11 @@ defmodule MyApp.Features.CompanyPageTest do
     state |> UI.click(testid: "createAndAssign")
   end
 
-  defp click_unassign(state) do
+  defp click_unassign_champion(state) do
     state |> UI.click(testid: "unassignChampion")
+  end
+
+  defp click_unassign_group(state) do
+    state |> UI.click(testid: "unassignGroup")
   end
 end


### PR DESCRIPTION
A user can visit the company page, click on a group associated with a goal, and unassign that group. This PR implements this functionality.

Closes https://github.com/operately/operately/issues/50.