### PR TITLE
Include soft-deleted goals in data migration

### DIFF
--- a/lib/operately/data/change_012_create_goals_access_context.ex
+++ b/lib/operately/data/change_012_create_goals_access_context.ex
@@ -8,7 +8,7 @@ defmodule Operately.Data.Change012CreateGoalsAccessContext do
 
   def run do
     Repo.transaction(fn ->
-      goals = Repo.all(from g in Goal, select: g.id)
+      goals = from(g in Goal, select: g.id) |> Repo.all(with_deleted: true)
 
       Enum.each(goals, fn goal_id ->
         case create_goal_access_contexts(goal_id) do


### PR DESCRIPTION
I've updated the data migration used to create access contexts for goals. Now, the migration also creates an access context for soft-deleted goals.