### PR TITLE
Creating a company automatically creates an access context 

### DIFF
--- a/lib/mix/tasks/operately.create.company.ex
+++ b/lib/mix/tasks/operately.create.company.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Operately.Create.Company do
     Application.ensure_started(Operately.Repo, [])
 
     validate_name(name)
-    {:ok, _} = Operately.Companies.create_company(%{name: name})
+    {:ok, _} = Operately.Companies.create_company(%{company_name: name})
 
     IO.puts("Company created successfully")
   end

--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -1,12 +1,10 @@
 defmodule Operately.Companies do
   import Ecto.Query, warn: false
   alias Operately.Repo
-  alias Ecto.Multi
 
   alias Operately.Companies.Company
   alias Operately.Tenets.Tenet
   alias Operately.People.Person
-  alias Operately.Groups
 
   def list_companies do
     Repo.all(Company)
@@ -23,23 +21,7 @@ defmodule Operately.Companies do
   def get_company!(id), do: Repo.get!(Company, id)
   def get_company_by_name(name), do: Repo.get_by(Company, name: name)
 
-  def create_company(attrs \\ %{}) do
-    group_attrs = %{
-      name: "Company",
-      mission: "Everyone in the company",
-      icon: "IconBuildingEstate",
-      color: "text-cyan-500"
-    }
-
-    Multi.new()
-    |> Multi.insert(:company, Company.changeset(attrs))
-    |> Groups.insert_group(group_attrs)
-    |> Multi.update(:updated_company, fn %{company: company, group: group} ->
-      Company.changeset(company, %{company_space_id: group.id})
-    end)
-    |> Repo.transaction()
-    |> Repo.extract_result(:updated_company)
-  end
+  defdelegate create_company(attrs \\ %{}),to: Operately.Operations.CompanyAdding, as: :run
 
   def update_company(%Company{} = company, attrs) do
     company

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -15,7 +15,7 @@ defmodule Operately.Operations.CompanyAdding do
     |> insert_account(attrs, opts)
     |> insert_person(attrs, opts)
     |> Repo.transaction()
-    |> Repo.extract_result(:company)
+    |> Repo.extract_result(:updated_company)
   end
 
   defp insert_company(multi, attrs) do

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -19,8 +19,13 @@ defmodule Operately.Operations.CompanyAdding do
   end
 
   defp insert_company(multi, attrs) do
+    attrs = Map.merge(%{
+      trusted_email_domains: [],
+    }, attrs)
+
     Multi.insert(multi, :company, Company.changeset(%{
       name: attrs.company_name,
+      trusted_email_domains: attrs.trusted_email_domains,
     }))
   end
 

--- a/lib/operately_web/graphql/mutations/companies.ex
+++ b/lib/operately_web/graphql/mutations/companies.ex
@@ -100,7 +100,7 @@ defmodule OperatelyWeb.Graphql.Mutations.Companies do
         allowed = Operately.Companies.count_companies() == 0
 
         if allowed do
-          Operately.Operations.CompanyAdding.run(input)
+          Operately.Operations.CompanyAdding.run(input, create_admin: true)
         else
           {:error, nil}
         end

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -22,12 +22,7 @@ defmodule Operately.AccessContextsTest do
     end
 
     test "list_contexts/0 returns all contexts", ctx do
-      contexts = Access.list_contexts()
-
-      assert length(contexts) == 2
-      assert Enum.any?(contexts, fn context ->
-        context == ctx.context
-      end)
+      assert Access.list_contexts() == [ctx.context]
     end
 
     test "get_context!/1 returns the context with given id", ctx do

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -12,7 +12,7 @@ defmodule Operately.AccessContextsTest do
 
   describe "access_contexts" do
     setup do
-      company = company_fixture()
+      company = create_company_without_context()
       creator = person_fixture_with_account(%{company_id: company.id})
 
       group = group_fixture(creator)
@@ -68,10 +68,10 @@ defmodule Operately.AccessContextsTest do
       {:ok, company: company, group: group, goal: goal, project: project, activity: activity, creator: creator}
     end
 
-    test "create access_context for a company", ctx do
-      attrs = %{company_id: ctx.company.id}
+    test "create access_context for a company" do
+      company = company_fixture()
 
-      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+      assert nil != Access.get_context!(company_id: company.id)
     end
 
     test "create access_context for a group", ctx do
@@ -120,7 +120,18 @@ defmodule Operately.AccessContextsTest do
   # Helpers
   #
 
