### PR TITLE
Add insert_sync to GoalDiscussionEditing operation

### DIFF
--- a/lib/operately/operations/goal_discussion_editing.ex
+++ b/lib/operately/operations/goal_discussion_editing.ex
@@ -17,16 +17,14 @@ defmodule Operately.Operations.GoalDiscussionEditing do
 
     Multi.new()
     |> Multi.update(:thread, change)
-    |> Multi.insert(:activity, Activities.Activity.changeset(%{
-      author_id: author.id,
-      action: Atom.to_string(@action),
-      content: Activities.build_content!(@action, %{
+    |> Activities.insert_sync(author.id, @action, fn _changes ->
+      %{
         company_id: goal.company_id,
         space_id: goal.group_id,
         goal_id: goal.id,
         activity_id: activity_id,
-      })
-    }))
+      }
+    end)
     |> Repo.transaction()
     |> Repo.extract_result(:activity)
   end


### PR DESCRIPTION
I've changed the way the activity was being created in `GoalDiscussionEditing`. Now this operation also uses `Activities.insert_sync` to create the activity. 

This change was necessary because, for the access context to be attached to the activity, the activity creation has to go through `Activities.insert_sync`.