### PR TITLE
Creating a project automatically creates access context

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -11,8 +11,7 @@ defmodule Operately.Access do
   def get_context!(id), do: Repo.get!(Context, id)
 
   def get_context_by_project!(project_id) do
-    from(c in Context, where: c.project_id == ^project_id)
-    |> Repo.one!()
+    Repo.get_by!(Context, project_id: project_id)
   end
 
   def create_context(attrs \\ %{}) do

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -10,6 +10,11 @@ defmodule Operately.Access do
 
   def get_context!(id), do: Repo.get!(Context, id)
 
+  def get_context_by_project!(project_id) do
+    from(c in Context, where: c.project_id == ^project_id)
+    |> Repo.one!()
+  end
+
   def create_context(attrs \\ %{}) do
     %Context{}
     |> Context.changeset(attrs)

--- a/lib/operately/operations/project_creation.ex
+++ b/lib/operately/operations/project_creation.ex
@@ -4,17 +4,18 @@ defmodule Operately.Operations.ProjectCreation do
   alias Operately.Projects.Contributor
   alias Operately.Projects.Project
   alias Operately.Activities
+  alias Operately.Access.Context
   alias Ecto.Multi
 
   defstruct [
-    :company_id, 
-    :name, 
-    :champion_id, 
+    :company_id,
+    :name,
+    :champion_id,
     :reviewer_id,
-    :creator_id, 
-    :creator_role, 
+    :creator_id,
+    :creator_role,
     :creator_is_contributor,
-    :visibility, 
+    :visibility,
     :group_id,
     :goal_id
   ]
@@ -32,6 +33,11 @@ defmodule Operately.Operations.ProjectCreation do
         :started_at => DateTime.utc_now(),
         :next_check_in_scheduled_at => Operately.Time.first_friday_from_today(),
         :health => :on_track,
