### PR TITLE
Fix goal notifications

### DIFF
--- a/lib/operately/activities/notifications/goal_discussion_creation.ex
+++ b/lib/operately/activities/notifications/goal_discussion_creation.ex
@@ -8,18 +8,18 @@ defmodule Operately.Activities.Notifications.GoalDiscussionCreation do
       goal.reviewer_id,
     ]
 
-    mentioned = 
+    mentioned =
       message
       |> ProsemirrorMentions.extract_ids()
-      |> Enum.map(fn id -> Operately.People.get_person!(id) end)
+      |> Enum.map(fn id -> Operately.People.get_person!(id).id end)
 
     people = Enum.uniq(assigned ++ mentioned)
 
-    notifications = 
+    notifications =
       people
       |> Enum.uniq()
       |> Enum.filter(fn person_id -> person_id != activity.author_id end)
-      |> Enum.map(fn person_id -> 
+      |> Enum.map(fn person_id ->
         %{
           person_id: person_id,
           activity_id: activity.id,

--- a/lib/operately/activities/notifications/goal_timeframe_editing.ex
+++ b/lib/operately/activities/notifications/goal_timeframe_editing.ex
@@ -8,18 +8,18 @@ defmodule Operately.Activities.Notifications.GoalTimeframeEditing do
       goal.reviewer_id,
     ]
 
-    mentioned = 
+    mentioned =
       message
       |> ProsemirrorMentions.extract_ids()
-      |> Enum.map(fn id -> Operately.People.get_person!(id) end)
+      |> Enum.map(fn id -> Operately.People.get_person!(id).id end)
 
     people = Enum.uniq(assigned ++ mentioned)
 
-    notifications = 
+    notifications =
       people
       |> Enum.uniq()
       |> Enum.filter(fn person_id -> person_id != activity.author_id end)
-      |> Enum.map(fn person_id -> 
+      |> Enum.map(fn person_id ->
         %{
           person_id: person_id,
           activity_id: activity.id,


### PR DESCRIPTION
The notifications `goal_discussion_creation` and `goal_timeframe_editing` were not working because they were trying to use the whole person object instead of person_id.