### PR TITLE
Visual changes for timezones

### DIFF
--- a/assets/js/components/Form/select.tsx
+++ b/assets/js/components/Form/select.tsx
@@ -14,6 +14,7 @@ interface SelectBoxNoLabelProps {
   props?: any;
   defaultValue?: any;
   error?: boolean;
+  placeholder?: string;
 }
 
 interface SelectBoxProps extends SelectBoxNoLabelProps {
@@ -28,6 +29,7 @@ function SelectBoxNoLabel(props: SelectBoxNoLabelProps) {
   let selectProps = {
     unstyled: true,
     className: "flex-1",
+    placeholder: props.placeholder,
     classNames: selectBoxStyles(props.error),
     value: value,
     onChange: onChange,

--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -90,7 +90,7 @@ function ProfileForm({ me }) {
         onChange={(option) => setTimezone(option)}
         options={timezones.map((tz) => ({
           value: tz,
-          label: tz,
+          label: tz.replace(/_/g, " "),
         }))}
         data-test-id="timezone-selector"
       />

--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -51,17 +51,24 @@ function ProfileForm({ me }) {
   const [title, setTitle] = React.useState(me.title);
   const [manager, setManager] = React.useState(me.manager);
   const [managerStatus, setManagerStatus] = React.useState(me.manager ? "select-from-list" : "no-manager");
-  const [timezone, setTimezone] = React.useState({ value: me.timezone, label: me.timezone});
-  const timezones = Intl.supportedValuesOf("timeZone")
+
+  const [timezone, setTimezone] = React.useState(() => {
+    if (me.timezone) {
+      return { value: me.timezone, label: me.timezone };
+    } else {
+      return null;
+    }
+  });
+
+  const timezones = Intl.supportedValuesOf("timeZone");
 
   const handleSubmit = () => {
-    const tz = timezone.value;
     update({
       variables: {
         input: {
           fullName: name,
           title: title,
-          timezone: tz,
+          timezone: timezone?.value,
           managerId: managerStatus === "select-from-list" ? manager?.id : null,
         },
       },
@@ -76,7 +83,8 @@ function ProfileForm({ me }) {
       <Forms.TextInput value={title} onChange={setTitle} label="Title in the Company" error={title.length === 0} />
 
       <Forms.SelectBox
-        label={`Actual timezone: ${me.timezone == null ? "Not set" : me.timezone}`}
+        label="Timezone"
+        placeholder="Select your timezone..."
         value={timezone}
         defaultValue={timezone}
         onChange={(option) => setTimezone(option)}


### PR DESCRIPTION
Replaces "Actual Timezone" with "Timezone".
Removes underscore from some timezone labels, e.g. "Sao_Paulo" is now "Sao Paulo".