### PR TITLE
First time setup

### DIFF
--- a/assets/js/app.tsx
+++ b/assets/js/app.tsx
@@ -17,7 +17,7 @@ import client from "./graphql/client";
 import "./i18n";
 
 import { ThemeProvider } from "./theme";
-import { CurrentUserProvider } from "./contexts/CurrentUserContext";
+
 
 if (window.appConfig.sentry.enabled) {
   Sentry.init({
@@ -42,11 +42,9 @@ const rootElement: HTMLElement | null = document.getElementById("root");
 const App: JSX.Element = (
   <React.StrictMode>
     <ApolloProvider client={client}>
-      <CurrentUserProvider>
-        <ThemeProvider>
-          <RouterProvider router={routes} />
-        </ThemeProvider>
-      </CurrentUserProvider>
+      <ThemeProvider>
+        <RouterProvider router={routes} />
+      </ThemeProvider>
     </ApolloProvider>
   </React.StrictMode>
 );

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -450,6 +450,15 @@ export type AddCompanyMemberInput = {
   title?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type AddFirstCompanyInput = {
+  companyName: Scalars['String']['input'];
+  email: Scalars['String']['input'];
+  fullName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  passwordConfirmation: Scalars['String']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type AddKeyResourceInput = {
   link: Scalars['String']['input'];
   projectId: Scalars['ID']['input'];
@@ -1089,6 +1098,7 @@ export type RootMutationType = {
   addCompanyAdmins?: Maybe<Scalars['Boolean']['output']>;
   addCompanyMember: Person;
   addCompanyTrustedEmailDomain: Company;
+  addFirstCompany?: Maybe<Scalars['Boolean']['output']>;
   addGroupContact?: Maybe<Group>;
   addGroupMembers?: Maybe<Group>;
   addKeyResource: ProjectKeyResource;
@@ -1192,6 +1202,11 @@ export type RootMutationTypeAddCompanyMemberArgs = {
 export type RootMutationTypeAddCompanyTrustedEmailDomainArgs = {
   companyId: Scalars['ID']['input'];
   domain: Scalars['String']['input'];
+};
+
+
+export type RootMutationTypeAddFirstCompanyArgs = {
+  input: AddFirstCompanyInput;
 };
 
 

--- a/assets/js/graphql/Me/index.tsx
+++ b/assets/js/graphql/Me/index.tsx
@@ -29,6 +29,26 @@ export function logOut() {
   });
 }
 
+export function logIn(email: string, password: string) {
+  const csrfToken = document.querySelector<HTMLMetaElement>("meta[name=csrf-token]")?.content;
+  
+  const headers = {
+    "x-csrf-token": csrfToken,
+    'Content-Type': 'application/json',
+  } as HeadersInit;
+  
+  const data = {
+    email,
+    password,
+  };
+
+  return fetch("/accounts/log_in", {
+    method: 'POST',
+    headers: headers,
+    body: JSON.stringify(data)
+  });
+}
+
 export function useProfileMutation(options = {}) {
   return useMutation(
     gql`

--- a/assets/js/graphql/client.tsx
+++ b/assets/js/graphql/client.tsx
@@ -76,7 +76,13 @@ function setupClient() {
 let client: any;
 
 if (typeof window !== "undefined") {
-  client = setupClient();
+  try {
+    client = setupClient();
+  } 
+  catch (e) {
+    console.error("Failed to setup Apollo client", e);
+    client = null;
+  }
 } else {
   client = null;
 }

--- a/assets/js/models/companies/index.tsx
+++ b/assets/js/models/companies/index.tsx
@@ -5,6 +5,7 @@ export { useAddTrustedEmailDomainMutation } from "./useAddTrustedEmailMutation";
 export { useRemoveTrustedEmailDomainMutation } from "./useRemoveTrustedEmailMutation";
 export { useRemoveAdminMutation } from "./useRemoveAdminMutation";
 export { useAddAdminsMutation } from "./useAddAdminsMutation";
+export { useAddFirstCompanyMutation } from "./useAddFirstCompanyMutation";
 
 import { Company } from "@/gql/generated";
 

--- a/assets/js/models/companies/useAddFirstCompanyMutation.tsx
+++ b/assets/js/models/companies/useAddFirstCompanyMutation.tsx
@@ -1,0 +1,14 @@
+import { gql, useMutation } from "@apollo/client";
+
+
+const MUTATION = gql`
+mutation AddFirstCompany($input: AddFirstCompanyInput!) {
+  addFirstCompany(input: $input) {
+    id
+  }
+}
+`
+
+export function useAddFirstCompanyMutation(options: any) {
+  return useMutation(MUTATION, options);
+}

--- a/assets/js/pages/FirstTimeSetupPage/index.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/index.tsx
@@ -1,0 +1,2 @@
+export { loader } from "./loader";
+export { Page } from "./page";

--- a/assets/js/pages/FirstTimeSetupPage/loader.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/loader.tsx
@@ -1,0 +1,3 @@
+export async function loader(): Promise<null> {
+  return null;
+}

--- a/assets/js/pages/FirstTimeSetupPage/page.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/page.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Forms from "@/components/Form";
+import { Spacer } from "@/components/Spacer";
+import { FilledButton } from "@/components/Button";
+
+
+export function Page() {
+  return (
+    <Pages.Page title={"FirstTimeSetupPage"}>
+      <Paper.Root>
+        <Paper.Body>
+          <div className="text-content-accent text-2xl font-extrabold">Welcome to Operately!</div>
+          <div className="text-content-accent">Let&apos;s set up your company.</div>
+
+          <Spacer size={6} />
+
+          <Form />
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
+  );
+}
+
+function Form() {
+  return (
+    <Forms.Form isValid={true} onSubmit={()=>{}}>
+      <Forms.TextInput 
+        label="Name of the company"
+        placeholder="e.g. Acme Co."
+        onChange={()=>{}}
+        value=""
+        error={false}
+      />
+
+      <Spacer />
+      <AdminAccountTitle />
+      <Spacer />
+
+      <Forms.TextInput 
+        label="Name"
+        placeholder="e.g. John Johnson"
+        onChange={()=>{}}
+        value=""
+        error={false}
+      />
+      <Forms.TextInput 
+        label="Role in the company"
+        placeholder="e.g. Founder"
+        onChange={()=>{}}
+        value=""
+        error={false}
+      />
+      <Forms.TextInput 
+        label="Password"
+        onChange={()=>{}}
+        value=""
+        error={false}
+      />
+      <Forms.TextInput 
+        label="Repeat password"
+        onChange={()=>{}}
+        value=""
+        error={false}
+      />
+
+      <div className="flex items-center justify-center">
+        <FilledButton>Submit</FilledButton>
+      </div>
+    </Forms.Form>
+  )
+}
+
+function AdminAccountTitle() {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="bg-content-accent flex-1 h-[1px] bg-black"></div>
+      <span className="text-content-accent text-center">ADMIN ACCOUNT</span>
+      <div className="bg-content-accent flex-1 h-[1px] bg-black"></div>
+    </div>
+  )
+}

--- a/assets/js/pages/FirstTimeSetupPage/page.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/page.tsx
@@ -3,8 +3,9 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Forms from "@/components/Form";
+
 import { Spacer } from "@/components/Spacer";
-import { FilledButton } from "@/components/Button";
+import { useForm } from "./useForm";
 
 
 export function Page() {
@@ -25,14 +26,20 @@ export function Page() {
 }
 
 function Form() {
+  const { fields, submit, submitting, errors } = useForm();
+
   return (
-    <Forms.Form isValid={true} onSubmit={()=>{}}>
+    <Forms.Form
+      isValid={true}
+      loading={submitting}
+      onSubmit={submit}
+    >
       <Forms.TextInput 
         label="Name of the company"
         placeholder="e.g. Acme Co."
-        onChange={()=>{}}
-        value=""
-        error={false}
+        onChange={fields.setCompanyName}
+        value={fields.companyName}
+        error={!!errors.find((e) => e.field === "companyName")?.message}
       />
 
       <Spacer />
@@ -40,34 +47,50 @@ function Form() {
       <Spacer />
 
       <Forms.TextInput 
-        label="Name"
+        label="Full name"
         placeholder="e.g. John Johnson"
-        onChange={()=>{}}
-        value=""
-        error={false}
+        onChange={fields.setFullName}
+        value={fields.fullName}
+        error={!!errors.find((e) => e.field === "fullName")?.message}
       />
+      
       <Forms.TextInput 
         label="Role in the company"
         placeholder="e.g. Founder"
-        onChange={()=>{}}
-        value=""
-        error={false}
+        onChange={fields.setRole}
+        value={fields.role}
+        error={!!errors.find((e) => e.field === "role")?.message}
+      />
+      <Forms.TextInput 
+        label="Email"
+        placeholder="e.g. john@your-company.com"
+        onChange={fields.setEmail}
+        value={fields.email}
+        error={!!errors.find((e) => e.field === "email")?.message}
       />
       <Forms.TextInput 
         label="Password"
-        onChange={()=>{}}
-        value=""
-        error={false}
+        onChange={fields.setPassword}
+        value={fields.password}
+        error={!!errors.find((e) => e.field === "password")?.message}
+        type="password"
       />
       <Forms.TextInput 
         label="Repeat password"
-        onChange={()=>{}}
-        value=""
-        error={false}
+        onChange={fields.setPasswordConfirmation}
+        value={fields.passwordConfirmation}
+        error={!!errors.find((e) => e.field === "passwordConfirmation")?.message}
+        type="password"
       />
 
+      {errors.map((e, idx) => (
+        <div key={idx} className="text-red-500 text-sm">{e.message}</div>
+      ))}
+
       <div className="flex items-center justify-center">
-        <FilledButton>Submit</FilledButton>
+        <Forms.SubmitButton>
+          Submit
+        </Forms.SubmitButton>
       </div>
     </Forms.Form>
   )

--- a/assets/js/pages/FirstTimeSetupPage/page.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/page.tsx
@@ -40,6 +40,7 @@ function Form() {
         onChange={fields.setCompanyName}
         value={fields.companyName}
         error={!!errors.find((e) => e.field === "companyName")?.message}
+        testId="company-name"
       />
 
       <Spacer />
@@ -52,6 +53,7 @@ function Form() {
         onChange={fields.setFullName}
         value={fields.fullName}
         error={!!errors.find((e) => e.field === "fullName")?.message}
+        testId="full-name"
       />
       
       <Forms.TextInput 
@@ -60,6 +62,7 @@ function Form() {
         onChange={fields.setRole}
         value={fields.role}
         error={!!errors.find((e) => e.field === "role")?.message}
+        testId="role"
       />
       <Forms.TextInput 
         label="Email"
@@ -67,6 +70,7 @@ function Form() {
         onChange={fields.setEmail}
         value={fields.email}
         error={!!errors.find((e) => e.field === "email")?.message}
+        testId="email"
       />
       <Forms.TextInput 
         label="Password"
@@ -74,6 +78,7 @@ function Form() {
         value={fields.password}
         error={!!errors.find((e) => e.field === "password")?.message}
         type="password"
+        testId="password"
       />
       <Forms.TextInput 
         label="Repeat password"
@@ -81,6 +86,7 @@ function Form() {
         value={fields.passwordConfirmation}
         error={!!errors.find((e) => e.field === "passwordConfirmation")?.message}
         type="password"
+        testId="password-confirmation"
       />
 
       {errors.map((e, idx) => (
@@ -88,7 +94,7 @@ function Form() {
       ))}
 
       <div className="flex items-center justify-center">
-        <Forms.SubmitButton>
+        <Forms.SubmitButton testId="submit-form">
           Submit
         </Forms.SubmitButton>
       </div>

--- a/assets/js/pages/FirstTimeSetupPage/page.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/page.tsx
@@ -94,7 +94,7 @@ function Form() {
       ))}
 
       <div className="flex items-center justify-center">
-        <Forms.SubmitButton testId="submit-form">
+        <Forms.SubmitButton data-test-id="submit-form">
           Submit
         </Forms.SubmitButton>
       </div>

--- a/assets/js/pages/FirstTimeSetupPage/useForm.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/useForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 
 import { useAddFirstCompanyMutation } from "@/models/companies";
+import { logIn } from "@/graphql/Me";
 
 
 export interface FormState {
@@ -62,13 +62,14 @@ export function useForm(): FormState {
 
 
 function useSubmit(fields: FormFields) {
-  const navigate = useNavigate();
-
   const [errors, setErrors] = useState<FormError[]>([]);
 
   const [add, { loading: submitting }] = useAddFirstCompanyMutation({
     onCompleted: () => {
-      navigate("/");
+      logIn(fields.email, fields.password)
+      .then(() => {
+        window.location.href = "/";
+      });
     }
   })
 

--- a/assets/js/pages/FirstTimeSetupPage/useForm.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/useForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useAddFirstCompanyMutation } from "@/models/companies";
 import { logIn } from "@/graphql/Me";
+import { camelCaseToSpacedWords } from "@/utils/strings";
 
 
 export interface FormState {
@@ -110,7 +111,7 @@ function validate(fields: FormFields): FormError[] {
 
   for (let key in fields) {
     if(!fields[key]) {
-      const fieldName = parseCamelCase(key, { capitalizeFirst: true });
+      const fieldName = camelCaseToSpacedWords(key, { capitalizeFirst: true });
       result.push({ field: key, message: `${fieldName} is required` });
     }
   }
@@ -137,17 +138,6 @@ function validate(fields: FormFields): FormError[] {
   
   if (fields.password !== fields.passwordConfirmation) {
     result.push({ field: "password", message: "Passoword and password confirmation do not match" });
-  }
-
-  return result;
-}
-
-
-function parseCamelCase(input: string, options?: { capitalizeFirst?: boolean }) {
-  let result = input.replace(/([A-Z])/g, ' $1').toLowerCase();
-
-  if (options?.capitalizeFirst) {
-    result = result.charAt(0).toUpperCase() + result.slice(1);
   }
 
   return result;

--- a/assets/js/pages/FirstTimeSetupPage/useForm.tsx
+++ b/assets/js/pages/FirstTimeSetupPage/useForm.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useAddFirstCompanyMutation } from "@/models/companies";
+
+
+export interface FormState {
+  fields: FormFields;
+  errors: FormError[];
+  submitting: boolean;
+  submit: () => Promise<boolean>;
+}
+
+export interface FormFields {
+  companyName: string;
+  fullName: string;
+  email: string;
+  role: string;
+  password: string;
+  passwordConfirmation: string;
+  
+  setCompanyName: (name: string) => void;
+  setFullName: (content: string) => void;
+  setEmail: (content: string) => void;
+  setRole: (content: string) => void;
+  setPassword: (content: string) => void;
+  setPasswordConfirmation: (content: string) => void;
+}
+
+export interface FormError {
+  field: string;
+  message: string;
+}
+
+
+export function useForm(): FormState {
+  const [companyName, setCompanyName] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+
+  const fields = {
+    companyName, setCompanyName,
+    fullName, setFullName,
+    email, setEmail,
+    role, setRole,
+    password, setPassword,
+    passwordConfirmation, setPasswordConfirmation,
+  };
+
+  const { submit, submitting, errors } = useSubmit(fields);
+
+  return {
+    fields,
+    errors,
+    submitting,
+    submit,
+  };
+}
+
+
+function useSubmit(fields: FormFields) {
+  const navigate = useNavigate();
+
+  const [errors, setErrors] = useState<FormError[]>([]);
+
+  const [add, { loading: submitting }] = useAddFirstCompanyMutation({
+    onCompleted: () => {
+      navigate("/");
+    }
+  })
+
+  const submit = async () => {
+    let errors = validate(fields);
+
+    if (errors.length > 0) {
+      setErrors(errors);
+      return false;
+    }
+    
+    await add({
+      variables: {
+        input: {
+          companyName: fields.companyName,
+          fullName: fields.fullName,
+          email: fields.email,
+          role: fields.role,
+          password: fields.password,
+          passwordConfirmation: fields.passwordConfirmation,
+        },
+      },
+    });
+
+    return true;
+  }
+  
+  return {
+    submit,
+    submitting,
+    errors,
+  };
+}
+
+
+function validate(fields: FormFields): FormError[] {
+  let result: FormError[] = [];
+
+  for (let key in fields) {
+    if(!fields[key]) {
+      const fieldName = parseCamelCase(key, { capitalizeFirst: true });
+      result.push({ field: key, message: `${fieldName} is required` });
+    }
+  }
+  
+  if (fields.companyName.length < 3) {
+    result.push({ field: "companyName", message: "Company name must have at least 3 characters" });
+  }
+  
+  if (fields.email.includes(" ") || !fields.email.includes("@")) {
+    result.push({ field: "email", message: "Email must have the @ sign and no spaces" });
+  }
+  
+  if (fields.email.length > 160) {
+    result.push({ field: "email", message: "Email must not have more than 160 characters" });
+  }
+
+  if (fields.password.length < 12) {
+    result.push({ field: "password", message: "Passoword must have at least 12 characters" });
+  }
+  
+  if (fields.password.length > 72) {
+    result.push({ field: "password", message: "Passoword must not have more than 72 characters" });
+  }
+  
+  if (fields.password !== fields.passwordConfirmation) {
+    result.push({ field: "password", message: "Passoword and password confirmation do not match" });
+  }
+
+  return result;
+}
+
+
+function parseCamelCase(input: string, options?: { capitalizeFirst?: boolean }) {
+  let result = input.replace(/([A-Z])/g, ' $1').toLowerCase();
+
+  if (options?.capitalizeFirst) {
+    result = result.charAt(0).toUpperCase() + result.slice(1);
+  }
+
+  return result;
+}

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -16,6 +16,7 @@ import * as DiscussionEditPage from "./DiscussionEditPage";
 import * as DiscussionNewPage from "./DiscussionNewPage";
 import * as DiscussionPage from "./DiscussionPage";
 import * as FeedPage from "./FeedPage";
+import * as FirstTimeSetupPage from "./FirstTimeSetupPage";
 import * as GoalAboutPage from "./GoalAboutPage";
 import * as GoalActivityPage from "./GoalActivityPage";
 import * as GoalAddPage from "./GoalAddPage";
@@ -130,6 +131,10 @@ export default {
   FeedPage: {
     loader: FeedPage.loader,
     Page: FeedPage.Page
+  },
+  FirstTimeSetupPage: {
+    loader: FirstTimeSetupPage.loader,
+    Page: FirstTimeSetupPage.Page
   },
   GoalAboutPage: {
     loader: GoalAboutPage.loader,

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -94,6 +94,8 @@ const routes = createBrowserRouter([
       pageRoute("/projects/:projectID/contributors", pages.ProjectContributorsPage),
       pageRoute("/projects/:id", pages.ProjectPage),
 
+      pageRoute("/first-time-setup", pages.FirstTimeSetupPage),
+
       pageRoute("*", pages.NotFoundPage),
     ],
   },

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -1,17 +1,31 @@
 import React from "react";
-
 import pages from "@/pages";
 
-import { createBrowserRouter } from "react-router-dom";
+import { Outlet, createBrowserRouter } from "react-router-dom";
 import { pageRoute } from "./pageRoute";
 
 import ErrorPage from "./ErrorPage";
 import DefaultLayout from "@/layouts/DefaultLayout";
 
+import { CurrentUserProvider } from "@/contexts/CurrentUserContext";
+
+
+function ProtectedRoutes() {
+  return (
+    <CurrentUserProvider>
+      <DefaultLayout />
+    </CurrentUserProvider>
+  );
+}
+
+function PublicRoutes() {
+  return <Outlet />;
+}
+
 const routes = createBrowserRouter([
   {
     path: "/",
-    element: <DefaultLayout />,
+    element: <ProtectedRoutes />,
     errorElement: <ErrorPage />,
     children: [
       pageRoute("/", pages.GroupListPage),
@@ -94,9 +108,15 @@ const routes = createBrowserRouter([
       pageRoute("/projects/:projectID/contributors", pages.ProjectContributorsPage),
       pageRoute("/projects/:id", pages.ProjectPage),
 
-      pageRoute("/first-time-setup", pages.FirstTimeSetupPage),
-
       pageRoute("*", pages.NotFoundPage),
+    ],
+  },
+  {
+    path: "/",
+    element: <PublicRoutes />,
+    errorElement: <ErrorPage />,
+    children: [
+      pageRoute("/first-time-setup", pages.FirstTimeSetupPage),
     ],
   },
 ]);

--- a/assets/js/theme/index.tsx
+++ b/assets/js/theme/index.tsx
@@ -11,13 +11,13 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const { data, loading, error } = useMe({});
 
   if (loading) return null;
-  if (error) return null;
-
-  if (!data) {
-    return null;
+  
+  if (!error) {
+    return <Context userTheme={data.me.theme}>{children}</Context>;
   }
-
-  return <Context userTheme={data.me.theme}>{children}</Context>;
+  else {
+    return <Context userTheme={"system"}>{children}</Context>;
+  }
 }
 
 function Context({ userTheme, children }: { userTheme: string; children: React.ReactNode }) {

--- a/assets/js/utils/strings.tsx
+++ b/assets/js/utils/strings.tsx
@@ -6,3 +6,13 @@ export function camelCaseToSnakeCase(str: string): string {
     .join("_")
     .toLowerCase();
 }
+
+export function camelCaseToSpacedWords(input: string, options?: { capitalizeFirst?: boolean }) {
+  let result = input.replace(/([A-Z])/g, ' $1').toLowerCase();
+
+  if (options?.capitalizeFirst) {
+    result = result.charAt(0).toUpperCase() + result.slice(1);
+  }
+
+  return result;
+}

--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -11,6 +11,10 @@ defmodule Operately.Companies do
     Repo.all(Company)
   end
 
+  def count_companies do
+    Repo.aggregate(Company, :count, :id)
+  end
+
   def list_tenets(id) do
     Repo.all(from t in Tenet, where: t.company_id == ^id)
   end

--- a/lib/operately/companies/company.ex
+++ b/lib/operately/companies/company.ex
@@ -23,5 +23,6 @@ defmodule Operately.Companies.Company do
     company
     |> cast(attrs, [:name, :mission, :trusted_email_domains, :enabled_experimental_features, :company_space_id])
     |> validate_required([:name])
+    |> validate_length(:name, min: 3)
   end
 end

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -1,0 +1,32 @@
+defmodule Operately.Operations.CompanyAdding do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Companies.Company
+  alias Operately.People.Account
+  alias Operately.People.Person
+
+  def run(attrs) do
+    Multi.new()
+    |> Multi.insert(:company, Company.changeset(%{name: attrs.company_name}))
+    |> Multi.insert(:account, Account.registration_changeset(%{email: attrs.email, password: attrs.password}))
+    |> insert_person(attrs.full_name, attrs.role)
+    |> Repo.transaction()
+    |> Repo.extract_result(:company)
+  end
+
+  def insert_person(multi, full_name, role) do
+    Multi.run(multi, :person, fn _repo, %{company: company, account: account} ->
+      Person.changeset(%{
+        company_id: company.id,
+        account_id: account.id,
+        full_name: full_name,
+        email: account.email,
+        avatar_url: "",
+        title: role
+      })
+      |> Repo.insert()
+
+      {:ok, nil}
+    end)
+  end
+end

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -4,29 +4,43 @@ defmodule Operately.Operations.CompanyAdding do
   alias Operately.Companies.Company
   alias Operately.People.Account
   alias Operately.People.Person
+  alias Operately.Groups.Group
 
   def run(attrs) do
     Multi.new()
     |> Multi.insert(:company, Company.changeset(%{name: attrs.company_name}))
+    |> insert_group()
     |> Multi.insert(:account, Account.registration_changeset(%{email: attrs.email, password: attrs.password}))
     |> insert_person(attrs.full_name, attrs.role)
     |> Repo.transaction()
     |> Repo.extract_result(:company)
   end
 
-  def insert_person(multi, full_name, role) do
-    Multi.run(multi, :person, fn _repo, %{company: company, account: account} ->
-      Person.changeset(%{
-        company_id: company.id,
-        account_id: account.id,
-        full_name: full_name,
-        email: account.email,
-        avatar_url: "",
-        title: role
-      })
-      |> Repo.insert()
+  def insert_group(multi) do
+    Multi.insert(multi, :group, fn changes ->
+      Group.changeset(%{
+        company_id: changes[:company].id,
+        name: "Company",
+        mission: "Everyone in the company",
+        icon: "IconBuildingEstate",
+        color: "text-cyan-500"
+        })
+      end)
+      |> Multi.update(:updated_company, fn %{company: company, group: group} ->
+        Company.changeset(company, %{company_space_id: group.id})
+      end)
+    end
 
-      {:ok, nil}
-    end)
-  end
+    def insert_person(multi, full_name, role) do
+      Multi.insert(multi, :person, fn changes ->
+        Person.changeset(%{
+          company_id: changes[:company].id,
+          account_id: changes[:account].id,
+          full_name: full_name,
+          email: changes[:account].email,
+          avatar_url: "",
+          title: role
+        })
+      end)
+    end
 end

--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -241,4 +241,26 @@ defmodule OperatelyWeb.AccountAuth do
   defp maybe_store_return_to(conn), do: conn
 
   defp signed_in_path(_conn), do: ~p"/"
+
+  @doc """
+  Used to redirect users if they haven't set up their company and admin account.
+
+  If they haven't, it redirects to /first-time-setup.
+  If they have, but end up accessing /first-time-setup, it redirects them back to /.
+  """
+  def redirect_if_account_not_setup(conn, _opts) do
+    if length(Operately.Companies.list_companies()) == 0 do
+      conn
+      |> redirect(to: ~p"/first-time-setup")
+      |> halt()
+    else
+      if conn.request_path == "/first-time-setup" do
+        conn
+        |> redirect(to: signed_in_path(conn))
+        |> halt()
+      else
+        conn
+      end
+    end
+  end
 end

--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -221,9 +221,14 @@ defmodule OperatelyWeb.AccountAuth do
       "AddFirstCompany",
     ]
 
+    operation_name = case conn.params do
+      %Plug.Conn.Unfetched{} -> nil
+      params when is_map(params) -> params["operationName"]
+    end
+
     cond do
       conn.request_path in unauthenticated_paths -> true
-      conn.params["operationName"] in unauthenticated_operations -> true
+      operation_name in unauthenticated_operations -> true
       true -> false
     end
   end

--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -200,13 +200,31 @@ defmodule OperatelyWeb.AccountAuth do
   they use the application at all, here would be a good place.
   """
   def require_authenticated_account(conn, _opts) do
-    if conn.assigns[:current_account] do
-      conn
-    else
-      conn
-      |> maybe_store_return_to()
-      |> redirect(to: ~p"/accounts/log_in")
-      |> halt()
+    cond do
+      allow_unauthenticated_account?(conn) ->
+        conn
+      conn.assigns[:current_account] ->
+        conn
+      true ->
+        conn
+        |> maybe_store_return_to()
+        |> redirect(to: ~p"/accounts/log_in")
+        |> halt()
+    end
+  end
+
+  defp allow_unauthenticated_account?(conn) do
+    unauthenticated_paths = [
+      "/first-time-setup",
+    ]
+    unauthenticated_operations = [
+      "AddFirstCompany",
+    ]
+
+    cond do
+      conn.request_path in unauthenticated_paths -> true
+      conn.params["operationName"] in unauthenticated_operations -> true
+      true -> false
     end
   end
 

--- a/lib/operately_web/controllers/page_controller.ex
+++ b/lib/operately_web/controllers/page_controller.ex
@@ -1,7 +1,62 @@
 defmodule OperatelyWeb.PageController do
   use OperatelyWeb, :controller
 
+  @public_pages [
+    "/accounts/log_in",
+  ]
+
   def index(conn, _params) do
+    if configured?() do
+      cond do
+        conn.request_path == "/first-time-setup" -> redirect_to_homepage(conn)
+        conn.request_path in @public_pages -> public_page(conn)
+        true -> private_page(conn)
+      end
+    else
+      redirect_to_first_time_setup(conn)
+    end
+  end
+
+  defp public_page(conn) do
     render(conn, :home)
+  end
+
+  #
+  # If the page is not public, we check whether the request
+  # is authenticated. The :fetch_current_account in the router
+  # is responsible for fetching the current account and
+  # assigning it to the conn. This function redirects the
+  # user to the login page if the current account is not assigned
+  # to the conn.
+  #
+  defp private_page(conn) do
+    if conn.assigns[:current_account] do
+      render(conn, :home)
+    else
+      conn
+      |> redirect(to: ~p"/accounts/log_in")
+      |> halt()
+    end
+  end
+
+  #
+  # If the companies count is 0, it means that the user
+  # hasn't gone through the first-time setup and the account
+  # is not configured yet.
+  #
+  defp configured?() do
+    Operately.Companies.count_companies() > 0
+  end
+
+  defp redirect_to_first_time_setup(conn) do
+    conn
+    |> redirect(to: ~p"/first-time-setup")
+    |> halt()
+  end
+
+  defp redirect_to_homepage(conn) do
+    conn
+    |> redirect(to: ~p"/")
+    |> halt()
   end
 end

--- a/lib/operately_web/controllers/page_controller.ex
+++ b/lib/operately_web/controllers/page_controller.ex
@@ -13,7 +13,11 @@ defmodule OperatelyWeb.PageController do
         true -> private_page(conn)
       end
     else
-      redirect_to_first_time_setup(conn)
+      if conn.request_path == "/first-time-setup" do
+        render(conn, :home)
+      else
+        redirect_to_first_time_setup(conn)
+      end
     end
   end
 

--- a/lib/operately_web/graphql/context.ex
+++ b/lib/operately_web/graphql/context.ex
@@ -1,10 +1,48 @@
 defmodule OperatelyWeb.Graphql.Context do
+  @public_operations [
+    "AddFirstCompany",
+  ]
+
   def init(opts), do: opts
 
   def call(conn, _) do
-    current_account = conn.assigns[:current_account]
-    context = %{current_account: current_account}
+    operation = conn.params["operationName"]
 
-    Absinthe.Plug.put_options(conn, context: context)
+    if operation in @public_operations do
+      public_operation(conn)
+    else
+      private_operation(conn)
+    end
+  end
+
+  #
+  # If the operation is a public operation, we don't need to
+  # authenticate the request.
+  #
+  defp public_operation(conn), do: conn
+
+  #
+  # If the operation is not public, we need to authenticate
+  # the request. The :fetch_current_account in the router
+  # is responsible for fetching the current account and
+  # assigning it to the conn. In this function, we only need
+  # to check if the current account is assigned to the conn.
+  #
+  defp private_operation(conn) do
+    if conn.assigns[:current_account] do
+      current_account = conn.assigns[:current_account]
+      context = %{current_account: current_account}
+
+      Absinthe.Plug.put_options(conn, context: context)
+    else
+      #
+      # IOs added for debugging the current errors in the tests
+      # They will be removed after the errors are fixed
+      #
+      IO.puts("\nFail")
+      IO.inspect(conn.params)
+      IO.puts("\n")
+      Plug.Conn.send_resp(conn, 401, "Unauthorized")
+    end
   end
 end

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -7,6 +7,15 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
     field :title, :string
   end
 
+  input_object :add_first_company_input do
+    field :company_name, non_null(:string)
+    field :full_name, non_null(:string)
+    field :email, non_null(:string)
+    field :role, :string
+    field :password, non_null(:string)
+    field :password_confirmation, non_null(:string)
+  end
+
   object :company_mutations do
     field :remove_company_admin, :person do
       arg :person_id, non_null(:id)
@@ -61,6 +70,14 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
         company = Operately.Companies.get_company!(args.company_id)
 
         Operately.Companies.remove_trusted_email_domain(company, person, args.domain)
+      end
+    end
+
+    field :add_first_company, non_null(:company) do
+      arg :input, non_null(:add_first_company_input)
+
+      resolve fn _, %{input: input}, _ ->
+        Operately.Operations.CompanyAdding.run(input)
       end
     end
   end

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -77,7 +77,13 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
       arg :input, non_null(:add_first_company_input)
 
       resolve fn _, %{input: input}, _ ->
-        Operately.Operations.CompanyAdding.run(input)
+        allowed = Operately.Companies.count_companies() == 0
+
+        if allowed do
+          Operately.Operations.CompanyAdding.run(input)
+        else
+          {:error, nil}
+        end
       end
     end
   end

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Router do
     plug :put_root_layout, {OperatelyWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug :redirect_if_account_not_setup
     plug :fetch_current_account
   end
 
@@ -31,7 +32,7 @@ defmodule OperatelyWeb.Router do
 
     get "/accounts/log_in", AccountSessionController, :new
 
-    # 
+    #
     # In development, we use the following route to log in as a user
     # during development. The route is not available in production.
     #

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -10,7 +10,6 @@ defmodule OperatelyWeb.Router do
     plug :put_root_layout, {OperatelyWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-    plug :redirect_if_account_not_setup
     plug :fetch_current_account
   end
 
@@ -78,7 +77,7 @@ defmodule OperatelyWeb.Router do
   forward "/media", OperatelyLocalMediaStorage.Plug
 
   scope "/api" do
-    pipe_through [:api, :require_authenticated_account, :graphql]
+    pipe_through [:api, :graphql]
 
     forward "/gql", Absinthe.Plug, schema: OperatelyWeb.Graphql.Schema
   end
@@ -90,9 +89,8 @@ defmodule OperatelyWeb.Router do
   end
 
   scope "/", OperatelyWeb do
-    pipe_through [:browser, :require_authenticated_account]
+    pipe_through [:browser]
 
     get "/*page", PageController, :index
   end
-
 end

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -11,7 +11,7 @@ defmodule Operately.Features.FirstTimeSetupTest do
     |> UI.assert_page("/first-time-setup")
 
     ctx
-    |> UI.visit("/accounts/log_in")
+    |> UI.visit("/people")
     |> UI.assert_page("/first-time-setup")
   end
 

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -4,6 +4,14 @@ defmodule Operately.Features.FirstTimeSetupTest do
 
   alias Operately.Support.Features.UI
 
+  @company_info %{
+    :companyName => "Acme Co.",
+    :fullName => "John Doe",
+    :email => "john@your-company.com",
+    :role => "CEO",
+    :password => "Aa12345#&!123",
+    :passwordConfirmation => "Aa12345#&!123"
+  }
 
   feature "redirects to /first-time-setup", ctx do
     ctx
@@ -21,5 +29,23 @@ defmodule Operately.Features.FirstTimeSetupTest do
     ctx
     |> UI.visit("/first-time-setup")
     |> UI.assert_page("/accounts/log_in")
+  end
+
+  feature "create company and admin account", ctx do
+    ctx
+    |> UI.visit("/")
+    |> UI.assert_page("/first-time-setup")
+    |> UI.assert_text("Welcome to Operately!")
+    |> UI.fill(testid: "company-name", with: @company_info[:companyName])
+    |> UI.fill(testid: "full-name", with: @company_info[:fullName])
+    |> UI.fill(testid: "email", with: @company_info[:email])
+    |> UI.fill(testid: "role", with: @company_info[:role])
+    |> UI.fill(testid: "password", with: @company_info[:password])
+    |> UI.fill(testid: "password-confirmation", with: @company_info[:passwordConfirmation])
+    |> UI.click(testid: "submit-form")
+    |> UI.assert_page("/accounts/log_in")
+
+    assert Operately.Companies.count_companies() == 1
+    assert Operately.People.get_account_by_email(@company_info[:email]) != nil
   end
 end

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -1,0 +1,25 @@
+defmodule Operately.Features.FirstTimeSetupTest do
+  use Operately.FeatureCase
+  import Operately.CompaniesFixtures
+
+  alias Operately.Support.Features.UI
+
+
+  feature "redirects to /first-time-setup", ctx do
+    ctx
+    |> UI.visit("/")
+    |> UI.assert_page("/first-time-setup")
+
+    ctx
+    |> UI.visit("/accounts/log_in")
+    |> UI.assert_page("/first-time-setup")
+  end
+
+  feature "redirects from /first-time-setup", ctx do
+    company_fixture(%{name: "Test Company"})
+
+    ctx
+    |> UI.visit("/first-time-setup")
+    |> UI.assert_page("/accounts/log_in")
+  end
+end

--- a/test/operately_web/controllers/account_session_controller_test.exs
+++ b/test/operately_web/controllers/account_session_controller_test.exs
@@ -2,8 +2,10 @@ defmodule OperatelyWeb.AccountSessionControllerTest do
   use OperatelyWeb.ConnCase, async: true
 
   import Operately.PeopleFixtures
+  import Operately.CompaniesFixtures
 
   setup do
+    company_fixture()
     %{account: account_fixture()}
   end
 

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -1,6 +1,7 @@
 defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
   use OperatelyWeb.ConnCase
 
+  setup :register_and_log_in_account
 
   @add_first_company """
   mutation addFirstCompany($input: AddFirstCompanyInput!) {
@@ -25,10 +26,11 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
     res = json_response(conn, 200)
     assert Map.has_key?(res["data"]["addFirstCompany"], "id")
 
-    id = res["data"]["addFirstCompany"]["id"]
+    company = Operately.Companies.get_company_by_name("Acme Co.")
+    account = Operately.People.get_account_by_email_and_password("john@your-company.com", "Aa12345#&!123")
 
-    assert length(Operately.People.list_people(id)) == 1
-    assert length(Operately.Companies.list_companies()) == 1
+    assert length(Operately.People.list_people(company.id)) == 1
+    assert account != nil
   end
 
   defp graphql(conn, query, variables) do

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -1,41 +1,62 @@
 defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
   use OperatelyWeb.ConnCase
 
-  setup :register_and_log_in_account
-
   @add_first_company """
-  mutation addFirstCompany($input: AddFirstCompanyInput!) {
+  mutation AddFirstCompany($input: AddFirstCompanyInput!) {
     addFirstCompany(input: $input) {
       id
     }
   }
   """
 
-  test "mutation: addFirstCompany", ctx do
-    conn = graphql(ctx.conn, @add_first_company, %{
-      :input => %{
-        :companyName => "Acme Co.",
-        :fullName => "John Doe",
-        :email => "john@your-company.com",
-        :role => "CEO",
-        :password => "Aa12345#&!123",
-        :passwordConfirmation => "Aa12345#&!123"
-      }
-    })
+  @add_first_company_input %{
+    :input => %{
+      :companyName => "Acme Co.",
+      :fullName => "John Doe",
+      :email => "john@your-company.com",
+      :role => "CEO",
+      :password => "Aa12345#&!123",
+      :passwordConfirmation => "Aa12345#&!123"
+    }
+  }
 
-    res = json_response(conn, 200)
-    assert Map.has_key?(res["data"]["addFirstCompany"], "id")
+  describe "mutation: AddFirstCompany" do
+    test "creates company and admin account", ctx do
+      conn = graphql(ctx.conn, @add_first_company, "AddFirstCompany", @add_first_company_input)
+      res = json_response(conn, 200)
 
-    company = Operately.Companies.get_company_by_name("Acme Co.")
-    account = Operately.People.get_account_by_email_and_password("john@your-company.com", "Aa12345#&!123")
-    group = Operately.Groups.get_group(company.company_space_id)
+      assert Map.has_key?(res["data"]["addFirstCompany"], "id")
 
-    assert length(Operately.People.list_people(company.id)) == 1
-    assert account != nil
-    assert group != nil
+      company = Operately.Companies.get_company_by_name("Acme Co.")
+      account = Operately.People.get_account_by_email_and_password("john@your-company.com", "Aa12345#&!123")
+      group = Operately.Groups.get_group(company.company_space_id)
+
+      assert Operately.Repo.aggregate(Operately.People.Person, :count, :id) == 1
+      assert account != nil
+      assert group != nil
+    end
+
+    test "allows company and admin account creation only once", ctx do
+      conn = graphql(ctx.conn, @add_first_company, "AddFirstCompany", @add_first_company_input)
+      res = json_response(conn, 200)
+
+      assert res["data"] != nil
+
+      conn = graphql(ctx.conn, @add_first_company, "AddFirstCompany", @add_first_company_input)
+      res = json_response(conn, 200)
+
+      assert res["data"] == nil
+      assert Operately.Companies.count_companies() == 1
+    end
   end
 
-  defp graphql(conn, query, variables) do
-    conn |> post("/api/gql", %{query: query, variables: variables})
+  defp graphql(conn, query, operation_name, variables) do
+    payload = %{
+      operationName: operation_name,
+      query: query,
+      variables: variables,
+    }
+
+    conn |> post("/api/gql", payload)
   end
 end

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -28,9 +28,11 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
 
     company = Operately.Companies.get_company_by_name("Acme Co.")
     account = Operately.People.get_account_by_email_and_password("john@your-company.com", "Aa12345#&!123")
+    group = Operately.Groups.get_group(company.company_space_id)
 
     assert length(Operately.People.list_people(company.id)) == 1
     assert account != nil
+    assert group != nil
   end
 
   defp graphql(conn, query, variables) do

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -1,0 +1,37 @@
+defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
+  use OperatelyWeb.ConnCase
+
+
+  @add_first_company """
+  mutation addFirstCompany($input: AddFirstCompanyInput!) {
+    addFirstCompany(input: $input) {
+      id
+    }
+  }
+  """
+
+  test "mutation: addFirstCompany", ctx do
+    conn = graphql(ctx.conn, @add_first_company, %{
+      :input => %{
+        :companyName => "Acme Co.",
+        :fullName => "John Doe",
+        :email => "john@your-company.com",
+        :role => "CEO",
+        :password => "Aa12345#&!123",
+        :passwordConfirmation => "Aa12345#&!123"
+      }
+    })
+
+    res = json_response(conn, 200)
+    assert Map.has_key?(res["data"]["addFirstCompany"], "id")
+
+    id = res["data"]["addFirstCompany"]["id"]
+
+    assert length(Operately.People.list_people(id)) == 1
+    assert length(Operately.Companies.list_companies()) == 1
+  end
+
+  defp graphql(conn, query, variables) do
+    conn |> post("/api/gql", %{query: query, variables: variables})
+  end
+end

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -144,7 +144,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_goal_link_on_project_page, ctx, goal_name: goal_name do
-    ctx 
+    ctx
     |> UI.assert_page("/projects/#{ctx.project.id}")
     |> UI.assert_text(goal_name)
     |> UI.click(testid: "project-goal-link")
@@ -199,7 +199,7 @@ defmodule Operately.Support.Features.ProjectSteps do
       to: ctx.reviewer,
       author: ctx.champion,
       action: "disconnected the project from the #{goal_name} goal",
-    })  
+    })
   end
 
   step :assert_goal_disconnected_notification_sent_to_reviewer, ctx do
@@ -235,7 +235,7 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> FeedSteps.assert_project_moved(author: ctx.champion, old_space: ctx.group, new_space: ctx.new_space)
   end
 
-  # 
+  #
   # Navigation between project pages
   #
 
@@ -278,7 +278,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :pause_project, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "project-options-button")
     |> UI.click(testid: "pause-project-link")
     |> UI.click(testid: "pause-project-button")
@@ -317,7 +317,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :resume_project, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "project-options-button")
     |> UI.click(testid: "resume-project-link")
     |> UI.click(testid: "resume-project-button")
@@ -376,7 +376,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   step :given_a_person_exists, ctx, name: name do
     person_fixture_with_account(%{
       full_name: name,
-      title: "Manager", 
+      title: "Manager",
       company_id: ctx.company.id
     })
 
@@ -394,6 +394,9 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_contributor_added, ctx, name: name, responsibility: responsibility do
+    ctx
+    |> UI.assert_text(name)
+
     contributors = Operately.Projects.list_project_contributors(ctx.project)
     contributors = Operately.Repo.preload(contributors, :person)
     contrib = Enum.find(contributors, fn c -> c.person.full_name == name end)
@@ -439,7 +442,7 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> EmailSteps.assert_activity_email_sent(%{
       where: ctx.project.name,
       to: contrib.person,
-      author: ctx.champion, 
+      author: ctx.champion,
       action: "added you as a contributor"
     })
   end
@@ -450,7 +453,7 @@ defmodule Operately.Support.Features.ProjectSteps do
     {:ok, _} = Operately.Projects.create_contributor(%{
       person_id: contrib.id,
       role: "contributor",
-      project_id: ctx.project.id, 
+      project_id: ctx.project.id,
       responsibility: "Lead the backend implementation"
     })
 

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -135,6 +135,9 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_goal_connected, ctx, goal_name: goal_name do
+    ctx
+    |> UI.assert_text(goal_name, testid: "project-goal-link")
+
     project = Operately.Projects.get_project!(ctx.project.id)
     project = Operately.Repo.preload(project, :goal)
 


### PR DESCRIPTION
I've created a wizard for the self-hosted installations. When the user runs the server for the first time, they are redirected to the /first-time-setup page, where they can create their company and their admin account. After going through the first time setup, they are redirected to the homepage, and they can start using Operately normally.

To make sure that the user goes through the first time setup only if they haven't set up their company and admin account yet, I've created a new plug, `redirect_if_account_not_setup`, which takes care of two tasks:

  - It always redirects users to /first-time-setup if they haven't set up their account yet.
  - It always redirects users from /first-time-setup to the homepage if they have already set up their account.

However, there remains an issue to be solved. In order to allow the necessary unauthenticated requests through, I had to make some changes in the `require_authenticated_account` plug. Unfortunately, these changes broke a couple of tests in test/operately_web/account_auth_test.exs and I haven't figured out a way to adapt the tests yet. 

This test suite uses a custom `conn` which seems not to go through `Plug.Parsers`, therefore 3 of the test cases throw the following error:

```
** (ArgumentError) cannot fetch key "operationName" from conn.params because they were not fetched. 
Configure and invoke Plug.Parsers to set params based on the request
```

