### PR TITLE
Add access context to companies

### DIFF
--- a/lib/operately/access/access_context.ex
+++ b/lib/operately/access/access_context.ex
@@ -4,6 +4,7 @@ defmodule Operately.Access.Context do
   schema "access_contexts" do
     belongs_to :project, Operately.Projects.Project, foreign_key: :project_id
     belongs_to :group, Operately.Groups.Group, foreign_key: :group_id
+    belongs_to :company, Operately.Companies.Company, foreign_key: :company_id
 
     timestamps()
   end
@@ -14,19 +15,19 @@ defmodule Operately.Access.Context do
 
   def changeset(context, attrs) do
     context
-    |> cast(attrs, [:project_id, :group_id])
+    |> cast(attrs, [:project_id, :group_id, :company_id])
     |> validate_one_association
     |> validate_required([])
   end
 
   defp validate_one_association(changeset) do
-    fields = [:project_id, :group_id]
+    fields = [:project_id, :group_id, :company_id]
     count = Enum.count(fields, fn field -> get_field(changeset, field) != nil end)
 
     if count == 1 do
       changeset
     else
-      add_error(changeset, :base, "Exactly one association (Project, Group, Activity, or Company) must be set.")
+      add_error(changeset, :base, "Exactly one association (Project, Group or Company) must be set.")
     end
   end
 end

--- a/lib/operately/companies/company.ex
+++ b/lib/operately/companies/company.ex
@@ -5,6 +5,8 @@ defmodule Operately.Companies.Company do
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
   schema "companies" do
+    has_one :access_context, Operately.Access.Context, foreign_key: :company_id
+
     field :mission, :string
     field :name, :string
     field :trusted_email_domains, {:array, :string}

--- a/lib/operately/data/change_011_create_companies_access_context.ex
+++ b/lib/operately/data/change_011_create_companies_access_context.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Data.Change012CreateCompaniesAccessContext do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+
+  def run do
+    Repo.transaction(fn ->
+      companies = Repo.all(from c in Operately.Companies.Company, select: c.id)
+
+      Enum.each(companies, fn company_id ->
+        case create_company_access_contexts(company_id) do
+          {:error, _} -> raise "Failed to create access context"
+          _ -> :ok
+        end
+      end)
+    end)
+  end
+
+  defp create_company_access_contexts(company_id) do
+    Access.create_context(%{company_id: company_id})
+  end
+end

--- a/lib/operately/data/change_011_create_companies_access_context.ex
+++ b/lib/operately/data/change_011_create_companies_access_context.ex
@@ -3,10 +3,12 @@ defmodule Operately.Data.Change012CreateCompaniesAccessContext do
 
   alias Operately.Repo
   alias Operately.Access
+  alias Operately.Companies.Company
+  alias Operately.Access.Context
 
   def run do
     Repo.transaction(fn ->
-      companies = Repo.all(from c in Operately.Companies.Company, select: c.id)
+      companies = Repo.all(from c in Company, select: c.id)
 
       Enum.each(companies, fn company_id ->
         case create_company_access_contexts(company_id) do
@@ -18,6 +20,12 @@ defmodule Operately.Data.Change012CreateCompaniesAccessContext do
   end
 
   defp create_company_access_contexts(company_id) do
-    Access.create_context(%{company_id: company_id})
+    existing_context = Repo.one(from c in Context, where: c.company_id == ^company_id, select: c.id)
+
+    if existing_context do
+      :ok
+    else
+      Access.create_context(%{company_id: company_id})
+    end
   end
 end

--- a/priv/repo/migrations/20240610204000_add_company_access_context.exs
+++ b/priv/repo/migrations/20240610204000_add_company_access_context.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddCompanyAccessContext do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_contexts) do
+      add :company_id, references(:companies, on_delete: :nothing, type: :binary_id), null: true
+    end
+
+    create unique_index(:access_contexts, [:company_id])
+  end
+end

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -65,6 +65,12 @@ defmodule Operately.AccessContextsTest do
       {:ok, company: company, group: group, project: project, activity: activity, creator: creator}
     end
 
+    test "create access_context for an company", ctx do
+      attrs = %{company_id: ctx.company.id}
+
+      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+    end
+
     test "create access_context for a group", ctx do
       attrs = %{group_id: ctx.group.id}
 
@@ -83,6 +89,12 @@ defmodule Operately.AccessContextsTest do
       changeset = Context.changeset(%Context{}, attrs)
       refute changeset.valid?
 
+      assert {:error, %Ecto.Changeset{}} = Access.create_context(attrs)
+
+      attrs = %{company_id: ctx.company.id, group_id: ctx.group.id}
+      changeset = Context.changeset(%Context{}, attrs)
+
+      refute changeset.valid?
       assert {:error, %Ecto.Changeset{}} = Access.create_context(attrs)
     end
   end

--- a/test/operately/data/change_011_create_companies_access_context_test.exs
+++ b/test/operately/data/change_011_create_companies_access_context_test.exs
@@ -1,0 +1,25 @@
+defmodule Operately.Data.Change012CreateCompaniesAccessContextTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Context
+  alias Operately.Data.Change012CreateCompaniesAccessContext
+
+  test "creates access_context for existing companies" do
+    companies = Enum.map(1..5, fn _ ->
+      company_fixture()
+    end)
+
+    Enum.each(companies, fn company ->
+      assert nil == Repo.get_by(Context, company_id: company.id)
+    end)
+
+    Change012CreateCompaniesAccessContext.run()
+
+    Enum.each(companies, fn company ->
+      assert %Context{} = Repo.get_by(Context, company_id: company.id)
+    end)
+  end
+end


### PR DESCRIPTION
I've added a one-to-one relationship between companies and access contexts, along with a data migration to create access contexts for existing companies.

Initially, I planned to add the relationship between activity and access context first. However, I realized that activity should be added last since it will use the same context as projects, groups, and companies.
