### PR TITLE
Creating a project automatically creates access context

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -11,8 +11,7 @@ defmodule Operately.Access do
   def get_context!(id), do: Repo.get!(Context, id)
 
   def get_context_by_project!(project_id) do
-    from(c in Context, where: c.project_id == ^project_id)
-    |> Repo.one!()
+    Repo.get_by!(Context, project_id: project_id)
   end
 
   def create_context(attrs \\ %{}) do

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -10,6 +10,11 @@ defmodule Operately.Access do
 
   def get_context!(id), do: Repo.get!(Context, id)
 
+  def get_context_by_project!(project_id) do
+    from(c in Context, where: c.project_id == ^project_id)
+    |> Repo.one!()
+  end
+
   def create_context(attrs \\ %{}) do
     %Context{}
     |> Context.changeset(attrs)

--- a/lib/operately/operations/project_creation.ex
+++ b/lib/operately/operations/project_creation.ex
@@ -4,17 +4,18 @@ defmodule Operately.Operations.ProjectCreation do
   alias Operately.Projects.Contributor
   alias Operately.Projects.Project
   alias Operately.Activities
+  alias Operately.Access.Context
   alias Ecto.Multi
 
   defstruct [
-    :company_id, 
-    :name, 
-    :champion_id, 
+    :company_id,
+    :name,
+    :champion_id,
     :reviewer_id,
-    :creator_id, 
-    :creator_role, 
+    :creator_id,
+    :creator_role,
     :creator_is_contributor,
-    :visibility, 
+    :visibility,
     :group_id,
     :goal_id
   ]
@@ -32,6 +33,11 @@ defmodule Operately.Operations.ProjectCreation do
         :started_at => DateTime.utc_now(),
         :next_check_in_scheduled_at => Operately.Time.first_friday_from_today(),
         :health => :on_track,
+      })
+    end)
+    |> Multi.insert(:context, fn changes ->
+      Context.changeset(%{
+        project_id: changes.project.id,
       })
     end)
     |> Multi.insert(:champion, fn changes ->

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -12,6 +12,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -24,6 +25,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -36,6 +38,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -49,6 +52,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -61,6 +65,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end

--- a/test/operately/projects_test.exs
+++ b/test/operately/projects_test.exs
@@ -52,6 +52,8 @@ defmodule Operately.ProjectsTest do
 
       assert {:ok, %Project{} = project} = Projects.create_project(project_attrs)
       assert project.name == "some name"
+
+      assert nil != Operately.Access.get_context_by_project!(project.id)
     end
 
     test "update_project/2 with valid data updates the project", ctx do
@@ -130,7 +132,7 @@ defmodule Operately.ProjectsTest do
     test "create_milestone/1 with valid data creates a milestone", ctx do
       valid_attrs = %{
         project_id: ctx.project.id,
-        deadline_at: ~N[2023-05-10 08:16:00], 
+        deadline_at: ~N[2023-05-10 08:16:00],
         title: "some title"
       }
 
@@ -223,7 +225,7 @@ defmodule Operately.ProjectsTest do
 
     setup ctx do
       document = document_fixture(%{
-        project_id: ctx.project.id, 
+        project_id: ctx.project.id,
         author_id: ctx.champion.id
       })
 
@@ -240,8 +242,8 @@ defmodule Operately.ProjectsTest do
 
     test "create_document/1 with valid data creates a document", ctx do
       valid_attrs = %{
-        content: %{}, 
-        title: "some title", 
+        content: %{},
+        title: "some title",
         author_id: ctx.champion.id,
         project_id: ctx.project.id
       }

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -21,11 +21,11 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     group = group_fixture(champion, %{company_id: company.id, name: "Test Group"})
 
     ctx = Map.merge(ctx, %{
-      company: company, 
-      champion: champion, 
-      reviewer: reviewer, 
-      group: group, 
-      non_contributor: non_contributor, 
+      company: company,
+      champion: champion,
+      reviewer: reviewer,
+      group: group,
+      non_contributor: non_contributor,
       project_manager: project_manager
     })
 
@@ -84,6 +84,13 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     ctx
   end
 
+  step :assert_access_context_created, ctx, fields do
+    project = Operately.Repo.get_by!(Operately.Projects.Project, name: fields.name)
+    assert nil != Operately.Access.get_context_by_project!(project.id)
+
+    ctx
+  end
+
   step :assert_project_created_email_sent, ctx, fields do
     people = who_should_be_notified(fields)
 
@@ -97,7 +104,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       })
     end)
   end
-  
+
   step :assert_project_created_notification_sent, ctx, fields do
     people = who_should_be_notified(fields)
 
@@ -105,7 +112,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       ctx
       |> UI.login_as(person)
       |> NotificationsSteps.assert_notification_exists(
-        author: fields.creator, 
+        author: fields.creator,
         subject: "#{Person.first_name(fields.creator)} created a new project and assigned you as the #{role}"
       )
     end)


### PR DESCRIPTION
I changed the project creation logic so that creating a project will automatically create an access context from now on.