### PR TITLE
Automatically assign access context to activities

### DIFF
--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -37,7 +37,6 @@ defmodule Operately.Activities do
       dispatch_notification(multi)
     else
       multi
-      |> dispatch_notification()
     end
   end
 

--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -1,5 +1,6 @@
 defmodule Operately.Activities do
   import Ecto.Query, warn: false
+  import Operately.Activities.ContextAutoAssigner, only: [assign_context: 1]
 
   alias Operately.Repo
   alias Operately.Activities.Activity
@@ -25,6 +26,7 @@ defmodule Operately.Activities do
         content: content
       })
     end)
+    |> assign_context()
     |> dispatch_notification(opts)
   end
 
@@ -35,6 +37,7 @@ defmodule Operately.Activities do
       dispatch_notification(multi)
     else
       multi
+      |> dispatch_notification()
     end
   end
 

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -1,0 +1,200 @@
+defmodule Operately.Activities.ContextAutoAssigner do
+  import Ecto.Query
+
+  require Logger
+
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Activities
+  alias Operately.Activities.Activity
+
+  @deprecated_actions [
+    "project_status_update_acknowledged",
+    "project_status_update_commented",
+    "project_status_update_edit",
+    "project_status_update_submitted",
+    "project_review_submitted",
+    "project_review_request_submitted",
+    "project_review_acknowledged",
+    "project_review_commented",
+  ]
+
+  @company_actions [
+    "company_member_removed",
+    "password_first_time_changed",
+    "company_invitation_token_created",
+    "company_member_added",
+  ]
+
+  @space_actions [
+    "space_joining",
+
+    "goal_archived",
+
+    "discussion_posting",
+    "discussion_editing",
+    "discussion_comment_submitted",
+
+    "task_assignee_assignment",
+    "task_description_change",
+    "task_name_editing",
+    "task_priority_change",
+    "task_reopening",
+    "task_size_change",
+
+    # exceptions
+    "group_edited",
+    "goal_reparent",
+  ]
+
+  @goal_actions [
+    "goal_check_in",
+    "goal_check_in_acknowledgement",
+    "goal_check_in_commented",
+    "goal_check_in_edit",
+    "goal_closing",
+    "goal_created",
+    "goal_discussion_creation",
+    "goal_discussion_editing",
+    "goal_editing",
+    "goal_reopening",
+    "goal_timeframe_editing",
+  ]
+
+  @project_actions [
+    "project_created",
+    "project_archived",
+    "project_check_in_acknowledged",
+    "project_check_in_commented",
+    "project_check_in_edit",
+    "project_check_in_submitted",
+    "project_closed",
+    "project_contributor_addition",
+    "project_discussion_submitted",
+    "project_goal_connection",
+    "project_goal_disconnection",
+    "project_milestone_commented",
+    "project_moved",
+    "project_pausing",
+    "project_renamed",
+    "project_resuming",
+    "project_timeline_edited",
+  ]
+
+  @task_actions [
+    "task_adding",
+    "task_closing",
+    "task_status_change",
+    "task_update",
+  ]
+
+  def assign_context(multi) do
+    multi
+    |> Multi.update(:updated_activity, fn %{activity: activity} ->
+      context_id = fetch_context(activity)
+
+      Activity.changeset(activity, %{context_id: context_id})
+    end)
+  end
+
+  defp fetch_context(activity) do
+    cond do
+      activity.action in @deprecated_actions -> :ok
+      activity.action in @company_actions -> fetch_company_context(activity.content.company_id)
+      activity.action in @space_actions -> fetch_space_context(activity)
+      activity.action in @goal_actions -> fetch_goal_context(activity.content.goal_id)
+      activity.action in @project_actions -> fetch_project_context(activity.content.project_id)
+      activity.action in @task_actions -> fetch_task_project_context(activity.content.task_id)
+      activity.action == "comment_added" -> fetch_comment_added_context(activity)
+      true ->
+        Logger.error("Unhandled activity: #{inspect(activity)}")
+        raise "Activity not handled in context assignment #{activity.action}"
+    end
+  end
+
+  defp fetch_company_context(company_id) do
+    company = from(c in Operately.Companies.Company,
+      where: c.id == ^company_id,
+      preload: :access_context
+    )
+    |> Repo.one()
+
+    company.access_context.id
+  end
+
+  defp fetch_space_context(activity) do
+    space_id = case activity.action do
+      "group_edited" ->
+        activity.content.group_id
+      "goal_reparent" ->
+        activity.content.new_parent_goal_id
+      _ ->
+        activity.content.space_id
+    end
+
+    space = from(g in Operately.Groups.Group,
+      where: g.id == ^space_id,
+      preload: :access_context
+    )
+    |> Repo.one()
+
+    space.access_context.id
+  end
+
+  defp fetch_goal_context(goal_id) do
+    goal = from(g in Operately.Goals.Goal,
+      where: g.id == ^goal_id,
+      preload: :access_context
+    )
+    |> Repo.one()
+
+    goal.access_context.id
+  end
+
+  defp fetch_project_context(project_id) do
+    project = from(p in Operately.Projects.Project,
+      where: p.id == ^project_id,
+      preload: :access_context
+    )
+    |> Repo.one()
+
+    project.access_context.id
+  end
+
+  defp fetch_task_project_context(task_id) do
+    project = from(p in Operately.Projects.Project,
+      join: m in assoc(p, :milestones),
+      join: t in assoc(m, :tasks),
+      where: t.id == ^task_id,
+      preload: :access_context
+    )
+    |> Repo.one()
+
+    project.access_context.id
+  end
+
+  defp fetch_comment_added_context(activity) do
+    comment = Operately.Updates.get_comment!(activity.content.comment_id)
+
+    case comment.entity_type do
+      :project_check_in -> fetch_project_context(comment.entity_id)
+      :update -> fetch_goal_context(comment.entity_id)
+      :comment_thread -> fetch_comment_thread_context(comment)
+      _ ->
+        Logger.error("Unhandled activity: #{inspect(activity)}")
+        Logger.error("Comment associated with activity: #{inspect(comment)}")
+        raise "Activity not handled in context assignment #{activity.action}"
+    end
+  end
+
+  defp fetch_comment_thread_context(comment) do
+    activity = from(a in Activity,
+      join: t in Operately.Comments.CommentThread,
+      on: a.id == t.parent_id,
+      where: t.id == ^comment.entity_id
+    )
+    |> Repo.one()
+
+    activity.context_id
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -5,8 +5,8 @@ defmodule Operately.Activities.ContextAutoAssigner do
 
   alias Ecto.Multi
   alias Operately.Repo
