### PR TITLE
Add access context to projects

### DIFF
--- a/lib/operately/access/access_context.ex
+++ b/lib/operately/access/access_context.ex
@@ -2,6 +2,7 @@ defmodule Operately.Access.Context do
   use Operately.Schema
 
   schema "access_contexts" do
+    belongs_to :project, Operately.Projects.Project, foreign_key: :project_id
 
     timestamps()
   end
@@ -12,7 +13,19 @@ defmodule Operately.Access.Context do
 
   def changeset(context, attrs) do
     context
-    |> cast(attrs, [])
+    |> cast(attrs, [:project_id])
+    |> validate_one_association
     |> validate_required([])
+  end
+
+  defp validate_one_association(changeset) do
+    fields = [:project_id]
+    count = Enum.count(fields, fn field -> get_field(changeset, field) != nil end)
+
+    if count == 1 do
+      changeset
+    else
+      add_error(changeset, :base, "Exactly one association (Project, Group, Activity, or Company) must be set.")
+    end
   end
 end

--- a/lib/operately/data/change_009_create_projects_access_context.ex
+++ b/lib/operately/data/change_009_create_projects_access_context.ex
@@ -1,0 +1,15 @@
+defmodule Operately.Data.Change009CreateProjectsAccessContext do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+
+  def run do
+    projects = Repo.all(from p in Operately.Projects.Project, select: p.id)
+    Enum.each(projects, &create_projects_access_contexts/1)
+  end
+
+  defp create_projects_access_contexts(project_id) do
+    Access.create_context(%{project_id: project_id})
+  end
+end

--- a/lib/operately/data/change_009_create_projects_access_context.ex
+++ b/lib/operately/data/change_009_create_projects_access_context.ex
@@ -5,8 +5,16 @@ defmodule Operately.Data.Change009CreateProjectsAccessContext do
   alias Operately.Access
 
   def run do
-    projects = Repo.all(from p in Operately.Projects.Project, select: p.id)
-    Enum.each(projects, &create_projects_access_contexts/1)
+    Repo.transaction(fn ->
+      projects = Repo.all(from p in Operately.Projects.Project, select: p.id)
+
+      Enum.each(projects, fn project_id ->
+        case create_projects_access_contexts(project_id) do
+          {:error, _} -> raise "Failed to create access context"
+          _ -> :ok
+        end
+      end)
+    end)
   end
 
   defp create_projects_access_contexts(project_id) do

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -13,6 +13,8 @@ defmodule Operately.Projects.Project do
     has_many :milestones, Operately.Projects.Milestone, foreign_key: :project_id
     has_many :check_ins, Operately.Projects.CheckIn, foreign_key: :project_id
 
+    has_one :access_context, Operately.Access.Context, foreign_key: :project_id
+
     field :description, :map
     field :name, :string
     field :private, :boolean, default: false

--- a/priv/repo/migrations/20240610091322_add_project_access_context.exs
+++ b/priv/repo/migrations/20240610091322_add_project_access_context.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddProjectAccessContext do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_contexts) do
+      add :project_id, references(:projects, on_delete: :nothing, type: :binary_id), null: true
+    end
+
+    create unique_index(:access_contexts, [:project_id])
+  end
+end

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -5,12 +5,20 @@ defmodule Operately.AccessBindingsTest do
   alias Operately.Access.Binding
 
   import Operately.AccessFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+  import Operately.CompaniesFixtures
 
   describe "access_bindings" do
     @invalid_attrs %{access_level: 11}
 
     setup do
-      context = context_fixture()
+      company = company_fixture()
+      creator = person_fixture_with_account(%{company_id: company.id})
+      group = Operately.GroupsFixtures.group_fixture(creator)
+      project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
+
+      context = context_fixture(%{project_id: project.id})
       group = group_fixture()
 
       {:ok, %{context: context, group: group}}

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -4,41 +4,72 @@ defmodule Operately.AccessContextsTest do
   alias Operately.Access
   alias Operately.Access.Context
 
-  import Operately.AccessFixtures
+  import Operately.AccessFixtures, only: [context_fixture: 1]
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+  import Operately.CompaniesFixtures
 
   describe "access_contexts" do
