### PR TITLE
Admins can reissue invitation tokens

### DIFF
--- a/assets/js/components/PaperContainer/index.tsx
+++ b/assets/js/components/PaperContainer/index.tsx
@@ -68,9 +68,15 @@ export function Navigation({ children }) {
   );
 }
 
-export function NavItem({ linkTo, children }) {
+interface NavItemProps {
+  linkTo: string;
+  children: React.ReactNode;
+  testId?: string;
+}
+
+export function NavItem({ linkTo, children, testId }: NavItemProps) {
   return (
-    <Link to={linkTo}>
+    <Link to={linkTo} testId={testId}>
       <span className="flex items-center gap-1.5">{children}</span>
     </Link>
   );

--- a/assets/js/features/CompanyAdmin/InvitationUrl.tsx
+++ b/assets/js/features/CompanyAdmin/InvitationUrl.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { CopyToClipboard } from "@/components/CopyToClipboard";
+
+
+export function InvitationUrl({url}) {
+  if(!url) return <></>;
+
+  return (
+    <div className="flex justify-between gap-3 m-2 px-2 bg-stroke-base rounded text-sm">
+      <div className="flex flex-col pt-2 pb-2">
+        Share this url with the new member:
+        <u className="text-sm break-all">{url}</u>
+      </div>
+      <CopyToClipboard
+        text={url}
+        size={25}
+        padding={1}
+        containerClass="mt-1"
+      />
+    </div>
+  );
+}

--- a/assets/js/features/CompanyAdmin/index.tsx
+++ b/assets/js/features/CompanyAdmin/index.tsx
@@ -1,0 +1,10 @@
+export { InvitationUrl } from "./InvitationUrl";
+
+
+export function createInvitationUrl(token: string) {
+  const url = `${window.location.protocol}//${window.location.host}`;
+  const route = "/first-time-login";
+  const queryString = "?token=" + token;
+
+  return url + route + queryString;
+}

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -939,7 +939,7 @@ export type PauseProjectInput = {
 export type Person = {
   __typename?: 'Person';
   avatarUrl?: Maybe<Scalars['String']['output']>;
-  company?: Maybe<Company>;
+  company: Company;
   companyRole?: Maybe<Scalars['String']['output']>;
   email?: Maybe<Scalars['String']['output']>;
   fullName: Scalars['String']['output'];
@@ -1161,12 +1161,14 @@ export type RootMutationType = {
   markAllNotificationsAsRead: Scalars['Boolean']['output'];
   markNotificationAsRead: Notification;
   moveProjectToSpace: Project;
+  newInvitationToken: Invitation;
   pauseProject: Project;
   pinProjectToHomePage: Scalars['Boolean']['output'];
   postDiscussion?: Maybe<Discussion>;
   postMilestoneComment: MilestoneComment;
   postProjectCheckIn: ProjectCheckIn;
   removeCompanyAdmin?: Maybe<Person>;
+  removeCompanyMember?: Maybe<Person>;
   removeCompanyTrustedEmailDomain: Company;
   removeGroupMember?: Maybe<Group>;
   removeKeyResource: ProjectKeyResource;
@@ -1457,6 +1459,11 @@ export type RootMutationTypeMoveProjectToSpaceArgs = {
 };
 
 
+export type RootMutationTypeNewInvitationTokenArgs = {
+  personId: Scalars['ID']['input'];
+};
+
+
 export type RootMutationTypePauseProjectArgs = {
   input: PauseProjectInput;
 };
@@ -1483,6 +1490,11 @@ export type RootMutationTypePostProjectCheckInArgs = {
 
 
 export type RootMutationTypeRemoveCompanyAdminArgs = {
+  personId: Scalars['ID']['input'];
+};
+
+
+export type RootMutationTypeRemoveCompanyMemberArgs = {
   personId: Scalars['ID']['input'];
 };
 
@@ -2143,6 +2155,13 @@ export type EditGoalTimeframeMutationVariables = Exact<{
 
 export type EditGoalTimeframeMutation = { __typename?: 'RootMutationType', editGoalTimeframe: { __typename?: 'Goal', id: string } };
 
+export type NewInvitationTokenMutationVariables = Exact<{
+  personId: Scalars['ID']['input'];
+}>;
+
+
+export type NewInvitationTokenMutation = { __typename?: 'RootMutationType', newInvitationToken: { __typename?: 'Invitation', id: string, token: string } };
+
 export type GetActivitiesQueryVariables = Exact<{
   scopeType: Scalars['String']['input'];
   scopeId: Scalars['String']['input'];
@@ -2186,7 +2205,7 @@ export type GetInvitationQueryVariables = Exact<{
 }>;
 
 
-export type GetInvitationQuery = { __typename?: 'RootQueryType', invitation: { __typename?: 'Invitation', admin: { __typename?: 'Person', fullName: string, company?: { __typename?: 'Company', name: string } | null }, member: { __typename?: 'Person', fullName: string, email?: string | null } } };
+export type GetInvitationQuery = { __typename?: 'RootQueryType', invitation: { __typename?: 'Invitation', admin: { __typename?: 'Person', fullName: string, company: { __typename?: 'Company', name: string } }, member: { __typename?: 'Person', fullName: string, email?: string | null } } };
 
 export type GetMeQueryVariables = Exact<{
   includeManager?: InputMaybe<Scalars['Boolean']['input']>;
@@ -2390,6 +2409,40 @@ export function useEditGoalTimeframeMutation(baseOptions?: Apollo.MutationHookOp
 export type EditGoalTimeframeMutationHookResult = ReturnType<typeof useEditGoalTimeframeMutation>;
 export type EditGoalTimeframeMutationResult = Apollo.MutationResult<EditGoalTimeframeMutation>;
 export type EditGoalTimeframeMutationOptions = Apollo.BaseMutationOptions<EditGoalTimeframeMutation, EditGoalTimeframeMutationVariables>;
+export const NewInvitationTokenDocument = gql`
+    mutation NewInvitationToken($personId: ID!) {
+  newInvitationToken(personId: $personId) {
+    id
+    token
+  }
+}
+    `;
+export type NewInvitationTokenMutationFn = Apollo.MutationFunction<NewInvitationTokenMutation, NewInvitationTokenMutationVariables>;
+
+/**
+ * __useNewInvitationTokenMutation__
+ *
+ * To run a mutation, you first call `useNewInvitationTokenMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useNewInvitationTokenMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [newInvitationTokenMutation, { data, loading, error }] = useNewInvitationTokenMutation({
+ *   variables: {
+ *      personId: // value for 'personId'
+ *   },
+ * });
+ */
+export function useNewInvitationTokenMutation(baseOptions?: Apollo.MutationHookOptions<NewInvitationTokenMutation, NewInvitationTokenMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<NewInvitationTokenMutation, NewInvitationTokenMutationVariables>(NewInvitationTokenDocument, options);
+      }
+export type NewInvitationTokenMutationHookResult = ReturnType<typeof useNewInvitationTokenMutation>;
+export type NewInvitationTokenMutationResult = Apollo.MutationResult<NewInvitationTokenMutation>;
+export type NewInvitationTokenMutationOptions = Apollo.BaseMutationOptions<NewInvitationTokenMutation, NewInvitationTokenMutationVariables>;
 export const GetActivitiesDocument = gql`
     query GetActivities($scopeType: String!, $scopeId: String!, $actions: [String!]) {
   activities(scopeType: $scopeType, scopeId: $scopeId, actions: $actions) {

--- a/assets/js/gql/mutations/NewInvitationToken.graphql
+++ b/assets/js/gql/mutations/NewInvitationToken.graphql
@@ -1,0 +1,6 @@
+mutation NewInvitationToken($personId: ID!) {
+  newInvitationToken(personId: $personId) {
+    id
+    token
+  }
+}

--- a/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
+++ b/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
@@ -20,8 +20,8 @@ export function Page() {
         <Paper.Navigation>
           <Paper.NavItem linkTo="/company/admin">Company Administration</Paper.NavItem>
           <Paper.NavSeparator />
-          <Paper.NavItem linkTo="/company/admin/managePeople">Manage People</Paper.NavItem>
-        </Paper.Navigation>
+          <Paper.NavItem linkTo="/company/admin/managePeople" testId="manage-people-link">Manage People</Paper.NavItem>
+        </Paper.Navigation> 
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-2xl font-extrabold">Add a new Member</div>

--- a/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
+++ b/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
@@ -3,12 +3,12 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 
 import { GhostButton } from "@/components/Button";
-import { CopyToClipboard } from "@/components/CopyToClipboard";
 import { TextInputNoLabel } from "@/components/Form";
 
 import { createPath } from "@/utils/paths";
 import { useLoadedData } from "./loader";
 import { useForm } from "./useForm";
+import { InvitationUrl } from "@/features/CompanyAdmin";
 
 
 export function Page() {
@@ -84,7 +84,7 @@ function PersonForm() {
         <div key={idx} className="text-red-500 text-sm">{e.message}</div>
       ))}
 
-      <ResultUrl url={result} />
+      <InvitationUrl url={result} />
 
       <div className="flex items-center justify-end gap-2 mt-8">
         <GhostButton linkTo={managePeoplePath} type="secondary">
@@ -95,25 +95,6 @@ function PersonForm() {
           Add Member
         </GhostButton>
       </div>
-    </div>
-  );
-}
-
-function ResultUrl({url}) {
-  if(!url) return <></>;
-
-  return (
-    <div className="flex justify-between gap-3 m-2 px-2 bg-stroke-base rounded text-sm">
-      <div className="flex flex-col pt-2 pb-2">
-        Share this url with the new member:
-        <u className="text-sm break-all">{url}</u>
-      </div>
-      <CopyToClipboard
-        text={url}
-        size={25}
-        padding={1}
-        containerClass="mt-1"
-      />
     </div>
   );
 }

--- a/assets/js/pages/CompanyAdminAddPeoplePage/useForm.tsx
+++ b/assets/js/pages/CompanyAdminAddPeoplePage/useForm.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useAddCompanyMemberMutation } from "@/gql";
 import { camelCaseToSpacedWords, snakeCaseToSpacedWords } from "@/utils/strings";
+import { createInvitationUrl } from "@/features/CompanyAdmin";
 
 
 interface FormState {
@@ -55,11 +56,9 @@ function useSubmit(fields: FormFields) {
   
   const [add, { loading: submitting }] = useAddCompanyMemberMutation({
     onCompleted: (res) => {
-      const url = `${window.location.protocol}//${window.location.host}`;
-      const route = "/first-time-login";
-      const queryString = "?token=" + res['addCompanyMember']['token'];
+      const url = createInvitationUrl(res['addCompanyMember']['token']);
       
-      setResult(url + route + queryString);
+      setResult(url);
     },
   });
 

--- a/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
@@ -58,11 +58,11 @@ export default function NewInvitationToken({ person }: { person: Person }) {
         type="secondary"
         testId={newTokenTestId}
       >
-        Invitation Token
+        New Invitation
       </GhostButton>
     
       <Modal
-        title="New Invitation Token"
+        title="New Invitation URL"
         isOpen={showToken}
         hideModal={handleHideModal}
         minHeight="120px"

--- a/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+
+import { GhostButton } from "@/components/Button";
+import Modal from "@/components/Modal";
+import { InvitationUrl, createInvitationUrl } from "@/features/CompanyAdmin";
+import { Person, useNewInvitationTokenMutation } from "@/gql";
+
+
+
+export default function NewInvitationToken({ person }: { person: Person }) {
+  const [showToken, setShowToken] = useState(false);
+  const [url, setUrl] = useState("");
+  const [error, setError] = useState("");
+  
+  const [create, { loading }] = useNewInvitationTokenMutation({
+    onCompleted: (res) => {
+      const result = createInvitationUrl(res["newInvitationToken"]["token"]);
+      
+      setUrl(result);
+      setShowToken(true);
+    },
+  });
+
+  const handleHideModal = () => {
+    setUrl("");
+    setError("");
+    setShowToken(false);
+  }
+
+  const handleTokenCreation = async () => {
+    try {
+      await create({
+        variables: {
+          personId: person.id,
+        }
+      });
+    }
+    catch (e) {
+      if (e.message) {
+        setError(e.message);
+      }
+      else {
+        setError("There was an unexpected error. Please try again.");
+      }
+      setShowToken(true);
+    }
+  }
+
+  return (
+    <>
+      <GhostButton
+        onClick={handleTokenCreation}
+        loading={loading}
+        size="xxs"
+        type="secondary"
+      >
+        Invitation Token
+      </GhostButton>
+    
+      <Modal
+        title="New Invitation Token"
+        isOpen={showToken}
+        hideModal={handleHideModal}
+        minHeight="120px"
+      >
+        {error ?
+          <div>{error}</div>
+        :
+          <InvitationUrl url={url} />
+        }
+      </Modal>
+    </>
+  );
+}

--- a/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
@@ -4,10 +4,13 @@ import { GhostButton } from "@/components/Button";
 import Modal from "@/components/Modal";
 import { InvitationUrl, createInvitationUrl } from "@/features/CompanyAdmin";
 import { Person, useNewInvitationTokenMutation } from "@/gql";
+import { createTestId } from "@/utils/testid";
 
 
 
 export default function NewInvitationToken({ person }: { person: Person }) {
+  const newTokenTestId = createTestId("new-token", person.fullName);
+
   const [showToken, setShowToken] = useState(false);
   const [url, setUrl] = useState("");
   const [error, setError] = useState("");
@@ -53,6 +56,7 @@ export default function NewInvitationToken({ person }: { person: Person }) {
         loading={loading}
         size="xxs"
         type="secondary"
+        testId={newTokenTestId}
       >
         Invitation Token
       </GhostButton>

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import React from "react";
 
 import { useLoadedData } from "./loader";
-import { useRemoveMemberMutation } from "@/models/companies";
-import { createTestId } from "@/utils/testid";
 import { Person } from "@/gql";
-import { FilledButton, GhostButton } from "@/components/Button";
-import Modal from "@/components/Modal";
 import Avatar from "@/components/Avatar";
+import RemoveMember from "./RemoveMember";
+import NewInvitationToken from "./NewInvitationToken";
 
 
 
@@ -23,76 +20,21 @@ export function PeopleList() {
   );
 }
 
-
 function PersonRow({ person }: { person: Person }) {
-  const [showRemoveMember, setShowRemoveMember] = useState(false);
-  const removeTestId = createTestId("remove", person.fullName);
-  
   return (
-    <>
-      <div className="flex flex-col gap-4 items-center border border-stroke-base rounded-lg p-4 py-6">
-        <Avatar person={person} size="xlarge" />
+    <div className="flex flex-col gap-4 items-center border border-stroke-base rounded-lg p-4 py-6">
+      <Avatar person={person} size="xlarge" />
 
-        <div className="flex flex-col text-center items-center">
-          <div className="text-content-primary font-bold">{person.fullName}</div>
-          <div className="text-content-secondary text-sm">{person.title}</div>
-          <div className="text-content-secondary text-sm break-all">{person.email}</div>
-        </div>
-
-        <div>
-          <GhostButton
-            onClick={() => setShowRemoveMember(true)}
-            size="xxs"
-            type="secondary"
-            testId={removeTestId}
-          >
-            Remove
-          </GhostButton>
-        </div>
+      <div className="flex flex-col text-center items-center">
+        <div className="text-content-primary font-bold">{person.fullName}</div>
+        <div className="text-content-secondary text-sm">{person.title}</div>
+        <div className="text-content-secondary text-sm break-all">{person.email}</div>
       </div>
 
-      <RemoveMemberModal
-        isOpen={showRemoveMember}
-        hideModal={() => setShowRemoveMember(false)}
-        person={person}
-      />
-    </>
-  );
-}
-
-
-function RemoveMemberModal({isOpen, hideModal, person}: {isOpen: boolean, hideModal: ()=>void, person: Person}) {
-  const navigate = useNavigate();
-  const [remove, { loading }] = useRemoveMemberMutation({
-    onCompleted: () => {
-      navigate(0);
-    }
-  });
-
-  const handleRemoveMember = async () => {
-    await remove({
-      variables: { personId: person.id }
-    });
-  }
-
-  return (
-    <Modal
-      title="Remove Company Member"
-      isOpen={isOpen}
-      hideModal={hideModal}
-      minHeight="150px"
-    >
-      <div>Are you sure you want to remove {person.fullName} from the company?</div>
-      <div className="mt-8 flex justify-center">
-        <FilledButton
-          onClick={handleRemoveMember}
-          type="primary"
-          loading={loading}
-          testId="remove-member"
-        >
-          Remove Member
-        </FilledButton>
+      <div className="flex flex-col gap-2">
+        <RemoveMember person={person} />
+        <NewInvitationToken person={person} />
       </div>
-    </Modal>
+    </div>
   );
 }

--- a/assets/js/pages/CompanyAdminManagePeoplePage/RemoveMember.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/RemoveMember.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useRemoveMemberMutation } from "@/models/companies";
+import { createTestId } from "@/utils/testid";
+import { Person } from "@/gql";
+import { FilledButton, GhostButton } from "@/components/Button";
+import Modal from "@/components/Modal";
+
+
+
+export default function RemoveMember({person}: {person: Person}) {
+  const removeTestId = createTestId("remove", person.fullName);
+  const [showRemoveMember, setShowRemoveMember] = useState(false);
+  
+  const navigate = useNavigate();
+  const [remove, { loading }] = useRemoveMemberMutation({
+    onCompleted: () => {
+      navigate(0);
+    }
+  });
+
+  const handleRemoveMember = async () => {
+    await remove({
+      variables: { personId: person.id }
+    });
+  }
+
+  return (
+    <>
+      <GhostButton
+        onClick={() => setShowRemoveMember(true)}
+        size="xxs"
+        type="secondary"
+        testId={removeTestId}
+      >
+        Remove
+      </GhostButton>
+
+      <Modal
+        title="Remove Company Member"
+        isOpen={showRemoveMember}
+        hideModal={() => setShowRemoveMember(false)}
+        minHeight="150px"
+      >
+        <div>Are you sure you want to remove {person.fullName} from the company?</div>
+        <div className="mt-8 flex justify-center">
+          <FilledButton
+            onClick={handleRemoveMember}
+            type="primary"
+            loading={loading}
+            testId="remove-member"
+          >
+            Remove Member
+          </FilledButton>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/lib/operately/activities/content/company_invitation_token_created.ex
+++ b/lib/operately/activities/content/company_invitation_token_created.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Activities.Content.CompanyInvitationTokenCreated do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    field :company_id, :string
+    field :invitatition_id, :string
+    field :name, :string
+    field :email, :string
+    field :title, :string
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/notifications/company_invitation_token_created.ex
+++ b/lib/operately/activities/notifications/company_invitation_token_created.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.CompanyInvitationTokenCreated do
+  def dispatch(_activity) do
+    # Notification dispatcher for CompanyInvitationTokenCreated not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/invitations.ex
+++ b/lib/operately/invitations.ex
@@ -33,6 +33,19 @@ defmodule Operately.Invitations do
     end
   end
 
+  def get_invitation_by_member(member_id) when is_binary(member_id) do
+    query = from i in Operately.Invitations.Invitation,
+      where: i.member_id == ^member_id,
+      preload: [:member],
+      select: i
+
+    Repo.one(query)
+  end
+
+  def get_invitation_by_member(%Operately.People.Person{id: member_id}) do
+    get_invitation_by_member(member_id)
+  end
+
   def create_invitation(attrs \\ %{}) do
     %Invitation{}
     |> Invitation.changeset(attrs)

--- a/lib/operately/operations/company_invitation_token_creation.ex
+++ b/lib/operately/operations/company_invitation_token_creation.ex
@@ -1,0 +1,22 @@
+defmodule Operately.Operations.CompanyInvitationTokenCreation do
+  alias Ecto.Multi
+  alias Operately.Repo
+
+  def run(admin, invitation) do
+    Multi.new()
+    |> insert_activity(admin, invitation)
+    |> Repo.transaction()
+  end
+
+  defp insert_activity(multi, admin, invitation) do
+    Operately.Activities.insert_sync(multi, admin.id, :company_invitation_token_created, fn _ ->
+      %{
+        company_id: admin.company_id,
+        invitatition_id: invitation.id,
+        name: invitation.member.full_name,
+        email: invitation.member.email,
+        title: invitation.member.title,
+      }
+    end)
+  end
+end

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -108,7 +108,7 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
     end
 
     # Retrieving :invitation automatically creates a new token
-    # so there is not need to create on manually
+    # so there is not need to create one manually
     field :new_invitation_token, non_null(:invitation) do
       arg :person_id, non_null(:id)
 

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -119,14 +119,14 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
         if allowed do
           case Operately.Invitations.get_invitation_by_member(args.person_id) do
             nil ->
-              {:error, "There is no invitation associated with this member"}
+              {:error, "This member didn't join the company using an invitation token."}
 
             invitation ->
               Operately.Operations.CompanyInvitationTokenCreation.run(admin, invitation)
               {:ok, invitation}
           end
         else
-          {:error, "Only admins can issue invitation tokens"}
+          {:error, "Only admins can issue invitation tokens."}
         end
       end
     end

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -106,5 +106,29 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
         end
       end
     end
+
+    # Retrieving :invitation automatically creates a new token
+    # so there is not need to create on manually
+    field :new_invitation_token, non_null(:invitation) do
+      arg :person_id, non_null(:id)
+
+      resolve fn _, args, %{context: context} ->
+        admin = context.current_account.person
+        allowed = admin.company_role == :admin
+
+        if allowed do
+          case Operately.Invitations.get_invitation_by_member(args.person_id) do
+            nil ->
+              {:error, "There is no invitation associated with this member"}
+
+            invitation ->
+              Operately.Operations.CompanyInvitationTokenCreation.run(admin, invitation)
+              {:ok, invitation}
+          end
+        else
+          {:error, "Only admins can issue invitation tokens"}
+        end
+      end
+    end
   end
 end

--- a/test/features/company_admin_test.exs
+++ b/test/features/company_admin_test.exs
@@ -107,6 +107,7 @@ defmodule Operately.Features.CompanyAdminTest do
     |> UI.assert_text("Dwight Schrute")
     |> UI.click(testid: "remove-dwight-schrute")
     |> UI.click(testid: "remove-member")
+    |> UI.sleep(300)
     |> UI.refute_text("Dwight Schrute")
 
     person = Operately.People.get_person_by_name!(ctx.company, "Dwight Schrute")

--- a/test/features/invite_member_test.exs
+++ b/test/features/invite_member_test.exs
@@ -24,6 +24,7 @@ defmodule Operately.Features.InviteMemberTest do
   end
 
   @new_member %{
+    newTokenTestId: "new-token-john-doe",
     fullName: "John Doe",
     email: "john@some-company.com",
     title: "Developer",
@@ -70,5 +71,15 @@ defmodule Operately.Features.InviteMemberTest do
     |> UI.assert_text("Title is required")
     |> Steps.invite_member(@new_member)
     |> UI.assert_text("Email has already been taken")
+  end
+
+  feature "admin can reissue tokens", ctx do
+    ctx
+    |> Steps.navigate_to_invitation_page
+    |> Steps.invite_member(@new_member)
+    |> Steps.assert_member_invited
+    |> UI.click(testid: "manage-people-link")
+    |> Steps.reissue_invitation_token(@new_member)
+    |> Steps.assert_member_invited
   end
 end

--- a/test/operately/invitations_test.exs
+++ b/test/operately/invitations_test.exs
@@ -1,6 +1,7 @@
 defmodule Operately.InvitationsTest do
   use Operately.DataCase
 
+  alias Operately.Repo
   alias Operately.Invitations
   alias Operately.Invitations.Invitation
   alias Operately.Invitations.InvitationToken
@@ -30,6 +31,18 @@ defmodule Operately.InvitationsTest do
       queried_invitation = Invitations.get_invitation_by_token(token)
 
       assert queried_invitation == invitation
+    end
+
+    test "get_invitation_by_member/1 returns the invitation" do
+      company = company_fixture(%{name: "Test Company"})
+      admin = person_fixture_with_account(%{company_id: company.id, company_role: :admin})
+      member = person_fixture_with_account(%{company_id: company.id})
+
+      invitation = invitation_fixture(%{member_id: member.id, admin_id: admin.id})
+      invitation = Repo.preload(invitation, [:member])
+
+      assert invitation == Invitations.get_invitation_by_member(member.id)
+      assert invitation == Invitations.get_invitation_by_member(member)
     end
 
     test "create_invitation/1 with valid data creates a invitation" do
@@ -104,7 +117,7 @@ defmodule Operately.InvitationsTest do
       queried_token = Invitations.get_invitation_token_by_invitation(invitation.id)
       assert queried_token.id == second_token.id
 
-      assert 1 == Operately.Repo.aggregate(InvitationToken, :count, :id)
+      assert 1 == Repo.aggregate(InvitationToken, :count, :id)
     end
 
     test "delete_invitation_token/1 deletes the invitation_token" do

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -245,7 +245,7 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
       conn = graphql(conn, @new_invitation_token, "NewInvitationToken", %{ :personId => ctx.member.id })
       res = json_response(conn, 200)
 
-      assert res["errors"] |> List.first() |> Map.get("message") == "Only admins can issue invitation tokens"
+      assert res["errors"] |> List.first() |> Map.get("message") == "Only admins can issue invitation tokens."
     end
 
     test "no invitation associated with member", ctx do
@@ -255,7 +255,7 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
       conn = graphql(conn, @new_invitation_token, "NewInvitationToken", %{ :personId => ctx.admin.id })
       res = json_response(conn, 200)
 
-      assert res["errors"] |> List.first() |> Map.get("message") == "There is no invitation associated with this member"
+      assert res["errors"] |> List.first() |> Map.get("message") == "This member didn't join the company using an invitation token."
     end
   end
 

--- a/test/operately_web/graphql/mutations/company_test.exs
+++ b/test/operately_web/graphql/mutations/company_test.exs
@@ -1,6 +1,8 @@
 defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
   use OperatelyWeb.ConnCase
 
+  import Operately.Repo, only: [preload: 2, aggregate: 3]
+  import Operately.InvitationsFixtures
   import Operately.PeopleFixtures
   import Operately.CompaniesFixtures
 
@@ -35,11 +37,11 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
       account = Operately.People.get_account_by_email_and_password("john@your-company.com", "Aa12345#&!123")
       group = Operately.Groups.get_group(company.company_space_id)
 
-      assert Operately.Repo.aggregate(Operately.People.Person, :count, :id) == 1
+      assert aggregate(Operately.People.Person, :count, :id) == 1
       assert account != nil
       assert group != nil
 
-      account = Operately.Repo.preload(account, :person)
+      account = preload(account, :person)
 
       assert account.person.company_role == :admin
     end
@@ -180,7 +182,7 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
     end
 
     test "admin can remove members", ctx do
-      admin = Operately.Repo.preload(ctx.admin, [:account])
+      admin = preload(ctx.admin, [:account])
       conn = log_in_account(ctx.conn, admin.account)
 
       conn = graphql(conn, @remove_company_member, "RemoveCompanyMember", %{ :personId => ctx.member.id })
@@ -196,13 +198,64 @@ defmodule OperatelyWeb.GraphQL.Mutations.CompanyTest do
     end
 
     test "member can't remove members", ctx do
-      member = Operately.Repo.preload(ctx.member, [:account])
+      member = preload(ctx.member, [:account])
       conn = log_in_account(ctx.conn, member.account)
 
       conn = graphql(conn, @remove_company_member, "RemoveCompanyMember", %{ :personId => ctx.member.id })
       res = json_response(conn, 200)
 
       assert res["errors"] |> List.first() |> Map.get("message") == "Only admins can remove members"
+    end
+  end
+
+
+  @new_invitation_token """
+  mutation NewInvitationToken($personId: ID!) {
+    newInvitationToken(personId: $personId) {
+      token
+    }
+  }
+  """
+
+  describe "mutation: NewInvitationToken" do
+    setup do
+      company = company_fixture()
+
+      admin = person_fixture_with_account(%{company_id: company.id, company_role: :admin})
+      member = person_fixture_with_account(%{company_id: company.id, full_name: "Unique Name"})
+      invitation_fixture(%{member_id: member.id, admin_id: admin.id})
+
+      %{ admin: admin, member: member }
+    end
+
+    test "admin can issue new invitation token", ctx do
+      admin = preload(ctx.admin, [:account])
+      conn = log_in_account(ctx.conn, admin.account)
+
+      conn = graphql(conn, @new_invitation_token, "NewInvitationToken", %{ :personId => ctx.member.id })
+      res = json_response(conn, 200)
+
+      assert Map.has_key?(res["data"]["newInvitationToken"], "token")
+    end
+
+    test "member can't issue new invitation token", ctx do
+      member = preload(ctx.member, [:account])
+      conn = log_in_account(ctx.conn, member.account)
+
+      conn = graphql(conn, @new_invitation_token, "NewInvitationToken", %{ :personId => ctx.member.id })
+      res = json_response(conn, 200)
+
+      assert res["errors"] |> List.first() |> Map.get("message") == "Only admins can issue invitation tokens"
+    end
+
+    test "no invitation associated with member", ctx do
+      admin = preload(ctx.admin, [:account])
+      conn = log_in_account(ctx.conn, admin.account)
+
+      conn = graphql(conn, @new_invitation_token, "NewInvitationToken", %{ :personId => ctx.admin.id })
+      res = json_response(conn, 200)
+
+      assert res["errors"] |> List.first() |> Map.get("message") == "There is no invitation associated with this member"
     end
   end
 

--- a/test/support/features/invite_member_steps.ex
+++ b/test/support/features/invite_member_steps.ex
@@ -26,6 +26,12 @@ defmodule Operately.Support.Features.InviteMemberSteps do
     |> UI.click(testid: "submit-form")
   end
 
+  step :reissue_invitation_token, ctx, params do
+    ctx
+    |> UI.click(testid: params[:newTokenTestId])
+
+  end
+
   step :assert_member_invited, ctx do
     ctx
     |> UI.assert_text("Share this url with the new member:")


### PR DESCRIPTION
Admin users can now reissue invitation tokens to new members. When a new token is issued, the old one is automatically deleted. New tokens are valid for 1 hour.

Before merging this PR, we may want to consider the following:

Currently, the admin will see the option to reissue invitation tokens for **every** member **forever**. I think that may be annoying to admins because:

- Once a member uses the token and sets up their password, it doesn't make much sense for the admin to reissue a new token. Even if the admin were to issue a token for the member so they can reset their password, I guess that shouldn't be an **invitation** token.

- Tokens cannot be reissued for members who did not join the company via an invitation token since there is no invitation associated with such members. 
(I made sure to handle this exception, so if the admin tries to reissue a token for such members, they will see a message indicating that it's not possible.)

Having said that, the way to fix these issues would be to display the "reissue token" option only for members who have joined the company via an invitation token and have not reset their passwords yet. 
The most straightforward solution would be to add a flag/field to the person schema to indicate whether a member might need a new token in the future. But maybe we can come up with a better way to handle this.

Now, this problem only exists if we assume that having the "reissue token" option forever available for every member would bother admins. If we conclude that admin users wouldn't mind it, then the PR should be ready.