### PR TITLE
Create access groups, bindings and memberships for existing spaces

### DIFF
--- a/lib/operately/data/change_019_create_access_groups_for_spaces.ex
+++ b/lib/operately/data/change_019_create_access_groups_for_spaces.ex
@@ -1,0 +1,92 @@
+defmodule Operately.Data.Change019CreateAccessGroupsForSpaces do
+  alias Operately.Repo
+  alias Operately.Companies
+  alias Operately.Groups
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  def run do
+    Repo.transaction(fn ->
+      companies = Companies.list_companies()
+
+      Enum.each(companies, fn company ->
+        spaces = Groups.list_groups_for_company(company.id)
+
+        Enum.each(spaces, fn space ->
+          context = Access.get_context!(group_id: space.id)
+
+          create_access_bindings_to_member(space, context.id)
+          create_access_bindings_to_company(company.id, context.id)
+
+          create_access_group(space.id, :full_access)
+
+          create_access_group(space.id, :standard)
+          |> create_access_memberships(space)
+        end)
+      end)
+    end)
+  end
+
+  defp create_access_group(space_id, tag) do
+    case Access.get_group(group_id: space_id, tag: tag) do
+      nil ->
+        {:ok, group} = Access.create_group(%{
+          group_id: space_id,
+          tag: tag,
+        })
+        group
+      group ->
+        group
+    end
+  end
+
+  defp create_access_memberships(access_group, space) do
+    members = Groups.list_members(space)
+
+    Enum.each(members, fn member ->
+      create_access_membership(access_group.id, member.id)
+    end)
+  end
+
+  defp create_access_membership(group_id, person_id) do
+    case Access.get_group_membership(group_id: group_id, person_id: person_id) do
+      nil ->
+        Access.create_group_membership(%{
+          group_id: group_id,
+          person_id: person_id,
+        })
+      _ ->
+        :ok
+    end
+  end
+
+  defp create_access_bindings_to_member(space, context_id) do
+    members = Groups.list_members(space)
+
+    Enum.each(members, fn member ->
+      Access.get_group!(person_id: member.id)
+      |> create_access_binding(context_id, Binding.edit_access())
+    end)
+  end
+
+  defp create_access_bindings_to_company(company_id, context_id) do
+    Access.get_group!(company_id: company_id, tag: :standard)
+    |> create_access_binding(context_id, Binding.edit_access())
+
+    Access.get_group!(company_id: company_id, tag: :full_access)
+    |> create_access_binding(context_id, Binding.full_access())
+  end
+
+  defp create_access_binding(group, context_id, access_level) do
+    case Access.get_binding(group_id: group.id, context_id: context_id) do
+      nil ->
+        Access.create_binding(%{
+          group_id: group.id,
+          context_id: context_id,
+          access_level: access_level,
+        })
+      binding ->
+        Access.update_binding(binding, %{access_level: access_level})
+    end
+  end
+end

--- a/test/operately/data/change_019_create_access_groups_for_spaces_test.exs
+++ b/test/operately/data/change_019_create_access_groups_for_spaces_test.exs
@@ -1,0 +1,95 @@
+defmodule Operately.Data.Change019CreateAccessGroupsForSpacesTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Groups
+  alias Operately.Groups.{Group, Member}
+
+  setup do
+    companies = Enum.map(1..3, fn _ ->
+      company = company_fixture()
+
+      Enum.each(1..3, fn _ ->
+        group = create_group(company.id)
+        person = person_fixture_with_account(%{company_id: company.id})
+
+        Enum.each(1..3, fn _ ->
+          create_member(group.id, person.id)
+        end)
+      end)
+
+      company
+    end)
+
+    {:ok, companies: companies}
+  end
+
+  test "creates access group membership for existing people", ctx do
+    Enum.each(ctx.companies, fn company ->
+      spaces = Groups.list_groups_for_company(company.id)
+
+      Enum.each(spaces, fn space ->
+        context = Access.get_context!(group_id: space.id)
+        standard = Access.get_group!(company_id: company.id, tag: :standard)
+        full_access = Access.get_group!(company_id: company.id, tag: :full_access)
+
+        refute Access.get_binding(group_id: standard.id, context_id: context.id)
+        refute Access.get_binding(group_id: full_access.id, context_id: context.id)
+
+        refute Access.get_group(group_id: space.id, tag: :standard)
+        refute Access.get_group(group_id: space.id, tag: :full_access)
+      end)
+    end)
+
+    Operately.Data.Change019CreateAccessGroupsForSpaces.run()
+
+    Enum.each(ctx.companies, fn company ->
+      spaces = Groups.list_groups_for_company(company.id)
+
+      Enum.each(spaces, fn space ->
+        context = Access.get_context!(group_id: space.id)
+        standard = Access.get_group!(company_id: company.id, tag: :standard)
+        full_access = Access.get_group!(company_id: company.id, tag: :full_access)
+
+        assert Access.get_binding(group_id: standard.id, context_id: context.id)
+        assert Access.get_binding(group_id: full_access.id, context_id: context.id)
+
+        assert Access.get_group(group_id: space.id, tag: :full_access)
+
+        standard = Access.get_group(group_id: space.id, tag: :standard)
+        members = Groups.list_members(space)
+
+        Enum.each(members, fn member ->
+          assert Access.get_group_membership(group_id: standard.id, person_id: member.id)
+        end)
+      end)
+    end)
+  end
+
+  def create_group(company_id) do
+    {:ok, group} = Group.changeset(%{
+      company_id: company_id,
+      name: "some name",
+      mission: "some mission",
+      icon: "some icon",
+      color: "come color",
+    })
+    |> Repo.insert()
+
+    Access.create_context(%{group_id: group.id})
+
+    group
+  end
+
+  def create_member(group_id, person_id) do
+    Member.changeset(%Member{}, %{
+      group_id: group_id,
+      person_id: person_id
+    })
+    |> Repo.insert()
+  end
+end


### PR DESCRIPTION
I've added a data migration for creating the following resources for existing spaces:

- Access groups for managers and members
- Access bindings to the company's access groups
- Access binding to each of the members' access groups
- Access membership between each of the members and the new member's access group