### PR TITLE
Fix flaky test "feature rename a project"

### DIFF
--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -367,13 +367,15 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_project_renamed, ctx, new_name: new_name do
+    ctx
+    |> UI.visit("/projects/#{ctx.project.id}")
+    |> UI.assert_text(new_name)
+
     project = Operately.Projects.get_project!(ctx.project.id)
 
     assert project.name == new_name
 
     ctx
-    |> UI.visit("/projects/#{ctx.project.id}")
-    |> UI.assert_text("New Name")
   end
 
   step :given_a_person_exists, ctx, name: name do


### PR DESCRIPTION
This test was sometimes failing (recently [here](https://operately.semaphoreci.com/workflows/80c555a8-fb55-4214-ab1c-a7e35f5e52f2/summary?pipeline_id=811f2d10-ccaf-4d6a-ab1c-b89c852ae40e&report_id=31c127ba-6edc-33b1-9f53-fc4a54e74c82&test_id=4e6e595c-da57-3af3-8415-abb2f1baf993)) because, after renaming a project, we tried to assert that the name was changed in the DB, but the assertion was running before the name change was complete. After asserting the project was renamed in the DB, we also checked that the new name was visible in the UI.

To fix the problem, I inverted the order of the assertions. Now, we first assert that the new name is visible in the UI, which indicates the renaming is complete. Then we assert the new name is correct in the DB.