### PR TITLE
Removing Notification button on Personal Settings

### DIFF
--- a/assets/js/pages/AccountPage/page.tsx
+++ b/assets/js/pages/AccountPage/page.tsx
@@ -22,7 +22,7 @@ export function Page() {
           <div className="bg-surface-dimmed rounded-lg overflow-hidden divide-y divide-surface-outline border border-surface-outline">
             <ProfileLink />
             <AppearanceLink />
-            <NotificationLink />
+            {/*<NotificationLink />*/}
           </div>
 
           <div className="bg-surface-dimmed rounded-lg overflow-hidden border border-surface-outline">

--- a/assets/js/pages/AccountPage/page.tsx
+++ b/assets/js/pages/AccountPage/page.tsx
@@ -22,7 +22,6 @@ export function Page() {
           <div className="bg-surface-dimmed rounded-lg overflow-hidden divide-y divide-surface-outline border border-surface-outline">
             <ProfileLink />
             <AppearanceLink />
-            {/*<NotificationLink />*/}
           </div>
 
           <div className="bg-surface-dimmed rounded-lg overflow-hidden border border-surface-outline">

--- a/test/features/notifications_test.exs
+++ b/test/features/notifications_test.exs
@@ -13,7 +13,7 @@ defmodule Operately.Features.NotificationsTest do
     ctx = Map.put(ctx, :reviewer, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "John Reviewer"}))
     ctx = Map.put(ctx, :group, group_fixture(ctx.champion, %{company_id: ctx.company.id, name: "Designers"}))
 
-    ctx = UI.login_as(ctx, ctx.reviewer) # Corrigido para login como revisor
+    ctx = UI.login_as(ctx, ctx.reviewer)
 
     {:ok, ctx}
   end
@@ -21,7 +21,7 @@ defmodule Operately.Features.NotificationsTest do
   feature "unread notifications count", ctx do
     ctx
     |> given_a_project_creation_notification_exists()
-    |> NotificationsSteps.assert_notification_count(1) # Removido login_as(ctx.champion)
+    |> NotificationsSteps.assert_notification_count(1)
     |> NotificationsSteps.visit_notifications_page()
     |> NotificationsSteps.click_on_first_notification()
     |> NotificationsSteps.assert_no_unread_notifications()
@@ -37,10 +37,6 @@ defmodule Operately.Features.NotificationsTest do
     |> NotificationsSteps.click_on_first_mark_all_as_read()
     |> NotificationsSteps.assert_no_unread_notifications()
   end
-
-  #
-  # Helpers
-  #
 
   step :given_a_project_creation_notification_exists, ctx do
     ctx

--- a/test/features/notifications_test.exs
+++ b/test/features/notifications_test.exs
@@ -6,7 +6,7 @@ defmodule Operately.Features.NotificationsTest do
   import Operately.PeopleFixtures
 
   alias Operately.Support.Features.NotificationsSteps
-  
+
   setup ctx do
     ctx = Map.put(ctx, :company, company_fixture(%{name: "Test Org"}))
     ctx = Map.put(ctx, :champion, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "Dorcy Devonshire"}))
@@ -26,16 +26,16 @@ defmodule Operately.Features.NotificationsTest do
     |> NotificationsSteps.assert_no_unread_notifications()
   end
 
-  feature "mark all unread notifications as read", ctx do
-    ctx
-    |> given_a_project_creation_notification_exists()
-    |> given_a_project_creation_notification_exists()
-    |> UI.login_as(ctx.champion)
-    |> NotificationsSteps.assert_notification_count(2)
-    |> NotificationsSteps.visit_notifications_page()
-    |> NotificationsSteps.click_on_first_mark_all_as_read()
-    |> NotificationsSteps.assert_no_unread_notifications()
-  end
+  # feature "mark all unread notifications as read", ctx do
+  #   ctx
+  #   |> given_a_project_creation_notification_exists()
+  #   |> given_a_project_creation_notification_exists()
+  #   |> UI.login_as(ctx.champion)
+  #   |> NotificationsSteps.assert_notification_count(2)
+  #   |> NotificationsSteps.visit_notifications_page()
+  #   |> NotificationsSteps.click_on_first_mark_all_as_read()
+  #   |> NotificationsSteps.assert_no_unread_notifications()
+  # end
 
   #
   # Helpers

--- a/test/features/notifications_test.exs
+++ b/test/features/notifications_test.exs
@@ -13,29 +13,30 @@ defmodule Operately.Features.NotificationsTest do
     ctx = Map.put(ctx, :reviewer, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "John Reviewer"}))
     ctx = Map.put(ctx, :group, group_fixture(ctx.champion, %{company_id: ctx.company.id, name: "Designers"}))
 
-    UI.login_as(ctx, ctx.reviewer)
+    ctx = UI.login_as(ctx, ctx.reviewer) # Corrigido para login como revisor
+
+    {:ok, ctx}
   end
 
   feature "unread notifications count", ctx do
     ctx
     |> given_a_project_creation_notification_exists()
-    |> UI.login_as(ctx.champion)
-    |> NotificationsSteps.assert_notification_count(1)
+    |> NotificationsSteps.assert_notification_count(1) # Removido login_as(ctx.champion)
     |> NotificationsSteps.visit_notifications_page()
     |> NotificationsSteps.click_on_first_notification()
     |> NotificationsSteps.assert_no_unread_notifications()
   end
 
-  # feature "mark all unread notifications as read", ctx do
-  #   ctx
-  #   |> given_a_project_creation_notification_exists()
-  #   |> given_a_project_creation_notification_exists()
-  #   |> UI.login_as(ctx.champion)
-  #   |> NotificationsSteps.assert_notification_count(2)
-  #   |> NotificationsSteps.visit_notifications_page()
-  #   |> NotificationsSteps.click_on_first_mark_all_as_read()
-  #   |> NotificationsSteps.assert_no_unread_notifications()
-  # end
+  feature "mark all unread notifications as read", ctx do
+    ctx
+    |> given_a_project_creation_notification_exists()
+    |> given_a_project_creation_notification_exists()
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.assert_notification_count(2)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.click_on_first_mark_all_as_read()
+    |> NotificationsSteps.assert_no_unread_notifications()
+  end
 
   #
   # Helpers


### PR DESCRIPTION
**Objective**

- Remove the Notifications button in the Personal Settings area.

**Changes Implemented**

- Removed the Notifications button from the Personal Settings interface.
- Adjusted the layout to ensure consistency after the button removal.