### PR TITLE
Wordsmith Spaces form copy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   license_finder

--- a/assets/js/components/SpaceColorChooser/index.tsx
+++ b/assets/js/components/SpaceColorChooser/index.tsx
@@ -6,15 +6,14 @@ import * as Icons from "@tabler/icons-react";
 
 interface SpaceColorChooserProps {
   color: string;
-  name: string;
   setColor: (color: string) => void;
 }
 
-export function SpaceColorChooser({ color, name, setColor }: SpaceColorChooserProps) {
+export function SpaceColorChooser({ color, setColor }: SpaceColorChooserProps) {
   return (
     <>
       <h2 className="font-bold">Color</h2>
-      <p className="text-sm text-content-dimmed">Choose a color for the {name} Space.</p>
+      <p className="text-sm text-content-dimmed">Select a color theme.</p>
 
       <div className="flex items-center gap-2 mt-2">
         <ColorOption setColor={setColor} color="text-blue-500" current={color} />

--- a/assets/js/components/SpaceIconChooser/index.tsx
+++ b/assets/js/components/SpaceIconChooser/index.tsx
@@ -5,17 +5,16 @@ import classnames from "classnames";
 import * as Icons from "@tabler/icons-react";
 
 interface SpaceIconChooserProps {
-  name: string;
   icon: string;
   setIcon: (icon: string) => void;
   color: string;
 }
 
-export function SpaceIconChooser({ name, color, icon, setIcon }: SpaceIconChooserProps) {
+export function SpaceIconChooser({ color, icon, setIcon }: SpaceIconChooserProps) {
   return (
     <>
       <h2 className="font-bold">Icon</h2>
-      <p className="text-sm text-content-dimmed">Choose an icon for the {name} Space.</p>
+      <p className="text-sm text-content-dimmed">Select an icon.</p>
 
       <div className="flex items-center gap-2 mt-2 flex-wrap">
         <IconOption setIcon={setIcon} color={color} icon="IconStar" current={icon} />

--- a/assets/js/features/Permissions/PrivacyLevel.tsx
+++ b/assets/js/features/Permissions/PrivacyLevel.tsx
@@ -31,7 +31,7 @@ export default function PrivacyLevel() {
 
   const PRIVACY_OPTIONS = [
     {label: "Public - Anyone on the internet", value: PermissionOptions.PUBLIC},
-    {label: "Internal - Only organization members", value: PermissionOptions.INTERNAL},
+    {label: "Internal - All organization members", value: PermissionOptions.INTERNAL},
     {label: "Confidential - Only people invited to the space", value: PermissionOptions.CONFIDENTIAL},
   ]
 

--- a/assets/js/pages/GroupAddPage/page.tsx
+++ b/assets/js/pages/GroupAddPage/page.tsx
@@ -21,7 +21,8 @@ export function Page() {
 
   return (
     <Paper.Root size="small">
-      <h1 className="mb-4 font-bold text-3xl text-center">Creating a new space</h1>
+      <h1 className="mb-1 font-bold text-3xl text-center">Create a new space</h1>
+      <span className="text-content-dimmed text-center block mb-4">Spaces help organize projects, goals, and team members in one place.</span>
       <Paper.Body minHeight="none">
         <PermissionsProvider companyName={company.name}>
           <Form />
@@ -84,14 +85,16 @@ function Form() {
       />
 
       <div>
-        <SpaceColorChooser color={color} setColor={setColor} name={name} />
+        <SpaceColorChooser color={color} setColor={setColor} />
       </div>
 
       <div>
-        <SpaceIconChooser icon={icon} setIcon={setIcon} color={color} name={name} />
+        <SpaceIconChooser icon={icon} setIcon={setIcon} color={color} />
       </div>
 
       <PermissionSelector />
+
+      <div className="text-content-dimmed text-sm block"><span>You can modify these settings later in Space preferences.</span></div>
 
       <Forms.SubmitArea>
         <Forms.SubmitButton>Create Space</Forms.SubmitButton>

--- a/assets/js/pages/GroupAppearancePage/page.tsx
+++ b/assets/js/pages/GroupAppearancePage/page.tsx
@@ -34,10 +34,10 @@ export function Page() {
           <div className="font-extrabold text-2xl text-center">Appearance of {space.name}</div>
 
           <div className="h-px bg-stroke-base my-8"></div>
-          <SpaceColorChooser color={color!} name={space.name!} setColor={setColor} />
+          <SpaceColorChooser color={color!} setColor={setColor} />
 
           <div className="h-px bg-stroke-base my-8"></div>
-          <SpaceIconChooser icon={icon!} name={space.name!} setIcon={setIcon} color={color!} />
+          <SpaceIconChooser icon={icon!} setIcon={setIcon} color={color!} />
 
           <div className="h-px bg-stroke-base my-8"></div>
 


### PR DESCRIPTION
Before:
<img width="844" alt="Screenshot 2024-07-03 at 11 28 10" src="https://github.com/operately/operately/assets/8651/bd3b463d-b5e4-432e-9069-e9de56cad39b">

After:
<img width="785" alt="Screenshot 2024-07-03 at 11 53 10" src="https://github.com/operately/operately/assets/8651/cd635235-61e5-40f5-8800-985d8b669b5f">

Reasoning:
- Title: use active voice, this common in UI (will apply to other screens but don't want to do too much in my first PR of the kind)
- subtitle to describe the purpose of spaces - a little bit of help
- color / icon - less words is better
- Privacy / Internal - "Only" felt off
- Added an assuring sentence before the buttons that everything can be changed later so no worries.