+      })
+    end)
+    |> Multi.insert(:context, fn changes ->
+      Context.changeset(%{
+        project_id: changes.project.id,
       })
     end)
     |> Multi.insert(:champion, fn changes ->

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -12,6 +12,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -24,6 +25,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -36,6 +38,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -49,6 +52,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -61,6 +65,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -12,7 +12,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
-    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -25,7 +24,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
-    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -38,7 +36,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
-    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -52,7 +49,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
-    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
@@ -65,7 +61,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
-    |> Steps.assert_access_context_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -18,7 +18,7 @@ defmodule Operately.AccessBindingsTest do
       group = Operately.GroupsFixtures.group_fixture(creator)
       project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
 
-      context = context_fixture(%{project_id: project.id})
+      context = Access.get_context_by_project!(project.id)
       group = group_fixture()
 
       {:ok, %{context: context, group: group}}

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -15,8 +15,7 @@ defmodule Operately.AccessContextsTest do
       company = company_fixture()
       creator = person_fixture_with_account(%{company_id: company.id})
       group = group_fixture(creator)
-      project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
-      context = context_fixture(%{project_id: project.id})
+      context = context_fixture(%{group_id: group.id})
 
       {:ok, company: company, group: group, creator: creator, context: context}
     end
@@ -30,15 +29,15 @@ defmodule Operately.AccessContextsTest do
     end
 
     test "create_context/1 with valid data creates a context", ctx do
-      another_project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
-      valid_attrs = %{project_id: another_project.id}
+      another_group = group_fixture(ctx.creator)
+      valid_attrs = %{group_id: another_group.id}
 
       assert {:ok, %Context{} = _context} = Access.create_context(valid_attrs)
     end
 
     test "update_context/2 with valid data updates the context", ctx do
-      another_project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
-      update_attrs = %{project_id: another_project.id}
+      another_group = group_fixture(ctx.creator)
+      update_attrs = %{group_id: another_group.id}
 
       assert {:ok, %Context{} = _context} = Access.update_context(ctx.context, update_attrs)
     end
@@ -63,7 +62,7 @@ defmodule Operately.AccessContextsTest do
       project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
       activity = activity_fixture(%{author_id: creator.id})
 
-      {:ok, company: company, group: group, project: project, activity: activity}
+      {:ok, company: company, group: group, project: project, activity: activity, creator: creator}
     end
 
     test "create access_context for a group", ctx do
@@ -73,9 +72,9 @@ defmodule Operately.AccessContextsTest do
     end
 
     test "create access_context for a project", ctx do
-      attrs = %{project_id: ctx.project.id}
+      project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
 
-      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+      assert nil != Access.get_context_by_project!(project.id)
     end
 
     test "access_context cannot be attached to more than one entity", ctx do

--- a/test/operately/data/change_009_create_projects_access_context_test.exs
+++ b/test/operately/data/change_009_create_projects_access_context_test.exs
@@ -4,7 +4,6 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import Operately.GroupsFixtures
-  import Operately.ProjectsFixtures
 
   alias Operately.Repo
   alias Operately.Access.Context
@@ -20,7 +19,8 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
 
   test "creates access_context for existing companies", ctx do
     projects = Enum.map(1..5, fn _ ->
-      project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+      {:ok, project} = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+      project
     end)
 
     Enum.each(projects, fn project ->
@@ -30,7 +30,20 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
     Change009CreateProjectsAccessContext.run()
 
     Enum.each(projects, fn project ->
-      assert %Context{} = Repo.get_by(Context, project_id: project.id)
+      context = Repo.get_by(Context, project_id: project.id)
+
+      assert nil != context
+      assert %Context{} = context
     end)
+  end
+
+  def create_project(attrs) do
+    Operately.Projects.Project.changeset(%{
+      name: "some name",
+      company_id: attrs.company_id,
+      group_id: attrs.group_id,
+      creator_id: attrs.creator_id,
+    })
+    |> Repo.insert()
   end
 end

--- a/test/operately/projects_test.exs
+++ b/test/operately/projects_test.exs
@@ -52,6 +52,8 @@ defmodule Operately.ProjectsTest do
 
       assert {:ok, %Project{} = project} = Projects.create_project(project_attrs)
       assert project.name == "some name"
+
+      assert nil != Operately.Access.get_context_by_project!(project.id)
     end
 
     test "update_project/2 with valid data updates the project", ctx do
@@ -130,7 +132,7 @@ defmodule Operately.ProjectsTest do
     test "create_milestone/1 with valid data creates a milestone", ctx do
       valid_attrs = %{
         project_id: ctx.project.id,
-        deadline_at: ~N[2023-05-10 08:16:00], 
+        deadline_at: ~N[2023-05-10 08:16:00],
         title: "some title"
       }
 
@@ -223,7 +225,7 @@ defmodule Operately.ProjectsTest do
 
     setup ctx do
       document = document_fixture(%{
-        project_id: ctx.project.id, 
+        project_id: ctx.project.id,
         author_id: ctx.champion.id
       })
 
@@ -240,8 +242,8 @@ defmodule Operately.ProjectsTest do
 
     test "create_document/1 with valid data creates a document", ctx do
       valid_attrs = %{
-        content: %{}, 
-        title: "some title", 
+        content: %{},
+        title: "some title",
         author_id: ctx.champion.id,
         project_id: ctx.project.id
       }

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -84,13 +84,6 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     ctx
   end
 
-  step :assert_access_context_created, ctx, fields do
-    project = Operately.Repo.get_by!(Operately.Projects.Project, name: fields.name)
-    assert nil != Operately.Access.get_context_by_project!(project.id)
-
-    ctx
-  end
-
   step :assert_project_created_email_sent, ctx, fields do
     people = who_should_be_notified(fields)
 

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -21,11 +21,11 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     group = group_fixture(champion, %{company_id: company.id, name: "Test Group"})
 
     ctx = Map.merge(ctx, %{
-      company: company, 
-      champion: champion, 
-      reviewer: reviewer, 
-      group: group, 
-      non_contributor: non_contributor, 
+      company: company,
+      champion: champion,
+      reviewer: reviewer,
+      group: group,
+      non_contributor: non_contributor,
       project_manager: project_manager
     })
 
@@ -84,6 +84,13 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     ctx
   end
 
+  step :assert_access_context_created, ctx, fields do
+    project = Operately.Repo.get_by!(Operately.Projects.Project, name: fields.name)
+    assert nil != Operately.Access.get_context_by_project!(project.id)
+
+    ctx
+  end
+
   step :assert_project_created_email_sent, ctx, fields do
     people = who_should_be_notified(fields)
 
@@ -97,7 +104,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       })
     end)
   end
-  
+
   step :assert_project_created_notification_sent, ctx, fields do
     people = who_should_be_notified(fields)
 
@@ -105,7 +112,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       ctx
       |> UI.login_as(person)
       |> NotificationsSteps.assert_notification_exists(
-        author: fields.creator, 
+        author: fields.creator,
         subject: "#{Person.first_name(fields.creator)} created a new project and assigned you as the #{role}"
       )
     end)


### PR DESCRIPTION
I changed the project creation logic so that creating a project will automatically create an access context from now on.