### PR TITLE
Add insert_sync to goal operations

### DIFF
--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -25,24 +25,34 @@ defmodule Operately.Activities do
         action: action,
         author_id: author_id,
         params: callback.(changes),
-      }) 
+      })
 
       Oban.insert(job)
     end)
   end
 
-  def insert_sync(multi, author_id, action, callback) do
+  def insert_sync(multi, author_id, action, callback, opts \\ []) do
     multi
     |> Ecto.Multi.insert(:activity, fn changes ->
       {:ok, content} = build_content(Atom.to_string(action), callback.(changes))
 
       Activity.changeset(%{
-        author_id: author_id, 
+        author_id: author_id,
         action: Atom.to_string(action),
         content: content
       })
     end)
-    |> dispatch_notification()
+    |> dispatch_notification(opts)
+  end
+
+  def dispatch_notification(multi, opts) do
+    include_notification = Keyword.get(opts, :include_notification, true)
+
+    if include_notification do
+      dispatch_notification(multi)
+    else
+      multi
+    end
   end
 
   def dispatch_notification(multi) do

--- a/lib/operately/operations/goal_closing.ex
+++ b/lib/operately/operations/goal_closing.ex
@@ -23,7 +23,7 @@ defmodule Operately.Operations.GoalClosing do
         goal_id: goal_id,
         success: success
       }
-    end)
+    end, include_notification: false)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
       parent_id: changes.activity.id,
       parent_type: "activity",
@@ -34,6 +34,7 @@ defmodule Operately.Operations.GoalClosing do
         comment_thread_id: changes.thread.id
       })
     end)
+    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/lib/operately/operations/goal_closing.ex
+++ b/lib/operately/operations/goal_closing.ex
@@ -9,36 +9,31 @@ defmodule Operately.Operations.GoalClosing do
     goal = Goals.get_goal!(goal_id)
 
     changeset = Goals.Goal.changeset(goal, %{
-      closed_at: DateTime.utc_now(), 
+      closed_at: DateTime.utc_now(),
       closed_by_id: author.id,
       success: success
     })
 
     Multi.new()
     |> Multi.update(:goal, changeset)
-    |> Multi.insert(:activity_without_thread, fn _changes ->
-      Activities.Activity.changeset(%{
-        author_id: author.id,
-        action: Atom.to_string(:goal_closing),
-        content: Activities.build_content!(:goal_closing, %{
-          company_id: author.company_id,
-          space_id: goal.group_id,
-          goal_id: goal_id,
-          success: success
-        })
-      })
+    |> Activities.insert_sync(author.id, :goal_closing, fn _changes ->
+      %{
+        company_id: author.company_id,
+        space_id: goal.group_id,
+        goal_id: goal_id,
+        success: success
+      }
     end)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
-      parent_id: changes.activity_without_thread.id,
+      parent_id: changes.activity.id,
       parent_type: "activity",
       message: Jason.decode!(retrospective)
     }) end)
-    |> Multi.update(:activity, fn changes ->
-      Activities.Activity.changeset(changes.activity_without_thread, %{
+    |> Multi.update(:activity_with_thread, fn changes ->
+      Activities.Activity.changeset(changes.activity, %{
         comment_thread_id: changes.thread.id
-      }) 
+      })
     end)
-    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/lib/operately/operations/goal_discussion_creation.ex
+++ b/lib/operately/operations/goal_discussion_creation.ex
@@ -14,7 +14,7 @@ defmodule Operately.Operations.GoalDiscussionCreation do
         space_id: goal.group_id,
         goal_id: goal.id,
       }
-    end)
+    end, include_notification: false)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
       parent_id: changes.activity.id,
       parent_type: "activity",
@@ -27,6 +27,7 @@ defmodule Operately.Operations.GoalDiscussionCreation do
         comment_thread_id: changes.thread.id
       })
     end)
+    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:activity_with_thread)
   end

