### PR TITLE
Groups data migration skips groups that already have context

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -8,7 +8,13 @@ defmodule Operately.Access do
     Repo.all(Context)
   end
 
-  def get_context!(id), do: Repo.get!(Context, id)
+  def get_context!(id) when is_binary(id) do
+    Repo.get!(Context, id)
+  end
+
+  def get_context!(attrs) when is_list(attrs) do
+    Repo.get_by!(Context, attrs)
+  end
 
   def get_context_by_project!(project_id) do
     Repo.get_by!(Context, project_id: project_id)

--- a/lib/operately/data/change_010_create_groups_access_context.ex
+++ b/lib/operately/data/change_010_create_groups_access_context.ex
@@ -3,10 +3,12 @@ defmodule Operately.Data.Change010CreateGroupsAccessContext do
 
   alias Operately.Repo
   alias Operately.Access
+  alias Operately.Groups.Group
+  alias Operately.Access.Context
 
   def run do
     Repo.transaction(fn ->
-      groups = Repo.all(from g in Operately.Groups.Group, select: g.id)
+      groups = Repo.all(from g in Group, select: g.id)
 
       Enum.each(groups, fn group_id ->
         case create_group_access_contexts(group_id) do
@@ -18,6 +20,12 @@ defmodule Operately.Data.Change010CreateGroupsAccessContext do
   end
 
   defp create_group_access_contexts(group_id) do
-    Access.create_context(%{group_id: group_id})
+    existing_context = Repo.one(from c in Context, where: c.group_id == ^group_id, select: c.id)
+
+    if existing_context do
+      :ok
+    else
+      Access.create_context(%{group_id: group_id})
+    end
   end
 end

--- a/test/operately/data/change_010_create_groups_access_context_test.exs
+++ b/test/operately/data/change_010_create_groups_access_context_test.exs
@@ -1,11 +1,13 @@
 defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
   use Operately.DataCase
 
+  import Operately.AccessFixtures, only: [context_fixture: 1]
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import Operately.GroupsFixtures
 
   alias Operately.Repo
+  alias Operately.Access
   alias Operately.Access.Context
   alias Operately.Data.Change010CreateGroupsAccessContext
 
@@ -30,5 +32,18 @@ defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
     Enum.each(groups, fn group ->
       assert %Context{} = Repo.get_by(Context, group_id: group.id)
     end)
+  end
+
+  test "creates access_context successfully when a group already has access context", ctx do
+    group_with_fixtures = group_fixture(ctx.creator)
+    group_without_fixtures = group_fixture(ctx.creator)
+
+    context_fixture(%{group_id: group_with_fixtures.id})
+
+    assert nil != Access.get_context!(group_id: group_with_fixtures.id)
+
+    Change010CreateGroupsAccessContext.run()
+
+    assert nil != Access.get_context!(group_id: group_without_fixtures.id)
   end
 end


### PR DESCRIPTION
Before there changes, if we ran the groups data migration and a group already had an access context associated with it, the migration would fail. Now the migration skips groups that already have an access context.