### PR TITLE
Remove group from a Target

### DIFF
--- a/lib/operately/okrs.ex
+++ b/lib/operately/okrs.ex
@@ -149,6 +149,14 @@ defmodule Operately.Okrs do
     |> Repo.update()
   end
 
+  def set_key_result_group(id, group_id \\ nil) do
+    key_result = get_key_result!(id)
+
+    key_result
+    |> KeyResult.changeset(%{group_id: group_id})
+    |> Repo.update()
+  end
+
   @doc """
   Deletes a objective.
 

--- a/lib/operately_web/graphql/mutations/key_results.ex
+++ b/lib/operately_web/graphql/mutations/key_results.ex
@@ -18,6 +18,15 @@ defmodule OperatelyWeb.GraphQL.Mutations.KeyResults do
         Operately.Okrs.set_key_result_owner(args.id, args.owner_id)
       end
     end
+
+    field :set_target_group, :key_result do
+      arg :id, non_null(:id)
+      arg :group_id, :id
+
+      resolve fn args, _ ->
+        Operately.Okrs.set_key_result_group(args.id, args.group_id)
+      end
+    end
   end
 
 end

--- a/test/features/company_page_test.exs
+++ b/test/features/company_page_test.exs
@@ -114,7 +114,7 @@ defmodule Operately.Features.CompanyPageTest do
     |> UI.assert_page("/groups/#{group.id}")
   end
 
-  feature "unassigning groups", state do
+  feature "unassigning goal group", state do
     group = create_group("Customer Success")
     create_goal("Increase retention rate", group: group)
 
@@ -124,6 +124,19 @@ defmodule Operately.Features.CompanyPageTest do
     |> click_unassign_group()
 
     assert_goal_group(state, "Unassigned")
+  end
+
+  feature "unassigning target group", state do
+    group = create_group("Customer Success")
+    goal = create_goal("Increase retention rate")
+    create_target("Increase retention rate", goal.id, group: group)
+
+    state
+    |> visit_page()
+    |> click_on_the_target_group()
+    |> click_unassign_group()
+
+    assert_target_group(state, "Unassigned")
   end
 
   # ===========================================================================
@@ -212,6 +225,10 @@ defmodule Operately.Features.CompanyPageTest do
 
   defp assert_goal_group(state, name) do
     UI.assert_has(state, title: name, in: UI.find(state, testid: "goalGroup"))
+  end
+
+  defp assert_target_group(state, name) do
+    UI.assert_has(state, title: name, in: UI.find(state, testid: "targetGroup"))
   end
 
   defp assert_target_champion(state, name) do


### PR DESCRIPTION
In this pull-request, I'm adding support for removing a group assignment from the a target on the company page. The flow is that a user opens the company page, clicks on the currently assigned group for a target, and chooses unassign from the dropdown menu.

Closes https://github.com/operately/operately/issues/60.