-  def create_group_without_context(company_id) do
+  defp create_company_without_context do
+    {:ok, company} = Operately.Companies.Company.changeset(%{
+      mission: "some mission",
+      name: "some name",
+      trusted_email_domains: []
+    })
+    |> Repo.insert()
+
+    company
+  end
+
+  defp create_group_without_context(company_id) do
     {:ok, group} = Operately.Groups.Group.changeset(%{
       company_id: company_id,
       name: "some name",

--- a/test/operately/companies_test.exs
+++ b/test/operately/companies_test.exs
@@ -8,8 +8,6 @@ defmodule Operately.CompaniesTest do
 
     import Operately.CompaniesFixtures
 
-    @invalid_attrs %{mission: nil, name: nil}
-
     test "list_companies/0 returns all companies" do
       company = company_fixture()
       assert Companies.list_companies() == [company]
@@ -21,15 +19,16 @@ defmodule Operately.CompaniesTest do
     end
 
     test "create_company/1 with valid data creates a company" do
-      valid_attrs = %{mission: "some mission", name: "some name"}
+      valid_attrs = %{mission: "some mission", company_name: "some name"}
 
       assert {:ok, %Company{} = company} = Companies.create_company(valid_attrs)
-      assert company.mission == "some mission"
       assert company.name == "some name"
     end
 
     test "create_company/1 with invalid data returns error changeset" do
-      assert {:error, :company, _, _} = Companies.create_company(@invalid_attrs)
+      invalid_attrs = %{mission: nil, company_name: nil}
+
+      assert {:error, :company, _, _} = Companies.create_company(invalid_attrs)
     end
 
     test "update_company/2 with valid data updates the company" do
@@ -43,7 +42,9 @@ defmodule Operately.CompaniesTest do
 
     test "update_company/2 with invalid data returns error changeset" do
       company = company_fixture()
-      assert {:error, %Ecto.Changeset{}} = Companies.update_company(company, @invalid_attrs)
+      invalid_attrs = %{mission: nil, name: nil}
+
+      assert {:error, %Ecto.Changeset{}} = Companies.update_company(company, invalid_attrs)
       assert company == Companies.get_company!(company.id)
     end
 

--- a/test/operately/data/change_011_create_companies_access_context_test.exs
+++ b/test/operately/data/change_011_create_companies_access_context_test.exs
@@ -4,12 +4,13 @@ defmodule Operately.Data.Change012CreateCompaniesAccessContextTest do
   import Operately.CompaniesFixtures
 
   alias Operately.Repo
+  alias Operately.Access
   alias Operately.Access.Context
   alias Operately.Data.Change012CreateCompaniesAccessContext
 
   test "creates access_context for existing companies" do
     companies = Enum.map(1..5, fn _ ->
-      company_fixture()
+      create_company()
     end)
 
     Enum.each(companies, fn company ->
@@ -21,5 +22,27 @@ defmodule Operately.Data.Change012CreateCompaniesAccessContextTest do
     Enum.each(companies, fn company ->
       assert %Context{} = Repo.get_by(Context, company_id: company.id)
     end)
+  end
+
+  test "creates access_context successfully when a company already has access context" do
+    company_with_context = company_fixture()
+    company_without_context = create_company()
+
+    assert nil != Access.get_context!(company_id: company_with_context.id)
+
+    Change012CreateCompaniesAccessContext.run()
+
+    assert nil != Access.get_context!(company_id: company_without_context.id)
+  end
+
+  defp create_company do
+    {:ok, company} = Operately.Companies.Company.changeset(%{
+      mission: "some mission",
+      name: "some name",
+      trusted_email_domains: []
+    })
+    |> Repo.insert()
+
+    company
   end
 end

--- a/test/support/fixtures/companies_fixtures.ex
+++ b/test/support/fixtures/companies_fixtures.ex
@@ -6,7 +6,10 @@ defmodule Operately.CompaniesFixtures do
       trusted_email_domains: []
     })
 
-    {:ok, company} = Operately.Companies.create_company(attrs)
+    {:ok, company} =
+      Operately.Companies.Company.changeset(attrs)
+      |> Operately.Repo.insert()
+
     company
   end
 end

--- a/test/support/fixtures/companies_fixtures.ex
+++ b/test/support/fixtures/companies_fixtures.ex
@@ -2,14 +2,11 @@ defmodule Operately.CompaniesFixtures do
   def company_fixture(attrs \\ %{}) do
     attrs = attrs |> Enum.into(%{
       mission: "some mission",
-      name: "some name",
+      company_name: "some name",
       trusted_email_domains: []
     })
 
-    {:ok, company} =
-      Operately.Companies.Company.changeset(attrs)
-      |> Operately.Repo.insert()
-
+    {:ok, company} = Operately.Companies.create_company(attrs)
     company
   end
 end


### PR DESCRIPTION
I've changed the project creation logic so that, from now on, creating a project automatically creates an access context.