### PR TITLE
Show initials immediately while user removes Avatar

### DIFF
--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -96,7 +96,7 @@ function initials(fullName: string): string {
   }
 }
 
-function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
+export function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
   const baseClass = classnames(
     "flex items-center justify-center",
     "text-dark-1",
@@ -128,7 +128,7 @@ function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
 //
 // Fixed based on this issue: https://github.com/chakra-ui/chakra-ui/issues/5909.
 //
-function ImageAvatar({ person, size }: AvatarProps): JSX.Element {
+export function ImageAvatar({ person, size }: AvatarProps): JSX.Element {
   if (!person) return <></>;
 
   const baseClass = "rounded-full overflow-hidden bg-white shrink-0";

--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -12,7 +12,7 @@ import { CreateBlob } from "@/graphql/Blobs";
 import moment from "moment-timezone";
 import { FilledButton } from "@/components/Button";
 import classnames from "classnames";
-import Avatar from "@/components/Avatar";
+import { BackupAvatar, ImageAvatar } from "@/components/Avatar";
 
 export async function loader() {
   return null;
@@ -151,13 +151,17 @@ function ProfileForm({ me }) {
 
   const isValid = name.length > 0 && title.length > 0;
 
+  const handleRemoveAvatar = () => {
+    setAvatarUrl(null);
+  };
+
   return (
     <Forms.Form onSubmit={handleSubmit} loading={loading} isValid={isValid}>
       <section className="flex flex-col w-full justify-center items-center text-center">
-        {avatarUrl === null ? (
-          <img src={avatarUrl} className="rounded-full w-24 h-24" />
+        {avatarUrl ? (
+          <ImageAvatar person={me} size="xxlarge" />
         ) : (
-          <Avatar person={me} size="xxlarge" />
+          <BackupAvatar person={me} size="xxlarge" />
         )}
         <div className="ml-4 mt-2">
           <FileInput
@@ -167,7 +171,7 @@ function ProfileForm({ me }) {
             }}
             error={false}
           />
-          <button className={dimmedClassName} type="button" onClick={() => setAvatarUrl(null)}>
+          <button className={dimmedClassName} type="button" onClick={handleRemoveAvatar}>
             Remove Avatar and Use Initials
           </button>
         </div>
@@ -205,6 +209,7 @@ function ProfileForm({ me }) {
     </Forms.Form>
   );
 }
+
 
 function ManagerSearch({ manager, setManager, managerStatus, setManagerStatus }) {
   const loader = People.usePeopleSearch();


### PR DESCRIPTION
This Pull Request implements improvements in the logic for displaying the user's avatar in the profile form. These changes ensure that the user's initials are shown immediately after the profile picture is removed. Additionally, the `ImageAvatar` and `BackupAvatar` components were created and exported to enhance code modularity and reusability.

### Main Changes

1. **New Components for Avatar**:
   - **`ImageAvatar`**: Component that displays the user's avatar image.
   - **`BackupAvatar`**: Component that displays the user's initials as a backup avatar.

2. **Updated Logic in the `ProfileForm` Component**:
   - The `handleRemoveAvatar` function now sets `avatarUrl` to `null` immediately when the remove button is clicked.
   - The conditional rendering of the avatar has been adjusted to use the new `ImageAvatar` and `BackupAvatar` components.

### Technical Details

- **Components**:
  - `ImageAvatar` and `BackupAvatar` have been exported from a separate file `Avatar Component`.
  - `ImageAvatar` displays the avatar image using the avatar URL.
  - `BackupAvatar` displays the user's initials using the `Avatar` component.

- **Profile Form**:
  - Added the `handleRemoveAvatar` function to update the `avatarUrl` state.
  - Adjusted conditional rendering to use `ImageAvatar` when `avatarUrl` is set and `BackupAvatar` when `avatarUrl` is `null`.

### Screenshots

- **Before Avatar Removal**:
![image](https://github.com/operately/operately/assets/68076306/02929207-476a-42c5-bfbf-bafc3ce67858)

- **After Avatar Removal**:
![image](https://github.com/operately/operately/assets/68076306/f46c6eaf-ff7e-40f3-b5f9-18d2f70bf0cf)