--- a/lib/operately/operations/goal_discussion_creation.ex
+++ b/lib/operately/operations/goal_discussion_creation.ex
@@ -8,29 +8,26 @@ defmodule Operately.Operations.GoalDiscussionCreation do
 
   def run(author, goal, title, message) do
     Multi.new()
-    |> Multi.insert(:activity_without_thread, Activities.Activity.changeset(%{
-      author_id: author.id,
-      action: Atom.to_string(@action),
-      content: Activities.build_content!(@action, %{
+    |> Activities.insert_sync(author.id, @action, fn _changes ->
+      %{
         company_id: goal.company_id,
         space_id: goal.group_id,
         goal_id: goal.id,
-      })
-    }))
+      }
+    end)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
-      parent_id: changes.activity_without_thread.id,
+      parent_id: changes.activity.id,
       parent_type: "activity",
       message: Jason.decode!(message),
       title: title,
       has_title: true,
     }) end)
-    |> Multi.update(:activity, fn changes ->
-      Activities.Activity.changeset(changes.activity_without_thread, %{
+    |> Multi.update(:activity_with_thread, fn changes ->
+      Activities.Activity.changeset(changes.activity, %{
         comment_thread_id: changes.thread.id
-      }) 
+      })
     end)
-    |> Activities.dispatch_notification()
     |> Repo.transaction()
-    |> Repo.extract_result(:activity)
+    |> Repo.extract_result(:activity_with_thread)
   end
 end

--- a/lib/operately/operations/goal_reopening.ex
+++ b/lib/operately/operations/goal_reopening.ex
@@ -13,28 +13,23 @@ defmodule Operately.Operations.GoalReopening do
 
     Multi.new()
     |> Multi.update(:goal, changeset)
-    |> Multi.insert(:activity_without_thread, fn _changes ->
-      Activities.Activity.changeset(%{
-        author_id: author.id,
-        action: Atom.to_string(@action),
-        content: Activities.build_content!(@action, %{
-          company_id: author.company_id,
-          space_id: goal.group_id,
-          goal_id: goal_id,
-        })
-      })
+    |> Activities.insert_sync(author.id, @action, fn _changes ->
+      %{
+        company_id: author.company_id,
+        space_id: goal.group_id,
+        goal_id: goal_id,
+      }
     end)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
-      parent_id: changes.activity_without_thread.id,
+      parent_id: changes.activity.id,
       parent_type: "activity",
       message: Jason.decode!(message)
     }) end)
-    |> Multi.update(:activity, fn changes ->
-      Activities.Activity.changeset(changes.activity_without_thread, %{
+    |> Multi.update(:activity_with_thread, fn changes ->
+      Activities.Activity.changeset(changes.activity, %{
         comment_thread_id: changes.thread.id
-      }) 
+      })
     end)
-    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/lib/operately/operations/goal_reopening.ex
+++ b/lib/operately/operations/goal_reopening.ex
@@ -19,7 +19,7 @@ defmodule Operately.Operations.GoalReopening do
         space_id: goal.group_id,
         goal_id: goal_id,
       }
-    end)
+    end, include_notification: false)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
       parent_id: changes.activity.id,
       parent_type: "activity",
@@ -30,6 +30,7 @@ defmodule Operately.Operations.GoalReopening do
         comment_thread_id: changes.thread.id
       })
     end)
+    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/lib/operately/operations/goal_timeframe_editing.ex
+++ b/lib/operately/operations/goal_timeframe_editing.ex
@@ -12,28 +12,23 @@ defmodule Operately.Operations.GoalTimeframeEditing do
 
     Multi.new()
     |> Multi.update(:goal, Goal.changeset(goal, %{timeframe: attrs.timeframe}))
