### PR TITLE
Routing for first time setup without touching auth code

### DIFF
--- a/lib/operately_web/controllers/page_controller.ex
+++ b/lib/operately_web/controllers/page_controller.ex
@@ -2,6 +2,16 @@ defmodule OperatelyWeb.PageController do
   use OperatelyWeb, :controller
 
   def index(conn, _params) do
-    render(conn, :home)
+    if configured?() do
+      render(conn, :home)
+    else
+      conn
+      |> redirect(to: ~p"/first-time-setup")
+      |> halt()
+    end
+  end
+
+  defp configured?() do
+    Operately.Repo.aggregate(Operately.Companies.Company, :count, :id) > 0
   end
 end

--- a/lib/operately_web/graphql/context.ex
+++ b/lib/operately_web/graphql/context.ex
@@ -1,10 +1,45 @@
 defmodule OperatelyWeb.Graphql.Context do
+  @public_operations [
+    "AddFirstCompany",
+  ]
+
   def init(opts), do: opts
 
   def call(conn, _) do
-    current_account = conn.assigns[:current_account]
-    context = %{current_account: current_account}
+    operation = conn.params["operationName"]
 
-    Absinthe.Plug.put_options(conn, context: context)
+    if operation in @public_operations do
+      public_operation(conn)
+    else
+      private_operation(conn)
+    end
+  end
+
+  #
+  # If the operation is a public operation, we don't need to
+  # authenticate the request.
+  #
+  defp public_operation(conn) do
+    conn
+  end
+
+  #
+  # If the operation is not public, we need to authenticate 
+  # the request. The :fetch_current_account in the router 
+  # is responsible for fetching the current account and
+  # assigning it to the conn. In this function, we only need
+  # to check if the current account is assigned to the conn.
+  # 
+  defp private_operation(conn) do
+    if conn.assigns[:current_account] do
+      current_account = conn.assigns[:current_account]
+      context = %{current_account: current_account}
+
+      Absinthe.Plug.put_options(conn, context: context)
+
+      conn
+    else
+      Plug.Conn.send_resp(conn, 401, "Unauthorized")
+    end
   end
 end

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -53,13 +53,11 @@ defmodule OperatelyWeb.Router do
 
   scope "/", OperatelyWeb do
     pipe_through [:browser, :require_authenticated_account]
-
     get "/blobs/:id", BlobController, :get
   end
 
   scope "/", OperatelyWeb do
     pipe_through [:browser]
-
     delete "/accounts/log_out", AccountSessionController, :delete
 
     #
@@ -77,7 +75,7 @@ defmodule OperatelyWeb.Router do
   forward "/media", OperatelyLocalMediaStorage.Plug
 
   scope "/api" do
-    pipe_through [:api, :require_authenticated_account, :graphql]
+    pipe_through [:api, :graphql]
 
     forward "/gql", Absinthe.Plug, schema: OperatelyWeb.Graphql.Schema
   end
@@ -89,7 +87,7 @@ defmodule OperatelyWeb.Router do
   end
 
   scope "/", OperatelyWeb do
-    pipe_through [:browser, :require_authenticated_account]
+    pipe_through [:browser]
 
     get "/*page", PageController, :index
   end


### PR DESCRIPTION
A proposal how to approach routing for the first time company setup.

Two observations:

1. The existing `require_authenticated_account` is meant for HTML based controllers. It is probably not suited best for APIs. For example, if the user is not authenticated it returns a 500 page, instead of simply returning 401 like an API should.

2. Not all pages should be protected in the final `scope "/", OperatelyWeb do` scope. Now we React pages that are public.

---

Based on this, I've split up the auth code into two parts:

1. One part in OperatelyWeb.Graphql.Context. Now we can expose public operations from there, and protect others. The good thing is that this plug is now returning a simple 401 for unauthenticad routes.

2. I'm allowing the code to go all the way down to the PagesController and there checking if the application has been configured or not.