### PR TITLE
Creating person's access group also creates access group membership

### DIFF
--- a/lib/operately/access/access_group.ex
+++ b/lib/operately/access/access_group.ex
@@ -17,6 +17,18 @@ defmodule Operately.Access.Group do
   def changeset(group, attrs) do
     group
     |> cast(attrs, [:person_id, :company_id, :tag])
+    |> validate_one_association
     |> validate_required([])
+  end
+
+  defp validate_one_association(changeset) do
+    fields = [:person_id, :company_id]
+    count = Enum.count(fields, fn field -> get_field(changeset, field) != nil end)
+
+    if count <= 1 do
+      changeset
+    else
+      add_error(changeset, :base, "Only one association (Person or Company) may be set.")
+    end
   end
 end

--- a/lib/operately/access/access_group.ex
+++ b/lib/operately/access/access_group.ex
@@ -17,7 +17,7 @@ defmodule Operately.Access.Group do
   def changeset(group, attrs) do
     group
     |> cast(attrs, [:person_id, :company_id, :tag])
-    |> validate_one_association
+    |> validate_one_association()
     |> validate_required([])
   end
 

--- a/lib/operately/data/change_016_create_people_access_group_membership.ex
+++ b/lib/operately/data/change_016_create_people_access_group_membership.ex
@@ -1,0 +1,41 @@
+defmodule Operately.Data.Change016CreatePeopleAccessGroupMembership do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.People.Person
+
+  def run do
+    Repo.transaction(fn ->
+      people_ids = from(p in Person, select: p.id) |> Repo.all()
+
+      Enum.each(people_ids, fn person_id ->
+        case create_group_membership(person_id) do
+          {:error, _} -> raise "Failed to create access group membership"
+          _ -> :ok
+        end
+      end)
+    end)
+  end
+
+  defp create_group_membership(person_id) do
+    group = get_group(person_id)
+
+    case Access.get_group_membership(person_id: person_id, group_id: group.id) do
+      nil -> Access.create_group_membership(%{
+        person_id: person_id,
+        group_id: group.id,
+      })
+      _ -> :ok
+    end
+  end
+
+  defp get_group(person_id) do
+    case Access.get_group(person_id: person_id) do
+      nil ->
+        {:ok, group} = Access.create_group(%{person_id: person_id})
+        group
+      group -> group
+    end
+  end
+end

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -40,6 +40,12 @@ defmodule Operately.People do
     |> Multi.insert(:person_access_group, fn changes ->
       Operately.Access.Group.changeset(%{person_id: changes.person.id})
     end)
+    |> Multi.insert(:person_access_membership, fn changes ->
+      Operately.Access.GroupMembership.changeset(%{
+        group_id: changes.person_access_group.id,
+        person_id: changes.person.id,
+      })
+    end)
   end
 
   def create_person(attrs \\ %{}) do

--- a/test/operately/data/change_016_create_people_access_group_membership_test.exs
+++ b/test/operately/data/change_016_create_people_access_group_membership_test.exs
@@ -1,0 +1,66 @@
+defmodule Operately.Data.Change016CreatePeopleAccessGroupMembershipTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+
+  alias Operately.Access
+
+  setup do
+    company = company_fixture()
+
+    {:ok, company: company}
+  end
+
+  test "creates access group membership for existing people", ctx do
+    people_with_group = Enum.map(1..3, fn _ ->
+      create_people_with_group(ctx.company.id)
+    end)
+
+    Enum.each(people_with_group, fn person ->
+      group = Access.get_group!(person_id: person.id)
+      assert nil == Access.get_group_membership(person_id: person.id, group_id: group.id)
+    end)
+
+    people_without_group = Enum.map(1..3, fn _ ->
+      create_people_without_group(ctx.company.id)
+    end)
+
+    Enum.each(people_without_group, fn person ->
+      assert nil == Access.get_group(person_id: person.id)
+    end)
+
+    Operately.Data.Change016CreatePeopleAccessGroupMembership.run()
+
+    people = people_with_group ++ people_without_group
+
+    Enum.each(people, fn person ->
+      group = Access.get_group!(person_id: person.id)
+      assert nil != Access.get_group_membership(person_id: person.id, group_id: group.id)
+    end)
+  end
+
+  defp create_people_with_group(company_id) do
+    {:ok, person} =
+      Operately.People.Person.changeset(%{
+        full_name: "some name",
+        company_id: company_id,
+      })
+      |> Repo.insert()
+
+    Access.Group.changeset(%{person_id: person.id})
+    |> Repo.insert()
+
+    person
+  end
+
+  defp create_people_without_group(company_id) do
+    {:ok, person} =
+      Operately.People.Person.changeset(%{
+        full_name: "some name",
+        company_id: company_id,
+      })
+      |> Repo.insert()
+
+    person
+  end
+end

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -52,12 +52,14 @@ defmodule Operately.Operations.CompanyAddingTest do
   end
 
 
-  test "CompanyAdding operation creates admin user's access group" do
+  test "CompanyAdding operation creates admin user's access group and membership" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs, create_admin: true)
 
     person = People.get_person_by_email(company, @email)
+    group = Access.get_group!(person_id: person.id)
 
-    assert nil != Access.get_group!(person_id: person.id)
+    assert nil != group
+    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
   end
 
   test "CompanyAdding operation creates access groups, bindings and group_memberships for admins and members" do

--- a/test/operately/operations/company_member_adding_test.exs
+++ b/test/operately/operations/company_member_adding_test.exs
@@ -43,12 +43,14 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
     assert person.title == "Developer"
   end
 
-  test "CompanyMemberAdding operation creates members's access group", ctx do
+  test "CompanyMemberAdding operation creates members's access group and membership", ctx do
     Operately.Operations.CompanyMemberAdding.run(ctx.admin, @member_attrs)
 
     person = People.get_person_by_email(ctx.company, @email)
+    group = Access.get_group!(person_id: person.id)
 
-    assert nil != Access.get_group!(person_id: person.id)
+    assert nil != group
+    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
   end
 
   test "CompanyMemberAdding operation creates invitation for person", ctx do

--- a/test/operately/operations/fetch_or_create_account_test.exs
+++ b/test/operately/operations/fetch_or_create_account_test.exs
@@ -37,8 +37,10 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
     Operately.People.FetchOrCreateAccountOperation.call(ctx.company, @attrs)
 
     person = People.get_person_by_email(ctx.company, @email)
+    group = Access.get_group!(person_id: person.id)
 
-    assert nil != Access.get_group!(person_id: person.id)
+    assert nil != group
+    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
   end
 
   test "FetchOrCreateAccountOperation doesn't create account for non-trusted email domain", ctx do


### PR DESCRIPTION
I've updated `Operately.People.insert_person` so that, after creating an access group for the user, it also creates an access group membership. 

I've also made a data migration for creating an access group membership between existing users and their access groups.