### PR TITLE
Allow using belongs_to on embedded schemas

### DIFF
--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -60,6 +60,21 @@ defmodule Operately.Activities do
     end
   end
 
+  def cast_content(activity) do
+    module = find_module("Operately.Activities.Content", activity.action)
+
+    if module do
+      schema = struct(module)
+      fields = module.__schema__(:fields)
+      changeset = Ecto.Changeset.cast(schema, activity.content, fields)
+      casted = Ecto.Changeset.apply_changes(changeset)
+
+      %{activity | content: casted}
+    else
+      %{activity | content: nil}
+    end
+  end
+
   def build_content(action, params) do
     module = find_module("Operately.Activities.Content", action)
     changeset = apply(module, :build, [params])

--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -77,11 +77,13 @@ defmodule Operately.Activities do
 
   def build_content(action, params) do
     module = find_module("Operately.Activities.Content", action)
-    changeset = apply(module, :build, [params])
+    changeset = module.changeset(params)
 
     if changeset.valid? do
+      fields = module.__schema__(:fields)
       content = Ecto.Changeset.apply_changes(changeset)
-      {:ok, content}
+
+      {:ok, Map.take(content, fields)}
     else
       {:error, changeset}
     end

--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -69,9 +69,7 @@ defmodule Operately.Activities do
     module = find_module("Operately.Activities.Content", activity.action)
 
     if module do
-      schema = struct(module)
-      fields = module.__schema__(:fields)
-      changeset = Ecto.Changeset.cast(schema, activity.content, fields)
+      changeset = module.cast_all_fields(activity.content)
       casted = Ecto.Changeset.apply_changes(changeset)
 
       %{activity | content: casted}

--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -8,11 +8,16 @@ defmodule Operately.Activities do
   alias Operately.Activities.ListActivitiesOperation
 
   def get_activity!(id) do
-    Repo.get!(Activity, id)
+    Repo.get!(Activity, id) |> cast_content()
   end
 
   def list_activities(scope_type, scope_id, actions) do
     ListActivitiesOperation.run(scope_type, scope_id, actions)
+  end
+
+  def load_for_notifications(notifications) do
+    Repo.preload(notifications, [activity: [:author]]) 
+    |> Enum.map(fn n -> %{n | activity: cast_content(n.activity)} end)
   end
 
   def insert(multi, author_id, action, callback) do

--- a/lib/operately/activities/content.ex
+++ b/lib/operately/activities/content.ex
@@ -14,6 +14,15 @@ defmodule Operately.Activities.Content do
       def fetch(term, key) when is_binary(key) do
         {:ok, Map.get(term, String.to_existing_atom(key))}
       end
+
+      def cast_all_fields(attrs) do
+        embeds = __schema__(:embeds)
+        fields = __schema__(:fields) -- embeds
+
+        changeset = struct(__MODULE__) |> cast(attrs, fields)
+
+        Enum.reduce(embeds, changeset, fn embed, cs -> cast_embed(cs, embed) end)
+      end
     end
   end
 end

--- a/lib/operately/activities/content.ex
+++ b/lib/operately/activities/content.ex
@@ -6,6 +6,14 @@ defmodule Operately.Activities.Content do
 
       @primary_key false
       @derive Jason.Encoder
+
+      def fetch(term, key) when is_atom(key) do
+        {:ok, Map.get(term, key)}
+      end
+
+      def fetch(term, key) when is_binary(key) do
+        {:ok, Map.get(term, String.to_existing_atom(key))}
+      end
     end
   end
 end

--- a/lib/operately/activities/content/project_created.ex
+++ b/lib/operately/activities/content/project_created.ex
@@ -2,8 +2,8 @@ defmodule Operately.Activities.Content.ProjectCreated do
   use Operately.Activities.Content
 
   embedded_schema do
-    field :company_id, :string
-    field :project_id, :string
+    belongs_to :company, Operately.Companies.Company, type: :string
+    belongs_to :project, Operately.Projects.Project, type: :string
   end
 
   def changeset(attrs) do

--- a/lib/operately/activities/list_activities_operation.ex
+++ b/lib/operately/activities/list_activities_operation.ex
@@ -16,6 +16,7 @@ defmodule Operately.Activities.ListActivitiesOperation do
     |> company_query()
     |> order_desc()
     |> Repo.all()
+    |> Enum.map(&Operately.Activities.cast_content/1)
   end
 
   def company_query(query) do

--- a/lib/operately/activities/recorder.ex
+++ b/lib/operately/activities/recorder.ex
@@ -14,23 +14,15 @@ defmodule Operately.Activities.Recorder do
     {:ok, content} = build_content(action, params)
 
     Multi.new()
