### PR TITLE
Removing useless comments

### DIFF
--- a/test/awsS3/s3mock.exs
+++ b/test/awsS3/s3mock.exs
@@ -8,14 +8,12 @@ defmodule MyApp.S3Test do
   @file_content "Hello, S3Mock!"
 
   setup do
-    # Cria o bucket antes dos testes, usando put_bucket/2
     case S3.put_bucket(@bucket, []) |> ExAws.request() do
       {:ok, _} -> :ok
       {:error, reason} -> raise "Failed to create bucket: #{inspect(reason)}"
     end
 
     on_exit fn ->
-      # Remove todos os objetos do bucket e, em seguida, remove o bucket
       S3.list_objects(@bucket) |> ExAws.request()
       |> case do
         {:ok, %{body: %{contents: contents}}} ->
@@ -32,33 +30,27 @@ defmodule MyApp.S3Test do
   end
 
   test "upload file to S3" do
-    # Envia um arquivo para o S3 usando o conteúdo definido
     case S3.put_object(@bucket, @file_path, @file_content) |> ExAws.request() do
       {:ok, _} -> :ok
       {:error, reason} -> raise "Failed to upload file: #{inspect(reason)}"
     end
 
-    # Recupera o arquivo do S3
     case S3.get_object(@bucket, @file_path) |> ExAws.request() do
       {:ok, %{body: body}} ->
-        # Verifica se o conteúdo do arquivo está correto
         assert body == @file_content
       {:error, reason} -> raise "Failed to get file: #{inspect(reason)}"
     end
   end
 
   test "list files in bucket" do
-    # Envia um arquivo para o S3 usando o conteúdo definido
     case S3.put_object(@bucket, @file_path, @file_content) |> ExAws.request() do
       {:ok, _} -> :ok
       {:error, reason} -> raise "Failed to upload file: #{inspect(reason)}"
 
     end
 
-    # Lista os arquivos no bucket
     case S3.list_objects(@bucket) |> ExAws.request() do
       {:ok, %{body: %{contents: contents}}} ->
-        # Verifica se o arquivo está listado no bucket
         assert Enum.any?(contents, fn %{key: key} -> key == @file_path end)
       {:error, reason} -> raise "Failed to list objects: #{inspect(reason)}"
     end


### PR DESCRIPTION
This PR removes comments from the `S3mock` module. The functionality of the tests remains unchanged. The comments were removed to make the code cleaner, focusing solely on the test logic, which includes:

1. **Setup**:
   - Creating an S3 bucket before the tests run.
   - Removing all objects and the bucket after the tests run using the `on_exit` function.

2. **Tests**:
   - **upload file to S3**: Uploads a file to the S3 bucket and verifies that the retrieved file content matches the uploaded content.
   - **list files in bucket**: Uploads a file and lists the files in the bucket, checking that the uploaded file is listed.

The comments were deemed unnecessary as the code is self-explanatory.