### PR TITLE
Don't start ACME server in test

### DIFF
--- a/lib/operately_web/certification.ex
+++ b/lib/operately_web/certification.ex
@@ -7,7 +7,7 @@ defmodule OperatelyWeb.Certification do
     case Application.get_env(:operately, :app_env) do
       :prod -> "https://acme-v02.api.letsencrypt.org/directory"
       :dev -> {:internal, port: 4003}
-      _ -> ""
+      :test -> {:internal, port: 4004}
     end
   end
 

--- a/lib/operately_web/certification.ex
+++ b/lib/operately_web/certification.ex
@@ -4,10 +4,10 @@ defmodule OperatelyWeb.Certification do
   """ 
 
   def directory_url do
-    if Application.get_env(:operately, :app_env) == :prod do
-      "https://acme-v02.api.letsencrypt.org/directory"
-    else
-      {:internal, port: 4003}
+    case Application.get_env(:operately, :app_env) do
+      :prod -> "https://acme-v02.api.letsencrypt.org/directory"
+      :dev -> {:internal, port: 4003}
+      _ -> ""
     end
   end
 


### PR DESCRIPTION
Fixes this https://github.com/operately/operately/issues/531.

The source of the problem was that site_encrypt was starting a local ACME server (responsible for giving out SSL certs) in both the development and test environments, on the same port: 4003.

This pull-request solves this problem by starting the ACME server on port 4003 for dev, and port 4004 for the test environemnt, so they don't clash.