-  alias Operately.Activities
   alias Operately.Activities.Activity
+  alias Operately.Access.Context
 
   @deprecated_actions [
     "project_status_update_acknowledged",
@@ -113,13 +113,12 @@ defmodule Operately.Activities.ContextAutoAssigner do
   end
 
   defp fetch_company_context(company_id) do
-    company = from(c in Operately.Companies.Company,
+    from(ac in Context,
+      join: c in assoc(ac, :company),
       where: c.id == ^company_id,
-      preload: :access_context
+      select: ac.id
     )
     |> Repo.one()
-
-    company.access_context.id
   end
 
   defp fetch_space_context(activity) do
@@ -132,45 +131,41 @@ defmodule Operately.Activities.ContextAutoAssigner do
         activity.content.space_id
     end
 
-    space = from(g in Operately.Groups.Group,
+    from(c in Context,
+      join: g in assoc(c, :group),
       where: g.id == ^space_id,
-      preload: :access_context
+      select: c.id
     )
     |> Repo.one()
-
-    space.access_context.id
   end
 
   defp fetch_goal_context(goal_id) do
-    goal = from(g in Operately.Goals.Goal,
+    from(c in Context,
+      join: g in assoc(c, :goal),
       where: g.id == ^goal_id,
-      preload: :access_context
+      select: c.id
     )
     |> Repo.one()
-
-    goal.access_context.id
   end
 
   defp fetch_project_context(project_id) do
-    project = from(p in Operately.Projects.Project,
+    from(c in Context,
+      join: p in assoc(c, :project),
       where: p.id == ^project_id,
-      preload: :access_context
+      select: c.id
     )
     |> Repo.one()
-
-    project.access_context.id
   end
 
   defp fetch_task_project_context(task_id) do
-    project = from(p in Operately.Projects.Project,
+    from(c in Context,
+      join: p in assoc(c, :project),
       join: m in assoc(p, :milestones),
       join: t in assoc(m, :tasks),
       where: t.id == ^task_id,
-      preload: :access_context
+      select: c.id
     )
     |> Repo.one()
-
-    project.access_context.id
   end
 
   defp fetch_comment_added_context(activity) do
@@ -188,13 +183,12 @@ defmodule Operately.Activities.ContextAutoAssigner do
   end
 
   defp fetch_comment_thread_context(comment) do
-    activity = from(a in Activity,
+    from(a in Activity,
       join: t in Operately.Comments.CommentThread,
       on: a.id == t.parent_id,
-      where: t.id == ^comment.entity_id
+      where: t.id == ^comment.entity_id,
+      select: a.context_id
     )
     |> Repo.one()
-
-    activity.context_id
   end
 end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -298,13 +298,16 @@ defmodule Operately.AccessActivityContextAssignerTest do
     end
 
     test "goal_discussion_creation action", ctx do
-      Operately.Operations.GoalDiscussionCreation.run(
+      {:ok, activity} = Operately.Operations.GoalDiscussionCreation.run(
         ctx.author,
-        ctx.goal.id,
+        ctx.goal,
         "some title",
         "{}"
       )
-      |> assert_context_assigned(ctx.goal.access_context.id)
+
+      activity = Repo.reload(activity)
+
+      assert activity.context_id == ctx.goal.access_context.id
     end
 
     test "goal_discussion_editing action", ctx do
@@ -458,38 +461,38 @@ defmodule Operately.AccessActivityContextAssignerTest do
       |> assert_context_assigned(ctx.project.access_context.id)
     end
 
-    # test "project_discussion_submitted action", ctx do
-    #   attrs = %{
-    #     action: "project_discussion_submitted",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, discussion_id: ctx.update.id, title: "some title" }
-    #   }
+    test "project_discussion_submitted action", ctx do
+      attrs = %{
+        action: "project_discussion_submitted",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, discussion_id: ctx.update.id, title: "some title" }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
-    # test "project_goal_connection action", ctx do
-    #   attrs = %{
-    #     action: "project_goal_connection",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
-    #   }
+    test "project_goal_connection action", ctx do
+      attrs = %{
+        action: "project_goal_connection",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
-    # test "project_goal_disconnection action", ctx do
-    #   attrs = %{
-    #     action: "project_goal_disconnection",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
-    #   }
+    test "project_goal_disconnection action", ctx do
+      attrs = %{
+        action: "project_goal_disconnection",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
     test "project_milestone_commented action", ctx do
       attrs = %{
@@ -502,16 +505,16 @@ defmodule Operately.AccessActivityContextAssignerTest do
       |> assert_context_assigned(ctx.project.access_context.id)
     end
 
-    # test "project_moved action", ctx do
-    #   attrs = %{
-    #     action: "project_moved",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_space_id: ctx.group.id, new_space_id: ctx.group.id }
-    #   }
+    test "project_moved action", ctx do
+      attrs = %{
+        action: "project_moved",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_space_id: ctx.group.id, new_space_id: ctx.group.id }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
     test "project_pausing action", ctx do
       attrs = %{
@@ -546,16 +549,16 @@ defmodule Operately.AccessActivityContextAssignerTest do
       |> assert_context_assigned(ctx.project.access_context.id)
     end
 
-    # test "project_timeline_edited action", ctx do
-    #   attrs = %{
-    #     action: "project_timeline_edited",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_start_date: DateTime.utc_now(), new_start_date: DateTime.utc_now(), old_end_date: DateTime.utc_now(), new_end_date: DateTime.utc_now() }
-    #   }
+    test "project_timeline_edited action", ctx do
+      attrs = %{
+        action: "project_timeline_edited",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_start_date: DateTime.utc_now(), new_start_date: DateTime.utc_now(), old_end_date: DateTime.utc_now(), new_end_date: DateTime.utc_now() }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
   end
 
   describe "assigns access_context to task activities" do

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -434,27 +434,29 @@ defmodule Operately.AccessActivityContextAssignerTest do
       |> assert_context_assigned(ctx.project.access_context.id)
     end
 
-    # test "project_closed action", ctx do
-    #   attrs = %{
-    #     action: "project_closed",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
-    #   }
+    test "project_closed action", ctx do
+      attrs = %{
+        action: "project_closed",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
-    # test "project_contributor_addition action", ctx do
-    #   attrs = %{
-    #     action: "project_contributor_addition",
-    #     author_id: ctx.author.id,
-    #     content: %{ project_id: ctx.project.id, company_id: ctx.company.id, person_id: ctx.author.id, contributor_id: ctx.author.id, responsibility: "-", role: "-" }
-    #   }
+    test "project_contributor_addition action", ctx do
+      contributor = contributor_fixture(%{person_id: ctx.author.id, project_id: ctx.project.id})
 
-    #   create_activity(attrs)
-    #   |> assert_context_assigned(ctx.project.access_context.id)
-    # end
+      attrs = %{
+        action: "project_contributor_addition",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, person_id: ctx.author.id, contributor_id: contributor.id, responsibility: "-", role: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
 
     # test "project_discussion_submitted action", ctx do
     #   attrs = %{

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -1,0 +1,686 @@
+defmodule Operately.AccessActivityContextAssignerTest do
+  use Operately.DataCase
+
+  import Operately.AccessFixtures, only: [context_fixture: 1]
+  import Operately.UpdatesFixtures, only: [update_fixture: 1]
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+  import Operately.TasksFixtures
+  import Operately.GoalsFixtures
+  import Operately.CommentsFixtures
+  import Operately.ActivitiesFixtures
+
+  alias Operately.Activities
+
+  setup do
+    company = company_fixture()
+    context_fixture(%{company_id: company.id})
+    company = Repo.preload(company, :access_context)
+
+    author = person_fixture_with_account(%{company_id: company.id})
+
+    group = group_fixture(author)
+    context_fixture(%{group_id: group.id})
+    group = Repo.preload(group, :access_context)
+
+    goal = goal_fixture(author, %{space_id: group.id, targets: []})
+    context_fixture(%{goal_id: goal.id})
+    goal = Repo.preload(goal, :access_context)
+
+    project = project_fixture(%{company_id: company.id, group_id: group.id, creator_id: author.id})
+    project = Repo.preload(project, :access_context)
+
+    {
+      :ok,
+      company: company,
+      author: author,
+      group: group,
+      goal: goal,
+      project: project,
+      update: update_fixture(%{author_id: author.id, updatable_id: Ecto.UUID.generate(), updatable_type: :goal}),
+      comment: comment_fixture(author, %{entity_id: project.id, entity_type: :project_check_in}),
+      check_in: check_in_fixture(%{author_id: author.id, project_id: project.id}),
+    }
+  end
+
+  describe "assigns access_context to company activities" do
+    test "company_member_removed action", ctx do
+      attrs = %{
+        action: "company_member_removed",
+        author_id: ctx.author.id,
+        content: %{ company_id: ctx.company.id, name: "-", email: "-", title: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.company.access_context.id)
+    end
+
+    test "password_first_time_changed action", ctx do
+      attrs = %{
+        action: "password_first_time_changed",
+        author_id: ctx.author.id,
+        content: %{ company_id: ctx.company.id, invitatition_id: "-", admin_name: "-", admin_email: "-", member_name: "-", member_email: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.company.access_context.id)
+    end
+
+    test "company_invitation_token_created action", ctx do
+      attrs = %{
+        action: "company_invitation_token_created",
+        author_id: ctx.author.id,
+        content: %{ company_id: ctx.company.id, invitatition_id: "-", name: "-", email: "-", title: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.company.access_context.id)
+    end
+
+    test "company_member_added action", ctx do
+      attrs = %{
+        action: "company_member_added",
+        author_id: ctx.author.id,
+        content: %{ company_id: ctx.company.id, invitatition_id: "-", name: "-", email: "-", title: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.company.access_context.id)
+    end
+  end
+
+  describe "assigns access_context to space activities" do
+    test "space_joining action", ctx do
+      attrs = %{
+        action: "space_joining",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "goal_archived action", ctx do
+      attrs = %{
+        action: "goal_archived",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", goal_id: ctx.goal.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "discussion_posting action", ctx do
+      attrs = %{
+        action: "discussion_posting",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", title: "-", discussion_id: ctx.update.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "discussion_editing action", ctx do
+      attrs = %{
+        action: "discussion_editing",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", discussion_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "discussion_comment_submitted action", ctx do
+      attrs = %{
+        action: "discussion_comment_submitted",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", discussion_id: ctx.update.id, comment_id: ctx.comment.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_assignee_assignment action", ctx do
+      attrs = %{
+        action: "task_assignee_assignment",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-", person_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_description_change action", ctx do
+      attrs = %{
+        action: "task_description_change",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_name_editing action", ctx do
+      attrs = %{
+        action: "task_name_editing",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-", old_name: "-", new_name: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_priority_change action", ctx do
+      attrs = %{
+        action: "task_priority_change",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-", old_priority: "-", new_priority: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_reopening action", ctx do
+      attrs = %{
+        action: "task_reopening",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "task_size_change action", ctx do
+      attrs = %{
+        action: "task_size_change",
+        author_id: ctx.author.id,
+        content: %{ space_id: ctx.group.id, company_id: "-", task_id: "-", old_size: "-", new_size: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "group_edited action", ctx do
+      attrs = %{
+        action: "group_edited",
+        author_id: ctx.author.id,
+        content: %{ group_id: ctx.group.id, company_id: "-", old_name: "-", old_mission: "-", new_name: "-", new_mission: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+
+    test "goal_reparent action", ctx do
+      attrs = %{
+        action: "goal_reparent",
+        author_id: ctx.author.id,
+        content: %{ new_parent_goal_id: ctx.group.id, company_id: "-", old_parent_goal_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.group.access_context.id)
+    end
+  end
+
+  describe "assigns access_context to goal activities" do
+    test "goal_check_in action", ctx do
+      attrs = %{
+        action: "goal_check_in",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, update_id: ctx.update.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_check_in_acknowledgement action", ctx do
+      attrs = %{
+        action: "goal_check_in_acknowledgement",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, update_id: ctx.update.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_check_in_commented action", ctx do
+      attrs = %{
+        action: "goal_check_in_commented",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, goal_check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_check_in_edit action", ctx do
+      attrs = %{
+        action: "goal_check_in_edit",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_closing action", ctx do
+      attrs = %{
+        action: "goal_closing",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.comment.id, space_id: ctx.group.id, success: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_created action", ctx do
+      attrs = %{
+        action: "goal_created",
+        author_id: ctx.author.id,
+        content: %{
+          goal_id: ctx.goal.id, company_id: ctx.company.id, space_id: ctx.group.id, creator_id: ctx.author.id, champion_id: ctx.author.id, reviewer_id: ctx.author.id, goal_name: "-",
+          new_timeframe: %{ type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 2) },
+        }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_discussion_creation action", ctx do
+      attrs = %{
+        action: "goal_discussion_creation",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, space_id: ctx.group.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_discussion_editing action", ctx do
+      attrs = %{
+        action: "goal_discussion_editing",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, space_id: ctx.group.id, activity_id: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_editing action", ctx do
+      attrs = %{
+        action: "goal_editing",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, old_name: "-", new_name: "-", old_champion_id: ctx.author.id, new_champion_id: ctx.author.id, old_reviewer_id: ctx.author.id, new_reviewer_id: ctx.author.id, }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_reopening action", ctx do
+      attrs = %{
+        action: "goal_reopening",
+        author_id: ctx.author.id,
+        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, space_id: ctx.group.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "goal_timeframe_editing action", ctx do
+      attrs = %{
+        action: "goal_timeframe_editing",
+        author_id: ctx.author.id,
+        content: %{
+          goal_id: ctx.goal.id, company_id: ctx.company.id, space_id: ctx.group.id,
+          old_timeframe: %{ type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 2) },
+          new_timeframe: %{ type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 2) },
+        }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+  end
+
+  describe "assigns access_context to project activities" do
+    test "project_created action", ctx do
+      attrs = %{
+        action: "project_created",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_archived action", ctx do
+      attrs = %{
+        action: "project_archived",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_check_in_acknowledged action", ctx do
+      attrs = %{
+        action: "project_check_in_acknowledged",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_check_in_commented action", ctx do
+      attrs = %{
+        action: "project_check_in_commented",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_check_in_edit action", ctx do
+      attrs = %{
+        action: "project_check_in_edit",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_check_in_submitted action", ctx do
+      attrs = %{
+        action: "project_check_in_submitted",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_closed action", ctx do
+      attrs = %{
+        action: "project_closed",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_contributor_addition action", ctx do
+      attrs = %{
+        action: "project_contributor_addition",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, person_id: ctx.author.id, contributor_id: ctx.author.id, responsibility: "-", role: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_discussion_submitted action", ctx do
+      attrs = %{
+        action: "project_discussion_submitted",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, discussion_id: ctx.update.id, title: "some title" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_goal_connection action", ctx do
+      attrs = %{
+        action: "project_goal_connection",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_goal_disconnection action", ctx do
+      attrs = %{
+        action: "project_goal_disconnection",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_milestone_commented action", ctx do
+      attrs = %{
+        action: "project_milestone_commented",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, milestone_id: "-", comment_id: ctx.comment.id, comment_action: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_moved action", ctx do
+      attrs = %{
+        action: "project_moved",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_space_id: ctx.group.id, new_space_id: ctx.group.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_pausing action", ctx do
+      attrs = %{
+        action: "project_pausing",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_renamed action", ctx do
+      attrs = %{
+        action: "project_renamed",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_name: "-", new_name: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_resuming action", ctx do
+      attrs = %{
+        action: "project_resuming",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "project_timeline_edited action", ctx do
+      attrs = %{
+        action: "project_timeline_edited",
+        author_id: ctx.author.id,
+        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_start_date: DateTime.utc_now(), new_start_date: DateTime.utc_now(), old_end_date: DateTime.utc_now(), new_end_date: DateTime.utc_now() }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+  end
+
+  describe "assigns access_context to task activities" do
+    setup ctx do
+      milestone = milestone_fixture(ctx.author, %{project_id: ctx.project.id})
+      task = task_fixture(%{ space_id: ctx.group.id, creator_id: ctx.author.id, milestone_id: milestone.id})
+
+      Map.merge(ctx, %{milestone: milestone, task: task})
+    end
+
+    test "task_adding action", ctx do
+      attrs = %{
+        action: "task_adding",
+        author_id: ctx.author.id,
+        content: %{ task_id: ctx.task.id, company_id: ctx.company.id, milestone_id: ctx.milestone.id, name: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "task_closing action", ctx do
+      attrs = %{
+        action: "task_closing",
+        author_id: ctx.author.id,
+        content: %{ task_id: ctx.task.id, company_id: ctx.company.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "task_status_change action", ctx do
+      attrs = %{
+        action: "task_status_change",
+        author_id: ctx.author.id,
+        content: %{ task_id: ctx.task.id, company_id: ctx.company.id, old_status: "-", new_status: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "task_update action", ctx do
+      attrs = %{
+        action: "task_update",
+        author_id: ctx.author.id,
+        content: %{ task_id: ctx.task.id, company_id: ctx.company.id, old_name: "-", new_name: "-" }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+  end
+
+  describe "assigns access_context to comment_added activity" do
+    setup ctx do
+      attrs = %{
+        action: "project_created",
+        author_id: ctx.author.id,
+        content: %{
+          project_id: ctx.project.id,
+        },
+        context_id: ctx.project.access_context.id,
+      }
+
+      parent_activity = activity_fixture(attrs)
+      thread = comment_thread_fixture(%{parent_id: parent_activity.id})
+
+      Map.merge(ctx, %{thread: thread, parent_activity: parent_activity})
+    end
+
+    test "entity_type is :project_check_in", ctx do
+      comment = comment_fixture(ctx.author, %{entity_id: ctx.project.id, entity_type: :project_check_in})
+
+      attrs = %{
+        action: "comment_added",
+        author_id: ctx.author.id,
+        content: %{ comment_id: comment.id, company_id: ctx.company.id, project_id: ctx.project.id, space_id: ctx.group.id, goal_id: ctx.goal.id, comment_thread_id: ctx.thread.id, activity_id: ctx.parent_activity.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+
+    test "entity_type is :update", ctx do
+      comment = comment_fixture(ctx.author, %{entity_id: ctx.goal.id, entity_type: :update})
+
+      attrs = %{
+        action: "comment_added",
+        author_id: ctx.author.id,
+        content: %{ comment_id: comment.id, company_id: ctx.company.id, project_id: ctx.project.id, space_id: ctx.group.id, goal_id: ctx.goal.id, comment_thread_id: ctx.thread.id, activity_id: ctx.parent_activity.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.goal.access_context.id)
+    end
+
+    test "entity_type is :comment_thread", ctx do
+      comment = comment_fixture(ctx.author, %{entity_id: ctx.thread.id, entity_type: :comment_thread})
+
+      attrs = %{
+        action: "comment_added",
+        author_id: ctx.author.id,
+        content: %{ comment_id: comment.id, company_id: ctx.company.id, project_id: ctx.project.id, space_id: ctx.group.id, goal_id: ctx.goal.id, comment_thread_id: ctx.thread.id, activity_id: ctx.parent_activity.id }
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.project.access_context.id)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  def create_activity(attrs) do
+    action = String.to_atom(attrs.action)
+
+    Ecto.Multi.new()
+    |> Activities.insert_sync(attrs.author_id, action, fn _ -> attrs.content end)
+    |> Operately.Repo.transaction()
+    |> Repo.extract_result(:updated_activity)
+  end
+
+  def assert_context_assigned(result, context_id) do
+    {:ok, activity} = result
+
+    assert activity.context_id == context_id
+  end
+end

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -99,4 +99,20 @@ defmodule Operately.ProjectsFixtures do
 
     phase_history
   end
+
+  @doc """
+  Generate a check_in_fixture.
+  """
+  def check_in_fixture(attrs) do
+    {:ok, check_in} =
+      attrs
+      |> Enum.into(%{
+        status: "on_track",
+        description: %{},
+      })
+      |> Operately.Projects.CheckIn.changeset()
+      |> Operately.Repo.insert()
+
+    check_in
+  end
 end


### PR DESCRIPTION
From now on, `Operately.Activities.insert_sync` automatically assigns an access context to newly created activities.

Since in https://github.com/operately/operately/pull/618 and https://github.com/operately/operately/pull/624, we made sure that every single activity record in the application is created by `Operately.Activities.insert_sync`, we are guaranteed that all new activities will have an access context assigned to them.