### PR TITLE
Red Abort in generators

### DIFF
--- a/lib/mix/operately.ex
+++ b/lib/mix/operately.ex
@@ -3,7 +3,7 @@ defmodule Mix.Operately do
 
   def generate_file(path, generator) do
     if File.exists?(path) do
-      IO.puts "#{IO.ANSI.green()}Aborting#{IO.ANSI.reset()} #{path} already exists"
+      IO.puts "#{IO.ANSI.red()}Aborting#{IO.ANSI.reset()} #{path} already exists"
       System.halt(1)
     else
       generate_file!(path, generator)


### PR DESCRIPTION
#### Problem:
When using the command `./devenv mix operately.gen.api.query get_activities`, the system returned the message: `Aborting lib/operately_web/api/queries/get_activities.ex already exists`. The word "Aborting" was displayed in green.

#### Implemented Change:
We changed the color of the word "Aborting" to red, improving visual clarity for developers. The new message is:

```elixir
def generate_file(path, generator) do
  if File.exists?(path) do
    IO.puts "#{IO.ANSI.red()}Aborting#{IO.ANSI.reset()} #{path} already exists"
    System.halt(1)
  else
    generate_file!(path, generator)
  end
end
```

#### Benefits:
- **Visual Clarity:** Red is commonly associated with errors and interruptions, making the message more intuitive.
- **Consistency:** Enhances consistency in displaying critical error messages.

This change aims to improve the developer experience when using our code generators, making it more evident when an operation is aborted due to the pre-existence of a file.