### PR TITLE
See target groups on company page

### DIFF
--- a/assets/js/graphql/Objectives/index.tsx
+++ b/assets/js/graphql/Objectives/index.tsx
@@ -35,6 +35,12 @@ const LIST_OBJECTIVES = gql`
           avatarUrl
           title
         }
+
+        group {
+          id
+          name
+          mission
+        }
       }
     }
   }

--- a/assets/js/graphql/Objectives/index.tsx
+++ b/assets/js/graphql/Objectives/index.tsx
@@ -29,17 +29,17 @@ const LIST_OBJECTIVES = gql`
         stepsTotal
         updatedAt
 
+        group {
+          id
+          name
+          mission
+        }
+
         owner {
           id
           fullName
           avatarUrl
           title
-        }
-
-        group {
-          id
-          name
-          mission
         }
       }
     }

--- a/lib/operately/okrs/key_result.ex
+++ b/lib/operately/okrs/key_result.ex
@@ -6,7 +6,8 @@ defmodule Operately.Okrs.KeyResult do
   @foreign_key_type :binary_id
   schema "key_results" do
     belongs_to :objective, Operately.Okrs.Objective
-    belongs_to :owner, Operately.Accounts.User, foreign_key: :owner_id
+    belongs_to :owner, Operately.People.Person, foreign_key: :owner_id
+    belongs_to :group, Operately.Groups.Group, foreign_key: :group_id
 
     field :name, :string
     field :status, Ecto.Enum, values: [:pending, :on_track, :at_risk, :off_track, :completed, :cancelled], default: :pending
@@ -24,7 +25,18 @@ defmodule Operately.Okrs.KeyResult do
   @doc false
   def changeset(key_result, attrs) do
     key_result
-    |> cast(attrs, [:name, :unit, :target, :direction, :objective_id, :status, :steps_completed, :steps_total, :owner_id])
+    |> cast(attrs, [
+      :name, 
+      :unit, 
+      :target, 
+      :direction, 
+      :objective_id, 
+      :status, 
+      :steps_completed, 
+      :steps_total, 
+      :owner_id, 
+      :group_id
+    ])
     |> validate_required([:name, :objective_id])
   end
 end

--- a/lib/operately_web/graphql/types/key_results.ex
+++ b/lib/operately_web/graphql/types/key_results.ex
@@ -18,6 +18,16 @@ defmodule OperatelyWeb.GraphQL.Types.KeyResults do
         end
       end
     end
+
+    field :group, :group do
+      resolve fn key_result, _, _ ->
+        if key_result.group_id == nil do
+          {:ok, nil}
+        else
+          {:ok, Operately.Groups.get_group!(key_result.group_id)}
+        end
+      end
+    end
   end
 
   input_object :create_key_result_input do

--- a/priv/repo/migrations/20230503165843_add_group_id_to_key_results.exs
+++ b/priv/repo/migrations/20230503165843_add_group_id_to_key_results.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddGroupIdToKeyResults do
+  use Ecto.Migration
+
+  def change do
+    alter table(:key_results) do
+      add :group_id, references(:groups, type: :binary_id)
+    end
+
+    create index(:key_results, [:group_id])
+  end
+end

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -104,7 +104,7 @@ defmodule Operately.Features.CompanyPageTest do
   feature "see target group details", state do
     group = create_group("Marketing")
     goal = create_goal("Increase retention rate")
-    target = create_target("Increase retention rate", goal.id, group: group)
+    create_target("Increase retention rate", goal.id, group: group)
 
     state
     |> visit_page()
@@ -192,6 +192,10 @@ defmodule Operately.Features.CompanyPageTest do
 
   defp click_on_the_goal_group(state) do
     state |> UI.click(testid: "goalGroup")
+  end
+
+  defp click_on_the_target_group(state) do
+    state |> UI.click(testid: "targetGroup")
   end
 
   defp click_on_go_to_group(state) do

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -89,7 +89,7 @@ defmodule Operately.Features.CompanyPageTest do
     assert_goal_champion(state, "Unassigned")
   end
 
-  feature "see group details", state do
+  feature "see goal group details", state do
     group = create_group("Customer Success")
     create_goal("Increase retention rate", group: group)
 
@@ -97,6 +97,19 @@ defmodule Operately.Features.CompanyPageTest do
     |> visit_page()
     |> click_on_the_goal_group()
     |> UI.assert_text("Customer Success")
+    |> click_on_go_to_group()
+    |> UI.assert_page("/groups/#{group.id}")
+  end
+
+  feature "see target group details", state do
+    group = create_group("Marketing")
+    goal = create_goal("Increase retention rate")
+    target = create_target("Increase retention rate", goal.id, group: group)
+
+    state
+    |> visit_page()
+    |> click_on_the_target_group()
+    |> UI.assert_text("Marketing")
     |> click_on_go_to_group()
     |> UI.assert_page("/groups/#{group.id}")
   end
@@ -129,6 +142,10 @@ defmodule Operately.Features.CompanyPageTest do
 
   defp create_target(name, objective_id) do
     Operately.OkrsFixtures.key_result_fixture(%{name: name, objective_id: objective_id})
+  end
+
+  defp create_target(name, objective_id, group: group) do
+    Operately.OkrsFixtures.key_result_fixture(%{name: name, objective_id: objective_id, group_id: group.id})
   end
 
   defp create_goal_with_targets(name, targets) do


### PR DESCRIPTION
When a user visits the company page, click on a group that is associated with a target, a popup appears giving further details about the group. On this popup there is a go to group button. This pull-request implements this button.

Closes https://github.com/operately/operately/issues/56.
Closes https://github.com/operately/operately/issues/57.