### PR TITLE
Data migration skips projects that already have access context

### DIFF
--- a/lib/operately/data/change_009_create_projects_access_context.ex
+++ b/lib/operately/data/change_009_create_projects_access_context.ex
@@ -3,10 +3,12 @@ defmodule Operately.Data.Change009CreateProjectsAccessContext do
 
   alias Operately.Repo
   alias Operately.Access
+  alias Operately.Projects.Project
+  alias Operately.Access.Context
 
   def run do
     Repo.transaction(fn ->
-      projects = Repo.all(from p in Operately.Projects.Project, select: p.id)
+      projects = Repo.all(from p in Project, select: p.id)
 
       Enum.each(projects, fn project_id ->
         case create_projects_access_contexts(project_id) do
@@ -18,6 +20,12 @@ defmodule Operately.Data.Change009CreateProjectsAccessContext do
   end
 
   defp create_projects_access_contexts(project_id) do
-    Access.create_context(%{project_id: project_id})
+    existing_context = Repo.one(from c in Context, where: c.project_id == ^project_id, select: c.id)
+
+    if existing_context do
+      :ok
+    else
+      Access.create_context(%{project_id: project_id})
+    end
   end
 end

--- a/test/operately/data/change_009_create_projects_access_context_test.exs
+++ b/test/operately/data/change_009_create_projects_access_context_test.exs
@@ -4,8 +4,10 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
 
   alias Operately.Repo
+  alias Operately.Access
   alias Operately.Access.Context
   alias Operately.Data.Change009CreateProjectsAccessContext
 
@@ -17,7 +19,7 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
     {:ok, company: company, creator: creator, group: group}
   end
 
-  test "creates access_context for existing companies", ctx do
+  test "creates access_context for existing projects", ctx do
     projects = Enum.map(1..5, fn _ ->
       {:ok, project} = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
       project
@@ -35,6 +37,17 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
       assert nil != context
       assert %Context{} = context
     end)
+  end
+
+  test "creates access_context successfully when a project already has access context", ctx do
+    project_with_context = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+    {:ok, project_without_context} = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+
+    assert nil != Access.get_context_by_project!(project_with_context.id)
+
+    Change009CreateProjectsAccessContext.run()
+
+    assert nil != Access.get_context_by_project!(project_without_context.id)
   end
 
   def create_project(attrs) do


### PR DESCRIPTION
I improved the Change009CreateProjectsAccessContext data migration. Now it creates an access context for projects that don't have them yet while skipping projects that may already have an access context.

This improvement was necessary because, after https://github.com/operately/operately/pull/553, if the data migration still hadn't been applied and new projects were created, the new projects would have access contexts and the data migration wouldn't work. 
