### PR TITLE
Send out notifications for project timeline edits

### DIFF
--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -50,7 +50,7 @@ export type Activity = {
   updatedAt: Scalars['NaiveDateTime']['output'];
 };
 
-export type ActivityContent = ActivityContentProjectArchived | ActivityContentProjectCreated | ActivityContentProjectDiscussionCommentSubmitted | ActivityContentProjectDiscussionSubmitted | ActivityContentProjectRenamed | ActivityContentProjectReviewAcknowledged | ActivityContentProjectReviewCommented | ActivityContentProjectReviewRequestSubmitted | ActivityContentProjectReviewSubmitted | ActivityContentProjectStatusUpdateAcknowledged | ActivityContentProjectStatusUpdateCommented | ActivityContentProjectStatusUpdateSubmitted;
+export type ActivityContent = ActivityContentProjectArchived | ActivityContentProjectCreated | ActivityContentProjectDiscussionCommentSubmitted | ActivityContentProjectDiscussionSubmitted | ActivityContentProjectRenamed | ActivityContentProjectReviewAcknowledged | ActivityContentProjectReviewCommented | ActivityContentProjectReviewRequestSubmitted | ActivityContentProjectReviewSubmitted | ActivityContentProjectStatusUpdateAcknowledged | ActivityContentProjectStatusUpdateCommented | ActivityContentProjectStatusUpdateSubmitted | ActivityContentProjectTimelineEdited;
 
 export type ActivityContentProjectArchived = {
   __typename?: 'ActivityContentProjectArchived';
@@ -134,6 +134,11 @@ export type ActivityContentProjectStatusUpdateSubmitted = {
   project: Project;
   projectId: Scalars['String']['output'];
   statusUpdateId: Scalars['String']['output'];
+};
+
+export type ActivityContentProjectTimelineEdited = {
+  __typename?: 'ActivityContentProjectTimelineEdited';
+  project: Project;
 };
 
 export type ActivityDataUnion = ActivityEventDataCommentPost | ActivityEventDataMilestoneCreate | ActivityEventDataProjectCreate;

--- a/assets/js/pages/NotificationsPage/NotificationItem/ProjectTimelineEdited.tsx
+++ b/assets/js/pages/NotificationsPage/NotificationItem/ProjectTimelineEdited.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { Card } from "../NotificationCard";
+
+import * as People from "@/models/people";
+
+export default function ProjectStatusUpdateSubmitted({ notification }) {
+  const author = notification.activity.author;
+  const projectName = notification.activity.content.project.name;
+  const link = `/projects/${notification.activity.content.projectId}`;
+
+  return (
+    <Card
+      notification={notification}
+      title={People.firstName(author) + " changed the project timeline"}
+      author={author}
+      link={link}
+      where={projectName}
+      who={notification.activity.author.fullName}
+      when={notification.activity.insertedAt}
+    />
+  );
+}

--- a/assets/js/pages/NotificationsPage/NotificationItem/ProjectTimelineEdited.tsx
+++ b/assets/js/pages/NotificationsPage/NotificationItem/ProjectTimelineEdited.tsx
@@ -7,7 +7,7 @@ import * as People from "@/models/people";
 export default function ProjectStatusUpdateSubmitted({ notification }) {
   const author = notification.activity.author;
   const projectName = notification.activity.content.project.name;
-  const link = `/projects/${notification.activity.content.projectId}`;
+  const link = `/projects/${notification.activity.content.project.id}`;
 
   return (
     <Card

--- a/assets/js/pages/NotificationsPage/NotificationItem/index.tsx
+++ b/assets/js/pages/NotificationsPage/NotificationItem/index.tsx
@@ -17,6 +17,7 @@ import ProjectReviewSubmitted from "./ProjectReviewSubmitted"
 import ProjectStatusUpdateAcknowledged from "./ProjectStatusUpdateAcknowledged"
 import ProjectStatusUpdateCommented from "./ProjectStatusUpdateCommented"
 import ProjectStatusUpdateSubmitted from "./ProjectStatusUpdateSubmitted"
+import ProjectTimelineEdited from "./ProjectTimelineEdited"
 
 export default function NotificationItem({notification}) {
   const activityType = notification.activity.content.__typename;
@@ -57,6 +58,9 @@ export default function NotificationItem({notification}) {
     
     case "ActivityContentProjectStatusUpdateSubmitted":
       return <ProjectStatusUpdateSubmitted notification={notification} />;
+    
+    case "ActivityContentProjectTimelineEdited":
+      return <ProjectTimelineEdited notification={notification} />;
     
     default:
       throw "unhandled activity type " + activityType + " in assets/js/pages/NotificationsPage/NotificationItem/index.tsx";

--- a/assets/js/pages/NotificationsPage/loader.tsx
+++ b/assets/js/pages/NotificationsPage/loader.tsx
@@ -20,6 +20,12 @@ const query = gql`
         content {
           __typename
 
+          ... on ActivityContentProjectTimelineEdited {
+            project {
+              name
+            }
+          }
+
           ... on ActivityContentProjectDiscussionSubmitted {
             title
             discussionId

--- a/assets/js/pages/NotificationsPage/loader.tsx
+++ b/assets/js/pages/NotificationsPage/loader.tsx
@@ -22,6 +22,7 @@ const query = gql`
 
           ... on ActivityContentProjectTimelineEdited {
             project {
+              id
               name
             }
           }

--- a/assets/js/pages/ProjectEditTimelinePage/index.tsx
+++ b/assets/js/pages/ProjectEditTimelinePage/index.tsx
@@ -71,9 +71,7 @@ export function Page() {
   const milestoneUpdates = React.useMemo(
     () =>
       milestones
-        .filter((m) => {
-          project.milestones.find((pm) => pm.id === m.id);
-        })
+        .filter((m) => project.milestones.find((pm) => pm.id === m.id))
         .map((m) => ({
           id: m.id,
           title: m.title,
@@ -127,7 +125,7 @@ export function Page() {
         <Phases dates={dates} setDates={setDates} />
 
         <h1 className="font-extrabold text-white-1 text-xl mt-8 mb-4">Milestones</h1>
-        <Millstones
+        <MilestoneList
           milestones={pendingMilestones}
           setMilestones={setMilestones}
           projectStart={dates.projectStart}
@@ -275,7 +273,7 @@ function DateSelector({ date, onChange, minDate, maxDate, placeholder = "Not set
   );
 }
 
-function Millstones({ milestones, setMilestones, projectStart, projectEnd }) {
+function MilestoneList({ milestones, setMilestones, projectStart, projectEnd }) {
   return (
     <div className="flex flex-col gap-2">
       {milestones.map((m: Milestones.Milestone) => (
@@ -315,7 +313,11 @@ function AddMilestone({ setMilestones, projectStart, projectEnd }) {
 
 function AddMilestoneButton({ onClick }) {
   return (
-    <div className="underline cursor-pointer text-white-2 hover:text-white-1" onClick={onClick}>
+    <div
+      className="underline cursor-pointer text-white-2 hover:text-white-1"
+      data-test-id="add-milestone"
+      onClick={onClick}
+    >
       + Add milestone
     </div>
   );
@@ -356,6 +358,7 @@ function AddMilestoneForm({ setMilestones, projectStart, projectEnd, close }) {
             className="w-full bg-dark-4 rounded px-2 py-1 outline-none border-none"
             placeholder="ex. Website launch"
             value={title}
+            data-test-id="new-milestone-title"
             onChange={(e) => setTitle(e.target.value)}
           />
         </div>
@@ -367,13 +370,21 @@ function AddMilestoneForm({ setMilestones, projectStart, projectEnd, close }) {
               minDate={projectStart}
               maxDate={projectEnd}
               placeholder="Select due date"
+              testID="new-milestone-due"
             />
           </div>
         </div>
       </div>
 
       <div className="mt-4 flex items-center gap-2">
-        <Button size="small" type="submit" variant="success" onClick={addMilestone} disabled={!valid}>
+        <Button
+          size="small"
+          type="submit"
+          variant="success"
+          onClick={addMilestone}
+          disabled={!valid}
+          data-test-id="add-milestone-button"
+        >
           Add
         </Button>
         <Button size="small" type="button" variant="secondary" onClick={close}>
@@ -413,6 +424,8 @@ function Milestone({ milestone, setMilestones, projectStart, projectEnd }) {
     });
   }, []);
 
+  const testId = "milestone-" + milestone.title.toLowerCase().replace(/\s+/g, "-") + "-due";
+
   return (
     <div className="flex items-center gap-2">
       <div className="w-2/3">{milestone.title}</div>
@@ -423,6 +436,7 @@ function Milestone({ milestone, setMilestones, projectStart, projectEnd }) {
             onChange={setDueDate}
             minDate={projectStart}
             maxDate={projectEnd}
+            testID={testId}
           />
         </div>
 

--- a/docs/dev_users.md
+++ b/docs/dev_users.md
@@ -1,0 +1,13 @@
+# Development Mode and Logging in as another account
+
+In development mode, you can log in with any account by visiting:
+
+```
+http://localhost:4000/accounts/auth/dev_login?email=<email>
+```
+
+For example:
+
+```
+http://localhost:4000/accounts/auth/dev_login?email=john@openjohn.com
+```

--- a/lib/operately/activities/content.ex
+++ b/lib/operately/activities/content.ex
@@ -5,6 +5,7 @@ defmodule Operately.Activities.Content do
       import Ecto.Changeset
 
       @primary_key false
+      @derive Jason.Encoder
     end
   end
 end

--- a/lib/operately/activities/content/project_timeline_edited.ex
+++ b/lib/operately/activities/content/project_timeline_edited.ex
@@ -1,0 +1,56 @@
+defmodule Operately.Activities.Content.ProjectTimelineEdited do
+  use Operately.Activities.Content
+
+  defmodule MilestoneEdit do
+    use Operately.Activities.Content
+
+    embedded_schema do
+      field :milestone_id, :string
+      field :old_due_date, :utc_datetime
+      field :new_due_date, :utc_datetime
+    end
+  end
+
+  defmodule NewMilestones do
+    use Operately.Activities.Content
+
+    embedded_schema do
+      field :milestone_id, :string
+      field :due_date, :utc_datetime
+    end
+  end
+
+  embedded_schema do
+    field :company_id, :string
+    field :project_id, :string
+
+    field :old_start_date, :utc_datetime
+    field :old_end_date, :utc_datetime
+    field :new_start_date, :utc_datetime
+    field :new_end_date, :utc_datetime
+
+    embeds_many :milestone_edits, MilestoneEdit
+    embeds_many :new_milestones, NewMilestones
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    project = Operately.Projects.get_project!(params["project_id"])
+
+    changeset(%{
+      company_id: project.company_id,
+      project_id: project.id,
+      old_start_date: params["old_start_date"],
+      new_start_date: params["new_start_date"],
+      old_end_date: params["old_end_date"],
+      new_end_date: params["new_end_date"],
+      milestone_edits: params["milestone_edits"],
+      new_milestones: params["new_milestones"]
+    })
+  end
+end

--- a/lib/operately/activities/notifications/project_timeline_edited.ex
+++ b/lib/operately/activities/notifications/project_timeline_edited.ex
@@ -1,0 +1,19 @@
+defmodule Operately.Activities.Notifications.ProjectTimelineEdited do
+  alias Operately.Projects
+
+  def dispatch(activity) do
+    author_id = activity.author_id
+    project_id = activity.content.project_id
+    people = Projects.list_notification_subscribers(project_id, exclude: author_id)
+
+    notifications = Enum.map(people, fn person ->
+      %{
+        person_id: person.id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+
+    Operately.Notifications.bulk_create(notifications)
+  end
+end

--- a/lib/operately/activities/recorder.ex
+++ b/lib/operately/activities/recorder.ex
@@ -26,7 +26,8 @@ defmodule Operately.Activities.Recorder do
     changeset = apply(module, :build, [params])
 
     if changeset.valid? do
-      {:ok, changeset.changes}
+      content = Ecto.Changeset.apply_changes(changeset)
+      {:ok, content}
     else
       {:error, changeset}
     end

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -1,13 +1,22 @@
 defmodule Operately.Projects do
   import Ecto.Query, warn: false
-  alias Operately.Repo
 
-  alias Operately.Projects.Project
-  alias Operately.Projects.Contributor
+  alias Operately.Repo
+  alias Ecto.Multi
+
   alias Operately.People.Person
   alias Operately.Updates
-  alias Ecto.Multi
   alias Operately.Activities
+
+  alias Operately.Projects.{
+    Project,
+    PhaseHistory,
+    Contributor,
+    Milestone,
+    ReviewRequest,
+    Document,
+    KeyResource
+  }
 
   def get_project!(id) do
     query = from p in Project, where: p.id == ^id
@@ -29,6 +38,10 @@ defmodule Operately.Projects do
     |> Repo.update()
   end
 
+  def update_project_timeline(author, project, attrs) do
+    Operately.Projects.EditTimelineOperation.run(author, project, attrs)
+  end
+
   def rename_project(author, project, new_name) do
     Multi.new()
     |> Multi.update(:project, change_project(project, %{name: new_name}))
@@ -48,8 +61,6 @@ defmodule Operately.Projects do
   def change_project(%Project{} = project, attrs \\ %{}) do
     Project.changeset(project, attrs)
   end
-
-  alias Operately.Projects.Milestone
 
   def get_milestone!(id, opts \\ []), do: Repo.get!(Milestone, id, opts)
 
@@ -134,8 +145,6 @@ defmodule Operately.Projects do
   def change_milestone(%Milestone{} = milestone, attrs \\ %{}) do
     Milestone.changeset(milestone, attrs)
   end
-
-  alias Operately.Projects.Contributor
 
   def get_contributor!(person_id: person_id, project_id: project_id) do
     Repo.one(from c in Contributor, where: c.person_id == ^person_id and c.project_id == ^project_id)
@@ -234,8 +243,6 @@ defmodule Operately.Projects do
     Contributor.changeset(contributor, attrs)
   end
 
-  alias Operately.Projects.Document
-
   def get_pitch(project) do
     Repo.preload(project, :pitch).pitch
   end
@@ -282,8 +289,6 @@ defmodule Operately.Projects do
     Document.changeset(document, attrs)
   end
 
-  alias Operately.Projects.KeyResource
-
   def list_key_resources(project) do
     Operately.Repo.preload(project, :key_resources).key_resources
   end
@@ -311,8 +316,6 @@ defmodule Operately.Projects do
   end
 
   # Phase History
-
-  alias Operately.Projects.PhaseHistory
 
   def list_project_phase_history(project) do
     Operately.Repo.preload(project, :phase_history).phase_history
@@ -375,8 +378,6 @@ defmodule Operately.Projects do
   def get_permissions(project, person) do
     Operately.Projects.Permissions.calculate_permissions(project, person)
   end
-
-  alias Operately.Projects.ReviewRequest
 
   def list_project_review_requests do
     Repo.all(ReviewRequest)

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -64,6 +64,12 @@ defmodule Operately.Projects do
 
   def get_milestone!(id, opts \\ []), do: Repo.get!(Milestone, id, opts)
 
+  def get_milestone_by_name(project, milestone_name) do
+    Repo.one(from m in Milestone,
+      where: m.project_id == ^project.id,
+      where: m.title == ^milestone_name)
+  end
+
   def get_next_milestone(project) do
     query = from m in Milestone,
       where: m.project_id == ^project.id,

--- a/lib/operately/projects/edit_timeline_operation.ex
+++ b/lib/operately/projects/edit_timeline_operation.ex
@@ -22,13 +22,13 @@ defmodule Operately.Projects.EditTimelineOperation do
     |> Multi.update(:control_phase, PhaseHistory.changeset(control, %{start_time: attrs.execution_due_time, due_time: due_date}))
     |> update_milestones(attrs)
     |> insert_new_milestones(project, attrs)
-    |> record_activity(author, project, attrs)
+    # |> record_activity(author, project, attrs)
     |> Repo.transaction()
     |> Repo.extract_result(:project)
   end
 
   defp update_milestones(multi, attrs) do
-    multi |> Enum.reduce(attrs.milestone_updates, fn milestone_update, multi ->
+    Enum.reduce(attrs.milestone_updates, multi, fn milestone_update, multi ->
       milestone = Operately.Projects.get_milestone!(milestone_update.milestone_id)
 
       changeset = Operately.Projects.Milestone.changeset(milestone, %{
@@ -41,8 +41,7 @@ defmodule Operately.Projects.EditTimelineOperation do
   end
 
   defp insert_new_milestones(multi, project, attrs) do
-    multi
-    |> Enum.reduce(attrs.input.new_milestones, fn milestone, multi ->
+    Enum.reduce(attrs.new_milestones, multi, fn milestone, multi ->
       changeset = Milestone.changeset(%{
         project_id: project.id,
         title: milestone.title,
@@ -63,7 +62,7 @@ defmodule Operately.Projects.EditTimelineOperation do
         old_end_date: project.deadline,
         new_end_date: changes.project.deadline,
         milestone_edits: attrs.milestone_updates,
-        new_milestones: attrs.input.new_milestones
+        new_milestones: attrs.new_milestones
       }
 
       Operately.Activities.Content.ProjectTimelineEdited.build(params)

--- a/lib/operately/projects/edit_timeline_operation.ex
+++ b/lib/operately/projects/edit_timeline_operation.ex
@@ -1,0 +1,72 @@
+defmodule Operately.Projects.EditTimelineOperation do
+  alias Operately.Repo
+  alias Ecto.Multi
+
+  alias Operately.Activities
+  alias Operately.Projects.{Project, PhaseHistory, Milestone}
+
+  def run(author, project, attrs) do
+    phases = Operately.Projects.list_project_phase_history(project)
+
+    planning = Enum.find(phases, fn phase -> phase.phase == :planning end)
+    execution = Enum.find(phases, fn phase -> phase.phase == :execution end)
+    control = Enum.find(phases, fn phase -> phase.phase == :control end)
+
+    start_date = attrs.project_start_time
+    due_date = attrs.control_due_time
+
+    Multi.new()
+    |> Multi.update(:project, Project.changeset(project, %{started_at: start_date, deadline: due_date}))
+    |> Multi.update(:planning_phase, PhaseHistory.changeset(planning, %{start_time: start_date, due_time: attrs.planning_due_time}))
+    |> Multi.update(:execution_phase, PhaseHistory.changeset(execution, %{start_time: attrs.planning_due_time, due_time: attrs.execution_due_time}))
+    |> Multi.update(:control_phase, PhaseHistory.changeset(control, %{start_time: attrs.execution_due_time, due_time: due_date}))
+    |> update_milestones(attrs)
+    |> insert_new_milestones(project, attrs)
+    |> record_activity(author, project, attrs)
+    |> Repo.transaction()
+    |> Repo.extract_result(:project)
+  end
+
+  defp update_milestones(multi, attrs) do
+    multi |> Enum.reduce(attrs.milestone_updates, fn milestone_update, multi ->
+      milestone = Operately.Projects.get_milestone!(milestone_update.milestone_id)
+
+      changeset = Operately.Projects.Milestone.changeset(milestone, %{
+        title: milestone_update.title,
+        deadline_at: milestone_update.due_time
+      })
+
+      multi |> Multi.update("milestone_#{milestone.id}", changeset)
+    end)
+  end
+
+  defp insert_new_milestones(multi, project, attrs) do
+    multi
+    |> Enum.reduce(attrs.input.new_milestones, fn milestone, multi ->
+      changeset = Milestone.changeset(%{
+        project_id: project.id,
+        title: milestone.title,
+        deadline_at: milestone.due_time
+      })
+
+      multi |> Multi.insert("new_milestone_#{milestone.id}", changeset)
+    end)
+  end
+
+  defp record_activity(multi, author, project, attrs) do
+    multi
+    |> Activities.insert(author.id, :project_timeline_edited, fn changes -> 
+      params = %{
+        project_id: project.id,
+        old_start_date: project.started_at,
+        new_start_date: changes.project.started_at,
+        old_end_date: project.deadline,
+        new_end_date: changes.project.deadline,
+        milestone_edits: attrs.milestone_updates,
+        new_milestones: attrs.input.new_milestones
+      }
+
+      Operately.Activities.Content.ProjectTimelineEdited.build(params)
+    end)
+  end
+end

--- a/lib/operately/projects/milestone.ex
+++ b/lib/operately/projects/milestone.ex
@@ -17,6 +17,10 @@ defmodule Operately.Projects.Milestone do
     soft_delete()
   end
 
+  def changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
   def changeset(milestone, attrs) do
     milestone
     |> cast(attrs, [:title, :deadline_at, :project_id, :status, :completed_at, :deleted_at, :description])

--- a/lib/operately/projects/milestone.ex
+++ b/lib/operately/projects/milestone.ex
@@ -1,10 +1,6 @@
 defmodule Operately.Projects.Milestone do
-  use Ecto.Schema
-  import Ecto.Changeset
-  import Operately.SoftDelete.Schema
+  use Operately.Schema
 
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
   schema "project_milestones" do
     belongs_to :project, Operately.Projects.Project
 
@@ -21,7 +17,6 @@ defmodule Operately.Projects.Milestone do
     soft_delete()
   end
 
-  @doc false
   def changeset(milestone, attrs) do
     milestone
     |> cast(attrs, [:title, :deadline_at, :project_id, :status, :completed_at, :deleted_at, :description])

--- a/lib/operately/projects/phase_history.ex
+++ b/lib/operately/projects/phase_history.ex
@@ -16,7 +16,10 @@ defmodule Operately.Projects.PhaseHistory do
     timestamps()
   end
 
-  @doc false
+  def changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
   def changeset(phase_history, attrs) do
     phase_history
     |> cast(attrs, __schema__(:fields))

--- a/lib/operately/schema.ex
+++ b/lib/operately/schema.ex
@@ -7,10 +7,6 @@ defmodule Operately.Schema do
 
       @primary_key {:id, :binary_id, autogenerate: true}
       @foreign_key_type :binary_id
-
-      def changeset(attrs) do
-        changeset(%__MODULE__{}, attrs)
-      end
     end
   end
 end

--- a/lib/operately/schema.ex
+++ b/lib/operately/schema.ex
@@ -1,0 +1,16 @@
+defmodule Operately.Schema do
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      import Ecto.Changeset
+      import Operately.SoftDelete.Schema
+
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+
+      def changeset(attrs) do
+        changeset(%__MODULE__{}, attrs)
+      end
+    end
+  end
+end

--- a/lib/operately_email/project_timeline_edited_email.ex
+++ b/lib/operately_email/project_timeline_edited_email.ex
@@ -1,0 +1,5 @@
+defmodule OperatelyEmail.ProjectTimelineEditedEmail do
+  def send(person, activity) do
+    raise "Not implemented"
+  end
+end

--- a/lib/operately_email/project_timeline_edited_email.ex
+++ b/lib/operately_email/project_timeline_edited_email.ex
@@ -1,5 +1,76 @@
 defmodule OperatelyEmail.ProjectTimelineEditedEmail do
+  @view OperatelyEmail.Views.ProjectTimelineEdited
+
+  alias Operately.People.Person
+
   def send(person, activity) do
-    raise "Not implemented"
+    compose(activity, person) |> OperatelyEmail.Mailer.deliver_now()
+  end
+
+  def compose(activity, recipient) do
+    import Bamboo.Email
+
+    author = Operately.Repo.preload(activity, :author).author
+    company = Operately.Repo.preload(author, :company).company
+    project = Operately.Projects.get_project!(activity.content["project_id"])
+
+    content = activity.content
+
+    old_duration = calculate_duration(content["old_start_date"], content["old_end_date"])
+    new_duration = calculate_duration(content["new_start_date"], content["new_end_date"])
+    duration_changed = old_duration != new_duration
+
+    new_milestones = Enum.map(activity.content["new_milestones"], fn milestone ->
+      Operately.Projects.get_milestone!(milestone["milestone_id"])
+    end)
+
+    assigns = %{
+      company: company,
+      project: project,
+      activity: activity,
+      duration_changed: duration_changed,
+      old_duration: old_duration,
+      new_duration: new_duration,
+      new_milestones: new_milestones,
+      author: Person.short_name(author),
+      project_url: OperatelyEmail.project_url(project.id),
+      cta_url: OperatelyEmail.project_url(project.id),
+      title: subject(company, author, project)
+    }
+
+    new_email(
+      to: recipient.email,
+      from: OperatelyEmail.sender(company),
+      subject: subject(company, author, project),
+      html_body: @view.html(assigns),
+      text_body: @view.text(assigns)
+    )
+  end
+
+  defp calculate_duration(start_time, end_time) do
+    if start_time && end_time do
+      {:ok, start_time, _} = DateTime.from_iso8601(start_time)
+      {:ok, end_time, _} = DateTime.from_iso8601(end_time)
+
+      duration_in_days = Date.diff(end_time, start_time)
+      duration_in_weeks = div(duration_in_days, 7)
+
+      cond do
+        duration_in_days == 1 ->
+          "1 day"
+        duration_in_days < 7 ->
+          "#{duration_in_days} days"
+        duration_in_weeks == 1 ->
+          "1 week"
+        true ->
+          "#{duration_in_weeks} weeks"
+      end
+    else
+      :undefined
+    end
+  end
+
+  def subject(company, author, project) do
+    "#{OperatelyEmail.sender_name(company)}: #{Person.short_name(author)} changed the timeline for #{project.name}"
   end
 end

--- a/lib/operately_email/templates/project_timeline_edited.html.eex
+++ b/lib/operately_email/templates/project_timeline_edited.html.eex
@@ -1,0 +1,1 @@
+<%= raise "HTML Email for ProjectTimelineEdited not implemented" %>

--- a/lib/operately_email/templates/project_timeline_edited.html.eex
+++ b/lib/operately_email/templates/project_timeline_edited.html.eex
@@ -1,1 +1,56 @@
-<%= raise "HTML Email for ProjectTimelineEdited not implemented" %>
+<html>
+  <head>
+    <title><%= @title %></title>
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+
+      h1 {
+        font-size: 18px;
+        margin-bottom: 20px;
+        font-weight: bold;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div style="padding: 10px 20px;">
+      <table width="100%" style="background:#fff;margin:0;padding:0;border:0;border-collapse:collapse;border-spacing:0; max-width: 40em">
+        <tr style="font-size: 22px; font-family: sans-serif; font-weight: 800;">
+          <td>
+            <%= @author %> changed the timeline for <%= @project.name %>.
+          </td>
+        </tr>
+
+        <%= if @duration_changed && @old_duration == :undefined do %>
+          <tr style="height: 20px">
+            <td>The duration is now <%= @new_duration %>.</td>
+          </tr>
+        <% end %>
+
+        <%= if @duration_changed && @old_duration != :undefined do %>
+          <tr style="height: 20px">
+            <td>The duration was changed from <%= @old_duration %> to <%= @new_duration %>.</td>
+          </tr>
+        <% end %>
+
+        <%= if Enum.any?(@new_milestones) do %>
+          <tr style="height: 20px">
+            <td>New milestones were added:</td>
+          </tr>
+
+          <%= for milestone <- @new_milestones do %>
+            <tr style="height: 20px">
+              <td><%= milestone.title %> %></td>
+            </tr>
+          <% end %>
+        <% end %>
+
+        <tr style="height: 20px">
+          <td><%= cta_button(@cta_url, "View Project") %></td>
+        </tr>
+      </table>
+    </div>
+  </body>
+</html>

--- a/lib/operately_email/templates/project_timeline_edited.text.eex
+++ b/lib/operately_email/templates/project_timeline_edited.text.eex
@@ -1,1 +1,3 @@
-<%= raise "Text Email for ProjectTimelineEdited not implemented" %>
+<%= @author %> changed the project timeline for <%= @project.name %>.
+
+Link: <%= @cta_url %>

--- a/lib/operately_email/templates/project_timeline_edited.text.eex
+++ b/lib/operately_email/templates/project_timeline_edited.text.eex
@@ -1,0 +1,1 @@
+<%= raise "Text Email for ProjectTimelineEdited not implemented" %>

--- a/lib/operately_email/views/project_timeline_edited.ex
+++ b/lib/operately_email/views/project_timeline_edited.ex
@@ -1,0 +1,9 @@
+defmodule OperatelyEmail.Views.ProjectTimelineEdited do
+  require EEx
+  @templates_root "lib/operately_email/templates"
+
+  import OperatelyEmail.Views.UIComponents
+
+  EEx.function_from_file(:def, :html, "#{@templates_root}/project_timeline_edited.html.eex", [:assigns])
+  EEx.function_from_file(:def, :text, "#{@templates_root}/project_timeline_edited.text.eex", [:assigns])
+end

--- a/lib/operately_web/graphql/mutations/projects.ex
+++ b/lib/operately_web/graphql/mutations/projects.ex
@@ -65,7 +65,31 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
         author = context.current_account.person
         project = Operately.Projects.get_project!(args.input.project_id)
 
-        Operately.Projects.update_project_timeline(author, project, args.input)
+        attrs = %{
+          project_id: args.input.project_id,
+
+          project_start_time: parse_date(args.input.project_start_time),
+          planning_due_time: parse_date(args.input.planning_due_time),
+          execution_due_time: parse_date(args.input.execution_due_time),
+          control_due_time: parse_date(args.input.control_due_time),
+
+          milestone_updates: Enum.map(args.input.milestone_updates, fn update ->
+            %{
+              milestone_id: update.id,
+              title: update.title,
+              due_time: parse_date(update.due_time)
+            }
+          end),
+
+          new_milestones: Enum.map(args.input.new_milestones, fn milestone ->
+            %{
+              title: milestone.title,
+              due_time: parse_date(milestone.due_time)
+            }
+          end)
+        }
+
+        Operately.Projects.update_project_timeline(author, project, attrs)
       end
     end
 
@@ -171,14 +195,6 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
 
           project
         end)
-      end
-    end
-
-    defp parse_date(date) do
-      if date do
-        NaiveDateTime.new!(date, ~T[00:00:00])
-      else
-        nil
       end
     end
 
@@ -322,6 +338,14 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
         Operately.Projects.archive_project(person, project)
 
         {:ok, project}
+      end
+    end
+
+    defp parse_date(date) do
+      if date do
+        NaiveDateTime.new!(date, ~T[00:00:00])
+      else
+        nil
       end
     end
   end

--- a/lib/operately_web/graphql/schema.ex
+++ b/lib/operately_web/graphql/schema.ex
@@ -23,6 +23,7 @@ defmodule OperatelyWeb.Graphql.Schema do
   import_types OperatelyWeb.Graphql.Types.ActivityContentProjectStatusUpdateAcknowledged
   import_types OperatelyWeb.Graphql.Types.ActivityContentProjectStatusUpdateCommented
   import_types OperatelyWeb.Graphql.Types.ActivityContentProjectStatusUpdateSubmitted
+  import_types OperatelyWeb.Graphql.Types.ActivityContentProjectTimelineEdited
   import_types OperatelyWeb.Graphql.Types.Assignments
   import_types OperatelyWeb.Graphql.Types.Blobs
   import_types OperatelyWeb.Graphql.Types.Comments

--- a/lib/operately_web/graphql/types/activity_content.ex
+++ b/lib/operately_web/graphql/types/activity_content.ex
@@ -19,7 +19,8 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContent do
     :activity_content_project_review_submitted,
     :activity_content_project_status_update_acknowledged,
     :activity_content_project_status_update_commented,
-    :activity_content_project_status_update_submitted
+    :activity_content_project_status_update_submitted,
+    :activity_content_project_timeline_edited
     ]
 
     resolve_type fn %{action: action}, _ ->

--- a/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
+++ b/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
@@ -2,9 +2,13 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentProjectTimelineEdited do
   use Absinthe.Schema.Notation
 
   object :activity_content_project_timeline_edited do
-    field :example_field, non_null(:string) do
-      resolve fn _parent, _args, _resolution ->
-        "Hello World"
+    field :project, non_null(:project) do
+      resolve fn activity, _, _ ->
+        project_id = activity.content["project_id"]
+
+        project = Operately.Projects.get_project!(project_id)
+
+        {:ok, project}
       end
     end
   end

--- a/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
+++ b/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
@@ -1,0 +1,11 @@
+defmodule OperatelyWeb.Graphql.Types.ActivityContentProjectTimelineEdited do
+  use Absinthe.Schema.Notation
+
+  object :activity_content_project_timeline_edited do
+    field :example_field, non_null(:string) do
+      resolve fn _parent, _args, _resolution ->
+        "Hello World"
+      end
+    end
+  end
+end

--- a/test/features/project_milestones_test.exs
+++ b/test/features/project_milestones_test.exs
@@ -30,7 +30,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "deleting a milestone on a project", ctx do
-    add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> ProjectSteps.visit_project_page()
@@ -40,9 +40,9 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "see all milestones", ctx do
-    add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
-    add_milestone(ctx.project, ctx.champion, %{title: "Demo Day", deadline_at: ~N[2023-07-17 00:00:00]})
-    add_milestone(ctx.project, ctx.champion, %{title: "Website Launched", deadline_at: ~N[2023-07-17 00:00:00]})
+    add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    add_milestone(ctx, %{title: "Demo Day", deadline_at: ~N[2023-07-17 00:00:00]})
+    add_milestone(ctx, %{title: "Website Launched", deadline_at: ~N[2023-07-17 00:00:00]})
 
     ctx
     |> ProjectSteps.visit_project_page()
@@ -56,8 +56,8 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "mark upcomming milestone completed", ctx do
-    add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
-    add_milestone(ctx.project, ctx.champion, %{title: "Website Launched", deadline_at: ~N[2023-07-17 00:00:00]})
+    add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    add_milestone(ctx, %{title: "Website Launched", deadline_at: ~N[2023-07-17 00:00:00]})
 
     ctx
     |> ProjectSteps.visit_project_page()
@@ -73,7 +73,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "change milestone deadline", ctx do
-    add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> ProjectSteps.visit_project_page()
@@ -84,7 +84,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "change milestone deadline on the milestone page", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> visit_page(ctx.project, milestone)
@@ -97,7 +97,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "visiting the milestone page", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> ProjectSteps.visit_project_page()
@@ -111,7 +111,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "adding a description", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> UI.visit("/projects/#{ctx.project.id}/milestones/#{milestone.id}")
@@ -122,7 +122,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "editing the description", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{
+    {:ok, milestone} = add_milestone(ctx, %{
       title: "Contract Signed", 
       deadline_at: ~N[2023-06-17 00:00:00],
       description: Operately.UpdatesFixtures.rich_text_fixture("This is a description")
@@ -143,7 +143,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "write a comment", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> visit_page(ctx.project, milestone)
@@ -153,7 +153,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "write a comment and complete the milestone", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> visit_page(ctx.project, milestone)
@@ -164,7 +164,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "write a comment and re-open the milestone", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00], completed_at: ~N[2023-06-17 00:00:00], status: "done"})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00], completed_at: ~N[2023-06-17 00:00:00], status: "done"})
 
     ctx
     |> visit_page(ctx.project, milestone)
@@ -175,7 +175,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
   end
 
   feature "rename a milestone", ctx do
-    {:ok, milestone} = add_milestone(ctx.project, ctx.champion, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
+    {:ok, milestone} = add_milestone(ctx, %{title: "Contract Signed", deadline_at: ~N[2023-06-17 00:00:00]})
 
     ctx
     |> visit_page(ctx.project, milestone)
@@ -187,10 +187,10 @@ defmodule Operately.Features.ProjectMilestonesTest do
 
   # ===========================================================================
 
-  defp add_milestone(project, creator, attrs) do
-    attrs = %{project_id: project.id} |> Map.merge(attrs)
+  defp add_milestone(ctx, attrs) do
+    attrs = Map.merge(attrs, %{project_id: ctx.project.id})
 
-    {:ok, _} = Operately.Projects.create_milestone(creator, attrs)
+    Operately.Projects.create_milestone(ctx.champion, attrs)
   end
 
   defp visit_page(ctx, project, milestone), do: UI.visit(ctx, "/projects" <> "/" <> project.id <> "/milestones" <> "/" <> milestone.id)

--- a/test/features/projects_test.exs
+++ b/test/features/projects_test.exs
@@ -193,6 +193,22 @@ defmodule Operately.Features.ProjectsTest do
     |> UI.click(testid: "control-due")
     |> UI.click(css: ".react-datepicker__day.react-datepicker__day--013")
     |> UI.click(testid: "save")
+
+    project = Operately.Projects.get_project!(ctx.project.id)
+    phases = Operately.Projects.list_project_phase_history(project)
+    planning = Enum.find(phases, fn phase -> phase.phase == :planning end)
+    execution = Enum.find(phases, fn phase -> phase.phase == :execution end)
+    control = Enum.find(phases, fn phase -> phase.phase == :control end)
+
+    assert project.started_at == day_in_current_month(10)
+    assert project.deadline == day_in_current_month(13)
+
+    assert planning.start_time == day_in_current_month(10)
+    assert planning.due_time == day_in_current_month(11)
+    assert execution.start_time == day_in_current_month(11)
+    assert execution.due_time == day_in_current_month(12)
+    assert control.start_time == day_in_current_month(12)
+    assert control.due_time == day_in_current_month(13)
   end
 
   # ===========================================================================
@@ -280,6 +296,15 @@ defmodule Operately.Features.ProjectsTest do
       project_id: project.id, 
       responsibility: responsibility
     })
+  end
+
+  def day_in_current_month(day) do
+    today = Date.utc_today()
+
+    {:ok, date} = Date.from_erl({today.year, today.month, day})
+    {:ok, date} = NaiveDateTime.new(date, ~T[00:00:00])
+
+    DateTime.from_naive!(date, "Etc/UTC")
   end
 
 end

--- a/test/support/features/email_steps.ex
+++ b/test/support/features/email_steps.ex
@@ -26,6 +26,13 @@ defmodule Operately.Support.Features.EmailSteps do
     ctx |> assert_sent(to: to, subject: "#{Person.short_name(author)} commented on a status update for #{ctx.project.name}")
   end
 
+  def assert_project_timeline_edited_sent(ctx, author: author, to: to) do
+    ctx |> assert_sent(to: to, subject: "#{Person.short_name(author)} changed the timeline for #{ctx.project.name}")
+  end
+
+  #
+  # Private
+  #
   defp assert_sent(ctx, to: to, subject: subject) do
     ctx |> UI.assert_email_sent("Operately (#{ctx.company.name}): #{subject}", to: to.email)
   end

--- a/test/support/features/notifications_steps.ex
+++ b/test/support/features/notifications_steps.ex
@@ -70,4 +70,8 @@ defmodule Operately.Support.Features.NotificationsSteps do
     ctx |> assert_notification_exists(author: author, subject: "#{Person.first_name(author)} commented on: #{title}")
   end
 
+  def assert_project_timeline_edited_sent(ctx, author: author) do
+    ctx |> assert_notification_exists(author: author, subject: "#{Person.first_name(author)} changed the project timeline")
+  end
+
 end

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -30,6 +30,14 @@ defmodule Operately.Support.Features.ProjectSteps do
     Map.merge(ctx, %{company: company, champion: champion, project: project, reviewer: reviewer})
   end
 
+  def add_milestone(ctx, attrs) do
+    attrs = %{project_id: ctx.project.id} |> Map.merge(attrs)
+
+    {:ok, _} = Operately.Projects.create_milestone(ctx.champion, attrs)
+
+    ctx
+  end
+
   def login(ctx) do
     case ctx[:login_as] do
       :champion ->
@@ -85,6 +93,12 @@ defmodule Operately.Support.Features.ProjectSteps do
 
   def visit_project_page(ctx) do
     ctx |> UI.visit("/projects/#{ctx.project.id}")
+  end
+
+  def visit_project_milestones_page(ctx, milestone_name) do
+    {:ok, milestone} = Operately.Projects.get_milestone_by_name(ctx.project, milestone_name)
+
+    ctx |> UI.visit("/projects/#{ctx.project.id}/milestones/#{milestone.id}")
   end
 
   #


### PR DESCRIPTION
Additionally, this PR fixes a bug where the updated deadlines for milestones on the edit project page were not persisted to the database.