### PR TITLE
Creating a company creates access groups, bindings and memberships

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -8,13 +8,13 @@ defmodule Operately.Access do
     Repo.all(Context)
   end
 
-  def get_context!(id) when is_binary(id) do
-    Repo.get!(Context, id)
-  end
+  def get_context!(id) when is_binary(id), do: Repo.get!(Context, id)
 
-  def get_context!(attrs) when is_list(attrs) do
-    Repo.get_by!(Context, attrs)
-  end
+  def get_context!(attrs) when is_list(attrs), do: Repo.get_by!(Context, attrs)
+
+  def get_context(id) when is_binary(id), do: Repo.get(Context, id)
+
+  def get_context(attrs) when is_list(attrs), do: Repo.get_by(Context, attrs)
 
   def create_context(attrs \\ %{}) do
     %Context{}
@@ -43,21 +43,13 @@ defmodule Operately.Access do
     Repo.all(Group)
   end
 
-  def get_group!(id) when is_binary(id) do
-    Repo.get!(Group, id)
-  end
+  def get_group!(id) when is_binary(id), do: Repo.get!(Group, id)
 
-  def get_group!(attrs) when is_list(attrs) do
-    Repo.get_by!(Group, attrs)
-  end
+  def get_group!(attrs) when is_list(attrs), do: Repo.get_by!(Group, attrs)
 
-  def get_group(id) when is_binary(id) do
-    Repo.get(Group, id)
-  end
+  def get_group(id) when is_binary(id), do: Repo.get(Group, id)
 
-  def get_group(attrs) when is_list(attrs) do
-    Repo.get_by(Group, attrs)
-  end
+  def get_group(attrs) when is_list(attrs), do: Repo.get_by(Group, attrs)
 
   def create_group(attrs \\ %{}) do
     %Group{}
@@ -86,7 +78,13 @@ defmodule Operately.Access do
     Repo.all(Binding)
   end
 
-  def get_binding!(id), do: Repo.get!(Binding, id)
+  def get_binding!(id) when is_binary(id), do: Repo.get!(Binding, id)
+
+  def get_binding!(attrs) when is_list(attrs), do: Repo.get_by!(Binding, attrs)
+
+  def get_binding(id) when is_binary(id), do: Repo.get(Binding, id)
+
+  def get_binding(attrs) when is_list(attrs), do: Repo.get_by(Binding, attrs)
 
   def create_binding(attrs \\ %{}) do
     %Binding{}
@@ -115,7 +113,13 @@ defmodule Operately.Access do
     Repo.all(GroupMembership)
   end
 
-  def get_group_membership!(id), do: Repo.get!(GroupMembership, id)
+  def get_group_membership!(id) when is_binary(id), do: Repo.get!(GroupMembership, id)
+
+  def get_group_membership!(attrs) when is_list(attrs), do: Repo.get_by!(GroupMembership, attrs)
+
+  def get_group_membership(id) when is_binary(id), do: Repo.get(GroupMembership, id)
+
+  def get_group_membership(attrs) when is_list(attrs), do: Repo.get_by(GroupMembership, attrs)
 
   def create_group_membership(attrs \\ %{}) do
     %GroupMembership{}

--- a/lib/operately/access/access_group.ex
+++ b/lib/operately/access/access_group.ex
@@ -5,6 +5,8 @@ defmodule Operately.Access.Group do
     belongs_to :person, Operately.People.Person, foreign_key: :person_id
     belongs_to :company, Operately.Companies.Company, foreign_key: :company_id
 
+    field :tag, Ecto.Enum, values: [:full_access, :standard]
+
     timestamps()
   end
 
@@ -14,7 +16,7 @@ defmodule Operately.Access.Group do
 
   def changeset(group, attrs) do
     group
-    |> cast(attrs, [:person_id, :company_id])
+    |> cast(attrs, [:person_id, :company_id, :tag])
     |> validate_required([])
   end
 end

