### PR TITLE
Add the possibility to remove members

### DIFF
--- a/assets/js/models/companies/index.tsx
+++ b/assets/js/models/companies/index.tsx
@@ -5,6 +5,7 @@ export { useAddTrustedEmailDomainMutation } from "./useAddTrustedEmailMutation";
 export { useRemoveTrustedEmailDomainMutation } from "./useRemoveTrustedEmailMutation";
 export { useRemoveAdminMutation } from "./useRemoveAdminMutation";
 export { useAddAdminsMutation } from "./useAddAdminsMutation";
+export { useRemoveMemberMutation } from "./useRemoveMemberMutation";
 export { useAddFirstCompanyMutation } from "./useAddFirstCompanyMutation";
 
 import { Company } from "@/gql/generated";

--- a/assets/js/models/companies/useRemoveMemberMutation.tsx
+++ b/assets/js/models/companies/useRemoveMemberMutation.tsx
@@ -1,0 +1,13 @@
+import { gql, useMutation } from "@apollo/client";
+
+const MUTATION = gql`
+  mutation RemoveCompanyMember($personId: ID!) {
+    removeCompanyMember(personId: $personId) {
+      id
+    }
+  }
+`;
+
+export function useRemoveMemberMutation(options = {}) {
+  return useMutation(MUTATION, options);
+}

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import Avatar from "@/components/Avatar";
 import { Person } from "@/gql";
 import { useLoadedData } from "./loader";
