### PR TITLE
[Draft] Update ProjectCreation operation (version 2)

### DIFF
--- a/assets/js/features/Permissions/AccessLevel.tsx
+++ b/assets/js/features/Permissions/AccessLevel.tsx
@@ -4,6 +4,7 @@ import { SelectBoxNoLabel } from "@/components/Form";
 import { IconBuildingCommunity, IconNetwork } from "@tabler/icons-react";
 import { usePermissionsContext, ReducerActions } from "./PermissionsContext";
 import { PermissionLevels, PERMISSIONS_LIST, PUBLIC_PERMISSIONS_LIST } from ".";
+import { Space } from "@/models/spaces";
 
 import { IconRocket } from "@tabler/icons-react";
 import * as Icons from "@tabler/icons-react";
@@ -16,6 +17,7 @@ interface DropdownOption {
 
 interface ResourceAccessLevelProps {
   companySpaceSelected: boolean;
+  space: Space | null;
 }
 
 
@@ -43,13 +45,13 @@ export function AccessLevel() {
 }
 
 
-export function ResourceAccessLevel({ companySpaceSelected }: ResourceAccessLevelProps) {
+export function ResourceAccessLevel({ companySpaceSelected, space }: ResourceAccessLevelProps) {
   const { permissions } = usePermissionsContext();
 
   if (permissions.public !== PermissionLevels.NO_ACCESS) {
       return (
         <AccessLevelContainer>
-          {!companySpaceSelected && <SpaceAccessLevel />}
+          {!companySpaceSelected && <SpaceAccessLevel space={space} />}
           <CompanyAccessLevel />
           <PublicAccessLevel />
         </AccessLevelContainer>
@@ -59,7 +61,7 @@ export function ResourceAccessLevel({ companySpaceSelected }: ResourceAccessLeve
   if(permissions.company !== PermissionLevels.NO_ACCESS) {
     return (
       <AccessLevelContainer>
-        {!companySpaceSelected && <SpaceAccessLevel />}
+        {!companySpaceSelected && <SpaceAccessLevel space={space} />}
         <CompanyAccessLevel />
       </AccessLevelContainer>
     );
@@ -68,7 +70,7 @@ export function ResourceAccessLevel({ companySpaceSelected }: ResourceAccessLeve
   if(permissions.space !== PermissionLevels.NO_ACCESS && !companySpaceSelected) {
     return (
       <AccessLevelContainer>
-        <SpaceAccessLevel />
+        <SpaceAccessLevel space={space} />
       </AccessLevelContainer>
     );
   }
@@ -77,8 +79,8 @@ export function ResourceAccessLevel({ companySpaceSelected }: ResourceAccessLeve
 }
 
 
-function SpaceAccessLevel() {
-  const { dispatch, permissions, space } = usePermissionsContext();
+function SpaceAccessLevel({space}: {space: Space | null}) {
+  const { dispatch, permissions } = usePermissionsContext();
 
   const currentPermission = useMemo(() => {
     return PERMISSIONS_LIST.find(option => option.value === permissions.space);

--- a/assets/js/features/Permissions/PermissionSelector.tsx
+++ b/assets/js/features/Permissions/PermissionSelector.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import PrivacyLevel from "./PrivacyLevel";
 import { AccessLevel, ResourceAccessLevel } from "./AccessLevel";
 import { ReducerActions, usePermissionsContext } from "./PermissionsContext";
+import { Space } from "@/models/spaces";
 
 
 export enum PermissionOptions {
@@ -31,8 +32,8 @@ export function SpacePermissionSelector() {
   )
 }
 
-export function ResourcePermissionSelector() {
-  const { space, company, dispatch } = usePermissionsContext();
+export function ResourcePermissionSelector({space}: {space: Space | null}) {
+  const { company, dispatch } = usePermissionsContext();
 
   const companySpaceSelected = company.companySpaceId === space?.id;
 
@@ -65,6 +66,7 @@ export function ResourcePermissionSelector() {
       />
       <ResourceAccessLevel
         companySpaceSelected={companySpaceSelected}
+        space={space}
       />
     </>
   )

--- a/assets/js/features/Permissions/PermissionsContext.tsx
+++ b/assets/js/features/Permissions/PermissionsContext.tsx
@@ -1,5 +1,4 @@
 import React, { Dispatch, ReactNode, createContext, useContext, useReducer } from "react"
-import { Space } from "@/models/spaces";
 import { Company } from "@/models/companies";
 import { PermissionLevels } from ".";
 
@@ -7,13 +6,11 @@ interface ContextType {
   company: Company;
   permissions: Permissions;
   dispatch: Dispatch<ActionOptions>;
-  space?: Space;
 }
 
 interface Props {
   children: NonNullable<ReactNode>;
   company: Company;
-  space?: Space;
 }
 
 export enum ReducerActions {
@@ -92,12 +89,11 @@ function reducerFunction(state: Permissions, action: ActionOptions) {
 }
 
 
-function PermissionsProvider({children, company, space}: Props) {
+function PermissionsProvider({children, company}: Props) {
   const [permissions, dispatch] = useReducer(reducerFunction, {...DEFAULT_PERMISSIONS});
 
   const data = {
     company,
-    space,
     permissions,
     dispatch,
   }

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -163,12 +163,15 @@ export type CreateGroupInput = {
 };
 
 export type CreateProjectInput = {
+  anonymousAccessLevel: Scalars['Int']['input'];
   championId: Scalars['ID']['input'];
+  companyAccessLevel: Scalars['Int']['input'];
   creatorIsContributor: Scalars['String']['input'];
   creatorRole?: InputMaybe<Scalars['String']['input']>;
   goalId?: InputMaybe<Scalars['ID']['input']>;
   name: Scalars['String']['input'];
   reviewerId: Scalars['ID']['input'];
+  spaceAccessLevel: Scalars['Int']['input'];
   spaceId: Scalars['ID']['input'];
   visibility: Scalars['String']['input'];
 };

--- a/assets/js/pages/ProjectAddPage/page.tsx
+++ b/assets/js/pages/ProjectAddPage/page.tsx
@@ -19,17 +19,21 @@ import { ResourcePermissionSelector } from "@/features/Permissions";
 
 
 export function Page() {
-  const { spaceID } = useLoadedData();
+  const { spaceID, company } = useLoadedData();
 
-  if (spaceID) {
-    return <NewProjectForSpacePage />;
-  } else {
-    return <NewProjectPage />;
-  }
+  return (
+    <PermissionsProvider company={company} >
+      {spaceID ?
+        <NewProjectForSpacePage />
+      :
+        <NewProjectPage />
+      }
+    </PermissionsProvider>
+  );
 }
 
 function NewProjectForSpacePage() {
-  const { space, spaceID, company } = useLoadedData();
+  const { space, spaceID } = useLoadedData();
   const form = useForm();
 
   const spaceProjectsPath = Paths.spaceProjectsPath(spaceID!);
@@ -44,9 +48,7 @@ function NewProjectForSpacePage() {
         <h1 className="mb-4 font-bold text-3xl text-center">Start a new project in {space!.name}</h1>
 
         <Paper.Body minHeight="300px">
-          <PermissionsProvider company={company} space={space}>
             <Form form={form} />
-          </PermissionsProvider>
         </Paper.Body>
 
         <SubmitButton form={form} />
@@ -56,7 +58,6 @@ function NewProjectForSpacePage() {
 }
 
 function NewProjectPage() {
-  const { company } = useLoadedData();
   const form = useForm();
 
   return (
@@ -69,9 +70,7 @@ function NewProjectPage() {
         <h1 className="mb-4 font-bold text-3xl text-center">Start a new project</h1>
 
         <Paper.Body minHeight="300px">
-          <PermissionsProvider company={company} space={form.fields.space || undefined} >
             <Form form={form} />
-          </PermissionsProvider>
         </Paper.Body>
 
         <SubmitButton form={form} />
@@ -104,7 +103,7 @@ function SubmitButton({ form }: { form: FormState }) {
 }
 
 function Form({ form }: { form: FormState }) {
-  const { allowSpaceSelection } = useLoadedData();
+  const { allowSpaceSelection, space } = useLoadedData();
   const showWillYouContribute = !form.fields.amIChampion && !form.fields.amIReviewer;
 
   return (
@@ -176,7 +175,7 @@ function Form({ form }: { form: FormState }) {
           </div>
         )}
 
-        <ResourcePermissionSelector />
+        <ResourcePermissionSelector space={space || form.fields.space} />
       </div>
     </Forms.Form>
   );

--- a/assets/js/pages/ProjectAddPage/useForm.tsx
+++ b/assets/js/pages/ProjectAddPage/useForm.tsx
@@ -9,6 +9,7 @@ import * as Spaces from "@/models/spaces";
 import * as Goals from "@/models/goals";
 
 import { useLoadedData } from "./loader";
+import { usePermissionsContext } from "@/features/Permissions/PermissionsContext";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths } from "@/routes/paths";
 
@@ -131,6 +132,7 @@ export function useForm(): FormState {
 
 function useSubmit(fields: Fields, cancelPath: string) {
   const navigate = useNavigate();
+  const { permissions } = usePermissionsContext();
 
   const [errors, setErrors] = React.useState<Error[]>([]);
 
@@ -159,6 +161,9 @@ function useSubmit(fields: Fields, cancelPath: string) {
           creatorRole: fields.creatorRole,
           spaceId: fields.space!.value,
           goalId: fields.goal?.id,
+          anonymousAccessLevel: permissions.public,
+          companyAccessLevel: permissions.company,
+          spaceAccessLevel: permissions.space,
         },
       },
     });

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -117,6 +117,15 @@ defmodule Operately.Access do
     |> maybe_insert_anonymous_binding(company_id, anonymous_access_level)
   end
 
+  def insert_bindings_to_space(multi, space_id, members_access_level) do
+    full_access = get_group!(group_id: space_id, tag: :full_access)
+    standard = get_group!(group_id: space_id, tag: :standard)
+
+    multi
+    |> insert_binding(:space_full_access_binding, full_access, Binding.full_access())
+    |> insert_binding(:space_members_binding, standard, members_access_level)
+  end
+
   defp insert_binding(multi, name, access_group, access_level) do
     Multi.insert(multi, name, fn %{context: context} ->
       Binding.changeset(%{

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -126,7 +126,7 @@ defmodule Operately.Access do
     |> insert_binding(:space_members_binding, standard, members_access_level)
   end
 
-  defp insert_binding(multi, name, access_group, access_level) do
+  def insert_binding(multi, name, access_group, access_level) do
     Multi.insert(multi, name, fn %{context: context} ->
       Binding.changeset(%{
         group_id: access_group.id,

--- a/lib/operately/operations/project_creation.ex
+++ b/lib/operately/operations/project_creation.ex
@@ -18,8 +18,9 @@ defmodule Operately.Operations.ProjectCreation do
     :visibility,
     :group_id,
     :goal_id,
-    :member_access,
-    :anonymous_access
+    :anonymous_access_level,
+    :company_access_level,
+    :space_access_level
   ]
 
   def run(%__MODULE__{} = params) do
@@ -108,7 +109,8 @@ defmodule Operately.Operations.ProjectCreation do
 
   defp insert_bindings(multi, params) do
     multi
-    |> Access.insert_bindings_to_company(params.company_id, params.member_access, params.anonymous_access)
+    |> Access.insert_bindings_to_company(params.company_id, params.company_access_level, params.anonymous_access_level)
+    |> Access.insert_bindings_to_space(params.group_id, params.space_access_level)
   end
 
   defp insert_activity(multi, params) do

--- a/lib/operately_web/graphql/mutations/projects.ex
+++ b/lib/operately_web/graphql/mutations/projects.ex
@@ -10,6 +10,9 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
     field :creator_is_contributor, non_null(:string)
     field :creator_role, :string
     field :goal_id, :id
+    field :anonymous_access_level, non_null(:integer)
+    field :company_access_level, non_null(:integer)
+    field :space_access_level, non_null(:integer)
   end
 
   input_object :add_key_resource_input do
@@ -178,7 +181,10 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           creator_id: person.id,
           company_id: person.company_id,
           group_id: args.input.space_id,
-          goal_id: args.input[:goal_id]
+          goal_id: args.input[:goal_id],
+          anonymous_access_level: args.input.anonymous_access_level,
+          company_access_level: args.input.company_access_level,
+          space_access_level: args.input.space_access_level,
         }
         |> Operately.Projects.create_project()
       end
@@ -236,8 +242,8 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           {:ok, project} = Operately.Projects.update_project(project, %{started_at: parse_date(args.start_date)})
           {:ok, _} = Operately.Projects.update_phase_history(history, %{start_time: parse_date(args.start_date)})
           {:ok, _} = Operately.Updates.record_project_start_time_changed(
-            person, 
-            project, 
+            person,
+            project,
             old_start_date,
             parse_date(args.start_date)
           )
@@ -260,8 +266,8 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           old_due_date = project.deadline
 
           {:ok, _} = Operately.Updates.record_project_end_time_changed(
-            person, 
-            project, 
+            person,
+            project,
             old_due_date,
             parse_date(args.due_date)
           )
@@ -320,7 +326,7 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           {:ok, contrib} = Operately.Projects.delete_contributor(contrib)
 
           {:ok, _} = Operately.Updates.record_project_contributor_removed(
-            person, 
+            person,
             contrib.project_id,
             contrib
           )

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -65,25 +65,25 @@ defmodule Operately.AccessContextsTest do
     test "create access_context for a company" do
       company = company_fixture()
 
-      assert nil != Access.get_context!(company_id: company.id)
+      assert Access.get_context!(company_id: company.id)
     end
 
     test "create access_context for a group", ctx do
       group = group_fixture(ctx.creator)
 
-      assert nil != Access.get_context!(group_id: group.id)
+      assert Access.get_context!(group_id: group.id)
     end
 
     test "create access_context for a goal", ctx do
       goal = goal_fixture(ctx.creator, %{space_id: ctx.group.id, targets: []})
 
-      assert nil != Access.get_context!(goal_id: goal.id)
+      assert Access.get_context!(goal_id: goal.id)
     end
 
     test "create access_context for a project", ctx do
       project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
 
-      assert nil != Access.get_context!(project_id: project.id)
+      assert Access.get_context!(project_id: project.id)
     end
 
     test "access_context cannot be attached to more than one entity", ctx do
@@ -140,6 +140,10 @@ defmodule Operately.AccessContextsTest do
       color: "come color",
     })
     |> Repo.insert()
+
+    Access.create_group(%{group_id: group.id, tag: :full_access})
+    Access.create_group(%{group_id: group.id, tag: :standard})
+
     group
   end
 

--- a/test/operately/operations/project_creation_test.exs
+++ b/test/operately/operations/project_creation_test.exs
@@ -80,6 +80,19 @@ defmodule Operately.Operations.ProjectCreationTest do
     assert Access.get_binding(group_id: members.id, context_id: context.id, access_level: Binding.edit_access())
   end
 
+  test "ProjectCreation operation creates bindings to contributors", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
+
+    context = Access.get_context!(project_id: project.id)
+    creator = Access.get_group!(person_id: ctx.creator.id)
+    reviewer = Access.get_group!(person_id: ctx.reviewer.id)
+    champion = Access.get_group!(person_id: ctx.champion.id)
+
+    assert Access.get_binding(group_id: creator.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: reviewer.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: champion.id, context_id: context.id, access_level: Binding.full_access())
+  end
+
   test "ProjectCreation operation creates activity and notification", ctx do
     {:ok, project} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.ProjectCreation.run(ctx.project_attrs)

--- a/test/operately/operations/project_creation_test.exs
+++ b/test/operately/operations/project_creation_test.exs
@@ -1,0 +1,79 @@
+defmodule Operately.Operations.ProjectCreationTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Projects
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+
+    creator = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+
+    group = group_fixture(creator)
+
+    {:ok, company: company, creator: creator, reviewer: reviewer, champion: champion, group: group}
+  end
+
+  test "ProjectCreation operation creates project", ctx do
+    attrs = %Operately.Operations.ProjectCreation{
+      name: "my project",
+      champion_id: ctx.champion.id,
+      reviewer_id: ctx.reviewer.id,
+      creator_is_contributor: "yes",
+      creator_role: "developer",
+      visibility: "everyone",
+      creator_id: ctx.creator.id,
+      company_id: ctx.company.id,
+      group_id: ctx.group.id,
+    }
+
+    {:ok, project} = Operately.Operations.ProjectCreation.run(attrs)
+
+    contributors = Projects.list_project_contributors(project)
+
+    assert 3 == length(contributors)
+
+    contributors = Enum.map(contributors, fn contributor -> {contributor.person_id, contributor.role} end)
+
+    assert Enum.member?(contributors, {ctx.creator.id, :contributor})
+    assert Enum.member?(contributors, {ctx.reviewer.id, :reviewer})
+    assert Enum.member?(contributors, {ctx.champion.id, :champion})
+  end
+
+  test "ProjectCreation operation creates activity and notification", ctx do
+    attrs = %Operately.Operations.ProjectCreation{
+      name: "my project",
+      champion_id: ctx.champion.id,
+      reviewer_id: ctx.reviewer.id,
+      creator_is_contributor: "yes",
+      creator_role: "developer",
+      visibility: "everyone",
+      creator_id: ctx.creator.id,
+      company_id: ctx.company.id,
+      group_id: ctx.group.id,
+    }
+
+    {:ok, project} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectCreation.run(attrs)
+    end)
+
+    activity = from(a in Activity, where: a.action == "project_created" and a.content["project_id"] == ^project.id) |> Repo.one()
+
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert fetch_notifications(activity.id)
+    assert 2 == notifications_count()
+  end
+end

--- a/test/operately/operations/project_creation_test.exs
+++ b/test/operately/operations/project_creation_test.exs
@@ -33,11 +33,12 @@ defmodule Operately.Operations.ProjectCreationTest do
       creator_id: creator.id,
       company_id: company.id,
       group_id: space.id,
-      member_access: Binding.comment_access(),
-      anonymous_access: Binding.view_access()
+      anonymous_access_level: Binding.view_access(),
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
     }
 
-    {:ok, company: company, creator: creator, reviewer: reviewer, champion: champion, project_attrs: project_attrs}
+    {:ok, company: company, space: space, creator: creator, reviewer: reviewer, champion: champion, project_attrs: project_attrs}
   end
 
   test "ProjectCreation operation creates project", ctx do
@@ -66,6 +67,17 @@ defmodule Operately.Operations.ProjectCreationTest do
     assert Access.get_binding(group_id: full_access.id, context_id: context.id, access_level: Binding.full_access())
     assert Access.get_binding(group_id: members.id, context_id: context.id, access_level: Binding.comment_access())
     assert Access.get_binding(group_id: anonymous.id, context_id: context.id, access_level: Binding.view_access())
+  end
+
+  test "ProjectCreation operation creates bindings to space", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
+
+    context = Access.get_context!(project_id: project.id)
+    full_access = Access.get_group!(group_id: ctx.space.id, tag: :full_access)
+    members = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+
+    assert Access.get_binding(group_id: full_access.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: members.id, context_id: context.id, access_level: Binding.edit_access())
   end
 
   test "ProjectCreation operation creates activity and notification", ctx do

--- a/test/operately/projects_test.exs
+++ b/test/operately/projects_test.exs
@@ -2,6 +2,7 @@ defmodule Operately.ProjectsTest do
   use Operately.DataCase
 
   alias Operately.Projects
+  alias Operately.Access.Binding
 
   import Operately.ProjectsFixtures
   import Operately.GroupsFixtures
@@ -48,6 +49,8 @@ defmodule Operately.ProjectsTest do
         champion_id: ctx.champion.id,
         reviewer_id: ctx.reviewer.id,
         creator_id: ctx.champion.id,
+        company_access_level: Binding.view_access(),
+        space_access_level: Binding.comment_access(),
       }
 
       assert {:ok, %Project{} = project} = Projects.create_project(project_attrs)

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -1,5 +1,6 @@
 defmodule Operately.Support.Features.ProjectSteps do
   use Operately.FeatureCase
+  alias Operately.Access.Binding
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.EmailSteps
   alias Operately.Support.Features.NotificationsSteps
@@ -57,6 +58,8 @@ defmodule Operately.Support.Features.ProjectSteps do
       creator_role: nil,
       visibility: "everyone",
       group_id: group.id,
+      company_access_level: Binding.view_access(),
+      space_access_level: Binding.comment_access(),
     }
 
     {:ok, project} = Operately.Projects.create_project(params)

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -1,4 +1,6 @@
 defmodule Operately.ProjectsFixtures do
+  alias Operately.Access.Binding
+
   @moduledoc """
   This module defines test helpers for creating
   entities via the `Operately.Projects` context.
@@ -14,7 +16,9 @@ defmodule Operately.ProjectsFixtures do
       name: "some name",
       visibility: "everyone",
       champion_id: attrs[:champion_id] || attrs[:creator_id],
-      reviewer_id: attrs[:reviewer_id] || attrs[:creator_id]
+      reviewer_id: attrs[:reviewer_id] || attrs[:creator_id],
+      company_access_level: Binding.view_access(),
+      space_access_level: Binding.comment_access(),
     }, attrs)
 
     attrs = struct!(Operately.Operations.ProjectCreation, attrs)

--- a/test/support/notifications.ex
+++ b/test/support/notifications.ex
@@ -23,6 +23,10 @@ defmodule Operately.Support.Notifications do
     from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.one()
   end
 
+  def fetch_notifications(activity_id) do
+    from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.all()
+  end
+
   def notification_message(%Person{id: id, full_name: full_name}) do
     %{
       type: :doc,


### PR DESCRIPTION
I've updated ProjectCreation operation so that it also creates `access bindings` between the project's `access context` and the company's, space's and contributors' `access groups`.

Updating the frontend side for the new operation was tricky because all the information related to the permission was inside the `PermissionsProvider`, however, the function that submits the form was in the `useForm` hook, which was outside of the provider.

I couldn't just move `useForm` into the `PermissionsProvider` because the provider takes the space as a prop which was coming from the `useForm` hook.

I've created two different solutions and I'm submitting them as drafts. 

In this one, I've moved `useForm` into `PermissionsProvider` and `PermissionsProvider` no longer takes the space as a prop. Instead, the space is passed as a prop to the `PermissionSelector` component and down to all the other components that need the space.

This way, the form can be submitted with the permissions information. The disadvantage is that the `space` prop is drilled down to many components.