-    |> Multi.insert(:activity_without_thread, fn changes ->
-      Activities.Activity.changeset(%{
-        author_id: author.id,
-        action: Atom.to_string(:goal_timeframe_editing),
-        content: Activities.build_content!(:goal_timeframe_editing, %{
-          company_id: goal.company_id,
-          space_id: goal.group_id,
-          goal_id: goal.id,
-          old_timeframe: Map.from_struct(goal.timeframe),
-          new_timeframe: Map.from_struct(changes.goal.timeframe)
-        })
-      })
+    |> Activities.insert_sync(author.id, :goal_timeframe_editing, fn changes ->
+      %{
+        company_id: goal.company_id,
+        space_id: goal.group_id,
+        goal_id: goal.id,
+        old_timeframe: Map.from_struct(goal.timeframe),
+        new_timeframe: Map.from_struct(changes.goal.timeframe)
+      }
     end)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
-      parent_id: changes.activity_without_thread.id,
+      parent_id: changes.activity.id,
       parent_type: "activity",
       message: Jason.decode!(attrs.comment)
     }) end)
-    |> Multi.update(:activity, fn changes ->
-      Activities.Activity.changeset(changes.activity_without_thread, %{comment_thread_id: changes.thread.id}) 
+    |> Multi.update(:activity_with_thread, fn changes ->
+      Activities.Activity.changeset(changes.activity, %{comment_thread_id: changes.thread.id})
     end)
-    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/lib/operately/operations/goal_timeframe_editing.ex
+++ b/lib/operately/operations/goal_timeframe_editing.ex
@@ -20,7 +20,7 @@ defmodule Operately.Operations.GoalTimeframeEditing do
         old_timeframe: Map.from_struct(goal.timeframe),
         new_timeframe: Map.from_struct(changes.goal.timeframe)
       }
-    end)
+    end, include_notification: false)
     |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
       parent_id: changes.activity.id,
       parent_type: "activity",
@@ -29,6 +29,7 @@ defmodule Operately.Operations.GoalTimeframeEditing do
     |> Multi.update(:activity_with_thread, fn changes ->
       Activities.Activity.changeset(changes.activity, %{comment_thread_id: changes.thread.id})
     end)
+    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
   end

--- a/test/operately/operations/goal_closing_test.exs
+++ b/test/operately/operations/goal_closing_test.exs
@@ -24,7 +24,9 @@ defmodule Operately.Operations.GoalClosingTest do
     assert ctx.goal.closed_at == nil
     assert ctx.goal.closed_by_id == nil
 
-    Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+    end)
 
     goal = Repo.reload(ctx.goal)
 
@@ -33,7 +35,9 @@ defmodule Operately.Operations.GoalClosingTest do
   end
 
   test "GoalClosing operation creates activity and thread", ctx do
-    Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+    end)
 
     activity = from(a in Activity, where: a.action == "goal_closing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 

--- a/test/operately/operations/goal_closing_test.exs
+++ b/test/operately/operations/goal_closing_test.exs
@@ -50,13 +50,11 @@ defmodule Operately.Operations.GoalClosingTest do
     activity = from(a in Activity, where: a.action == "goal_closing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 
     assert activity.comment_thread_id != nil
-
     assert 0 == notifications_count()
 
     perform_job(activity.id)
 
     assert 1 == notifications_count()
-
     assert nil != fetch_notification(activity.id)
   end
 end

--- a/test/operately/operations/goal_closing_test.exs
+++ b/test/operately/operations/goal_closing_test.exs
@@ -1,5 +1,6 @@
 defmodule Operately.Operations.GoalClosingTest do
   use Operately.DataCase
+  use Operately.Support.Notifications
 
   import Ecto.Query, only: [from: 2]
 
@@ -9,13 +10,20 @@ defmodule Operately.Operations.GoalClosingTest do
   import Operately.GroupsFixtures
 
   alias Operately.Repo
+  alias Operately.Goals
   alias Operately.Activities.Activity
 
   setup do
     company = company_fixture()
     author = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
     group = group_fixture(author)
-    goal = goal_fixture(author, %{space_id: group.id, targets: []})
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      goal_fixture(author, %{space_id: group.id, champion_id: champion.id, targets: []})
+    end)
+
+    goal = Goals.list_goals() |> hd()
 
     {:ok, author: author, goal: goal}
   end
@@ -34,7 +42,7 @@ defmodule Operately.Operations.GoalClosingTest do
     assert goal.closed_by_id == ctx.author.id
   end
 
-  test "GoalClosing operation creates activity and thread", ctx do
+  test "GoalClosing operation creates activity, thread and notification", ctx do
     Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
     end)