-    test "list_contexts/0 returns all contexts" do
-      context = context_fixture()
-      assert Access.list_contexts() == [context]
+    setup do
+      company = company_fixture()
+      creator = person_fixture_with_account(%{company_id: company.id})
+      group = group_fixture(creator)
+      project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
+      context = context_fixture(%{project_id: project.id})
+
+      {:ok, company: company, group: group, creator: creator, context: context}
     end
 
-    test "get_context!/1 returns the context with given id" do
-      context = context_fixture()
-      assert Access.get_context!(context.id) == context
+    test "list_contexts/0 returns all contexts", ctx do
+      assert Access.list_contexts() == [ctx.context]
     end
 
-    test "create_context/1 with valid data creates a context" do
-      valid_attrs = %{}
+    test "get_context!/1 returns the context with given id", ctx do
+      assert Access.get_context!(ctx.context.id) == ctx.context
+    end
+
+    test "create_context/1 with valid data creates a context", ctx do
+      another_project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+      valid_attrs = %{project_id: another_project.id}
 
       assert {:ok, %Context{} = _context} = Access.create_context(valid_attrs)
     end
 
-    test "update_context/2 with valid data updates the context" do
-      context = context_fixture()
-      update_attrs = %{}
+    test "update_context/2 with valid data updates the context", ctx do
+      another_project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+      update_attrs = %{project_id: another_project.id}
 
-      assert {:ok, %Context{} = _context} = Access.update_context(context, update_attrs)
+      assert {:ok, %Context{} = _context} = Access.update_context(ctx.context, update_attrs)
     end
 
-    test "delete_context/1 deletes the context" do
-      context = context_fixture()
-      assert {:ok, %Context{}} = Access.delete_context(context)
-      assert_raise Ecto.NoResultsError, fn -> Access.get_context!(context.id) end
+    test "delete_context/1 deletes the context", ctx do
+      assert {:ok, %Context{}} = Access.delete_context(ctx.context)
+      assert_raise Ecto.NoResultsError, fn -> Access.get_context!(ctx.context.id) end
     end
 
-    test "change_context/1 returns a context changeset" do
-      context = context_fixture()
-      assert %Ecto.Changeset{} = Access.change_context(context)
+    test "change_context/1 returns a context changeset", ctx do
+      assert %Ecto.Changeset{} = Access.change_context(ctx.context)
+    end
+  end
+
+  describe "access_contexts relationships with projects, groups, activities and companies" do
+    import Operately.ActivitiesFixtures
+
+    setup do
+      company = company_fixture()
+      creator = person_fixture_with_account(%{company_id: company.id})
+      group = group_fixture(creator)
+      project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
+      activity = activity_fixture(%{author_id: creator.id})
+
+      {:ok, company: company, group: group, project: project, activity: activity}
+    end
+
+    test "create access_context for a project", ctx do
+      attrs = %{project_id: ctx.project.id}
+
+      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
     end
   end
 end

--- a/test/operately/data/change_009_create_projects_access_context_test.exs
+++ b/test/operately/data/change_009_create_projects_access_context_test.exs
@@ -19,7 +19,7 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
   end
 
   test "creates access_context for existing companies", ctx do
-    projects = Enum.map(1..3, fn _ ->
+    projects = Enum.map(1..5, fn _ ->
       project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
     end)
 

--- a/test/operately/data/change_009_create_projects_access_context_test.exs
+++ b/test/operately/data/change_009_create_projects_access_context_test.exs
@@ -1,0 +1,36 @@
+defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Context
+  alias Operately.Data.Change009CreateProjectsAccessContext
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(creator)
+
+    {:ok, company: company, creator: creator, group: group}
+  end
+
+  test "creates access_context for existing companies", ctx do
+    projects = Enum.map(1..3, fn _ ->
+      project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+    end)
+
+    Enum.each(projects, fn project ->
+      assert nil == Repo.get_by(Context, project_id: project.id)
+    end)
+
+    Change009CreateProjectsAccessContext.run()
+
+    Enum.each(projects, fn project ->
+      assert %Context{} = Repo.get_by(Context, project_id: project.id)
+    end)
+  end
+end


### PR DESCRIPTION
I've added a one-to-one relationship between projects and access contexts.
I've also added a data migration to create access contexts for existing projects.