### PR TITLE
Improve and clean up access context tests

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -16,10 +16,6 @@ defmodule Operately.Access do
     Repo.get_by!(Context, attrs)
   end
 
-  def get_context_by_project!(project_id) do
-    Repo.get_by!(Context, project_id: project_id)
-  end
-
   def create_context(attrs \\ %{}) do
     %Context{}
     |> Context.changeset(attrs)

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -18,7 +18,7 @@ defmodule Operately.AccessBindingsTest do
       group = Operately.GroupsFixtures.group_fixture(creator)
       project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: creator.id})
 
-      context = Access.get_context_by_project!(project.id)
+      context = Access.get_context!(project_id: project.id)
       group = group_fixture()
 
       {:ok, %{context: context, group: group}}

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -89,7 +89,7 @@ defmodule Operately.AccessContextsTest do
     test "create access_context for a project", ctx do
       project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
 
-      assert nil != Access.get_context_by_project!(project.id)
+      assert nil != Access.get_context!(project_id: project.id)
     end
 
     test "access_context cannot be attached to more than one entity", ctx do

--- a/test/operately/data/change_009_create_projects_access_context_test.exs
+++ b/test/operately/data/change_009_create_projects_access_context_test.exs
@@ -21,8 +21,7 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
 
   test "creates access_context for existing projects", ctx do
     projects = Enum.map(1..5, fn _ ->
-      {:ok, project} = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
-      project
+      create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
     end)
 
     Enum.each(projects, fn project ->
@@ -41,22 +40,24 @@ defmodule Operately.Data.Change009CreateProjectsAccessContextTest do
 
   test "creates access_context successfully when a project already has access context", ctx do
     project_with_context = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
-    {:ok, project_without_context} = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
+    project_without_context = create_project(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
 
-    assert nil != Access.get_context_by_project!(project_with_context.id)
+    assert nil != Access.get_context!(project_id: project_with_context.id)
 
     Change009CreateProjectsAccessContext.run()
 
-    assert nil != Access.get_context_by_project!(project_without_context.id)
+    assert nil != Access.get_context!(project_id: project_without_context.id)
   end
 
   def create_project(attrs) do
-    Operately.Projects.Project.changeset(%{
+    {:ok, project} = Operately.Projects.Project.changeset(%{
       name: "some name",
       company_id: attrs.company_id,
       group_id: attrs.group_id,
       creator_id: attrs.creator_id,
     })
     |> Repo.insert()
+
+    project
   end
 end

--- a/test/operately/projects_test.exs
+++ b/test/operately/projects_test.exs
@@ -53,7 +53,7 @@ defmodule Operately.ProjectsTest do
       assert {:ok, %Project{} = project} = Projects.create_project(project_attrs)
       assert project.name == "some name"
 
-      assert nil != Operately.Access.get_context_by_project!(project.id)
+      assert nil != Operately.Access.get_context!(project_id: project.id)
     end
 
     test "update_project/2 with valid data updates the project", ctx do


### PR DESCRIPTION
Now that most of the code related to access contexts has already been merged, I was able to clean up the tests a bit and remove some code that was no longer needed.