### PR TITLE
First-time-setup now creates account with admin privileges

### DIFF
--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -39,7 +39,8 @@ defmodule Operately.Operations.CompanyAdding do
           full_name: full_name,
           email: changes[:account].email,
           avatar_url: "",
-          title: role
+          title: role,
+          company_role: :admin,
         })
       end)
     end

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -45,7 +45,13 @@ defmodule Operately.Features.FirstTimeSetupTest do
     |> UI.click(testid: "submit-form")
     |> UI.assert_page("/accounts/log_in")
 
+    account = Operately.People.get_account_by_email_and_password(@company_info[:email], @company_info[:password])
+
     assert Operately.Companies.count_companies() == 1
-    assert Operately.People.get_account_by_email(@company_info[:email]) != nil
+    assert account != nil
+
+    account = Operately.Repo.preload(account, :person)
+
+    assert account.person.company_role == :admin
   end
 end

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -36,6 +36,10 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
       assert Operately.Repo.aggregate(Operately.People.Person, :count, :id) == 1
       assert account != nil
       assert group != nil
+
+      account = Operately.Repo.preload(account, :person)
+
+      assert account.person.company_role == :admin
     end
 
     test "allows company and admin account creation only once", ctx do


### PR DESCRIPTION
The first-time-setup was creating the first account without admin privileges. Now that is fixed.