### PR TITLE
Creating a group automatically creates an access context

### DIFF
--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -6,6 +6,7 @@ defmodule Operately.Companies do
   alias Operately.Companies.Company
   alias Operately.Tenets.Tenet
   alias Operately.People.Person
+  alias Operately.Groups
 
   def list_companies do
     Repo.all(Company)
@@ -23,17 +24,16 @@ defmodule Operately.Companies do
   def get_company_by_name(name), do: Repo.get_by(Company, name: name)
 
   def create_company(attrs \\ %{}) do
+    group_attrs = %{
+      name: "Company",
+      mission: "Everyone in the company",
+      icon: "IconBuildingEstate",
+      color: "text-cyan-500"
+    }
+
     Multi.new()
     |> Multi.insert(:company, Company.changeset(attrs))
-    |> Multi.insert(:group, fn changes ->
-      Operately.Groups.Group.changeset(%{
-        company_id: changes[:company].id,
-        name: "Company",
-        mission: "Everyone in the company",
-        icon: "IconBuildingEstate",
-        color: "text-cyan-500"
-      })
-    end)
+    |> Groups.insert_group(group_attrs)
     |> Multi.update(:updated_company, fn %{company: company, group: group} ->
       Company.changeset(company, %{company_space_id: group.id})
     end)

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -80,10 +80,6 @@ defmodule Operately.Groups do
     |> Repo.extract_result(:group)
   end
 
-  def delete_group(%Group{} = group) do
-    Repo.delete(group)
-  end
-
   def change_group(%Group{} = group, attrs \\ %{}) do
     Group.changeset(group, attrs)
   end

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -4,7 +4,7 @@ defmodule Operately.Operations.CompanyAdding do
   alias Operately.Companies.Company
   alias Operately.People.Account
   alias Operately.People.Person
-  alias Operately.Groups.Group
+  alias Operately.Groups
 
   def run(attrs) do
     Multi.new()
@@ -17,31 +17,31 @@ defmodule Operately.Operations.CompanyAdding do
   end
 
   def insert_group(multi) do
-    Multi.insert(multi, :group, fn changes ->
-      Group.changeset(%{
-        company_id: changes[:company].id,
-        name: "Company",
-        mission: "Everyone in the company",
-        icon: "IconBuildingEstate",
-        color: "text-cyan-500"
-        })
-      end)
-      |> Multi.update(:updated_company, fn %{company: company, group: group} ->
-        Company.changeset(company, %{company_space_id: group.id})
-      end)
-    end
+    attrs = %{
+      name: "Company",
+      mission: "Everyone in the company",
+      icon: "IconBuildingEstate",
+      color: "text-cyan-500"
+    }
 
-    def insert_person(multi, full_name, role) do
-      Multi.insert(multi, :person, fn changes ->
-        Person.changeset(%{
-          company_id: changes[:company].id,
-          account_id: changes[:account].id,
-          full_name: full_name,
-          email: changes[:account].email,
-          avatar_url: "",
-          title: role,
-          company_role: :admin,
-        })
-      end)
-    end
+    multi
+    |> Groups.insert_group(attrs)
+    |> Multi.update(:updated_company, fn %{company: company, group: group} ->
+      Company.changeset(company, %{company_space_id: group.id})
+    end)
+  end
+
+  def insert_person(multi, full_name, role) do
+    Multi.insert(multi, :person, fn changes ->
+      Person.changeset(%{
+        company_id: changes[:company].id,
+        account_id: changes[:account].id,
+        full_name: full_name,
+        email: changes[:account].email,
+        avatar_url: "",
+        title: role,
+        company_role: :admin,
+      })
+    end)
+  end
 end

--- a/lib/operately/operations/group_creation.ex
+++ b/lib/operately/operations/group_creation.ex
@@ -1,0 +1,20 @@
+defmodule Operately.Operations.GroupCreation do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Groups
+  alias Operately.Groups.Member
+
+  def run(creator, attrs) do
+    attrs = Map.merge(attrs, %{
+      company_id: creator.company_id,
+    })
+
+    Multi.new()
+    |> Groups.insert_group(attrs)
+    |> Multi.insert(:creator, fn %{group: group} ->
+      Member.changeset(%{group_id: group.id, person_id: creator.id})
+    end)
+    |> Repo.transaction()
+    |> Repo.extract_result(:group)
+  end
+end

