### PR TITLE
Include soft-deleted projects in data migration

### DIFF
--- a/lib/operately/data/change_009_create_projects_access_context.ex
+++ b/lib/operately/data/change_009_create_projects_access_context.ex
@@ -8,7 +8,7 @@ defmodule Operately.Data.Change009CreateProjectsAccessContext do
 
   def run do
     Repo.transaction(fn ->
-      projects = Repo.all(from p in Project, select: p.id)
+      projects = from(p in Project, select: p.id) |> Repo.all(with_deleted: true)
 
       Enum.each(projects, fn project_id ->
         case create_projects_access_contexts(project_id) do


### PR DESCRIPTION
I've updated the data migration used to create access contexts for projects. Now, the migration also creates an access context for soft-deleted projects.