### PR TITLE
Fix transparent calendar

### DIFF
--- a/assets/js/components/Form/dateselector.tsx
+++ b/assets/js/components/Form/dateselector.tsx
@@ -52,7 +52,7 @@ export function DateSelector(props: DateSelectorProps) {
           </Popover.Trigger>
 
           <Popover.Portal>
-            <Popover.Content className="outline-red-400 border border-surface-outline" align="start">
+            <Popover.Content className="bg-surface outline-red-400 border border-surface-outline" align="start">
               <DatePicker
                 inline
                 selected={date}

--- a/assets/js/pages/ProjectEditTimelinePage/DateSelector.tsx
+++ b/assets/js/pages/ProjectEditTimelinePage/DateSelector.tsx
@@ -46,7 +46,7 @@ export function DateSelector({ date, onChange, minDate, maxDate, placeholder = "
       </Popover.Trigger>
 
       <Popover.Portal>
-        <Popover.Content className="outline-red-400 border border-surface-outline z-[1000]" align="start">
+        <Popover.Content className="bg-surface outline-red-400 border border-surface-outline z-[1000]" align="start">
           <DatePicker
             inline
             selected={date}


### PR DESCRIPTION
I've fixed two places where the calendar (date selector) had a transparent background:

- When editing the timeline of a project.
- When editing a milestone of a project.