### PR TITLE
Creating a goal automatically creates an access context

### DIFF
--- a/lib/operately/operations/goal_creation.ex
+++ b/lib/operately/operations/goal_creation.ex
@@ -3,10 +3,12 @@ defmodule Operately.Operations.GoalCreation do
   alias Operately.Repo
   alias Operately.Goals.{Goal, Target}
   alias Operately.Activities
+  alias Operately.Access.Context
 
   def run(creator, attrs) do
     Multi.new()
     |> insert_goal(creator, attrs)
+    |> insert_context()
     |> insert_targets(attrs[:targets] || [])
     |> insert_activity(creator)
     |> Repo.transaction()
@@ -26,6 +28,14 @@ defmodule Operately.Operations.GoalCreation do
       creator_id: creator.id,
       next_update_scheduled_at: Operately.Time.first_friday_from_today(),
     }))
+  end
+
+  defp insert_context(multi) do
+    Multi.insert(multi, :context, fn changes ->
+      Context.changeset(%{
+        goal_id: changes.goal.id,
+      })
+    end)
   end
 
   defp insert_activity(multi, creator) do

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -81,9 +81,9 @@ defmodule Operately.AccessContextsTest do
     end
 
     test "create access_context for a goal", ctx do
-      attrs = %{goal_id: ctx.goal.id}
+      goal = goal_fixture(ctx.creator, %{space_id: ctx.group.id, targets: []})
 
-      assert {:ok, %Context{} = _context} = Access.create_context(attrs)
+      assert nil != Access.get_context!(goal_id: goal.id)
     end
 
     test "create access_context for a project", ctx do


### PR DESCRIPTION
I've changed the goals creation logic so that, from now on, creating a goal automatically creates an access context.