@@ -42,5 +50,13 @@ defmodule Operately.Operations.GoalClosingTest do
     activity = from(a in Activity, where: a.action == "goal_closing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 
     assert activity.comment_thread_id != nil
+
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert 1 == notifications_count()
+
+    assert nil != fetch_notification(activity.id)
   end
 end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -38,13 +38,11 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
 
     assert activity.comment_thread_id != nil
     assert activity.comment_thread.title == title
-
     assert 0 == notifications_count()
 
     perform_job(activity.id)
 
     assert 1 == notifications_count()
-
     assert nil != fetch_notification(activity.id)
   end
 end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -22,9 +22,9 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
     {:ok, author: author, reader: reader, goal: goal}
   end
 
-  test "GoalDiscussionCreation operation creates activity and thread", ctx do
+  test "GoalDiscussionCreation operation creates activity, thread and notification", ctx do
     title = "some title"
-    message = "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"mention\",\"attrs\":{\"id\":\"#{ctx.reader.id}\",\"label\":\"#{ctx.reader.full_name}\"}}]}]}"
+    message = notification_message(ctx.reader)
 
     Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal, title, message)
@@ -45,6 +45,6 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
 
     assert 1 == notifications_count()
 
-    assert nil != fetch_notification(ctx.reader.id)
+    assert nil != fetch_notification(activity.id)
   end
 end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -10,21 +10,24 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
 
   alias Operately.Repo
   alias Operately.Activities.Activity
+  alias Operately.Notifications.Notification
 
   setup do
     company = company_fixture()
     author = person_fixture_with_account(%{company_id: company.id})
+    reader = person_fixture_with_account(%{company_id: company.id})
     group = group_fixture(author)
     goal= goal_fixture(author, %{space_id: group.id, targets: []})
 
-    {:ok, author: author, goal: goal}
+    {:ok, author: author, reader: reader, goal: goal}
   end
 
   test "GoalDiscussionCreation operation creates activity and thread", ctx do
     title = "some title"
+    message = "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"mention\",\"attrs\":{\"id\":\"#{ctx.reader.id}\",\"label\":\"#{ctx.reader.full_name}\"}}]}]}"
 
     Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal.id, title, "{}")
