### PR TITLE
Add avatar blob id reference

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -460,6 +460,7 @@ export interface Assignments {
 }
 
 export interface Blob {
+  id?: string | null;
   author?: Person | null;
   status?: string | null;
   filename?: string | null;

--- a/assets/js/components/Editor/Blob/FileUploader.tsx
+++ b/assets/js/components/Editor/Blob/FileUploader.tsx
@@ -5,11 +5,11 @@ import { CreateBlob } from "@/graphql/Blobs";
 type ProgressCallback = (number: number) => any;
 
 export interface FileUploader {
-  upload: (file: File, progressCallback: ProgressCallback) => Promise<string>;
+  upload: (file: File, progressCallback: ProgressCallback) => Promise<{ id: string, url: string }>;
 }
 
 export class MultipartFileUploader implements FileUploader {
-  async upload(file: File, progressCallback: ProgressCallback): Promise<string> {
+  async upload(file: File, progressCallback: ProgressCallback): Promise<{ id: string, url: string }> {
     try {
       const blob = await CreateBlob({ filename: file.name });
 
@@ -21,7 +21,10 @@ export class MultipartFileUploader implements FileUploader {
 
       await this.uploadFile(file, signedUploadUrl, progressCallback);
 
-      return blob.data.createBlob.url;
+      return {
+        id: blob.data.createBlob.id,
+        url: blob.data.createBlob.url
+      };
     } catch (error) {
       console.error("Error during file upload:", error);
       throw new Error(`File upload failed: ${error.message}`);

--- a/assets/js/components/Editor/Blob/S3Upload/S3Upload.tsx
+++ b/assets/js/components/Editor/Blob/S3Upload/S3Upload.tsx
@@ -18,7 +18,10 @@ export const S3Upload = async (file) => {
 
     const response = await axios.put(signedUploadUrl, file, config);
     if (response.status === 200) {
-      return signedUploadUrl;
+      return {
+        id: data.createBlob.id,
+        url: data.createBlob.url,
+      };
     } else {
       throw new Error(`Upload failed with status ${response.status}`);
     }

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -490,6 +490,7 @@ export type Assignments = {
 
 export type Blob = {
   __typename?: 'Blob';
+  id: Scalars['ID']['output'];
   author: Person;
   filename: Scalars['String']['output'];
   signedUploadUrl: Scalars['String']['output'];

--- a/assets/js/graphql/Blobs/index.tsx
+++ b/assets/js/graphql/Blobs/index.tsx
@@ -8,6 +8,7 @@ interface BlobInput {
 const CREATE_BLOB_MUTATION = gql`
   mutation CreateBlob($input: BlobInput!) {
     createBlob(input: $input) {
+      id
       url
       signedUploadUrl
       storageType

--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -33,6 +33,7 @@ export function Page() {
   }
 
   const me = data.me;
+  console.log(me);
 
   return (
     <Paper.Root size="small">
@@ -93,6 +94,7 @@ function ProfileForm({ me }) {
   const [managerStatus, setManagerStatus] = useState(me.manager ? "select-from-list" : "no-manager");
   const [avatarUrl, setAvatarUrl] = useState(me.avatarUrl ? me.avatarUrl : "");
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [blobId, setBlobId] = useState(me.avatarBlobId ? me.avatarBlobId : "");
   const fileUploader = new MultipartFileUploader();
 
   const [timezone, setTimezone] = useState(() => {
@@ -106,8 +108,8 @@ function ProfileForm({ me }) {
   async function S3FileUploader(file) {
     try {
       const response = await S3Upload(file);
-      const url = response;
-      setAvatarUrl(url);
+      setBlobId(response.id);
+      setAvatarUrl(response.url);
     } catch (error) {
       throw new Error(`File upload failed: ${error.message}`);
     }
@@ -143,16 +145,18 @@ function ProfileForm({ me }) {
           timezone: timezone?.value,
           managerId: managerStatus === "select-from-list" ? manager?.id : null,
           avatarUrl: avatarUrl,
+          avatarBlobId: blobId,
         },
       },
     });
   };
 
   const handleFileUpload = async (file) => {
-    const url = await fileUploader.upload(file, (progress) => {
+    const blob = await fileUploader.upload(file, (progress) => {
       setUploadProgress(progress);
     });
-    setAvatarUrl(url);
+    setBlobId(blob.id);
+    setAvatarUrl(blob.url);
   };
 
   async function uploadFile(file) {

--- a/assets/js/pages/AccountEditProfilePage/index.tsx
+++ b/assets/js/pages/AccountEditProfilePage/index.tsx
@@ -33,7 +33,6 @@ export function Page() {
   }
 
   const me = data.me;
-  console.log(me);
 
   return (
     <Paper.Root size="small">

--- a/lib/operately/blobs/blob.ex
+++ b/lib/operately/blobs/blob.ex
@@ -4,6 +4,7 @@ defmodule Operately.Blobs.Blob do
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
+
   schema "blobs" do
     belongs_to :company, Operately.Companies.Company
     belongs_to :author, Operately.People.Person
@@ -19,6 +20,6 @@ defmodule Operately.Blobs.Blob do
   def changeset(blob, attrs) do
     blob
     |> cast(attrs, [:filename, :author_id, :company_id, :status, :storage_type])
-    |> validate_required([:filename, :author_id, :status, :company_id, :storage_type])
+    |> validate_required([:filename, :author_id, :company_id, :status, :storage_type])
   end
 end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -34,6 +34,10 @@ defmodule Operately.People.Person do
     timestamps()
   end
 
+  def changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
   @doc false
   def changeset(person, attrs) do
     person

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -29,11 +29,9 @@ defmodule Operately.People.Person do
     field :suspended, :boolean, default: false
     field :suspended_at, :utc_datetime
 
-    timestamps()
-  end
+    field :avatar_blob_id, :binary_id
 
-  def changeset(attrs) do
-    changeset(%__MODULE__{}, attrs)
+    timestamps()
   end
 
   @doc false
@@ -55,9 +53,11 @@ defmodule Operately.People.Person do
       :company_role,
       :theme,
       :suspended,
-      :suspended_at
+      :suspended_at,
+      :avatar_blob_id
     ])
     |> validate_required([:full_name, :company_id])
+    |> foreign_key_constraint(:avatar_blob_id, name: :people_avatar_blob_id_fkey)
   end
 
   def short_name(person) do

--- a/lib/operately_web/api/queries/get_me.ex
+++ b/lib/operately_web/api/queries/get_me.ex
@@ -22,7 +22,7 @@ defmodule OperatelyWeb.Api.Queries.GetMe do
   defp preload_manager(me, _), do: me
 
   defp serialize(me, include_manager) do
-    %{me: 
+    %{me:
       %{
         id: me.id,
         full_name: me.full_name,
@@ -31,6 +31,7 @@ defmodule OperatelyWeb.Api.Queries.GetMe do
         avatar_url: me.avatar_url,
         timezone: me.timezone,
         companyRole: me.company_role,
+        avatar_blob_id: me.avatar_blob_id,
 
         send_daily_summary: me.send_daily_summary,
         notify_on_mention: me.notify_on_mention,

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -711,6 +711,7 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :blob do
+    field :id, :string
     field :author, :person
     field :status, :string
     field :filename, :string

--- a/lib/operately_web/graphql/mutations/people.ex
+++ b/lib/operately_web/graphql/mutations/people.ex
@@ -7,6 +7,7 @@ defmodule OperatelyWeb.Graphql.Mutations.People do
     field :manager_id, :id
     field :timezone, :string
     field :avatar_url, :string
+    field :avatar_blob_id, :id
   end
 
   input_object :update_notification_settings_input do
@@ -25,6 +26,7 @@ defmodule OperatelyWeb.Graphql.Mutations.People do
       arg :title, non_null(:string)
       arg :timezone, non_null(:string)
       arg :avatar_url, non_null(:string)
+      arg :avatar_blob_id, :id
 
       resolve fn _, args, _ ->
         Operately.People.create_person(args)
@@ -41,6 +43,7 @@ defmodule OperatelyWeb.Graphql.Mutations.People do
           full_name: args.input.full_name,
           title: args.input.title,
           timezone: args.input.timezone,
+          blob_id: args.input.avatar_blob_id,
           avatar_url: args.input.avatar_url,
           manager_id: args.input[:manager_id]
         })

--- a/lib/operately_web/graphql/mutations/people.ex
+++ b/lib/operately_web/graphql/mutations/people.ex
@@ -43,7 +43,7 @@ defmodule OperatelyWeb.Graphql.Mutations.People do
           full_name: args.input.full_name,
           title: args.input.title,
           timezone: args.input.timezone,
-          blob_id: args.input.avatar_blob_id,
+          avatar_blob_id: args.input.avatar_blob_id,
           avatar_url: args.input.avatar_url,
           manager_id: args.input[:manager_id]
         })

--- a/lib/operately_web/graphql/types/blobs.ex
+++ b/lib/operately_web/graphql/types/blobs.ex
@@ -2,6 +2,7 @@ defmodule OperatelyWeb.Graphql.Types.Blobs do
   use Absinthe.Schema.Notation
 
   object :blob do
+    field :id, non_null(:id)
     field :author, non_null(:person)
     field :status, non_null(:string)
     field :filename, non_null(:string)

--- a/lib/operately_web/graphql/types/person.ex
+++ b/lib/operately_web/graphql/types/person.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Graphql.Types.Person do
     field :title, :string
     field :avatar_url, :string
     field :timezone, :string
+    field :avatar_blob_id, :id
     field :company_role, :string
     field :email, :string
 

--- a/priv/repo/migrations/20240613093658_add_blob_id_to_people_table.exs
+++ b/priv/repo/migrations/20240613093658_add_blob_id_to_people_table.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddBlobIdToPeopleTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:people) do
+      add :avatar_blob_id, references(:blobs, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20240613124458_add_blob_id_to_blob_table.exs
+++ b/priv/repo/migrations/20240613124458_add_blob_id_to_blob_table.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddBlobIdToBlobTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blobs) do
+      add :blob_id, references(:blobs, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20240613124458_add_blob_id_to_blob_table.exs
+++ b/priv/repo/migrations/20240613124458_add_blob_id_to_blob_table.exs
@@ -1,9 +1,0 @@
-defmodule Operately.Repo.Migrations.AddBlobIdToBlobTable do
-  use Ecto.Migration
-
-  def change do
-    alter table(:blobs) do
-      add :blob_id, references(:blobs, on_delete: :delete_all, type: :binary_id)
-    end
-  end
-end

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -69,8 +69,6 @@ defmodule Operately.PeopleTest do
         avatar_blob_id: blob.id
       })
 
-      IO.inspect(valid_attrs)
-
       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
       assert person.title == "some title"

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -71,8 +71,6 @@ defmodule Operately.PeopleTest do
         avatar_blob_id: ctx.blob.id
       }
 
-      IO.inspect(valid_attrs)
-
       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
       assert person.title == "some title"

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -63,16 +63,19 @@ defmodule Operately.PeopleTest do
       %{blob: blob}
     end
 
-    test "create_person/1 with valid data creates a person", %{blob: blob} do
-      valid_attrs = Map.merge(@valid_person_attrs, %{
-        company_id: blob.company_id,
-        avatar_blob_id: blob.id
-      })
+    test "create_person/1 with valid data creates a person", ctx do
+      valid_attrs = %{
+        full_name: "some full_name",
+        title: "some title",
+        company_id: ctx.person.company_id,
+        avatar_blob_id: ctx.blob.id
+      }
+
+      IO.inspect(valid_attrs)
 
       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
       assert person.title == "some title"
-      assert person.avatar_blob_id == blob.id
     end
 
     test "create_person/1 with invalid data returns error changeset" do

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -1,5 +1,5 @@
 defmodule Operately.PeopleTest do
-  use Operately.DataCase, async: true
+  use Operately.DataCase
 
   alias Operately.People
   alias Operately.People.Person

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -1,11 +1,12 @@
 defmodule Operately.PeopleTest do
-  use Operately.DataCase
+  use Operately.DataCase, async: true
 
   alias Operately.People
+  alias Operately.People.Person
+  alias Operately.Blobs.Blob
+  alias Operately.Companies.Company
 
   describe "people" do
-    alias Operately.People.Person
-
     import Operately.PeopleFixtures
     import Operately.CompaniesFixtures
 
@@ -22,19 +23,58 @@ defmodule Operately.PeopleTest do
       assert People.get_person!(ctx.person.id) == ctx.person
     end
 
-    test "create_person/1 with valid data creates a person", ctx do
-      valid_attrs = %{
-        full_name: "some full_name",
-        title: "some title",
-        company_id: ctx.person.company_id,
-        avatar_blob_id: Ecto.UUID.generate()
-      }
+    @valid_company_attrs %{
+      name: "some company"
+    }
+
+    @valid_person_attrs %{
+      full_name: "some full_name",
+      title: "some title",
+      suspended: false
+    }
+
+    @valid_blob_attrs %{
+      filename: "some_file.png",
+      status: :uploaded,
+      storage_type: :s3
+    }
+
+    setup do
+      {:ok, company} =
+        %Company{}
+        |> Company.changeset(@valid_company_attrs)
+        |> Repo.insert()
+
+      valid_person_attrs = Map.put(@valid_person_attrs, :company_id, company.id)
+      {:ok, person} =
+        %Person{}
+        |> Person.changeset(valid_person_attrs)
+        |> Repo.insert()
+
+      valid_blob_attrs = Map.merge(@valid_blob_attrs, %{
+        author_id: person.id,
+        company_id: company.id
+      })
+      {:ok, blob} =
+        %Blob{}
+        |> Blob.changeset(valid_blob_attrs)
+        |> Repo.insert()
+
+      %{blob: blob}
+    end
+
+    test "create_person/1 with valid data creates a person", %{blob: blob} do
+      valid_attrs = Map.merge(@valid_person_attrs, %{
+        company_id: blob.company_id,
+        avatar_blob_id: blob.id
+      })
 
       IO.inspect(valid_attrs)
 
       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
       assert person.title == "some title"
+      assert person.avatar_blob_id == blob.id
     end
 
     test "create_person/1 with invalid data returns error changeset" do
@@ -57,16 +97,17 @@ defmodule Operately.PeopleTest do
       assert ctx.person == People.get_person!(ctx.person.id)
     end
 
-    test "update_person/3 with valid avatar_blob_id updates the person", ctx do
+    test "update_person/3 with valid avatar_blob_id updates the person", %{person: person, blob: blob} do
       update_attrs = %{
         full_name: "some updated full_name",
         title: "some updated title",
-        avatar_blob_id: Ecto.UUID.generate()
+        avatar_blob_id: blob.id
       }
 
-      assert {:ok, %Person{} = person} = People.update_person(ctx.person, update_attrs)
-      assert person.full_name == "some updated full_name"
-      assert person.title == "some updated title"
+      assert {:ok, %Person{} = updated_person} = People.update_person(person, update_attrs)
+      assert updated_person.full_name == "some updated full_name"
+      assert updated_person.title == "some updated title"
+      assert updated_person.avatar_blob_id == blob.id
     end
 
     test "delete_person/1 deletes the person", ctx do

--- a/test/operately/people_test.exs
+++ b/test/operately/people_test.exs
@@ -24,10 +24,13 @@ defmodule Operately.PeopleTest do
 
     test "create_person/1 with valid data creates a person", ctx do
       valid_attrs = %{
-        full_name: "some full_name", 
+        full_name: "some full_name",
         title: "some title",
-        company_id: ctx.person.company_id
+        company_id: ctx.person.company_id,
+        avatar_blob_id: Ecto.UUID.generate()
       }
+
+      IO.inspect(valid_attrs)
 
       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
@@ -40,7 +43,7 @@ defmodule Operately.PeopleTest do
 
     test "update_person/2 with valid data updates the person", ctx do
       update_attrs = %{
-        full_name: "some updated full_name", 
+        full_name: "some updated full_name",
         title: "some updated title"
       }
 
@@ -52,6 +55,18 @@ defmodule Operately.PeopleTest do
     test "update_person/2 with invalid data returns error changeset", ctx do
       assert {:error, %Ecto.Changeset{}} = People.update_person(ctx.person, @invalid_attrs)
       assert ctx.person == People.get_person!(ctx.person.id)
+    end
+
+    test "update_person/3 with valid avatar_blob_id updates the person", ctx do
+      update_attrs = %{
+        full_name: "some updated full_name",
+        title: "some updated title",
+        avatar_blob_id: Ecto.UUID.generate()
+      }
+
+      assert {:ok, %Person{} = person} = People.update_person(ctx.person, update_attrs)
+      assert person.full_name == "some updated full_name"
+      assert person.title == "some updated title"
     end
 
     test "delete_person/1 deletes the person", ctx do

--- a/test/operately_web/api/queries/get_me_test.exs
+++ b/test/operately_web/api/queries/get_me_test.exs
@@ -21,6 +21,7 @@ defmodule OperatelyWeb.Api.Queries.GetMeTest do
         email: ctx.person.email,
         title: ctx.person.title,
         avatar_url: ctx.person.avatar_url,
+        avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: ctx.person.timezone,
         send_daily_summary: ctx.person.send_daily_summary,
         notify_on_mention: ctx.person.notify_on_mention,
@@ -43,6 +44,7 @@ defmodule OperatelyWeb.Api.Queries.GetMeTest do
         email: me.email,
         title: ctx.person.title,
         avatar_url: ctx.person.avatar_url,
+        avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: me.timezone,
         send_daily_summary: me.send_daily_summary,
         notify_on_mention: me.notify_on_mention,
@@ -68,6 +70,7 @@ defmodule OperatelyWeb.Api.Queries.GetMeTest do
         email: ctx.person.email,
         title: ctx.person.title,
         avatar_url: ctx.person.avatar_url,
+        avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: ctx.person.timezone,
         send_daily_summary: ctx.person.send_daily_summary,
         notify_on_mention: ctx.person.notify_on_mention,
@@ -78,4 +81,4 @@ defmodule OperatelyWeb.Api.Queries.GetMeTest do
       }
     end
   end
-end 
+end

--- a/test/operately_web/graphql/mutations/people_test.exs
+++ b/test/operately_web/graphql/mutations/people_test.exs
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.GraphQL.Mutations.PeopleTest do
       title
       timezone
       avatar_url
+      avatarBlobId
     }
   }
   """
@@ -20,7 +21,8 @@ defmodule OperatelyWeb.GraphQL.Mutations.PeopleTest do
         :fullName => "John Doe",
         :title => "CEO",
         :timezone => "Europe/Berlin",
-        :avatarUrl => "/media/3ff2295a-09fa-44a7-8ac7-f7c120c163ba-21e4a757-1196-40a0-bb3f-360e565955aa"
+        :avatarUrl => "/media/3ff2295a-09fa-44a7-8ac7-f7c120c163ba-21e4a757-1196-40a0-bb3f-360e565955aa",
+        :avatarBlobId => nil
       }
     })
 
@@ -31,6 +33,7 @@ defmodule OperatelyWeb.GraphQL.Mutations.PeopleTest do
           "title" => "CEO",
           "timezone" => "Europe/Berlin",
           "avatar_url" => "/media/3ff2295a-09fa-44a7-8ac7-f7c120c163ba-21e4a757-1196-40a0-bb3f-360e565955aa",
+          "avatarBlobId" => nil
         }
       }
     }


### PR DESCRIPTION
#### Proposed Changes
This PR introduces significant enhancements to support custom avatars in the Operately application. The key changes include:

1. **Database Migration**:
   - Adds a new `avatar_blob_id` column to the `people` table, which references the `blobs` table. This allows each user to have a custom avatar stored as a blob in the database.

   ```elixir
   defmodule Operately.Repo.Migrations.AddBlobIdToPeopleTable do
     use Ecto.Migration

     def change do
       alter table(:people) do
         add :avatar_blob_id, references(:blobs, on_delete: :delete_all, type: :binary_id)
       end
     end
   end
   ```

2. **Update to `Person` Schema**:
   - Updates the schema of the `Person` entity to include the `avatar_blob_id` field, ensuring that the application aligns with the new database structure.

   ```elixir
   defmodule Operately.People.Person do
     use Ecto.Schema
     import Ecto.Changeset

     schema "people" do
       # ... other fields ...
       field :avatar_blob_id, :binary_id

       timestamps()
     end

     @doc false
     def changeset(person, attrs) do
       person
       |> cast(attrs, [
         :full_name,
         :title,
         :avatar_url,
         :timezone,
         :email,
         :account_id,
         :company_id,
         :manager_id,
         :home_dashboard_id,
         :send_daily_summary,
         :notify_on_mention,
         :notify_about_assignments,
         :company_role,
         :theme,
         :suspended,
         :suspended_at,
         :avatar_blob_id
       ])
       |> validate_required([:full_name, :company_id])
       |> foreign_key_constraint(:avatar_blob_id, name: :people_avatar_blob_id_fkey)
     end
   end
   ```

3. **Test Updates**:
   - Adapts existing tests to ensure that creating and updating individuals (`Person`) work correctly with the addition of the `avatar_blob_id` field.

   ```elixir
   defmodule Operately.PeopleTest do
     use Operately.DataCase, async: true

     alias Operately.People
     alias Operately.People.Person
     alias Operately.Blobs.Blob
     alias Operately.Companies.Company

     # Setup omitted for brevity

     test "create_person/1 with valid data creates a person" do
       valid_attrs = Map.merge(@valid_person_attrs, %{
         company_id: blob.company_id,
         avatar_blob_id: blob.id
       })

       assert {:ok, %Person{} = person} = People.create_person(valid_attrs)
       assert person.full_name == "some full_name"
       assert person.title == "some title"
       assert person.avatar_blob_id == blob.id
     end

     test "update_person/3 with valid avatar_blob_id updates the person" do
       update_attrs = %{
         full_name: "some updated full_name",
         title: "some updated title",
         avatar_blob_id: blob.id
       }

       assert {:ok, %Person{} = updated_person} = People.update_person(person, update_attrs)
       assert updated_person.full_name == "some updated full_name"
       assert updated_person.title == "some updated title"
       assert updated_person.avatar_blob_id == blob.id
     end
   end
   ```

#### Context and Justification
These changes are crucial to enable custom avatars for users within the Operately application. By introducing the `avatar_blob_id` reference in the `people` table, users can store and display personalized avatars directly from the database. This enhancement allows for greater customization and enhances user interaction with the platform.

#### Potential Impact
- **Enhanced Functionality**: Users can configure and display custom avatars directly within the application.
- **Database Updates**: The migration ensures that both new installations and existing upgrades seamlessly support the `avatar_blob_id` functionality.

#### Tests Conducted
- Tests have been added and/or modified to ensure that creation, retrieval, and updating of avatars (`avatar_blob_id`) are thoroughly covered.
- Unit and integration tests validate the integrity and expected behavior of the feature.