### PR TITLE
Speed up slowest test

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -43,10 +43,6 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :wallaby, screenshot_on_failure: true
-
-config :mix_test_watch, extra_extensions: [".feature"]
-
 config :operately, :start_query_counter, true
 config :operately, :restrict_entry, false
 
@@ -77,4 +73,6 @@ config :ex_aws,
     debug_requests: true
   ]
 
+config :wallaby, screenshot_on_failure: true
 config :wallaby, otp_app: :operately
+config :wallaby, hackney_options: [timeout: 3_000]

--- a/test/features/goals_test.exs
+++ b/test/features/goals_test.exs
@@ -57,9 +57,9 @@ defmodule Operately.Features.GoalTest do
     |> Steps.close_goal(params)
     |> Steps.assert_goal_closed(params)
     |> Steps.assert_goal_is_not_editable()
-    |> Steps.assert_goal_closed_email_sent()
-    |> Steps.assert_goal_closed_feed_posted()
-    |> Steps.assert_goal_closed_notification_sent()
+    # |> Steps.assert_goal_closed_email_sent()
+    # |> Steps.assert_goal_closed_feed_posted()
+    # |> Steps.assert_goal_closed_notification_sent()
   end
 
   @tag login_as: :champion

--- a/test/features/goals_test.exs
+++ b/test/features/goals_test.exs
@@ -57,9 +57,9 @@ defmodule Operately.Features.GoalTest do
     |> Steps.close_goal(params)
     |> Steps.assert_goal_closed(params)
     |> Steps.assert_goal_is_not_editable()
-    # |> Steps.assert_goal_closed_email_sent()
-    # |> Steps.assert_goal_closed_feed_posted()
-    # |> Steps.assert_goal_closed_notification_sent()
+    |> Steps.assert_goal_closed_email_sent()
+    |> Steps.assert_goal_closed_feed_posted()
+    |> Steps.assert_goal_closed_notification_sent()
   end
 
   @tag login_as: :champion

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -233,7 +233,9 @@ defmodule Operately.Support.Features.UI do
 
   def refute_text(state, text) do
     execute(state, fn session ->
-      session |> Browser.refute_has(Query.text(text))
+      visible_text = session |> Browser.text()
+      refute String.contains?(visible_text, text)
+      session
     end)
   end
 


### PR DESCRIPTION
I've noticed that some UI tests are excessively slow. For example this one:

![Screenshot 2024-06-25 at 18 23 52](https://github.com/operately/operately/assets/1779493/d092aa17-b8eb-4b0e-808e-1d2f5aeda251)

I went down the rabbithole to figure out the reason.

Turns out, this test was heavily using `Wallaby.Browser.refute_has`, which in turn is calling https://github.com/elixir-wallaby/wallaby/blob/main/lib/wallaby/browser.ex#L1496. I've put an IO.inspect into that function and noticed that it is reaching out to the running browser hundreds of times. 

Basically, it was trying to find the element for 3 seconds, and if it didn't found it, it declared that refute_has(text) has passed. In the original test, we were running 4 times in a row refute_has, amount to 12 seconds of needless waiting.

---

the new implementation of the `UI.refute_text` now simply gets all the available text on the screen, and tests if the desired text is visible. This reduced the execution time to below 0.1s, making the original test 5 seconds in total, instead of 19 seconds.