### PR TITLE
Add data migration for creating access groups for companies

### DIFF
--- a/lib/operately/data/change_015_create_companies_access_group.ex
+++ b/lib/operately/data/change_015_create_companies_access_group.ex
@@ -1,0 +1,88 @@
+defmodule Operately.Data.Change015CreateCompaniesAccessGroup do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Companies
+  alias Operately.Access
+
+  def run do
+    Repo.transaction(fn ->
+      companies = Companies.list_companies()
+
+      Enum.each(companies, fn company ->
+        case create_groups(company.id) do
+          {:error, _} -> raise "Failed to create access groups"
+          _ -> :ok
+        end
+      end)
+    end)
+  end
+
+  defp create_groups(company_id) do
+    create_group(company_id, :full_access)
+    create_group(company_id, :standard)
+  end
+
+  defp create_group(company_id, tag) do
+    case Access.get_group(company_id: company_id, tag: tag) do
+      nil ->
+        {:ok, group} = Access.create_group(%{
+          company_id: company_id,
+          tag: tag,
+        })
+        create_bindings(company_id, group, tag)
+        create_memberships(company_id, group)
+
+      group ->
+        create_bindings(company_id, group, tag)
+        create_memberships(company_id, group)
+        :ok
+    end
+  end
+
+  defp create_bindings(company_id, group, tag) do
+    context = Access.get_context!(company_id: company_id)
+    access_level = get_access_level(tag)
+
+    case Access.get_binding(group_id: group.id, context_id: context.id, access_level: access_level) do
+      nil -> Access.create_binding(%{
+        group_id: group.id,
+        context_id: context.id,
+        access_level: access_level,
+      })
+      _ -> :ok
+    end
+  end
+
+  defp create_memberships(company_id, group) do
+    people = from(p in Operately.People.Person, where: p.company_id == ^company_id) |> Repo.all()
+
+    Enum.each(people, fn person ->
+      if person.company_role == :admin and group.tag == :full_access do
+        create_membership(person, group)
+      end
+
+      if person.company_role == :member and group.tag == :standard do
+        create_membership(person, group)
+      end
+    end)
+  end
+
+  defp create_membership(person, group) do
+    case Access.get_group_membership(person_id: person.id, group_id: group.id) do
+      nil ->
+        Access.create_group_membership(%{
+          person_id: person.id,
+          group_id: group.id,
+        })
+      _ -> :ok
+    end
+  end
+
+  defp get_access_level(tag) do
+    case tag do
+      :standard -> 10
+      :full_access -> 100
+    end
+  end
+end

--- a/test/operately/data/change_015_create_companies_access_group_test.exs
+++ b/test/operately/data/change_015_create_companies_access_group_test.exs
@@ -1,0 +1,92 @@
+defmodule Operately.Data.Change015CreateCompaniesAccessGroupTest do
+  use Operately.DataCase
+
+  alias Operately.Access
+  alias Operately.People.Person
+  alias Operately.Companies.Company
+
+  test "creates access groups, bindings and memberships" do
+    companies = Enum.map(1..3, fn _ ->
+      create_company()
+    end)
+
+    Enum.each(companies, fn company ->
+      assert nil == Access.get_group(company_id: company.id)
+    end)
+
+    Operately.Data.Change015CreateCompaniesAccessGroup.run()
+
+    Enum.each(companies, fn company ->
+      full_access = Access.get_group(company_id: company.id, tag: :full_access)
+      standard = Access.get_group(company_id: company.id, tag: :standard)
+
+      assert nil != full_access
+      assert nil != standard
+
+      assert nil != Access.get_binding!(group_id: full_access.id, access_level: 100)
+      assert nil != Access.get_binding!(group_id: standard.id, access_level: 10)
+
+      people = from(p in Person, where: p.company_id == ^company.id) |> Repo.all()
+
+      Enum.each(people, fn person ->
+        if person.company_role == :admin do
+          assert nil != Access.get_group_membership(group_id: full_access.id, person_id: person.id)
+          assert nil == Access.get_group_membership(group_id: standard.id, person_id: person.id)
+        else
+          assert nil == Access.get_group_membership(group_id: full_access.id, person_id: person.id)
+          assert nil != Access.get_group_membership(group_id: standard.id, person_id: person.id)
+        end
+      end)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_company do
+    {:ok, company} =
+      Company.changeset(%{name: "some name"})
+      |> Repo.insert()
+
+    create_access_context(company.id)
+    create_people(company.id)
+    create_admins(company.id)
+
+    company
+  end
+
+  defp create_access_context(company_id) do
+    Access.Context.changeset(%{
+      company_id: company_id,
+    })
+    |> Repo.insert()
+  end
+
+  defp create_people(company_id) do
+    Enum.map(1..3, fn _ ->
+      {:ok, person} =
+        Person.changeset(%{
+          full_name: "some name",
+          company_id: company_id,
+        })
+        |> Repo.insert()
+
+      person
+    end)
+  end
+
+  defp create_admins(company_id) do
+    Enum.map(1..3, fn _ ->
+      {:ok, person} =
+        Person.changeset(%{
+          full_name: "some name",
+          company_id: company_id,
+          company_role: :admin,
+        })
+        |> Repo.insert()
+
+      person
+    end)
+  end
+end


### PR DESCRIPTION
I've created a data migration that:

- Creates access groups for existing companies
- Creates access bindings between the companies and the new access groups
- Creates access group memberships between existing users and the new access groups