### PR TITLE
Add access groups for anonymous users

### DIFF
--- a/lib/operately/access/access_group.ex
+++ b/lib/operately/access/access_group.ex
@@ -5,7 +5,7 @@ defmodule Operately.Access.Group do
     belongs_to :person, Operately.People.Person, foreign_key: :person_id
     belongs_to :company, Operately.Companies.Company, foreign_key: :company_id
 
-    field :tag, Ecto.Enum, values: [:full_access, :standard]
+    field :tag, Ecto.Enum, values: [:full_access, :standard, :anonymous]
 
     timestamps()
   end

--- a/lib/operately/data/change_017_create_access_group_for_anonymous_users.ex
+++ b/lib/operately/data/change_017_create_access_group_for_anonymous_users.ex
@@ -1,0 +1,30 @@
+defmodule Operately.Data.Change017CreateAccessGroupForAnonymousUsers do
+  alias Operately.Repo
+  alias Operately.Companies
+  alias Operately.Access
+
+  def run do
+    Repo.transaction(fn ->
+      companies = Companies.list_companies()
+
+      Enum.each(companies, fn company ->
+        case create_groups(company.id) do
+          {:error, _} -> raise "Failed to create access groups"
+          _ -> :ok
+        end
+      end)
+    end)
+  end
+
+  defp create_groups(company_id) do
+    case Access.get_group(company_id: company_id, tag: :anonymous) do
+      nil ->
+        Access.create_group(%{
+          company_id: company_id,
+          tag: :anonymous,
+        })
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -68,6 +68,12 @@ defmodule Operately.Operations.CompanyAdding do
         tag: :standard,
       })
     end)
+    |> Multi.insert(:anonymous_access_group, fn changes ->
+      Group.changeset(%{
+        company_id: changes.company.id,
+        tag: :anonymous,
+      })
+    end)
   end
 
   defp insert_access_bindings(multi) do

--- a/test/operately/data/change_017_create_access_group_for_anonymous_users_test.exs
+++ b/test/operately/data/change_017_create_access_group_for_anonymous_users_test.exs
@@ -1,0 +1,34 @@
+defmodule Operately.Data.Change017CreateAccessGroupForAnonymousUsersTest do
+  use Operately.DataCase
+
+  alias Operately.Access
+  alias Operately.Companies.Company
+
+  test "creates access groups for anonymous users" do
+    companies = Enum.map(1..3, fn _ ->
+      create_company()
+    end)
+
+    Enum.each(companies, fn company ->
+      assert nil == Access.get_group(company_id: company.id, tag: :anonymous)
+    end)
+
+    Operately.Data.Change017CreateAccessGroupForAnonymousUsers.run()
+
+    Enum.each(companies, fn company ->
+      assert nil != Access.get_group(company_id: company.id, tag: :anonymous)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_company do
+    {:ok, company} =
+      Company.changeset(%{name: "some name"})
+      |> Repo.insert()
+
+    company
+  end
+end

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -68,9 +68,11 @@ defmodule Operately.Operations.CompanyAddingTest do
     person = People.get_person_by_email(company, @email)
     full_access = Access.get_group!(company_id: company.id, tag: :full_access)
     standard = Access.get_group!(company_id: company.id, tag: :standard)
+    anonymous = Access.get_group!(company_id: company.id, tag: :anonymous)
 
     assert nil != full_access
     assert nil != standard
+    assert nil != anonymous
 
     assert nil != Access.get_binding!(group_id: full_access.id, access_level: 100)
     assert nil != Access.get_binding!(group_id: standard.id, access_level: 10)

--- a/test/operately/operations/goal_timeframe_editing_test.exs
+++ b/test/operately/operations/goal_timeframe_editing_test.exs
@@ -24,8 +24,6 @@ defmodule Operately.Operations.GoalTimeframeEditingTest do
 
   test "GoalTimeframeEditing operation updates goal", ctx do
     assert ctx.goal.timeframe.type == "quarter"
-    assert ctx.goal.timeframe.start_date == ~D[2024-04-01]
-    assert ctx.goal.timeframe.end_date == ~D[2024-06-30]
 
     Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalTimeframeEditing.run(


### PR DESCRIPTION
I've updated `Operately.Operations.CompanyAdding` so that it also creates an access group for anonymous users (users who are not logged in). 
This access group is not meant to have a relationship with any specific user. Instead, it will be used to give view access to anonymous users for resources that are supposed to be public.