### PR TITLE
Include soft-deleted groups in data migration

### DIFF
--- a/lib/operately/data/change_010_create_groups_access_context.ex
+++ b/lib/operately/data/change_010_create_groups_access_context.ex
@@ -8,7 +8,7 @@ defmodule Operately.Data.Change010CreateGroupsAccessContext do
 
   def run do
     Repo.transaction(fn ->
-      groups = Repo.all(from g in Group, select: g.id)
+      groups = from(g in Group, select: g.id) |> Repo.all(with_deleted: true)
 
       Enum.each(groups, fn group_id ->
         case create_group_access_contexts(group_id) do


### PR DESCRIPTION
I've updated the data migration used to create access contexts for groups. Now, the migration also creates an access context for soft-deleted groups.