### PR TITLE
Fix:  Feed bottom border

### DIFF
--- a/assets/js/components/PaperContainer/DimmedSection.tsx
+++ b/assets/js/components/PaperContainer/DimmedSection.tsx
@@ -18,7 +18,7 @@ function calcNegativeMargins(size: string) {
     case "medium":
       return "-mx-12 px-12 -my-10 py-10";
     case "large":
-      return "-mx-12 px-12 -my-12 py-12";
+      return "-mx-12 px-12 -my-10 py-12";
     case "xlarge":
       return "-mx-12 px-12 -my-12 py-12";
     case "xxlarge":


### PR DESCRIPTION
## Context
Hello!

This PR fixes the bottom from the `DimmedSection` component in the Company space page:
- when the `size` is `large`, use the margin-top/bottom of 10.

![Captura de Tela 2024-05-13 às 21 22 48](https://github.com/operately/operately/assets/25110363/06b2b2b7-6147-4fb9-8246-46cd9293b660)

closes https://github.com/operately/operately/issues/446.

