### PR TITLE
Goto user profile from company page

### DIFF
--- a/assets/js/pages/ObjectiveListPage/Champion.tsx
+++ b/assets/js/pages/ObjectiveListPage/Champion.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Avatar, { AvatarSize } from "../../components/Avatar";
 import Icon from "../../components/Icon";
 
+import { useNavigate } from "react-router-dom";
 import { useApolloClient } from "@apollo/client";
 import { setObjectiveOwner, setTargetOwner } from "../../graphql/Objectives";
 import { createProfile, useDebouncedPeopleSearch } from "../../graphql/People";
@@ -11,12 +12,10 @@ import * as Popover from "../../components/Popover";
 
 type Screen = "default" | "setChampion" | "createProfile";
 
-function Profile({
-  person,
-  onSeeProfile,
-  onUnassign,
-  onChangeChampion,
-}): JSX.Element {
+function Profile({ person, onUnassign, onChangeChampion }): JSX.Element {
+  const navigate = useNavigate();
+  const handleSeeProfile = () => navigate(`/people/${person.id}`);
+
   return (
     <div>
       <div className="w-56 p-2 flex flex-col items-center">
@@ -32,7 +31,11 @@ function Profile({
       </div>
 
       <div className="flex flex-col gap-1">
-        <Popover.Button children="See profile" onClick={onSeeProfile} />
+        <Popover.Button
+          data-test-id="viewChampionsProfile"
+          children="See profile"
+          onClick={handleSeeProfile}
+        />
         <Popover.Button
           children="Unassign"
           data-test-id="unassignChampion"
@@ -162,7 +165,6 @@ function Owner({ person, dataTestID, setChampion }): JSX.Element {
     setOpen(false);
   };
 
-  let handleSeeProfile = () => console.log("see profile");
   let handleChangeChampion = () => setScreen("setChampion");
 
   let content: JSX.Element | null = null;
@@ -173,7 +175,6 @@ function Owner({ person, dataTestID, setChampion }): JSX.Element {
         content = (
           <Profile
             person={person}
-            onSeeProfile={handleSeeProfile}
             onUnassign={handleUnassign}
             onChangeChampion={handleChangeChampion}
           />

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -24,6 +24,19 @@ defmodule Operately.Features.CompanyPageTest do
     |> UI.assert_text(target1)
   end
 
+  feature "viewing details about a goal's champion", state do
+    person = create_person("John Doe", "Head of Customer Success")
+    create_goal("Increase retention rate", champion: person)
+
+    state
+    |> visit_page()
+    |> click_on_the_goal_champion()
+    |> UI.assert_text("John Doe")
+    |> UI.assert_text("Head of Customer Success")
+    |> click_on_view_profile()
+    |> UI.assert_page("/people/#{person.id}")
+  end
+
   feature "assigning goal champions", state do
     create_person("John Doe")
     create_goal("Increase retention rate")
@@ -124,8 +137,8 @@ defmodule Operately.Features.CompanyPageTest do
     goal
   end
 
-  defp create_person(name) do
-    Operately.PeopleFixtures.person_fixture(%{full_name: name})
+  defp create_person(name, title \\ nil) do
+    Operately.PeopleFixtures.person_fixture(%{full_name: name, title: title})
   end
 
   defp create_group(name) do
@@ -186,6 +199,10 @@ defmodule Operately.Features.CompanyPageTest do
 
   defp click_create_new_profile(state) do
     state |> UI.click(testid: "createNewProfile")
+  end
+
+  defp click_on_view_profile(state) do
+    state |> UI.click(testid: "viewChampionsProfile")
   end
 
   defp fill_person_form(state, name, title) do


### PR DESCRIPTION
When a user click on the Goal's champion on the company page, their details are shown in a dropdown. Below that, a button that says "See Profile" can be clicked that leads to the Champion's profile to see further details. This PR implements this functionality.

Closes https://github.com/operately/operately/issues/55.