### PR TITLE
The test suite formatter should not stop when a suite is finished

### DIFF
--- a/test/support/custom_formatter.ex
+++ b/test/support/custom_formatter.ex
@@ -10,7 +10,7 @@ defmodule CustomFormatter do
   end
 
   def handle_cast({:suite_started, _}, state), do: {:noreply, state}
-  def handle_cast({:suite_finished, _}, state), do: display_suite_finished(state)
+  def handle_cast({:suite_finished, _}, state), do: {:noreply, state}
 
   # deprecated events
   def handle_cast({:case_started, _}, state), do: {:noreply, state}
@@ -59,11 +59,6 @@ defmodule CustomFormatter do
   defp display_test_finished(%ExUnit.Test{state: {:failed, _}}, state) do
     IO.puts("\n\n    #{red("FAILED")}")
     {:noreply, state}
-  end
-
-  defp display_suite_finished(state) do
-    IO.puts("")
-    {:stop, :normal, state}
   end
 
   defp red(text), do: IO.ANSI.red() <> text <> IO.ANSI.reset()


### PR DESCRIPTION
Fixes test flakkines caused by this error:

![Screenshot 2024-06-06 at 14 51 47](https://github.com/operately/operately/assets/1779493/40c6c30a-1746-41b8-b0d6-bb014ae86268)