+      Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal, title, message)
     end)
 
     activity = from(a in Activity,
@@ -35,5 +38,13 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
 
     assert activity.comment_thread_id != nil
     assert activity.comment_thread.title == title
+
+    assert 0 == Repo.aggregate(Notification, :count, :id)
+
+    Oban.Testing.perform_job(Operately.Activities.NotificationDispatcher, %{activity_id: activity.id}, [])
+
+    assert 1 == Repo.aggregate(Notification, :count, :id)
+
+    assert nil != from(n in Notification, where: n.person_id == ^ctx.reader.id) |> Repo.one()
   end
 end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -1,5 +1,6 @@
 defmodule Operately.Operations.GoalDiscussionCreationTest do
   use Operately.DataCase
+  use Operately.Support.Notifications
 
   import Ecto.Query, only: [from: 2]
 
@@ -10,7 +11,6 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
 
   alias Operately.Repo
   alias Operately.Activities.Activity
-  alias Operately.Notifications.Notification
 
   setup do
     company = company_fixture()
@@ -39,12 +39,12 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
     assert activity.comment_thread_id != nil
     assert activity.comment_thread.title == title
 
-    assert 0 == Repo.aggregate(Notification, :count, :id)
+    assert 0 == notifications_count()
 
-    Oban.Testing.perform_job(Operately.Activities.NotificationDispatcher, %{activity_id: activity.id}, [])
+    perform_job(activity.id)
 
-    assert 1 == Repo.aggregate(Notification, :count, :id)
+    assert 1 == notifications_count()
 
-    assert nil != from(n in Notification, where: n.person_id == ^ctx.reader.id) |> Repo.one()
+    assert nil != fetch_notification(ctx.reader.id)
   end
 end

--- a/test/operately/operations/goal_discussion_creation_test.exs
+++ b/test/operately/operations/goal_discussion_creation_test.exs
@@ -23,7 +23,9 @@ defmodule Operately.Operations.GoalDiscussionCreationTest do
   test "GoalDiscussionCreation operation creates activity and thread", ctx do
     title = "some title"
 
-    Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal, title, "{}")
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalDiscussionCreation.run(ctx.author, ctx.goal.id, title, "{}")
+    end)
 
     activity = from(a in Activity,
       where: a.action == "goal_discussion_creation" and a.content["goal_id"] == ^ctx.goal.id,

--- a/test/operately/operations/goal_reopening_test.exs
+++ b/test/operately/operations/goal_reopening_test.exs
@@ -31,7 +31,9 @@ defmodule Operately.Operations.GoalReopeningTest do
     assert ctx.goal.closed_at != nil
     assert ctx.goal.closed_by_id == ctx.author.id
 
-    Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+    end)
 
     goal = Repo.reload(ctx.goal)
 
@@ -40,7 +42,10 @@ defmodule Operately.Operations.GoalReopeningTest do
   end
 
   test "GoalReopening operation creates activity and thread", ctx do
-    Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalReopening.run(ctx.author, ctx.goal.id, "{}")
+    end)
 
     activity = from(a in Activity, where: a.action == "goal_reopening" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 

--- a/test/operately/operations/goal_reopening_test.exs
+++ b/test/operately/operations/goal_reopening_test.exs
@@ -10,7 +10,6 @@ defmodule Operately.Operations.GoalReopeningTest do
   import Operately.GroupsFixtures
 
   alias Operately.Repo
-  alias Operately.Goals
   alias Operately.Goals.Goal
   alias Operately.Activities.Activity
 
@@ -20,16 +19,12 @@ defmodule Operately.Operations.GoalReopeningTest do
     reader = person_fixture_with_account(%{company_id: company.id})
     group = group_fixture(author)
 
-    Oban.Testing.with_testing_mode(:manual, fn ->
-      goal_fixture(author, %{space_id: group.id, targets: []})
-        |> Goal.changeset(%{
-          closed_at: DateTime.utc_now(),
-          closed_by_id: author.id,
-        })
-        |> Repo.update()
-    end)
-
-    goal = Goals.list_goals() |> hd()
+    {:ok, goal} = goal_fixture(author, %{space_id: group.id, targets: []})
+      |> Goal.changeset(%{
+        closed_at: DateTime.utc_now(),
+        closed_by_id: author.id,
+      })
+      |> Repo.update()
 
     {:ok, author: author, reader: reader, goal: goal}
   end

--- a/test/operately/operations/goal_timeframe_editing_test.exs
+++ b/test/operately/operations/goal_timeframe_editing_test.exs
@@ -1,5 +1,6 @@
 defmodule Operately.Operations.GoalTimeframeEditingTest do
   use Operately.DataCase
+  use Operately.Support.Notifications
 
   import Ecto.Query, only: [from: 2]
 
@@ -14,10 +15,11 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
   setup do
     company = company_fixture()
     author = person_fixture_with_account(%{company_id: company.id})
+    reader = person_fixture_with_account(%{company_id: company.id})
     group = group_fixture(author)
     goal = goal_fixture(author, %{space_id: group.id, targets: []})
 
-    {:ok, author: author, goal: goal}
+    {:ok, author: author, reader: reader, goal: goal}
   end
 
   test "GoalTimeframeEditing operation updates goal", ctx do
@@ -50,7 +52,7 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
         %{
           id: ctx.goal.id,
           timeframe: %{type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 5)},
-          comment: "{}"
+          comment: notification_message(ctx.reader)
         }
       )
     end)