--- a/test/operately/data/change_010_create_groups_access_context_test.exs
+++ b/test/operately/data/change_010_create_groups_access_context_test.exs
@@ -1,7 +1,6 @@
 defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
   use Operately.DataCase
 
-  import Operately.AccessFixtures, only: [context_fixture: 1]
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import Operately.GroupsFixtures
@@ -15,12 +14,12 @@ defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
     company = company_fixture()
     creator = person_fixture_with_account(%{company_id: company.id})
 
-    {:ok, creator: creator}
+    {:ok, company: company, creator: creator}
   end
 
   test "creates access_context for existing groups", ctx do
     groups = Enum.map(1..5, fn _ ->
-      group_fixture(ctx.creator)
+      create_group(ctx.company.id)
     end)
 
     Enum.each(groups, fn group ->
@@ -34,16 +33,28 @@ defmodule Operately.Data.Change010CreateGroupsAccessContextTest do
     end)
   end
 
+
   test "creates access_context successfully when a group already has access context", ctx do
     group_with_fixtures = group_fixture(ctx.creator)
-    group_without_fixtures = group_fixture(ctx.creator)
-
-    context_fixture(%{group_id: group_with_fixtures.id})
+    group_without_fixtures = create_group(ctx.company.id)
 
     assert nil != Access.get_context!(group_id: group_with_fixtures.id)
 
     Change010CreateGroupsAccessContext.run()
 
     assert nil != Access.get_context!(group_id: group_without_fixtures.id)
+  end
+
+  def create_group(company_id) do
+    {:ok, group} = Operately.Groups.Group.changeset(%{
+      company_id: company_id,
+      name: "some name",
+      mission: "some mission",
+      icon: "some icon",
+      color: "come color",
+    })
+    |> Repo.insert()
+
+    group
   end
 end

--- a/test/operately/groups_test.exs
+++ b/test/operately/groups_test.exs
@@ -61,12 +61,6 @@ defmodule Operately.GroupsTest do
       assert ctx.group == Groups.get_group!(ctx.group.id)
     end
 
-    test "delete_group/1 deletes the group", ctx do
-      Groups.remove_member(ctx.group, ctx.creator.id)
-      assert {:ok, %Group{}} = Groups.delete_group(ctx.group)
-      assert_raise Ecto.NoResultsError, fn -> Groups.get_group!(ctx.group.id) end
-    end
-
     test "change_group/1 returns a group changeset", ctx do
       assert %Ecto.Changeset{} = Groups.change_group(ctx.group)
     end


### PR DESCRIPTION
I've made changes to the way groups are created so that now, creating a group automatically creates an access context. To achieve this, I had to solve two problems:

### Different logics for group creation

Groups were being created in three different places:

- lib/operately/groups.ex
- lib/operately/companies.ex
- lib/operately/operations/company_adding.ex

I didn't want to hard code the insertion of access contexts in all these places as it would make the code hard to maintain. Instead, I implemented the group creation logic similarly to the way projects are created. Just as `create_project` delegates the action to `Operately.Operations.ProjectCreation`, `create_group` now delegates the action to `Operately.Operations.GroupCreation`.

Then, I added `insert_group`, which inserts the group and the context in the multi transactions. Now, all group creation operations go through `insert_group`.

### Broken delete_group function

Since creating a group now automatically creates an access context, deleting a group stopped working due to a DB constraint, causing the unit test for the `delete_group` function to fail. I initially updated delete_group to also delete the access context, but I figured that it was a bad idea because, in the near future, the group's access context will also be associated with activities.

However, if I'm not mistaken, the application in the moment does not support deleting a group and this function was not being used anywhere. Therefore, I decided to delete the function and its unit test for now. In the future, if we implement a "deleting group/space" feature, we can address this issue, most likely with a soft delete.

--

Do you think there are better ways to solve these problems, @shiroyasha? Let me know if you have any suggestions for improvement!