### PR TITLE
Don't show redundant flash on login page

### DIFF
--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -204,7 +204,6 @@ defmodule OperatelyWeb.AccountAuth do
       conn
     else
       conn
-      |> put_flash(:error, "You must log in to access this page.")
       |> maybe_store_return_to()
       |> redirect(to: ~p"/accounts/log_in")
       |> halt()

--- a/test/operately_web/account_auth_test.exs
+++ b/test/operately_web/account_auth_test.exs
@@ -232,9 +232,6 @@ defmodule OperatelyWeb.AccountAuthTest do
       assert conn.halted
 
       assert redirected_to(conn) == ~p"/accounts/log_in"
-
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
-               "You must log in to access this page."
     end
 
     test "stores the path to redirect to on GET", %{conn: conn} do


### PR DESCRIPTION
Before, it looked like this, which makes no sense:

![Screenshot 2024-04-26 at 14 42 49](https://github.com/operately/operately/assets/1779493/51c215ee-40b4-4dee-bee0-605796718241)
