### PR TITLE
docs: Self-Hosted Installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ organization with 10x less effort.
 
 This project is in alpha and may experience significant changes.
 
+## Installation
+
+- [Try out Operately on your local machine](docs/installation/local.md)
+- [Single Host Installation](docs/installation/single-host.md)
+
 ## Development
 
 - [How to contribute to Operately](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ This project is in alpha and may experience significant changes.
 
 ## Installation
 
-- [Try out Operately on your local machine](docs/installation/local.md)
-- [Single Host Installation](docs/installation/single-host.md)
+- [Try out Operately Locally](docs/installation/local.md): Explore Operately on your local machine.
+- [Single Host Installation](docs/installation/single-host.md): Perfect for teams up to 30 people.
+- [Kubernetes Installation](docs/installation/kubernetes.md): For larger teams and enterprise use cases (coming soon).
 
 ## Development
 

--- a/docs/installation/local.md
+++ b/docs/installation/local.md
@@ -1,0 +1,55 @@
+# Try out Operately on your local machine
+
+This guide will walk you through the steps to try out Operately on your local machine.
+
+- [Install Docker and Docker Compose](#install-docker-and-docker-compose)
+- [Download the latest release of Operately](#download-the-latest-release-of-operately)
+- [Configure Operately](#configure-operately)
+
+Running Operately locally is a great way to get a feel for the application and 
+explore its features. For a production installation, see the 
+[Single Host Installation](installation/single-host.md) guide.
+
+### Install Docker and Docker Compose
+
+Operately is a set of Docker containers orchestrated by Docker Compose. To install 
+Docker and Docker Compose, follow the instructions for your operating system:
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Download the latest release of Operately
+
+First, create a directory for Operately and navigate to it:
+
+```bash
+mkdir ~/operately
+cd ~/operately
+```
+
+Next, download the latest release of Operately:
+
+```bash
+curl -L https://github.com/opera/operately/releases/latest/download/operately.tar.gz
+tar -xvf operately.tar.gz
+```
+
+### Configure Operately
+
+Operately uses environment variables to configure the application. Edit the `operately.env` and
+fill in the required values:
+
+```bash
+OPERATELY_HOST="localhost:4000"
+```
+
+### Start Operately
+
+Start Operately with Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+Operately should now be running on your local machine. You can access it by navigating to 
+`http://localhost:4000`.

--- a/docs/installation/single-host.md
+++ b/docs/installation/single-host.md
@@ -6,7 +6,7 @@ Pre-requisites:
 
 - [Pick a server](#pick-a-server)
 - [Point a domain to your server](#point-a-domain-to-your-server)
-- [Set up a mailbox](#set-up-a-mailbox)
+- [Set up mail server](#set-up-mail-server)
 
 Installation steps:
 
@@ -40,7 +40,7 @@ and Docker Compose, follow the instructions for your operating system:
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
-### Set up a mailbox
+### Set up a mail server
 
 Operately uses SendGrid to send emails. You need to set up a SendGrid account and create an API key.
 Follow the instructions on the [SendGrid documentation](https://sendgrid.com/docs/ui/account-and-settings/api-keys/).

--- a/docs/installation/single-host.md
+++ b/docs/installation/single-host.md
@@ -1,0 +1,92 @@
+# Instal Operately on a single host
+
+This guide will walk you through the steps to install Operately on a single host.
+
+Pre-requisites:
+
+- [Pick a server](#pick-a-server)
+- [Point a domain to your server](#point-a-domain-to-your-server)
+- [Set up a mailbox](#set-up-a-mailbox)
+
+Installation steps:
+
+- [Install Docker and Docker Compose](#install-docker-and-docker-compose)
+- [Download the latest release of Operately](#download-the-latest-release-of-operately)
+- [Configure Operately](#configure-operately)
+- [Start Operately](#start-operately)
+
+## Pre-requisites
+
+### Pick a server
+
+Pick a machine to host Operately. If you need one in the cloud, we recommend checking out 
+[DigitalOcean](https://www.digitalocean.com/), [Linode](https://www.linode.com/), or 
+[Hetzer](https://www.hetzner.com/). 
+
+The minimum requirements are 2GB of RAM and 1 CPU which should be enough for a team up 
+to 30 people. For larger teams, we recommend 8GB of RAM and 4 CPUs.
+
+### Point a domain to your server
+
+Point a domain to your server. You can use a subdomain like `operately.example.com` or a
+root domain like `example.com`. You need to configure the DNS records to point to the IP
+address of your server. Make sure it's a straigth DNS pointer and not a proxy (e.g. Cloudflare proxy).
+
+### Install Docker and Docker Compose
+
+Operately is a set of Docker containers orchestrated by Docker Compose. To install Docker 
+and Docker Compose, follow the instructions for your operating system:
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+### Set up a mailbox
+
+Operately uses SendGrid to send emails. You need to set up a SendGrid account and create an API key.
+Follow the instructions on the [SendGrid documentation](https://sendgrid.com/docs/ui/account-and-settings/api-keys/).
+
+## Installation steps
+
+### Download the latest release of Operately
+
+First, create a directory for Operately and navigate to it:
+
+```bash
+mkdir /opt/operately
+cd /opt/operately
+```
+
+Next, download the latest release of Operately:
+
+```bash
+curl -L https://github.com/opera/operately/releases/latest/download/operately.tar.gz
+tar -xvf operately.tar.gz
+```
+
+### Configure Operately
+
+Operately uses environment variables to configure the application. Edit the `operately.env` and
+fill in the required values:
+
+```bash
+OPERATELY_HOST="operately.example.com"
+SENDGRID_API_KEY="your-sendgrid-api-key"
+OPERATELY_BLOB_TOKEN_SECRET="generate-a-random-string"
+```
+
+To generate a random string for `OPERATELY_BLOB_TOKEN_SECRET`, you can use the following command:
+
+```bash
+openssl rand -hex 32
+```
+
+### Start Operately
+
+Start Operately with Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+Operately should now be running on your server. You can access it by navigating to the domain you
+configured earlier (e.g. `https://operately.example.com`).

--- a/rel/single-host/docker-compose.yml.eex
+++ b/rel/single-host/docker-compose.yml.eex
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+  app:
+    image: operately/operately:<%= @version %>
+    ports:
+      - "80:4000"
+    depends_on:
+      - db
+    environment:
+      - MIX_ENV=prod
+      - DB_HOST=db
+    env_file:
+      - operately.env
+    volumes:
+      - media:/media
+
+  db:
+    image: postgres:14.5
+    environment:
+      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_DB: operately-prod
+    env_file:
+      - operately.env
+    restart: always
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+    driver: local
+  media:
+    driver: local

--- a/rel/single-host/operately.env
+++ b/rel/single-host/operately.env
@@ -1,0 +1,42 @@
+# ----------------------------
+# Operately Configuration
+# ----------------------------
+
+# Hostname of the Operately instance, e.g. "operately.example.com"
+OPERATELY_HOST=""
+
+# Secret key for signing the blob tokens
+# Generate a random string of 64 characters, e.g. "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
+OPERATELY_BLOB_TOKEN_SECRET_KEY=""
+
+# URL scheme for the Operately instance, either "http" or "https"
+OPERATELY_URL_SCHEME="https"
+
+# Key for encrypting session cookies and other sensitive data.
+# Generate a random string of 64 characters, e.g. "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
+SECRET_KEY_BASE=""
+
+
+# ----------------------------
+# Database Configuration
+# ----------------------------
+
+DB_USERNAME="operately"
+POSTGRES_USER="operately"
+
+# Password for the database user, generate a random string of 32 characters, e.g. "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5"
+POSTGRES_PASSWORD=""
+
+# Database URL, format: ecto://USERNAME:PASSOWORD@db/operately
+DATABASE_URL=""
+
+
+# ----------------------------
+# Email Configuration
+# ----------------------------
+
+# SendGrid API Key, get it from https://sendgrid.com/
+SENDGRID_API_KEY=""
+
+# Email address to send notifications from, e.g. "notifications@example.com"
+NOTIFICATION_EMAIL=""


### PR DESCRIPTION
This is a proposal how the installation steps should look like. For the first pass, we will release Operately that is able to run on a single host bundled with a database and file storage.

The missing part for this installation is setting up a valid SSL cert. Setting this up is probably the most complicated step, as it either requires setting up a letsencrypt schema, or purchasing an SSL cert. Not yet sure how to tackle that one. 

**What is not included in this PR?**

HA configuration will come in the future. The installation steps for HA are more involved, as you need to set up an external database, external S3 based file storage, and a load balancer. The HA steps will most likely be based on Kubernetes manifests. 

---

@markoa @Rockyy174 I'm adding you as reviewers to this PR. My main question is your overall opinion about the approach taken in the docs. Are they understandable? Do you feel that we should automate some parts?