+import { GhostButton } from "@/components/Button";
+import { useRemoveMemberMutation } from "@/models/companies";
 
 export function PeopleList() {
   const { company } = useLoadedData();
@@ -16,6 +18,14 @@ export function PeopleList() {
 }
 
 function PersonRow({ person }: { person: Person }) {
+  const [remove, { loading }] = useRemoveMemberMutation();
+
+  const handleRemoveMember = async () => {
+    await remove({
+      variables: { personId: person.id }
+    });
+  }
+
   return (
     <div className="flex flex-col gap-4 items-center border border-stroke-base rounded-lg p-4 py-6">
       <Avatar person={person} size="xlarge" />
@@ -23,7 +33,18 @@ function PersonRow({ person }: { person: Person }) {
       <div className="flex flex-col text-center items-center">
         <div className="text-content-primary font-bold">{person.fullName}</div>
         <div className="text-content-secondary text-sm">{person.title}</div>
-        <div className="text-content-secondary text-sm">{person.email}</div>
+        <div className="text-content-secondary text-sm break-all">{person.email}</div>
+      </div>
+
+      <div>
+        <GhostButton
+          onClick={handleRemoveMember}
+          size="xxs"
+          loading={loading}
+          testId="remove-member"
+        >
+          Remove
+        </GhostButton>
       </div>
     </div>
   );

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -1,9 +1,12 @@
 import * as React from "react";
-import Avatar from "@/components/Avatar";
-import { Person } from "@/gql";
+import { useNavigate } from "react-router-dom";
+
 import { useLoadedData } from "./loader";
-import { GhostButton } from "@/components/Button";
 import { useRemoveMemberMutation } from "@/models/companies";
+import { Person } from "@/gql";
+import { GhostButton } from "@/components/Button";
+import Avatar from "@/components/Avatar";
+
 
 export function PeopleList() {
   const { company } = useLoadedData();
@@ -18,7 +21,12 @@ export function PeopleList() {
 }
 
 function PersonRow({ person }: { person: Person }) {
-  const [remove, { loading }] = useRemoveMemberMutation();
+  const navigate = useNavigate();
+  const [remove, { loading }] = useRemoveMemberMutation({
+    onCompleted: () => {
+      navigate(0);
+    }
+  });
 
   const handleRemoveMember = async () => {
     await remove({

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { useLoadedData } from "./loader";
 import { useRemoveMemberMutation } from "@/models/companies";
+import { createTestId } from "@/utils/testid";
 import { Person } from "@/gql";
 import { FilledButton, GhostButton } from "@/components/Button";
 import Modal from "@/components/Modal";
@@ -25,6 +26,7 @@ export function PeopleList() {
 
 function PersonRow({ person }: { person: Person }) {
   const [showRemoveMember, setShowRemoveMember] = useState(false);
+  const removeTestId = createTestId("remove", person.fullName);
   
   return (
     <>
@@ -42,7 +44,7 @@ function PersonRow({ person }: { person: Person }) {
             onClick={() => setShowRemoveMember(true)}
             size="xxs"
             type="secondary"
-            testId="remove-member"
+            testId={removeTestId}
           >
             Remove
           </GhostButton>
@@ -86,6 +88,7 @@ function RemoveMemberModal({isOpen, hideModal, person}: {isOpen: boolean, hideMo
           onClick={handleRemoveMember}
           type="primary"
           loading={loading}
+          testId="remove-member"
         >
           Remove Member
         </FilledButton>

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -1,11 +1,13 @@
-import * as React from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useLoadedData } from "./loader";
 import { useRemoveMemberMutation } from "@/models/companies";
 import { Person } from "@/gql";
-import { GhostButton } from "@/components/Button";
+import { FilledButton, GhostButton } from "@/components/Button";
+import Modal from "@/components/Modal";
 import Avatar from "@/components/Avatar";
+
 
 
 export function PeopleList() {
@@ -20,7 +22,44 @@ export function PeopleList() {
   );
 }
 
+
 function PersonRow({ person }: { person: Person }) {
+  const [showRemoveMember, setShowRemoveMember] = useState(false);
+  
+  return (
+    <>
+      <div className="flex flex-col gap-4 items-center border border-stroke-base rounded-lg p-4 py-6">
+        <Avatar person={person} size="xlarge" />
+
+        <div className="flex flex-col text-center items-center">
+          <div className="text-content-primary font-bold">{person.fullName}</div>
+          <div className="text-content-secondary text-sm">{person.title}</div>
+          <div className="text-content-secondary text-sm break-all">{person.email}</div>
+        </div>
+
+        <div>
+          <GhostButton
+            onClick={() => setShowRemoveMember(true)}
+            size="xxs"
+            type="secondary"
+            testId="remove-member"
+          >
+            Remove
+          </GhostButton>
+        </div>
+      </div>
+
+      <RemoveMemberModal
+        isOpen={showRemoveMember}
+        hideModal={() => setShowRemoveMember(false)}
+        person={person}
+      />
+    </>
+  );
+}
+
+
+function RemoveMemberModal({isOpen, hideModal, person}: {isOpen: boolean, hideModal: ()=>void, person: Person}) {
   const navigate = useNavigate();
   const [remove, { loading }] = useRemoveMemberMutation({
     onCompleted: () => {
@@ -35,25 +74,22 @@ function PersonRow({ person }: { person: Person }) {
   }
 
   return (
-    <div className="flex flex-col gap-4 items-center border border-stroke-base rounded-lg p-4 py-6">
-      <Avatar person={person} size="xlarge" />
-
-      <div className="flex flex-col text-center items-center">
-        <div className="text-content-primary font-bold">{person.fullName}</div>
-        <div className="text-content-secondary text-sm">{person.title}</div>
-        <div className="text-content-secondary text-sm break-all">{person.email}</div>
-      </div>
-
-      <div>
-        <GhostButton
+    <Modal
+      title="Remove Company Member"
+      isOpen={isOpen}
+      hideModal={hideModal}
+      minHeight="150px"
+    >
+      <div>Are you sure you want to remove {person.fullName} from the company?</div>
+      <div className="mt-8 flex justify-center">
+        <FilledButton
           onClick={handleRemoveMember}
-          size="xxs"
+          type="primary"
           loading={loading}
-          testId="remove-member"
         >
-          Remove
-        </GhostButton>
+          Remove Member
+        </FilledButton>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/lib/operately/activities/content/company_member_removed.ex
+++ b/lib/operately/activities/content/company_member_removed.ex
@@ -1,0 +1,20 @@
+defmodule Operately.Activities.Content.CompanyMemberRemoved do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    field :company_id, :string
+    field :name, :string
+    field :email, :string
+    field :title, :string
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/notifications/company_member_removed.ex
+++ b/lib/operately/activities/notifications/company_member_removed.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.CompanyMemberRemoved do
+  def dispatch(_activity) do
+    # Notification dispatcher for CompanyMemberRemoved not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/operations/company_member_removing.ex
+++ b/lib/operately/operations/company_member_removing.ex
@@ -13,7 +13,7 @@ defmodule Operately.Operations.CompanyMemberRemoving do
 
   defp suspend_person(multi, person_id) do
     changeset = People.get_person!(person_id)
-    |> People.Person.changeset(%{suspended: true})
+    |> People.Person.changeset(%{suspended: true, suspended_at: DateTime.utc_now()})
 
     Multi.update(multi, :person, changeset)
   end

--- a/lib/operately/operations/company_member_removing.ex
+++ b/lib/operately/operations/company_member_removing.ex
@@ -3,9 +3,10 @@ defmodule Operately.Operations.CompanyMemberRemoving do
   alias Operately.Repo
   alias Operately.People
 
-  def run(person_id) do
+  def run(admin, person_id) do
     Multi.new()
     |> suspend_person(person_id)
+    |> insert_activity(admin)
     |> Repo.transaction()
     |> Repo.extract_result(:person)
   end
@@ -15,5 +16,16 @@ defmodule Operately.Operations.CompanyMemberRemoving do
     |> People.Person.changeset(%{suspended: true})
 
     Multi.update(multi, :person, changeset)
+  end
+
+  defp insert_activity(multi, admin) do
+    Operately.Activities.insert_sync(multi, admin.id, :company_member_removed, fn changes ->
+      %{
+        company_id: admin.company_id,
+        name: changes[:person].full_name,
+        email: changes[:person].email,
+        title: changes[:person].title,
+      }
+    end)
   end
 end

--- a/lib/operately/operations/company_member_removing.ex
+++ b/lib/operately/operations/company_member_removing.ex
@@ -1,0 +1,19 @@
+defmodule Operately.Operations.CompanyMemberRemoving do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.People
+
+  def run(person_id) do
+    Multi.new()
+    |> suspend_person(person_id)
+    |> Repo.transaction()
+    |> Repo.extract_result(:person)
+  end
+
+  defp suspend_person(multi, person_id) do
+    changeset = People.get_person!(person_id)
+    |> People.Person.changeset(%{suspended: true})
+
+    Multi.update(multi, :person, changeset)
+  end
+end

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -54,6 +54,21 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
       end
     end
 
+    field :remove_company_member, :person do
+      arg :person_id, non_null(:id)
+
+      resolve fn _, args, %{context: context} ->
+        person = context.current_account.person
+        allowed = person.company_role == :admin
+
+        if allowed do
+          Operately.Operations.CompanyMemberRemoving.run(args.person_id)
+        else
+          {:error, "Only admins can remove members"}
+        end
+      end
+    end
+
     field :add_company_trusted_email_domain, non_null(:company) do
       arg :company_id, non_null(:id)
       arg :domain, non_null(:string)

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -62,7 +62,7 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
         allowed = person.company_role == :admin
 
         if allowed do
-          Operately.Operations.CompanyMemberRemoving.run(args.person_id)
+          Operately.Operations.CompanyMemberRemoving.run(person, args.person_id)
         else
           {:error, "Only admins can remove members"}
         end

--- a/test/features/company_admin_test.exs
+++ b/test/features/company_admin_test.exs
@@ -101,6 +101,20 @@ defmodule Operately.Features.CompanyAdminTest do
     assert company.trusted_email_domains == []
   end
 
+  feature "remove members from the company", ctx do
+    ctx
+    |> UI.click(testid: "add-remove-people-manually")
+    |> UI.assert_text("Dwight Schrute")
+    |> UI.click(testid: "remove-dwight-schrute")
+    |> UI.click(testid: "remove-member")
+    |> UI.refute_text("Dwight Schrute")
+
+    person = Operately.People.get_person_by_name!(ctx.company, "Dwight Schrute")
+
+    assert person != nil
+    assert person.suspended
+  end
+
   #
   # ======== Helper functions ========
   #

--- a/test/features/company_admin_test.exs
+++ b/test/features/company_admin_test.exs
@@ -113,6 +113,7 @@ defmodule Operately.Features.CompanyAdminTest do
 
     assert person != nil
     assert person.suspended
+    assert person.suspended_at != nil
   end
 
   #

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -174,9 +174,9 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
     company = company_fixture()
 
     admin = person_fixture_with_account(%{company_id: company.id, company_role: :admin})
-    member = person_fixture_with_account(%{company_id: company.id})
+    member = person_fixture_with_account(%{company_id: company.id, full_name: "Unique Name"})
 
-    %{ admin: admin, member: member }
+    %{ admin: admin, member: member, company: company }
     end
 
     test "admin can remove members", ctx do
@@ -186,7 +186,13 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
       conn = graphql(conn, @remove_company_member, "RemoveCompanyMember", %{ :personId => ctx.member.id })
       res = json_response(conn, 200)
 
+      person = Operately.People.get_person_by_name!(ctx.company, ctx.member.full_name)
+
       assert Map.has_key?(res["data"]["removeCompanyMember"], "id")
+
+      assert person != nil
+      assert person.suspended
+      assert person.suspended_at != nil
     end
 
     test "member can't remove members", ctx do


### PR DESCRIPTION
Now admin users can remove members from the company. This feature is a continuation of https://github.com/operately/operately/pull/439. 
When an admin removes a member, under the hood, the member is only marked as suspended.