--- a/lib/operately/access/access_group.ex
+++ b/lib/operately/access/access_group.ex
@@ -2,7 +2,8 @@ defmodule Operately.Access.Group do
   use Operately.Schema
 
   schema "access_groups" do
-    belongs_to :person, Operately.Groups.Group, foreign_key: :person_id
+    belongs_to :person, Operately.People.Person, foreign_key: :person_id
+    belongs_to :company, Operately.Companies.Company, foreign_key: :company_id
 
     timestamps()
   end
@@ -13,7 +14,7 @@ defmodule Operately.Access.Group do
 
   def changeset(group, attrs) do
     group
-    |> cast(attrs, [:person_id])
+    |> cast(attrs, [:person_id, :company_id])
     |> validate_required([])
   end
 end

--- a/lib/operately/companies/company.ex
+++ b/lib/operately/companies/company.ex
@@ -7,6 +7,8 @@ defmodule Operately.Companies.Company do
   schema "companies" do
     has_one :access_context, Operately.Access.Context, foreign_key: :company_id
 
+    has_many :access_groups, Operately.Access.Group, foreign_key: :company_id
+
     field :mission, :string
     field :name, :string
     field :trusted_email_domains, {:array, :string}

--- a/priv/repo/migrations/20240628081627_add_company_id_field_to_access_groups_schema.exs
+++ b/priv/repo/migrations/20240628081627_add_company_id_field_to_access_groups_schema.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddCompanyIdFieldToAccessGroupsSchema do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_groups) do
+      add :company_id, references(:companies, type: :binary_id, on_delete: :nothing)
+    end
+
+    create index(:access_groups, [:company_id])
+  end
+end

--- a/priv/repo/migrations/20240628084820_add_tag_field_to_access_group_schema.exs
+++ b/priv/repo/migrations/20240628084820_add_tag_field_to_access_group_schema.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddTagFieldToAccessGroupSchema do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_groups) do
+      add :tag, :string
+    end
+  end
+end

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -30,7 +30,10 @@ defmodule Operately.AccessBindingsTest do
         context_id: ctx.context.id,
       })
 
-      assert Access.list_bindings() == [binding]
+      bindings_list = Access.list_bindings()
+
+      assert 3 == length(bindings_list)
+      assert Enum.member?(bindings_list, binding)
     end
 
     test "get_binding!/1 returns the binding with given id", ctx do

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -52,12 +52,29 @@ defmodule Operately.Operations.CompanyAddingTest do
   end
 
 
-  test "CompanyAdding operation creates admin's access group" do
+  test "CompanyAdding operation creates admin user's access group" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs, create_admin: true)
 
     person = People.get_person_by_email(company, @email)
 
     assert nil != Access.get_group!(person_id: person.id)
+  end
+
+  test "CompanyAdding operation creates access groups, bindings and group_memberships for admins and members" do
+    {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs, create_admin: true)
+
+    person = People.get_person_by_email(company, @email)
+    full_access = Access.get_group!(company_id: company.id, tag: :full_access)
+    standard = Access.get_group!(company_id: company.id, tag: :standard)
+
+    assert nil != full_access
+    assert nil != standard
+
+    assert nil != Access.get_binding!(group_id: full_access.id, access_level: 100)
+    assert nil != Access.get_binding!(group_id: standard.id, access_level: 10)
+
+    assert nil != Access.get_group_membership(group_id: full_access.id, person_id: person.id)
+    assert nil == Access.get_group_membership(group_id: standard.id, person_id: person.id)
   end
 
   test "CompanyAdding operation creates company and group access contexts" do


### PR DESCRIPTION
I've updated `Operately.Operations.CompanyAdding` so that, from now on, creating a company automatically creates:

- An access group for company admins
- An access group for company members
- Access bindings between the new access groups and the company's access context
- If an admin user is created with the company, an access group membership between the admin and the new admins access group is also created

By default, the admins access group gets full access and the members access group gets read-only access. I think that's a reasonable behavior, but we can easily change it in the future. 