### PR TITLE
Add access context to groups

### DIFF
--- a/lib/operately/access/access_context.ex
+++ b/lib/operately/access/access_context.ex
@@ -3,6 +3,7 @@ defmodule Operately.Access.Context do
 
   schema "access_contexts" do
     belongs_to :project, Operately.Projects.Project, foreign_key: :project_id
+    belongs_to :group, Operately.Groups.Group, foreign_key: :group_id
 
     timestamps()
   end
@@ -13,13 +14,13 @@ defmodule Operately.Access.Context do
 
   def changeset(context, attrs) do
     context
-    |> cast(attrs, [:project_id])
+    |> cast(attrs, [:project_id, :group_id])
     |> validate_one_association
     |> validate_required([])
   end
 
   defp validate_one_association(changeset) do
-    fields = [:project_id]
+    fields = [:project_id, :group_id]
     count = Enum.count(fields, fn field -> get_field(changeset, field) != nil end)
 
     if count == 1 do

--- a/lib/operately/data/change_010_create_groups_access_context.ex
+++ b/lib/operately/data/change_010_create_groups_access_context.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Data.Change010CreateGroupsAccessContext do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+
+  def run do
+    Repo.transaction(fn ->
+      groups = Repo.all(from g in Operately.Groups.Group, select: g.id)
+
+      Enum.each(groups, fn group_id ->
+        case create_group_access_contexts(group_id) do
+          {:error, _} -> raise "Failed to create access context"
+          _ -> :ok
+        end
+      end)
+    end)
+  end
+
+  defp create_group_access_contexts(group_id) do
+    Access.create_context(%{group_id: group_id})
+  end
+end

--- a/lib/operately/groups/group.ex
+++ b/lib/operately/groups/group.ex
@@ -4,6 +4,8 @@ defmodule Operately.Groups.Group do
   schema "groups" do
     has_many :members, Operately.Groups.Member, foreign_key: :group_id
 
+    has_one :access_context, Operately.Access.Context, foreign_key: :group_id
+
     field :company_id, :binary_id
     field :name, :string
     field :mission, :string

--- a/priv/repo/migrations/20240610184000_add_group_access_context.exs
+++ b/priv/repo/migrations/20240610184000_add_group_access_context.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddGroupAccessContext do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_contexts) do
+      add :group_id, references(:groups, on_delete: :nothing, type: :binary_id), null: true
+    end
+
+    create unique_index(:access_contexts, [:group_id])
+  end
+end

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -66,10 +66,25 @@ defmodule Operately.AccessContextsTest do
       {:ok, company: company, group: group, project: project, activity: activity}
     end
 
+    test "create access_context for a group", ctx do
+      attrs = %{group_id: ctx.group.id}
+
+      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+    end
+
     test "create access_context for a project", ctx do
       attrs = %{project_id: ctx.project.id}
 
       assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+    end
+
+    test "access_context cannot be attached to more than one entity", ctx do
+      attrs = %{project_id: ctx.project.id, group_id: ctx.group.id}
+
+      changeset = Context.changeset(%Context{}, attrs)
+      refute changeset.valid?
+
+      assert {:error, %Ecto.Changeset{}} = Access.create_context(attrs)
     end
   end
 end

--- a/test/operately/data/change_010_create_groups_access_context_test.exs
+++ b/test/operately/data/change_010_create_groups_access_context_test.exs
@@ -1,0 +1,34 @@
+defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Context
+  alias Operately.Data.Change010CreateGroupsAccessContext
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+
+    {:ok, creator: creator}
+  end
+
+  test "creates access_context for existing groups", ctx do
+    groups = Enum.map(1..5, fn _ ->
+      group_fixture(ctx.creator)
+    end)
+
+    Enum.each(groups, fn group ->
+      assert nil == Repo.get_by(Context, group_id: group.id)
+    end)
+
+    Change010CreateGroupsAccessContext.run()
+
+    Enum.each(groups, fn group ->
+      assert %Context{} = Repo.get_by(Context, group_id: group.id)
+    end)
+  end
+end


### PR DESCRIPTION
I've added a one-to-one relationship between groups and access contexts.
I've also added a data migration to create access contexts for existing groups.