### PR TITLE
Add GroupMemberRemoving operation

### DIFF
--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -600,7 +600,7 @@ export type RootMutationType = {
   removeCompanyAdmin?: Maybe<Person>;
   removeCompanyMember?: Maybe<Person>;
   removeCompanyTrustedEmailDomain: Company;
-  removeGroupMember?: Maybe<Group>;
+  removeGroupMember?: Maybe<Scalars['Boolean']['output']>;
   removeKeyResource: ProjectKeyResource;
   removeProjectContributor: ProjectContributor;
   removeProjectMilestone: Milestone;

--- a/assets/js/models/spaces/index.tsx
+++ b/assets/js/models/spaces/index.tsx
@@ -78,9 +78,7 @@ export const LIST_GROUPS = gql`
 
 const REMOVE_GROUP_MEMBER = gql`
   mutation RemoveGroupMember($groupId: ID!, $memberId: ID!) {
-    removeGroupMember(groupId: $groupId, memberId: $memberId) {
-      id
-    }
+    removeGroupMember(groupId: $groupId, memberId: $memberId)
   }
 `;
 

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -145,15 +145,6 @@ defmodule Operately.Groups do
     Repo.insert(changeset)
   end
 
-  def remove_member(group, people_id) do
-    query = (
-      from m in Member,
-      where: m.group_id == ^group.id and m.person_id == ^people_id
-    )
-
-    Repo.delete_all(query)
-  end
-
   def add_contact(group, name, value, type) do
     contact = %Contact{
       group_id: group.id,

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -136,14 +136,7 @@ defmodule Operately.Groups do
     Repo.one(query) != nil
   end
 
-  def add_member(group, people_id) do
-    changeset = Member.changeset(%Member{}, %{
-      group_id: group.id,
-      person_id: people_id
-    })
-
-    Repo.insert(changeset)
-  end
+  defdelegate add_members(group_id, people_ids), to: Operately.Operations.GroupMembersAdding, as: :run
 
   def add_contact(group, name, value, type) do
     contact = %Contact{

--- a/lib/operately/operations/group_member_removing.ex
+++ b/lib/operately/operations/group_member_removing.ex
@@ -1,0 +1,50 @@
+defmodule Operately.Operations.GroupMemberRemoving do
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Groups.Member
+  alias Operately.Access.Group
+
+  def run(group_id, person_id) do
+    Multi.new()
+    |> delete_member(group_id, person_id)
+    |> delete_access_group_memberships(group_id, person_id)
+    |> delete_access_binding(group_id, person_id)
+    |> Repo.transaction()
+  end
+
+  defp delete_member(multi, group_id, person_id) do
+    Multi.run(multi, :member_deleted, fn repo, _ ->
+      case repo.get_by(Member, group_id: group_id, person_id: person_id) do
+        nil ->
+          {:error, nil}
+        member ->
+          repo.delete(member)
+          {:ok, member}
+      end
+    end)
+  end
+
+  defp delete_access_group_memberships(multi, group_id, person_id) do
+    from(g in Group, where: g.group_id == ^group_id)
+    |> Repo.all()
+    |> Enum.reduce(multi, fn (access_group, multi) ->
+      case Access.get_group_membership(group_id: access_group.id, person_id: person_id) do
+        nil -> multi
+        membership ->
+          name = Atom.to_string(access_group.tag) <> "_membership_deleted"
+          Multi.delete(multi, name, membership)
+      end
+    end)
+  end
+
+  defp delete_access_binding(multi, group_id, person_id) do
+    access_group = Access.get_group!(person_id: person_id)
+    access_context = Access.get_context!(group_id: group_id)
+    binding = Access.get_binding!(context_id: access_context.id, group_id: access_group.id)
+
+    Multi.delete(multi, :binding_deleted, binding)
+  end
+end

--- a/lib/operately_web/graphql/mutations/groups.ex
+++ b/lib/operately_web/graphql/mutations/groups.ex
@@ -94,16 +94,14 @@ defmodule OperatelyWeb.Graphql.Mutations.Groups do
       end
     end
 
-    field :remove_group_member, :group do
+    field :remove_group_member, :boolean do
       arg :group_id, non_null(:id)
       arg :member_id, non_null(:id)
 
       resolve fn args, _ ->
-        group = Operately.Groups.get_group(args.group_id)
+        Operately.Operations.GroupMemberRemoving.run(args.group_id, args.member_id)
 
-        Operately.Groups.remove_member(group, args.member_id)
-
-        {:ok, group}
+        {:ok, true}
       end
     end
 

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -7,6 +7,7 @@ defmodule Operately.Features.DiscussionsTest do
 
   alias Operately.Support.Features.NotificationsSteps
   alias Operately.Support.Features.EmailSteps
+  alias Operately.Access.Binding
 
   alias Operately.Support.Features.DiscussionSteps, as: Steps
 
@@ -17,8 +18,16 @@ defmodule Operately.Features.DiscussionsTest do
 
     space = group_fixture(author, %{name: "Marketing", mission: "Let the world know about our products"})
 
-    Operately.Groups.add_member(space, author.id)
-    Operately.Groups.add_member(space, reader.id)
+    Operately.Groups.add_members(space.id, [
+      %{
+        id: reader.id,
+        permissions: Binding.view_access(),
+      },
+      %{
+        id: author.id,
+        permissions: Binding.full_access(),
+      }
+    ])
 
     ctx = Map.merge(ctx, %{company: company, author: author, reader: reader, space: space})
     ctx = UI.login_as(ctx, ctx.author)
@@ -70,7 +79,7 @@ defmodule Operately.Features.DiscussionsTest do
       to: ctx.author,
       author: ctx.reader,
       action: "commented on: This is a discussion"
-    })  
+    })
   end
 
   @tag login_as: :author
@@ -110,7 +119,7 @@ defmodule Operately.Features.DiscussionsTest do
   # Utilities
   #
   defp last_discussion(ctx) do
-    discussions = Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion) 
+    discussions = Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion)
 
     if discussions != [] do
       hd(discussions)

--- a/test/features/spaces_test.exs
+++ b/test/features/spaces_test.exs
@@ -5,6 +5,7 @@ defmodule Operately.Features.SpacesTest do
   import Operately.PeopleFixtures
   import Operately.ProjectsFixtures
 
+  alias Operately.Access.Binding
   alias Operately.Support.Features.SpaceSteps, as: Steps
 
   setup ctx, do: Steps.setup(ctx)
@@ -18,9 +19,9 @@ defmodule Operately.Features.SpacesTest do
 
   feature "creating a new space", ctx do
     params = %{
-      name: "Marketing", 
-      mission: "Let the world know about our products", 
-      color: "text-green-500", 
+      name: "Marketing",
+      mission: "Let the world know about our products",
+      color: "text-green-500",
       icon: "IconBolt"
     }
 
@@ -37,7 +38,10 @@ defmodule Operately.Features.SpacesTest do
     group = group_fixture(ctx.person, %{name: "Marketing"})
     person = person_fixture(%{full_name: "Mati Aharoni", company_id: ctx.company.id})
 
-    Operately.Groups.add_member(group, person.id)
+    Operately.Groups.add_members(group.id, [%{
+      id: person.id,
+      permissions: Binding.edit_access(),
+    }])
 
     ctx
     |> visit_page()
@@ -83,7 +87,10 @@ defmodule Operately.Features.SpacesTest do
     group = group_fixture(ctx.person, %{name: "Marketing"})
     person = person_fixture(%{full_name: "Mati Aharoni", company_id: ctx.company.id})
 
-    Operately.Groups.add_member(group, person.id)
+    Operately.Groups.add_members(group.id, [%{
+      id: person.id,
+      permissions: Binding.edit_access(),
+    }])
 
     ctx
     |> visit_page()

--- a/test/operately/operations/group_member_removing_test.exs
+++ b/test/operately/operations/group_member_removing_test.exs
@@ -1,0 +1,48 @@
+defmodule Operately.Operations.GroupMemberRemovingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Groups
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(creator)
+
+    member = person_fixture_with_account(%{company_id: company.id})
+
+    Operately.Operations.GroupMembersAdding.run(group.id, [%{
+      id: member.id,
+      permissions: Binding.comment_access(),
+    }])
+
+    {:ok, group: group, member: member}
+  end
+
+  test "GroupMemberRemoving operation removes member from group", ctx do
+    assert Groups.is_member?(ctx.group, ctx.member)
+
+    Operately.Operations.GroupMemberRemoving.run(ctx.group.id, ctx.member.id)
+
+    refute Groups.is_member?(ctx.group, ctx.member)
+  end
+
+  test "GroupMemberRemoving operation deletes access memberships and bindings", ctx do
+    access_group = Access.get_group!(group_id: ctx.group.id, tag: :standard)
+    access_context = Access.get_context!(group_id: ctx.group.id)
+    person_access_group = Access.get_group!(person_id: ctx.member.id)
+
+    assert Access.get_group_membership(group_id: access_group.id, person_id: ctx.member.id)
+    assert Access.get_binding(context_id: access_context.id, group_id: person_access_group.id)
+
+    Operately.Operations.GroupMemberRemoving.run(ctx.group.id, ctx.member.id)
+
+    refute Access.get_group_membership(group_id: access_group.id, person_id: ctx.member.id)
+    refute Access.get_binding(context_id: access_context.id, group_id: person_access_group.id)
+  end
+end


### PR DESCRIPTION
I've added `Operately.Operations.GroupMemberRemoving` which removes a member from a space and deletes their access binding and access group membership.

It's worth mentioning that `Operately.Operations.GroupMemberRemoving` still doesn't create an activity record. 