### PR TITLE
Add first tests for operations

### DIFF
--- a/test/operately/operations/goal_closing_test.exs
+++ b/test/operately/operations/goal_closing_test.exs
@@ -1,0 +1,42 @@
+defmodule Operately.Operations.GoalClosingTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    author = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(author)
+    goal = goal_fixture(author, %{space_id: group.id, targets: []})
+
+    {:ok, author: author, goal: goal}
+  end
+
+  test "GoalClosing operation updates goal", ctx do
+    assert ctx.goal.closed_at == nil
+    assert ctx.goal.closed_by_id == nil
+
+    Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+
+    goal = Repo.reload(ctx.goal)
+
+    assert goal.closed_at != nil
+    assert goal.closed_by_id == ctx.author.id
+  end
+
+  test "GoalClosing operation creates activity and thread", ctx do
+    Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+
+    activity = from(a in Activity, where: a.action == "goal_closing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
+
+    assert activity.comment_thread_id != nil
+  end
+end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -1,0 +1,37 @@
+defmodule Operately.Operations.GoalDiscussionCreationTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    author = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(author)
+    goal= goal_fixture(author, %{space_id: group.id, targets: []})
+
+    {:ok, author: author, goal: goal}
+  end
+
+  test "GoalDiscussionCreation operation creates activity and thread", ctx do
+    title = "some title"
+
+    Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal.id, title, "{}")
+
+    activity = from(a in Activity,
+      where: a.action == "goal_discussion_creation" and a.content["goal_id"] == ^ctx.goal.id,
+      preload: :comment_thread
+    )
+    |> Repo.one()
+
+    assert activity.comment_thread_id != nil
+    assert activity.comment_thread.title == title
+  end
+end

--- a/test/operately/operations/goal_reopening_test.exs
+++ b/test/operately/operations/goal_reopening_test.exs
@@ -1,0 +1,49 @@
+defmodule Operately.Operations.GoalReopeningTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Goals.Goal
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    author = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(author)
+
+    {:ok, goal} = goal_fixture(author, %{space_id: group.id, targets: []})
+      |> Goal.changeset(%{
+        closed_at: DateTime.utc_now(),
+        closed_by_id: author.id,
+      })
+      |> Repo.update()
+
+    {:ok, author: author, goal: goal}
+  end
+
+  test "GoalReopening operation updates goal", ctx do
+    assert ctx.goal.closed_at != nil
+    assert ctx.goal.closed_by_id == ctx.author.id
+
+    Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+
+    goal = Repo.reload(ctx.goal)
+
+    assert goal.closed_at == nil
+    assert goal.closed_by_id == nil
+  end
+
+  test "GoalReopening operation creates activity and thread", ctx do
+    Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+
+    activity = from(a in Activity, where: a.action == "goal_reopening" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
+
+    assert activity.comment_thread_id != nil
+  end
+end

--- a/test/operately/operations/goal_timeframe_editing_test.exs
+++ b/test/operately/operations/goal_timeframe_editing_test.exs
@@ -1,0 +1,59 @@
+defmodule Operately.Operations.GoalTimeframeEditingTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    author = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(author)
+    goal = goal_fixture(author, %{space_id: group.id, targets: []})
+
+    {:ok, author: author, goal: goal}
+  end
+
+  test "GoalTimeframeEditing operation updates goal", ctx do
+    assert ctx.goal.timeframe.type == "quarter"
+    assert ctx.goal.timeframe.start_date == ~D[2024-04-01]
+    assert ctx.goal.timeframe.end_date == ~D[2024-06-30]
+
+
+    Operately.Operations.GoalTimeframeEditing.run(
+      ctx.author,
+      %{
+        id: ctx.goal.id,
+        timeframe: %{ type: "days", start_date: ~D[2024-04-15], end_date: ~D[2024-08-30]},
+        comment: "{}"
+      }
+    )
+
+    goal = Repo.reload(ctx.goal)
+
+    assert goal.timeframe.type == "days"
+    assert goal.timeframe.start_date == ~D[2024-04-15]
+    assert goal.timeframe.end_date == ~D[2024-08-30]
+  end
+
+  test "GoalTimeframeEditing operation creates activity and thread", ctx do
+    Operately.Operations.GoalTimeframeEditing.run(
+        ctx.author,
+        %{
+          id: ctx.goal.id,
+          timeframe: %{type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 5)},
+          comment: "{}"
+        }
+      )
+
+    activity = from(a in Activity, where: a.action == "goal_timeframe_editing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
+
+    assert activity.comment_thread_id != nil
+  end
+end


### PR DESCRIPTION
In order to complete the changes in the activities creation logic, the following operations need to be updated:

- lib/operately/operations/goal_closing.ex
- lib/operately/operations/goal_reopening.ex
- lib/operately/operations/goal_discussion_creation.ex
- lib/operately/operations/goal_timeframe_editing.ex

This pull request includes the tests for all the above operations. All the tests pass, as the operations are correctly implemented.
After changing the operations in the near future, these tests should still pass.