-    |> Multi.insert(:activity, Activity.changeset(%{author_id: author_id, action: action, content: content }))
+    |> Multi.insert(:activity, Activity.changeset(%{
+      author_id: author_id, 
+      action: action, 
+      content: content 
+    }))
     |> Multi.run(:notifications, fn _, changes -> schedule_notifications(changes.activity) end)
     |> Repo.transaction()
   rescue
     err -> Logger.error(Exception.format(:error, err, __STACKTRACE__))
-  end
-
-  def build_content(action, params) do
-    module = find_module("Operately.Activities.Content", action)
-    changeset = apply(module, :build, [params])
-
-    if changeset.valid? do
-      content = Ecto.Changeset.apply_changes(changeset)
-      {:ok, content}
-    else
-      {:error, changeset}
-    end
   end
 
   def schedule_notifications(activity) do
@@ -38,7 +30,25 @@ defmodule Operately.Activities.Recorder do
     apply(module, :dispatch, [activity])
   end
 
-  defp find_module(base, action) do
+  def build_content(action, params) do
+    module = find_module("Operately.Activities.Content", action)
+    changeset = module.changeset(params)
+
+    if changeset.valid? do
+      fields = module.__schema__(:fields)
+      content = Ecto.Changeset.apply_changes(changeset)
+
+      {:ok, Map.take(content, fields)}
+    else
+      {:error, changeset}
+    end
+  end
+
+  defp find_module(base, action) when is_atom(action) do
+    find_module(base, Atom.to_string(action))
+  end
+
+  defp find_module(base, action) when is_binary(action) do
     full_module_name = "Elixir.#{base}.#{Macro.camelize(action)}"
     String.to_existing_atom(full_module_name)
   end

--- a/lib/operately_email/emails/goal_timeframe_editing_email.ex
+++ b/lib/operately_email/emails/goal_timeframe_editing_email.ex
@@ -7,9 +7,6 @@ defmodule OperatelyEmail.Emails.GoalTimeframeEditingEmail do
     company = Repo.preload(author, :company).company
     goal = Goals.get_goal!(activity.content["goal_id"])
 
-    old_timeframe = Operately.Goals.Timeframe.parse_json!(activity.content["old_timeframe"])
-    new_timeframe = Operately.Goals.Timeframe.parse_json!(activity.content["new_timeframe"])
-
     message = Operately.Repo.preload(activity, :comment_thread).comment_thread.message
     link = OperatelyEmail.goal_activity_url(goal.id, activity.id)
 
@@ -20,8 +17,8 @@ defmodule OperatelyEmail.Emails.GoalTimeframeEditingEmail do
     |> subject(where: goal.name, who: author, action: "edited the timeframe")
     |> assign(:author, author)
     |> assign(:goal, goal)
-    |> assign(:old_timeframe, old_timeframe)
-    |> assign(:new_timeframe, new_timeframe)
+    |> assign(:old_timeframe, activity.content.old_timeframe)
+    |> assign(:new_timeframe, activity.content.new_timeframe)
     |> assign(:message, message)
     |> assign(:link, link)
     |> render("goal_timeframe_editing")

--- a/lib/operately_email/emails/project_timeline_edited_email.ex
+++ b/lib/operately_email/emails/project_timeline_edited_email.ex
@@ -34,9 +34,6 @@ defmodule OperatelyEmail.Emails.ProjectTimelineEditedEmail do
 
   defp calculate_duration(start_time, end_time) do
     if start_time && end_time do
-      {:ok, start_time, _} = DateTime.from_iso8601(start_time)
-      {:ok, end_time, _} = DateTime.from_iso8601(end_time)
-
       duration_in_days = Date.diff(end_time, start_time)
       duration_in_weeks = div(duration_in_days, 7)
 

--- a/lib/operately_web/graphql/queries/notifications.ex
+++ b/lib/operately_web/graphql/queries/notifications.ex
@@ -19,7 +19,7 @@ defmodule OperatelyWeb.Graphql.Queries.Notifications do
           per_page: args.per_page
         )
 
-        notifications = Operately.Repo.preload(notifications, [activity: [:author]])
+        notifications = Operately.Activities.load_for_notifications(notifications)
 
         {:ok, notifications}
       end

--- a/lib/operately_web/graphql/types/activity_content_goal_editing.ex
+++ b/lib/operately_web/graphql/types/activity_content_goal_editing.ex
@@ -37,7 +37,7 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentGoalEditing do
     field :old_timeframe, non_null(:timeframe) do
       resolve fn activity, _, _ ->
         if activity.content["previous_timeframe"] do
-          {:ok, Operately.Goals.Timeframe.parse_json!(activity.content["previous_timeframe"])}
+          {:ok, activity.content["previous_timeframe"]}
         else
           {:ok, Operately.Goals.Timeframe.convert_old_timeframe(activity.content["old_timeframe"])}
         end
