### PR TITLE
Fix flaky tests caused by incorrect login

### DIFF
--- a/test/support/custom_formatter.ex
+++ b/test/support/custom_formatter.ex
@@ -1,0 +1,79 @@
+defmodule CustomFormatter do
+  use GenServer
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  def init(_) do
+    {:ok, []}
+  end
+
+  def handle_cast({:suite_started, _}, state), do: {:noreply, state}
+  def handle_cast({:suite_finished, _}, state), do: display_suite_finished(state)
+
+  # deprecated events
+  def handle_cast({:case_started, _}, state), do: {:noreply, state}
+  def handle_cast({:case_finished, _}, state), do: {:noreply, state}
+
+  # module events
+  def handle_cast({:module_started, mod}, state), do: display_module_started(mod, state)
+  def handle_cast({:module_finished, _}, state), do: {:noreply, state}
+  def handle_cast({:test_started, test}, state), do: display_test_started(test, state)
+  def handle_cast({:test_finished, test}, state), do: display_test_finished(test, state)
+
+  def handle_cast(event, state) do
+    IO.puts("CustomFormatter. Unhandler Event: #{inspect(event)}")
+    {:noreply, state}
+  end
+
+  #
+  # Private
+  #
+
+  defp display_module_started(mod, state) do
+    name = String.replace(Atom.to_string(mod.name), "Elixir.", "")
+    IO.puts("\n#{yellow(name)}")
+
+    {:noreply, state}
+  end
+
+  defp display_test_started(%ExUnit.Test{state: {:excluded, _}}, state) do
+    {:noreply, state}
+  end
+
+  defp display_test_started(%ExUnit.Test{name: name}, state) do
+    [type | rest] = String.split(Atom.to_string(name), " ")
+
+    case type do
+      "test" -> IO.write("\n  #{yellow("Test")}: #{Enum.join(rest, " ")}")
+      "feature" -> IO.write("\n  #{yellow("Feature")}: #{Enum.join(rest, " ")}")
+    end
+    
+    {:noreply, state}
+  end
+
+  defp display_test_finished(%ExUnit.Test{state: {:excluded, _}}, state) do
+    {:noreply, state}
+  end
+
+  defp display_test_finished(%ExUnit.Test{state: nil}, state) do
+    IO.puts("\n\n    #{green("PASSED")}")
+    {:noreply, state}
+  end
+
+  defp display_test_finished(%ExUnit.Test{state: {:failed, _}}, state) do
+    IO.puts("\n\n    #{red("FAILED")}")
+    {:noreply, state}
+  end
+
+  defp display_suite_finished(state) do
+    IO.puts("")
+    {:stop, :normal, state}
+  end
+
+  defp red(text), do: IO.ANSI.red() <> text <> IO.ANSI.reset()
+  defp green(text), do: IO.ANSI.green() <> text <> IO.ANSI.reset()
+  defp yellow(text), do: IO.ANSI.yellow() <> text <> IO.ANSI.reset()
+
+end

--- a/test/support/custom_formatter.ex
+++ b/test/support/custom_formatter.ex
@@ -33,7 +33,7 @@ defmodule CustomFormatter do
 
   defp display_module_started(mod, state) do
     name = String.replace(Atom.to_string(mod.name), "Elixir.", "")
-    IO.puts("\n#{yellow(name)}")
+    IO.puts("\n#{blue(name)}")
 
     {:noreply, state}
   end
@@ -46,8 +46,8 @@ defmodule CustomFormatter do
     [type | rest] = String.split(Atom.to_string(name), " ")
 
     case type do
-      "test" -> IO.write("\n  #{yellow("Test")}: #{Enum.join(rest, " ")}")
-      "feature" -> IO.write("\n  #{yellow("Feature")}: #{Enum.join(rest, " ")}")
+      "test" -> IO.write("\n  #{blue("Test")}: #{Enum.join(rest, " ")}")
+      "feature" -> IO.write("\n  #{blue("Feature")}: #{Enum.join(rest, " ")}")
     end
     
     {:noreply, state}
@@ -74,6 +74,6 @@ defmodule CustomFormatter do
 
   defp red(text), do: IO.ANSI.red() <> text <> IO.ANSI.reset()
   defp green(text), do: IO.ANSI.green() <> text <> IO.ANSI.reset()
-  defp yellow(text), do: IO.ANSI.yellow() <> text <> IO.ANSI.reset()
+  defp blue(text), do: IO.ANSI.blue() <> text <> IO.ANSI.reset()
 
 end

--- a/test/support/custom_formatter.ex
+++ b/test/support/custom_formatter.ex
@@ -42,14 +42,8 @@ defmodule CustomFormatter do
     {:noreply, state}
   end
 
