### PR TITLE
Bug Fix: User Profile Inaccessible When Title in the Company is Set to Empty

### DIFF
--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -118,7 +118,23 @@ function ProfileForm({ me }) {
     label: formatTimezone(tz),
   }));
 
+  const verifyFields = () => {
+    if (name.length === 0) {
+      return false;
+    }
+    if (title.length === 0) {
+      return false;
+    }
+    if (!timezone) {
+      return false;
+    }
+    return true;
+  };
+
   const handleSubmit = () => {
+    if (!verifyFields()) {
+      return;
+    }
     update({
       variables: {
         input: {
@@ -158,11 +174,7 @@ function ProfileForm({ me }) {
   return (
     <Forms.Form onSubmit={handleSubmit} loading={loading} isValid={isValid}>
       <section className="flex flex-col w-full justify-center items-center text-center">
-        {avatarUrl ? (
-          <ImageAvatar person={me} size="xxlarge" />
-        ) : (
-          <BackupAvatar person={me} size="xxlarge" />
-        )}
+        {avatarUrl ? <ImageAvatar person={me} size="xxlarge" /> : <BackupAvatar person={me} size="xxlarge" />}
         <div className="ml-4 mt-2">
           <FileInput
             onChange={async (e) => {
@@ -181,18 +193,28 @@ function ProfileForm({ me }) {
         <div className="progress-bar" style={{ width: `${uploadProgress}%` }}></div>
       </div>
 
-      <Forms.TextInput value={name} onChange={setName} label="Name" error={name.length === 0} />
-      <Forms.TextInput value={title} onChange={setTitle} label="Title in the Company" error={title.length === 0} />
+      <div>
+        <Forms.TextInput value={name} onChange={setName} label="Name" error={name.length === 0} />
+        {name.length === 0 && <div className="text-red-500">Name is required</div>}
+      </div>
 
-      <Forms.SelectBox
-        label="Timezone"
-        placeholder="Select your timezone..."
-        value={timezone}
-        defaultValue={timezone}
-        onChange={(option) => setTimezone(option)}
-        options={timezones}
-        data-test-id="timezone-selector"
-      />
+      <div>
+        <Forms.TextInput value={title} onChange={setTitle} label="Title in the Company" error={title.length === 0} />
+        {title.length === 0 && <div className="text-red-500">Role is required</div>}
+      </div>
+
+      <div>
+        <Forms.SelectBox
+          label={`Timezone`}
+          placeholder="Select your timezone..."
+          value={timezone}
+          defaultValue={timezone}
+          onChange={(option) => setTimezone(option)}
+          options={timezones}
+          data-test-id="timezone-selector"
+        />
+        {!timezone && <div className="text-red-500">Timezone is required</div>}
+      </div>
 
       <ManagerSearch
         manager={manager}
@@ -209,7 +231,6 @@ function ProfileForm({ me }) {
     </Forms.Form>
   );
 }
-
 
 function ManagerSearch({ manager, setManager, managerStatus, setManagerStatus }) {
   const loader = People.usePeopleSearch();


### PR DESCRIPTION
### Fix: Prevent Profile Access Issues When "Title in the Company" is Empty

**Issue Description:**
Previously, when a user set their "Title in the Company" field to an empty value and saved the changes, they were unable to access their own profile. This issue impacted the user's ability to view or edit their profile effectively.

**Steps to Reproduce the Issue:**
1. Navigate to the user profile settings.
2. Set the "Title in the Company" field to an empty value.
3. Save the changes.
4. Attempt to access the user profile again.

**Expected Result:**
The user should be able to access their profile regardless of the "Title in the Company" field being empty.

**Actual Result:**
The user is unable to access their profile after setting the "Title in the Company" field to an empty value.

**Solution:**
This PR addresses the issue by ensuring that the "Title in the Company" field cannot be left empty when saving the profile. If the field is empty, an error message is displayed, prompting the user to fill in the required information.

**Changes Made:**
- Updated the `ProfileForm` component to include validation for the "Title in the Company" field.
- Added error messages to indicate when the "Title in the Company" or "Name" fields are empty.
- Ensured the form submission is blocked if required fields are not filled out.
- Adjusted the styling and structure to provide a consistent user experience.