### PR TITLE
Add possibility to hide or display "Sign in with Google"

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -92,6 +92,11 @@ config :ex_aws,
 config :operately, OperatelyEmail.Mailer,
   adapter: Bamboo.LocalAdapter
 
+# Determines if the 'Sign in with Google' feature is enabled.
+# Set `ALLOW_LOGIN_WITH_GOOGLE` in the .env file to "yes"
+# to enable user sign-in with Google.
+config :operately, allow_login_with_google: System.get_env("ALLOW_LOGIN_WITH_GOOGLE", "no")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/lib/operately_web/controllers/account_session_controller.ex
+++ b/lib/operately_web/controllers/account_session_controller.ex
@@ -4,7 +4,9 @@ defmodule OperatelyWeb.AccountSessionController do
   alias OperatelyWeb.AccountAuth
 
   def new(conn, _params) do
-    render(conn, :new, error_message: nil, layout: false)
+    allow_google_login = Application.get_env(:operately, :allow_login_with_google)
+
+    render(conn, :new, error_message: nil, layout: false, allow_google_login: allow_google_login)
   end
 
   if Application.compile_env(:operately, :dev_routes) do

--- a/lib/operately_web/controllers/account_session_html/new.html.heex
+++ b/lib/operately_web/controllers/account_session_html/new.html.heex
@@ -55,7 +55,7 @@
     </div>
 
     <div class="flex justify-center">
-      <div class="text-center">
+      <div class="text-center" data-test-id="google-sign-in">
         <a href={~p"/accounts/auth/google"} class="bg-blue-500 text-white-1 px-6 py-2.5 flex items-center font-medium hover:bg-blue-600">
           <svg class="w-4 h-4 mr-2 -ml-1" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512"><path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path></svg>
           Sign in with Google

--- a/lib/operately_web/controllers/account_session_html/new.html.heex
+++ b/lib/operately_web/controllers/account_session_html/new.html.heex
@@ -47,18 +47,20 @@
     </.form>
   </div>
 
-  <div class="flex items-center gap-4 my-8 text-content-dimmed uppercase text-xs font-medium tracking-wide">
-    <div class="border-t border-stroke-base flex-1" />
-    or
-    <div class="border-t border-stroke-base flex-1" />
-  </div>
-
-  <div class="flex justify-center">
-    <div class="text-center">
-      <a href={~p"/accounts/auth/google"} class="bg-blue-500 text-white-1 px-6 py-2.5 flex items-center font-medium hover:bg-blue-600">
-        <svg class="w-4 h-4 mr-2 -ml-1" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512"><path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path></svg>
-        Sign in with Google
-      </a>
+  <%= if @allow_google_login == "yes" do %>
+    <div class="flex items-center gap-4 my-8 text-content-dimmed uppercase text-xs font-medium tracking-wide">
+      <div class="border-t border-stroke-base flex-1" />
+      or
+      <div class="border-t border-stroke-base flex-1" />
     </div>
-  </div>
+
+    <div class="flex justify-center">
+      <div class="text-center">
+        <a href={~p"/accounts/auth/google"} class="bg-blue-500 text-white-1 px-6 py-2.5 flex items-center font-medium hover:bg-blue-600">
+          <svg class="w-4 h-4 mr-2 -ml-1" aria-hidden="true" focusable="false" data-prefix="fab" data-icon="google" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 488 512"><path fill="currentColor" d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"></path></svg>
+          Sign in with Google
+        </a>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/test/features/login_test.exs
+++ b/test/features/login_test.exs
@@ -1,0 +1,36 @@
+defmodule Operately.Features.LoginTest do
+  use Operately.FeatureCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Support.Features.UI
+
+  @google_sign_in_query Query.css("[data-test-id=google-sign-in]")
+
+
+  setup ctx do
+    company = company_fixture()
+    person_fixture_with_account(%{company_id: company.id, full_name: "John Admin"})
+
+    {:ok, ctx}
+  end
+
+  feature "\"Sign in with Google\" hidden", ctx do
+    Application.put_env(:operately, :allow_login_with_google, "no")
+
+    ctx
+    |> UI.visit("/")
+    |> UI.assert_page("/accounts/log_in")
+    |> UI.refute_has(@google_sign_in_query)
+  end
+
+  feature "\"Sign in with Google\" visible", ctx do
+    Application.put_env(:operately, :allow_login_with_google, "yes")
+
+    ctx
+    |> UI.visit("/")
+    |> UI.assert_page("/accounts/log_in")
+    |> UI.assert_has(@google_sign_in_query)
+  end
+end

--- a/test/operately_web/controllers/account_session_controller_test.exs
+++ b/test/operately_web/controllers/account_session_controller_test.exs
@@ -11,6 +11,8 @@ defmodule OperatelyWeb.AccountSessionControllerTest do
 
   describe "GET /accounts/log_in" do
     test "renders log in page", %{conn: conn} do
+      Application.put_env(:operately, :allow_login_with_google, "yes")
+
       conn = get(conn, ~p"/accounts/log_in")
       response = html_response(conn, 200)
       assert response =~ "Sign in with Google"


### PR DESCRIPTION
I've added the possibility of hiding or showing the 'Sign in with Google' option in the login page. 
Users can now set `ALLOW_LOGIN_WITH_GOOGLE` to 'yes' or 'no' in the .env file. If the variable isn't set, it defaults to "no".