@@ -47,7 +47,7 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentGoalEditing do
     field :new_timeframe, non_null(:timeframe) do
       resolve fn activity, _, _ ->
         if activity.content["current_timeframe"] do
-          {:ok, Operately.Goals.Timeframe.parse_json!(activity.content["current_timeframe"])}
+          {:ok, activity.content["current_timeframe"]}
         else
           {:ok, Operately.Goals.Timeframe.convert_old_timeframe(activity.content["new_timeframe"])}
         end
@@ -96,25 +96,19 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentGoalEditing do
 
     field :added_targets, non_null(list_of(:target)) do
       resolve fn activity, _, _ ->
-        targets = activity.content["added_targets"] |> Enum.map(&atomize_keys/1)
-
-        {:ok, targets}
+        {:ok, activity.content["added_targets"]}
       end
     end
 
     field :updated_targets, non_null(list_of(:goal_editing_updated_target)) do
       resolve fn activity, _, _ ->
-        targets = activity.content["updated_targets"] |> Enum.map(&atomize_keys/1)
-
-        {:ok, targets}
+        {:ok, activity.content["updated_targets"]}
       end
     end
 
     field :deleted_targets, non_null(list_of(:target)) do
       resolve fn activity, _, _ ->
-        targets = activity.content["deleted_targets"] |> Enum.map(&atomize_keys/1)
-
-        {:ok, targets}
+        {:ok, activity.content["deleted_targets"]}
       end
     end
   end
@@ -123,14 +117,5 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentGoalEditing do
     field :id, non_null(:string)
     field :old_name, non_null(:string)
     field :new_name, non_null(:string)
-  end
-
-  defp atomize_keys(map) do
-    map
-    |> Map.to_list()
-    |> Enum.map(fn {key, value} ->
-      {String.to_atom(key), value}
-    end)
-    |> Map.new()
   end
 end

--- a/lib/operately_web/graphql/types/activity_content_goal_timeframe_editing.ex
+++ b/lib/operately_web/graphql/types/activity_content_goal_timeframe_editing.ex
@@ -10,14 +10,14 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentGoalTimeframeEditing do
 
     field :old_timeframe, non_null(:timeframe) do
       resolve fn activity, _, _ ->
-        {:ok, Operately.Goals.Timeframe.parse_json!(activity.content["old_timeframe"])}
+        {:ok, activity.content.old_timeframe}
       end
     end
     
     
     field :new_timeframe, non_null(:timeframe) do
       resolve fn activity, _, _ ->
-        {:ok, Operately.Goals.Timeframe.parse_json!(activity.content["new_timeframe"])}
+        {:ok, activity.content.new_timeframe}
       end
     end
     

--- a/lib/operately_web/graphql/types/activity_content_project_created.ex
+++ b/lib/operately_web/graphql/types/activity_content_project_created.ex
@@ -10,11 +10,9 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentProjectCreated do
 
     field :project, non_null(:project) do
       resolve fn activity, _, _ ->
-        project_id = activity.content["project_id"]
+        content = Operately.Repo.preload(activity.content, :project)
 
-        project = Operately.Projects.get_project!(project_id)
-
-        {:ok, project}
+        {:ok, content.project}
       end
     end
   end

--- a/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
+++ b/lib/operately_web/graphql/types/activity_content_project_timeline_edited.ex
@@ -52,5 +52,6 @@ defmodule OperatelyWeb.Graphql.Types.ActivityContentProjectTimelineEdited do
   end
 
   defp as_date(nil), do: nil
-  defp as_date(date), do: NaiveDateTime.from_iso8601!(date)
+  defp as_date(%DateTime{} = date), do: date
+  defp as_date(date) when is_binary(date), do: NaiveDateTime.from_iso8601!(date)
 end

--- a/test/features/goal_creation_test.exs
+++ b/test/features/goal_creation_test.exs
@@ -5,9 +5,6 @@ defmodule Operately.Features.GoalCreationTest do
   import Operately.GroupsFixtures
   import Operately.PeopleFixtures
 
-  alias Operately.Support.Features.NotificationsSteps
-  alias Operately.Support.Features.EmailSteps
-  alias Operately.Support.Features.FeedSteps
   alias Operately.Support.Features.GoalSteps, as: Steps
 
   setup ctx do
@@ -47,7 +44,6 @@ defmodule Operately.Features.GoalCreationTest do
     |> Steps.assert_company_goal_added(@goal_params)
     |> Steps.assert_company_goal_created_email_sent(@goal_params.name)
   end
-
 
   @tag login_as: :champion
   feature "add subgoal to a company wide goal", ctx do


### PR DESCRIPTION
Up until now, we couldn't use use a `belongs_to` association on activity data, which means that we couldn't use `Repo.preload(record, [:association1, :association1])`, but had to manually load them.

Loading referenced records without this was error prone, and hard to optimize.