### PR TITLE
Fix project create page

### DIFF
--- a/assets/js/features/goals/GoalTree/GoalSelectorDropdown.tsx
+++ b/assets/js/features/goals/GoalTree/GoalSelectorDropdown.tsx
@@ -44,6 +44,7 @@ export function GoalSelectorDropdown({ goals, onSelect, selected, error }: GoalS
             "border-surface-outline": !error,
           })}
           onClick={() => setOpen(!open)}
+          data-test-id="goal-selector"
         >
           {selected ? (
             <div className="truncate flex items-center gap-1.5">

--- a/assets/js/pages/ProjectAddPage/loader.tsx
+++ b/assets/js/pages/ProjectAddPage/loader.tsx
@@ -26,7 +26,10 @@ export async function loader({ request, params }): Promise<LoaderResult> {
   const goal = goalID ? await Goals.getGoal({ id: goalID }) : undefined;
 
   const company = await Companies.getCompany();
-  const goals = await Goals.getGoals({}).then((data) => data.goals!);
+  const goals = await Goals.getGoals({
+    includeSpace: true,
+    includeChampion: true,
+  }).then((data) => data.goals!);
 
   let space: Spaces.Space | undefined;
   let spaces: Spaces.Space[] | undefined;

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -64,4 +64,22 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
   end
+
+  @tag login_as: :champion
+  feature "select a parent goal while adding a project", ctx do
+    params = %{
+      name: "Website Redesign", 
+      creator: ctx.champion, 
+      champion: ctx.champion, 
+      reviewer: ctx.reviewer,
+      goal: ctx.goal
+    }
+
+    ctx
+    |> Steps.start_adding_project()
+    |> Steps.submit_project_form(params)
+    |> Steps.assert_project_created(params)
+    |> Steps.assert_project_created_email_sent(params)
+    |> Steps.assert_project_created_notification_sent(params)
+  end
 end

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -373,4 +373,10 @@ defmodule Operately.Support.Features.UI do
       session |> Browser.take_screenshot()
     end)
   end
+
+  def str_to_testid(str) do
+    str
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]/, "-")
+  end
 end


### PR DESCRIPTION
The old API included the champion and the space of the listed goals by default. The new one needs an explicit "include_space", "include_champion".

Added tests to cover project creation when the parent goal is selected in order to catch such bugs in the future earlier.