### PR TITLE
Fix broken navigation for long project/milestone titles

### DIFF
--- a/assets/js/pages/TaskPage/page.tsx
+++ b/assets/js/pages/TaskPage/page.tsx
@@ -14,6 +14,8 @@ import { useLoadedData } from "./loader";
 import { useForm, FormState } from "./useForm";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { MultiPeopleSearch } from "@/features/Tasks/NewTaskModal/MultiPeopleSearch";
+import { truncateString } from "@/utils/strings";
+
 
 export function Page() {
   const { task } = useLoadedData();
@@ -48,9 +50,9 @@ export function Navigation({ task }: { task: Tasks.Task }) {
 
   return (
     <Paper.Navigation>
-      <Paper.NavItem linkTo={projectPath}>{task.project.name}</Paper.NavItem>
+      <Paper.NavItem linkTo={projectPath}>{truncateString(task.project.name, 40)}</Paper.NavItem>
       <Paper.NavSeparator />
-      <Paper.NavItem linkTo={milestonePath}>{task.milestone.title}</Paper.NavItem>
+      <Paper.NavItem linkTo={milestonePath}>{truncateString(task.milestone.title, 40)}</Paper.NavItem>
     </Paper.Navigation>
   );
 }

--- a/assets/js/utils/strings.test.tsx
+++ b/assets/js/utils/strings.test.tsx
@@ -1,0 +1,75 @@
+import * as Strings from "./strings";
+
+
+describe("Strings.camelCaseToSnakeCase", () => {
+  it("parses a camel case string to snake case", () => {
+    const input = "thisIsACamelCaseString";
+    const result = "this_is_a_camel_case_string";
+    
+    expect(Strings.camelCaseToSnakeCase(input)).toEqual(result);
+  });
+});
+
+describe("Strings.snakeCaseToSpacedWords", () => {
+  it("parses a snake case string to words separated by space", () => {
+    const input = "this_is_a_snake_case_string";
+    const result = "this is a snake case string";
+
+    expect(Strings.snakeCaseToSpacedWords(input)).toEqual(result);
+  });
+  
+  it("parses a snake case string to words separated by space and capitalizes first word", () => {
+    const input = "this_is_a_snake_case_string";
+    const result = "This is a snake case string";
+
+    expect(Strings.snakeCaseToSpacedWords(input, { capitalizeFirst: true })).toEqual(result);
+  });
+});
+
+describe("Strings.camelCaseToSpacedWords", () => {
+  it("parses a camel case string to words separated by space", () => {
+    const input = "thisIsACamelCaseString";
+    const result = "this is a camel case string";
+    
+    expect(Strings.camelCaseToSpacedWords(input)).toEqual(result);
+  });
+  
+  it("parses a camel case string to words separated by space and capitalizes first word", () => {
+    const input = "thisIsACamelCaseString";
+    const result = "This is a camel case string";
+    
+    expect(Strings.camelCaseToSpacedWords(input, { capitalizeFirst: true })).toEqual(result);
+  });
+});
+
+describe("Strings.truncateString", () => {
+  it("Truncates string with default suffix", () => {
+    const input = "This is an unnecessarily long string.";
+    const result = "This is an...";
+    
+    expect(Strings.truncateString(input, 10)).toEqual(result);
+  });
+  
+  it("Truncates string with custom suffix", () => {
+    const input = "This is an unnecessarily long string.";
+    const result = "This is an___";
+    
+    expect(Strings.truncateString(input, 10, "___")).toEqual(result);
+  });
+  
+  it("Truncates string without suffix", () => {
+    const input = "This is an unnecessarily long string.";
+    const result = "This is an";
+    
+    expect(Strings.truncateString(input, 10, "")).toEqual(result);
+  });
+  
+  it("Truncates string and removes white space", () => {
+    const input = "This is a string.";
+    const result = "This is a...";
+    
+    expect(Strings.truncateString(input, 10)).toEqual(result);
+    
+    expect(Strings.truncateString(input, 10, "").length).toEqual(9);
+  });
+});

--- a/assets/js/utils/strings.tsx
+++ b/assets/js/utils/strings.tsx
@@ -26,3 +26,9 @@ export function camelCaseToSpacedWords(input: string, options?: { capitalizeFirs
 
   return result;
 }
+
+export function truncateString(str: string, limit: number, suffix: string = "...") {
+  if(str.length <= limit) return str;
+  
+  return str.slice(0, limit).trim() + suffix;
+}

--- a/assets/js/utils/strings.tsx
+++ b/assets/js/utils/strings.tsx
@@ -8,7 +8,7 @@ export function camelCaseToSnakeCase(str: string): string {
 }
 
 export function snakeCaseToSpacedWords(str: string, options?: { capitalizeFirst?: boolean }): string {
-  let name = str.replace("_", " ");
+  let name = str.replace(/_/g, " ");
 
   if (options?.capitalizeFirst) {
     name =  name.charAt(0).toUpperCase() + name.slice(1);


### PR DESCRIPTION
I've fixed the broken navigation for long project/milestone titles by truncating the titles.
I've also fixed a bug in the snakeCaseToSpacedWords util function and added unit tests for all the string utils.