-  defp display_test_started(%ExUnit.Test{name: name}, state) do
-    [type | rest] = String.split(Atom.to_string(name), " ")
-
-    case type do
-      "test" -> IO.write("\n  #{blue("Test")}: #{Enum.join(rest, " ")}")
-      "feature" -> IO.write("\n  #{blue("Feature")}: #{Enum.join(rest, " ")}")
-    end
-    
+  defp display_test_started(%ExUnit.Test{name: _} = test, state) do
+    IO.write("\n  #{blue(test_type(test))}: #{test_name(test)} (#{file_and_line(test)})")
     {:noreply, state}
   end
 
@@ -75,5 +69,30 @@ defmodule CustomFormatter do
   defp red(text), do: IO.ANSI.red() <> text <> IO.ANSI.reset()
   defp green(text), do: IO.ANSI.green() <> text <> IO.ANSI.reset()
   defp blue(text), do: IO.ANSI.blue() <> text <> IO.ANSI.reset()
+
+  defp file_and_line(test) do
+    {:ok, cwd} = File.cwd()
+
+    file = String.replace(test.tags.file, cwd <> "/", "")
+    line = Integer.to_string(test.tags.line)
+
+    "#{file}:#{line}"
+  end
+
+  defp test_type(test) do
+    test.name
+    |> Atom.to_string()
+    |> String.split(" ")
+    |> hd()
+    |> String.capitalize()
+  end
+
+  defp test_name(test) do
+    test.name
+    |> Atom.to_string()
+    |> String.split(" ")
+    |> tl()
+    |> Enum.join(" ")
+  end
 
 end

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -44,6 +44,8 @@ defmodule Operately.Support.Features.UI do
       |> Browser.visit("/")
       |> Browser.set_cookie("_operately_key", "")
       |> Browser.visit(path)
+      |> Browser.visit("/")
+      |> Browser.assert_text("Company Space") # Ensure we are logged in and that the lobby is loaded
     end)
     |> Map.put(:last_login, person)
   end

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -39,9 +39,11 @@ defmodule Operately.Support.Features.UI do
   def login_as(state, person) do
     path = URI.encode("/accounts/auth/test_login?email=#{person.email}&full_name=#{person.full_name}")
 
-    execute(state, fn session ->
-      Wallaby.start_session()
-      |> Wallaby.Browser.resize_window(data.session, 1920, 2000)
+    execute(state, fn _ ->
+      {:ok, session} = Wallaby.start_session()
+
+      session
+      |> Wallaby.Browser.resize_window(1920, 2000)
       |> Browser.visit(path)
       |> Browser.assert_text("Company Space") # Ensure we are logged in and that the lobby is loaded
     end)

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -40,7 +40,8 @@ defmodule Operately.Support.Features.UI do
     path = URI.encode("/accounts/auth/test_login?email=#{person.email}&full_name=#{person.full_name}")
 
     execute(state, fn _ ->
-      {:ok, session} = Wallaby.start_session()
+      metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(Operately.Repo, self())
+      {:ok, session} = Wallaby.start_session([metadata: metadata])
 
       session
       |> Wallaby.Browser.resize_window(1920, 2000)

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -40,11 +40,9 @@ defmodule Operately.Support.Features.UI do
     path = URI.encode("/accounts/auth/test_login?email=#{person.email}&full_name=#{person.full_name}")
 
     execute(state, fn session ->
-      session
-      |> Browser.visit("/")
-      |> Browser.set_cookie("_operately_key", "")
+      Wallaby.start_session()
+      |> Wallaby.Browser.resize_window(data.session, 1920, 2000)
       |> Browser.visit(path)
-      |> Browser.visit("/")
       |> Browser.assert_text("Company Space") # Ensure we are logged in and that the lobby is loaded
     end)
     |> Map.put(:last_login, person)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,5 +4,5 @@ Application.put_env(:wallaby, :base_url, OperatelyWeb.Endpoint.url())
 Application.put_env(:wallaby, :screenshot_dir, "/tmp/screenshots")
 Application.put_env(:wallaby, :screenshot_on_failure, true)
 
-ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
+ExUnit.configure(formatters: [JUnitFormatter, CustomFormatter])
 ExUnit.start([])


### PR DESCRIPTION
I've set up screenshot collection for flaky tests on Semaphore. One thing in common for most of the flaky tests is that it is breaking when we switch from one login session to another.

Example:

``` elixir
ctx
|> UI.login_as(ctx.champion)
|> ...
|> UI.login_as(ctx.reviewew)
|> ...
```

Based on the screenshots, the application is still on the login page when the user action are passed, e.g. "click on the notification bell".

Example screenshot taken after the `UI.login_as(ctx.reviewer)` step:

![Screenshot 2024-05-24 at 12 19 47](https://github.com/operately/operately/assets/1779493/8269b86d-e467-4940-8b33-db2a21927709)

To mitigate this, I'm adding extra steps to the `UI.login_as` step that will wait for the Operately lobby to load.