### PR TITLE
Show UTC for Time zones

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -52,6 +52,7 @@
         "esbuild": "^0.14.54",
         "jest": "^29.6.1",
         "knip": "^2.41.5",
+        "moment-timezone": "^0.5.45",
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.3"
       }
@@ -10806,6 +10807,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dev": true,
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -21297,6 +21319,21 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
+    },
+    "moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dev": true,
+      "requires": {
+        "moment": "^2.29.4"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -47,6 +47,7 @@
     "esbuild": "^0.14.54",
     "jest": "^29.6.1",
     "knip": "^2.41.5",
+    "moment-timezone": "^0.5.45",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.3"
   },


### PR DESCRIPTION
### Objective

This pull request aims to improve the way time zones are displayed in the user's profile form, making the information more comprehensible and user-friendly. Additionally, several improvements and bug fixes have been implemented in the code.

### Main Changes

1. **Time Zone Formatting:**
   - Added the `formatTimezone` function to format time zones in the format `(UTC-03:00) Sao Paulo`.
   - Replaced the previous time zone display, such as `America/Sao_Paulo`, with the new, more descriptive formatting.

2. **User Interface Adjustments:**
   - Updated the time zone values in the time zone selector options to use the new formatting.
   - Fixes in the styling of the file input and other form components.

### Detailed Changes

- **`formatTimezone` Function:**
  - The new `formatTimezone` function has been implemented to format the time zone string in a more user-friendly way.
  - It uses the `moment-timezone` library to get the UTC offset and format the city names.

- **Profile Form:**
  - The time zone selector now uses the `formatTimezone` function to display time zones more clearly.
  - Updated the initial state of the time zone in the form to reflect the new formatting.
  - Improvements in the styling of the file input, ensuring a more user-friendly and consistent interface.

### Steps to Test

1. Access the profile page.
2. Verify that the time zone selector displays the time zones in the new format `(UTC-XX:XX) City.
3. Check that the information is saved correctly when submitting the form.
4. Test uploading a new profile picture to ensure the functionality works as expected.

### Screenshot

![image](https://github.com/operately/operately/assets/68076306/07bb9291-9fcd-4032-bbf1-0cf66e9a24b6)

### Additional Information

- **Dependencies:** Added `moment-timezone` dependency to facilitate time zone formatting.
- **Compatibility:** Tested on modern browsers and compatible with major devices.