@@ -58,5 +60,11 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
     activity = from(a in Activity, where: a.action == "goal_timeframe_editing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 
     assert activity.comment_thread_id != nil
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert 1 == notifications_count()
+    assert nil != fetch_notification(activity.id)
   end
 end

--- a/test/operately/operations/goal_timeframe_editing_test.exs
+++ b/test/operately/operations/goal_timeframe_editing_test.exs
@@ -25,15 +25,16 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
     assert ctx.goal.timeframe.start_date == ~D[2024-04-01]
     assert ctx.goal.timeframe.end_date == ~D[2024-06-30]
 
-
-    Operately.Operations.GoalTimeframeEditing.run(
-      ctx.author,
-      %{
-        id: ctx.goal.id,
-        timeframe: %{ type: "days", start_date: ~D[2024-04-15], end_date: ~D[2024-08-30]},
-        comment: "{}"
-      }
-    )
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalTimeframeEditing.run(
+        ctx.author,
+        %{
+          id: ctx.goal.id,
+          timeframe: %{ type: "days", start_date: ~D[2024-04-15], end_date: ~D[2024-08-30]},
+          comment: "{}"
+        }
+      )
+    end)
 
     goal = Repo.reload(ctx.goal)
 
@@ -43,7 +44,8 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
   end
 
   test "GoalTimeframeEditing operation creates activity and thread", ctx do
-    Operately.Operations.GoalTimeframeEditing.run(
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalTimeframeEditing.run(
         ctx.author,
         %{
           id: ctx.goal.id,
@@ -51,6 +53,7 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
           comment: "{}"
         }
       )
+    end)
 
     activity = from(a in Activity, where: a.action == "goal_timeframe_editing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
 

--- a/test/support/notifications.ex
+++ b/test/support/notifications.ex
@@ -2,6 +2,7 @@ defmodule Operately.Support.Notifications do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
+  alias Operately.People.Person
   alias Operately.Notifications.Notification
 
   defmacro __using__(_opts) do
@@ -18,7 +19,28 @@ defmodule Operately.Support.Notifications do
     Oban.Testing.perform_job(Operately.Activities.NotificationDispatcher, %{activity_id: activity_id}, [])
   end
 
-  def fetch_notification(person_id) do
-    from(n in Notification, where: n.person_id == ^person_id) |> Repo.one()
+  def fetch_notification(activity_id) do
+    from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.one()
+  end
+
+  def notification_message(%Person{id: id, full_name: full_name}) do
+    %{
+      type: :doc,
+      content: [
+        %{
+          type: :paragraph,
+          content: [
+            %{
+              type: :mention,
+              attrs: %{
+                id: id,
+                label: full_name
+              }
+            }
+          ]
+        }
+      ]
+    }
+    |> Jason.encode!()
   end
 end

--- a/test/support/notifications.ex
+++ b/test/support/notifications.ex
@@ -1,0 +1,24 @@
+defmodule Operately.Support.Notifications do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Notifications.Notification
+
+  defmacro __using__(_opts) do
+    quote do
+       import Operately.Support.Notifications
+    end
+  end
+
+  def notifications_count do
+    Repo.aggregate(Notification, :count, :id)
+  end
+
+  def perform_job(activity_id) do
+    Oban.Testing.perform_job(Operately.Activities.NotificationDispatcher, %{activity_id: activity_id}, [])
+  end
+
+  def fetch_notification(person_id) do
+    from(n in Notification, where: n.person_id == ^person_id) |> Repo.one()
+  end
+end


### PR DESCRIPTION
I've added insert_sync to the following operations:

- lib/operately/operations/goal_closing.ex
- lib/operately/operations/goal_reopening.ex
- lib/operately/operations/goal_discussion_creation.ex
- lib/operately/operations/goal_timeframe_editing.ex
