### PR TITLE
Update ProjectCreation operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1453,6 +1453,9 @@ export interface CreateProjectInput {
   creatorIsContributor?: string | null;
   creatorRole?: string | null;
   goalId?: string | null;
+  anonymousAccessLevel?: number | null;
+  companyAccessLevel?: number | null;
+  spaceAccessLevel?: number | null;
 }
 
 export interface CreateProjectResult {

--- a/assets/js/features/Permissions/PermissionsContext.tsx
+++ b/assets/js/features/Permissions/PermissionsContext.tsx
@@ -7,13 +7,13 @@ interface ContextType {
   company: Company;
   permissions: Permissions;
   dispatch: Dispatch<ActionOptions>;
-  space?: Space;
+  space?: Space | null;
 }
 
 interface Props {
   children: NonNullable<ReactNode>;
   company: Company;
-  space?: Space;
+  space?: Space | null;
 }
 
 export enum ReducerActions {
@@ -35,7 +35,7 @@ type ActionOptions = { type: ReducerActions.SET_PUBLIC } |
   { type: ReducerActions.SET_SPACE_ACCESS, access_level: PermissionLevels }
 
 
-interface Permissions {
+export interface Permissions {
   public: PermissionLevels;
   company: PermissionLevels;
   space: PermissionLevels;

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -131,6 +131,48 @@ export type CreateCommentInput = {
   entityType: Scalars['String']['input'];
 };
 
+export type CreateGoalInput = {
+  championId: Scalars['ID']['input'];
+  description?: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  parentGoalId?: InputMaybe<Scalars['ID']['input']>;
+  reviewerId: Scalars['ID']['input'];
+  spaceId: Scalars['ID']['input'];
+  targets: Array<InputMaybe<CreateTargetInput>>;
+  timeframe: TimeframeInput;
+};
+
+export type CreateGroupInput = {
+  color: Scalars['String']['input'];
+  companyPermissions: Scalars['Int']['input'];
+  icon: Scalars['String']['input'];
+  mission: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  publicPermissions: Scalars['Int']['input'];
+};
+
+export type CreateProjectInput = {
+  anonymousAccessLevel: Scalars['Int']['input'];
+  championId: Scalars['ID']['input'];
+  companyAccessLevel: Scalars['Int']['input'];
+  creatorIsContributor: Scalars['String']['input'];
+  creatorRole?: InputMaybe<Scalars['String']['input']>;
+  goalId?: InputMaybe<Scalars['ID']['input']>;
+  name: Scalars['String']['input'];
+  reviewerId: Scalars['ID']['input'];
+  spaceAccessLevel: Scalars['Int']['input'];
+  spaceId: Scalars['ID']['input'];
+  visibility: Scalars['String']['input'];
+};
+
+export type CreateTargetInput = {
+  from: Scalars['Float']['input'];
+  index: Scalars['Int']['input'];
+  name: Scalars['String']['input'];
+  to: Scalars['Float']['input'];
+  unit: Scalars['String']['input'];
+};
+
 export type CreateTaskInput = {
   assigneeIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   description?: InputMaybe<Scalars['String']['input']>;

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -131,48 +131,6 @@ export type CreateCommentInput = {
   entityType: Scalars['String']['input'];
 };
 
-export type CreateGoalInput = {
-  championId: Scalars['ID']['input'];
-  description?: InputMaybe<Scalars['String']['input']>;
-  name: Scalars['String']['input'];
-  parentGoalId?: InputMaybe<Scalars['ID']['input']>;
-  reviewerId: Scalars['ID']['input'];
-  spaceId: Scalars['ID']['input'];
-  targets: Array<InputMaybe<CreateTargetInput>>;
-  timeframe: TimeframeInput;
-};
-
-export type CreateGroupInput = {
-  color: Scalars['String']['input'];
-  companyPermissions: Scalars['Int']['input'];
-  icon: Scalars['String']['input'];
-  mission: Scalars['String']['input'];
-  name: Scalars['String']['input'];
-  publicPermissions: Scalars['Int']['input'];
-};
-
-export type CreateProjectInput = {
-  anonymousAccessLevel: Scalars['Int']['input'];
-  championId: Scalars['ID']['input'];
-  companyAccessLevel: Scalars['Int']['input'];
-  creatorIsContributor: Scalars['String']['input'];
-  creatorRole?: InputMaybe<Scalars['String']['input']>;
-  goalId?: InputMaybe<Scalars['ID']['input']>;
-  name: Scalars['String']['input'];
-  reviewerId: Scalars['ID']['input'];
-  spaceAccessLevel: Scalars['Int']['input'];
-  spaceId: Scalars['ID']['input'];
-  visibility: Scalars['String']['input'];
-};
-
-export type CreateTargetInput = {
-  from: Scalars['Float']['input'];
-  index: Scalars['Int']['input'];
-  name: Scalars['String']['input'];
-  to: Scalars['Float']['input'];
-  unit: Scalars['String']['input'];
-};
-
 export type CreateTaskInput = {
   assigneeIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   description?: InputMaybe<Scalars['String']['input']>;

--- a/assets/js/pages/ProjectAddPage/page.tsx
+++ b/assets/js/pages/ProjectAddPage/page.tsx
@@ -14,23 +14,27 @@ import { FilledButton } from "@/components/Button";
 import { DimmedLink } from "@/components/Link";
 import { GoalSelectorDropdown } from "@/features/goals/GoalTree/GoalSelectorDropdown";
 import { Paths } from "@/routes/paths";
-import { PermissionsProvider } from "@/features/Permissions/PermissionsContext";
+import { PermissionsProvider, usePermissionsContext } from "@/features/Permissions/PermissionsContext";
 import { ResourcePermissionSelector } from "@/features/Permissions";
 
 
 export function Page() {
-  const { spaceID } = useLoadedData();
+  const { spaceID, company, space } = useLoadedData();
+  const form = useForm();
 
-  if (spaceID) {
-    return <NewProjectForSpacePage />;
-  } else {
-    return <NewProjectPage />;
-  }
+  return (
+    <PermissionsProvider company={company} space={space || form.fields.space} >
+      {spaceID ?
+        <NewProjectForSpacePage form={form} />
+      :
+        <NewProjectPage form={form} />
+      }
+    </PermissionsProvider>
+  );
 }
 
-function NewProjectForSpacePage() {
-  const { space, spaceID, company } = useLoadedData();
-  const form = useForm();
+function NewProjectForSpacePage({ form }: { form: FormState }) {
+  const { space, spaceID } = useLoadedData();
 
   const spaceProjectsPath = Paths.spaceProjectsPath(spaceID!);
 
@@ -44,9 +48,7 @@ function NewProjectForSpacePage() {
         <h1 className="mb-4 font-bold text-3xl text-center">Start a new project in {space!.name}</h1>
 
         <Paper.Body minHeight="300px">
-          <PermissionsProvider company={company} space={space}>
             <Form form={form} />
-          </PermissionsProvider>
         </Paper.Body>
 
         <SubmitButton form={form} />
@@ -55,10 +57,7 @@ function NewProjectForSpacePage() {
   );
 }
 
-function NewProjectPage() {
-  const { company } = useLoadedData();
-  const form = useForm();
-
+function NewProjectPage({ form }: { form: FormState }) {
   return (
     <Pages.Page title="New Project">
       <Paper.Root size="small">
@@ -69,9 +68,7 @@ function NewProjectPage() {
         <h1 className="mb-4 font-bold text-3xl text-center">Start a new project</h1>
 
         <Paper.Body minHeight="300px">
-          <PermissionsProvider company={company} space={form.fields.space || undefined} >
             <Form form={form} />
-          </PermissionsProvider>
         </Paper.Body>
 
         <SubmitButton form={form} />
@@ -81,6 +78,8 @@ function NewProjectPage() {
 }
 
 function SubmitButton({ form }: { form: FormState }) {
+  const { permissions } = usePermissionsContext();
+
   return (
     <div className="mt-8">
       {form.errors.length > 0 && (
@@ -90,7 +89,7 @@ function SubmitButton({ form }: { form: FormState }) {
       <div className="flex items-center justify-center gap-4">
         <FilledButton
           type="primary"
-          onClick={form.submit}
+          onClick={() => form.submit(permissions)}
           loading={form.submitting}
           size="lg"
           testId="save"
@@ -108,7 +107,7 @@ function Form({ form }: { form: FormState }) {
   const showWillYouContribute = !form.fields.amIChampion && !form.fields.amIReviewer;
 
   return (
-    <Forms.Form onSubmit={form.submit} loading={form.submitting} isValid={true} onCancel={form.cancel}>
+    <Forms.Form onSubmit={()=>{}} loading={form.submitting} isValid={true} onCancel={form.cancel}>
       <div className="flex flex-col gap-8">
         <div>
           <Forms.TextInput

--- a/assets/js/pages/ProjectAddPage/useForm.tsx
+++ b/assets/js/pages/ProjectAddPage/useForm.tsx
@@ -9,6 +9,7 @@ import * as Spaces from "@/models/spaces";
 import * as Goals from "@/models/goals";
 
 import { useLoadedData } from "./loader";
+import { Permissions } from "@/features/Permissions/PermissionsContext";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths } from "@/routes/paths";
 
@@ -16,7 +17,7 @@ export interface FormState {
   fields: Fields;
   errors: Error[];
   submitting: boolean;
-  submit: () => Promise<boolean>;
+  submit: (permissions: Permissions) => Promise<boolean>;
   cancel: () => void;
 }
 
@@ -136,7 +137,7 @@ function useSubmit(fields: Fields, cancelPath: string) {
 
   const [add, { loading: submitting }] = Projects.useCreateProject();
 
-  const submit = async () => {
+  const submit = async (permissions: Permissions) => {
     let errors = validate(fields);
 
     if (errors.length > 0) {
@@ -153,6 +154,9 @@ function useSubmit(fields: Fields, cancelPath: string) {
       creatorRole: fields.creatorRole,
       spaceId: fields.space!.value,
       goalId: fields.goal?.id,
+      anonymousAccessLevel: permissions.public,
+      companyAccessLevel: permissions.company,
+      spaceAccessLevel: permissions.space,
     });
 
     navigate(Paths.projectPath(res.project.id!));

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -1,7 +1,8 @@
 defmodule Operately.Access do
   import Ecto.Query, warn: false
-  alias Operately.Repo
 
+  alias Ecto.Multi
+  alias Operately.Repo
   alias Operately.Access.Context
 
   def list_contexts do
@@ -104,6 +105,44 @@ defmodule Operately.Access do
 
   def change_binding(%Binding{} = binding, attrs \\ %{}) do
     Binding.changeset(binding, attrs)
+  end
+
+  def insert_bindings_to_company(multi, company_id, members_access_level, anonymous_access_level \\ 0) do
+    full_access = get_group!(company_id: company_id, tag: :full_access)
+    standard = get_group!(company_id: company_id, tag: :standard)
+
+    multi
+    |> insert_binding(:company_full_access_binding, full_access, Binding.full_access())
+    |> insert_binding(:company_members_binding, standard, members_access_level)
+    |> maybe_insert_anonymous_binding(company_id, anonymous_access_level)
+  end
+
+  def insert_bindings_to_space(multi, space_id, members_access_level) do
+    full_access = get_group!(group_id: space_id, tag: :full_access)
+    standard = get_group!(group_id: space_id, tag: :standard)
+
+    multi
+    |> insert_binding(:space_full_access_binding, full_access, Binding.full_access())
+    |> insert_binding(:space_members_binding, standard, members_access_level)
+  end
+
+  def insert_binding(multi, name, access_group, access_level) do
+    Multi.insert(multi, name, fn %{context: context} ->
+      Binding.changeset(%{
+        group_id: access_group.id,
+        context_id: context.id,
+        access_level: access_level,
+      })
+    end)
+  end
+
+  defp maybe_insert_anonymous_binding(multi, company_id, access_level) do
+    if access_level == Binding.view_access() do
+      anonymous = get_group!(company_id: company_id, tag: :anonymous)
+      insert_binding(multi, :anonymous_binding, anonymous, Binding.view_access())
+    else
+      multi
+    end
   end
 
 

--- a/lib/operately_web/api/mutations/create_project.ex
+++ b/lib/operately_web/api/mutations/create_project.ex
@@ -11,6 +11,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
     field :creator_is_contributor, :string
     field :creator_role, :string
     field :goal_id, :string
+    field :anonymous_access_level, :integer
+    field :company_access_level, :integer
+    field :space_access_level, :integer
   end
 
   outputs do
@@ -19,7 +22,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
 
   def call(conn, inputs) do
     person = me(conn)
-    
+
     {:ok, space_id} = decode_id(inputs.space_id, :allow_nil)
 
     args = %Operately.Operations.ProjectCreation{
@@ -32,9 +35,12 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
       creator_id: person.id,
       company_id: person.company_id,
       group_id: space_id,
-      goal_id: inputs[:goal_id]
+      goal_id: inputs[:goal_id],
+      anonymous_access_level: inputs.anonymous_access_level,
+      company_access_level: inputs.company_access_level,
+      space_access_level: inputs.space_access_level,
     }
-    
+
     {:ok, project} = Operately.Projects.create_project(args)
 
     {:ok, %{project: Serializer.serialize(project, level: :essential)}}

--- a/lib/operately_web/graphql/mutations/projects.ex
+++ b/lib/operately_web/graphql/mutations/projects.ex
@@ -1,20 +1,6 @@
 defmodule OperatelyWeb.Graphql.Mutations.Projects do
   use Absinthe.Schema.Notation
 
-  # input_object :create_project_input do
-  #   field :space_id, non_null(:id)
-  #   field :name, non_null(:string)
-  #   field :champion_id, non_null(:id)
-  #   field :reviewer_id, non_null(:id)
-  #   field :visibility, non_null(:string)
-  #   field :creator_is_contributor, non_null(:string)
-  #   field :creator_role, :string
-  #   field :goal_id, :id
-  #   field :anonymous_access_level, non_null(:integer)
-  #   field :company_access_level, non_null(:integer)
-  #   field :space_access_level, non_null(:integer)
-  # end
-
   input_object :add_key_resource_input do
     field :project_id, non_null(:id)
     field :title, non_null(:string)
@@ -147,31 +133,6 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
         Operately.Projects.EditTimelineOperation.run(author, project, attrs)
       end
     end
-
-    # field :create_project, non_null(:project) do
-    #   arg :input, non_null(:create_project_input)
-
-    #   resolve fn args, %{context: context} ->
-    #     person = context.current_account.person
-
-    #     %Operately.Operations.ProjectCreation{
-    #       name: args.input.name,
-    #       champion_id: args.input.champion_id,
-    #       reviewer_id: args.input.reviewer_id,
-    #       creator_is_contributor: args.input[:creator_is_contributor],
-    #       creator_role: args.input[:creator_role],
-    #       visibility: args.input.visibility,
-    #       creator_id: person.id,
-    #       company_id: person.company_id,
-    #       group_id: args.input.space_id,
-    #       goal_id: args.input[:goal_id],
-    #       anonymous_access_level: args.input.anonymous_access_level,
-    #       company_access_level: args.input.company_access_level,
-    #       space_access_level: args.input.space_access_level,
-    #     }
-    #     |> Operately.Projects.create_project()
-    #   end
-    # end
 
     field :add_key_resource, non_null(:project_key_resource) do
       arg :input, non_null(:add_key_resource_input)

--- a/lib/operately_web/graphql/mutations/projects.ex
+++ b/lib/operately_web/graphql/mutations/projects.ex
@@ -1,6 +1,20 @@
 defmodule OperatelyWeb.Graphql.Mutations.Projects do
   use Absinthe.Schema.Notation
 
+  # input_object :create_project_input do
+  #   field :space_id, non_null(:id)
+  #   field :name, non_null(:string)
+  #   field :champion_id, non_null(:id)
+  #   field :reviewer_id, non_null(:id)
+  #   field :visibility, non_null(:string)
+  #   field :creator_is_contributor, non_null(:string)
+  #   field :creator_role, :string
+  #   field :goal_id, :id
+  #   field :anonymous_access_level, non_null(:integer)
+  #   field :company_access_level, non_null(:integer)
+  #   field :space_access_level, non_null(:integer)
+  # end
+
   input_object :add_key_resource_input do
     field :project_id, non_null(:id)
     field :title, non_null(:string)
@@ -134,6 +148,31 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
       end
     end
 
+    # field :create_project, non_null(:project) do
+    #   arg :input, non_null(:create_project_input)
+
+    #   resolve fn args, %{context: context} ->
+    #     person = context.current_account.person
+
+    #     %Operately.Operations.ProjectCreation{
+    #       name: args.input.name,
+    #       champion_id: args.input.champion_id,
+    #       reviewer_id: args.input.reviewer_id,
+    #       creator_is_contributor: args.input[:creator_is_contributor],
+    #       creator_role: args.input[:creator_role],
+    #       visibility: args.input.visibility,
+    #       creator_id: person.id,
+    #       company_id: person.company_id,
+    #       group_id: args.input.space_id,
+    #       goal_id: args.input[:goal_id],
+    #       anonymous_access_level: args.input.anonymous_access_level,
+    #       company_access_level: args.input.company_access_level,
+    #       space_access_level: args.input.space_access_level,
+    #     }
+    #     |> Operately.Projects.create_project()
+    #   end
+    # end
+
     field :add_key_resource, non_null(:project_key_resource) do
       arg :input, non_null(:add_key_resource_input)
 
@@ -186,8 +225,8 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           {:ok, project} = Operately.Projects.update_project(project, %{started_at: parse_date(args.start_date)})
           {:ok, _} = Operately.Projects.update_phase_history(history, %{start_time: parse_date(args.start_date)})
           {:ok, _} = Operately.Updates.record_project_start_time_changed(
-            person, 
-            project, 
+            person,
+            project,
             old_start_date,
             parse_date(args.start_date)
           )
@@ -210,8 +249,8 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           old_due_date = project.deadline
 
           {:ok, _} = Operately.Updates.record_project_end_time_changed(
-            person, 
-            project, 
+            person,
+            project,
             old_due_date,
             parse_date(args.due_date)
           )
@@ -270,7 +309,7 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
           {:ok, contrib} = Operately.Projects.delete_contributor(contrib)
 
           {:ok, _} = Operately.Updates.record_project_contributor_removed(
-            person, 
+            person,
             contrib.project_id,
             contrib
           )

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -65,25 +65,25 @@ defmodule Operately.AccessContextsTest do
     test "create access_context for a company" do
       company = company_fixture()
 
-      assert nil != Access.get_context!(company_id: company.id)
+      assert Access.get_context!(company_id: company.id)
     end
 
     test "create access_context for a group", ctx do
       group = group_fixture(ctx.creator)
 
-      assert nil != Access.get_context!(group_id: group.id)
+      assert Access.get_context!(group_id: group.id)
     end
 
     test "create access_context for a goal", ctx do
       goal = goal_fixture(ctx.creator, %{space_id: ctx.group.id, targets: []})
 
-      assert nil != Access.get_context!(goal_id: goal.id)
+      assert Access.get_context!(goal_id: goal.id)
     end
 
     test "create access_context for a project", ctx do
       project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.group.id, creator_id: ctx.creator.id})
 
-      assert nil != Access.get_context!(project_id: project.id)
+      assert Access.get_context!(project_id: project.id)
     end
 
     test "access_context cannot be attached to more than one entity", ctx do
@@ -140,6 +140,10 @@ defmodule Operately.AccessContextsTest do
       color: "come color",
     })
     |> Repo.insert()
+
+    Access.create_group(%{group_id: group.id, tag: :full_access})
+    Access.create_group(%{group_id: group.id, tag: :standard})
+
     group
   end
 

--- a/test/operately/operations/project_creation_test.exs
+++ b/test/operately/operations/project_creation_test.exs
@@ -1,0 +1,79 @@
+defmodule Operately.Operations.ProjectCreationTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Projects
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+
+    creator = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+
+    group = group_fixture(creator)
+
+    {:ok, company: company, creator: creator, reviewer: reviewer, champion: champion, group: group}
+  end
+
+  test "ProjectCreation operation creates project", ctx do
+    attrs = %Operately.Operations.ProjectCreation{
+      name: "my project",
+      champion_id: ctx.champion.id,
+      reviewer_id: ctx.reviewer.id,
+      creator_is_contributor: "yes",
+      creator_role: "developer",
+      visibility: "everyone",
+      creator_id: ctx.creator.id,
+      company_id: ctx.company.id,
+      group_id: ctx.group.id,
+    }
+
+    {:ok, project} = Operately.Operations.ProjectCreation.run(attrs)
+
+    contributors = Projects.list_project_contributors(project)
+
+    assert 3 == length(contributors)
+
+    contributors = Enum.map(contributors, fn contributor -> {contributor.person_id, contributor.role} end)
+
+    assert Enum.member?(contributors, {ctx.creator.id, :contributor})
+    assert Enum.member?(contributors, {ctx.reviewer.id, :reviewer})
+    assert Enum.member?(contributors, {ctx.champion.id, :champion})
+  end
+
+  test "ProjectCreation operation creates activity and notification", ctx do
+    attrs = %Operately.Operations.ProjectCreation{
+      name: "my project",
+      champion_id: ctx.champion.id,
+      reviewer_id: ctx.reviewer.id,
+      creator_is_contributor: "yes",
+      creator_role: "developer",
+      visibility: "everyone",
+      creator_id: ctx.creator.id,
+      company_id: ctx.company.id,
+      group_id: ctx.group.id,
+    }
+
+    {:ok, project} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectCreation.run(attrs)
+    end)
+
+    activity = from(a in Activity, where: a.action == "project_created" and a.content["project_id"] == ^project.id) |> Repo.one()
+
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert fetch_notifications(activity.id)
+    assert 2 == notifications_count()
+  end
+end

--- a/test/operately/operations/project_creation_test.exs
+++ b/test/operately/operations/project_creation_test.exs
@@ -10,6 +10,8 @@ defmodule Operately.Operations.ProjectCreationTest do
 
   alias Operately.Repo
   alias Operately.Projects
+  alias Operately.Access
+  alias Operately.Access.Binding
   alias Operately.Activities.Activity
 
   setup do
@@ -19,25 +21,28 @@ defmodule Operately.Operations.ProjectCreationTest do
     reviewer = person_fixture_with_account(%{company_id: company.id})
     champion = person_fixture_with_account(%{company_id: company.id})
 
-    group = group_fixture(creator)
+    space = group_fixture(creator)
 
-    {:ok, company: company, creator: creator, reviewer: reviewer, champion: champion, group: group}
-  end
-
-  test "ProjectCreation operation creates project", ctx do
-    attrs = %Operately.Operations.ProjectCreation{
+    project_attrs = %Operately.Operations.ProjectCreation{
       name: "my project",
-      champion_id: ctx.champion.id,
-      reviewer_id: ctx.reviewer.id,
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
       creator_is_contributor: "yes",
       creator_role: "developer",
       visibility: "everyone",
-      creator_id: ctx.creator.id,
-      company_id: ctx.company.id,
-      group_id: ctx.group.id,
+      creator_id: creator.id,
+      company_id: company.id,
+      group_id: space.id,
+      anonymous_access_level: Binding.view_access(),
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
     }
 
-    {:ok, project} = Operately.Operations.ProjectCreation.run(attrs)
+    {:ok, company: company, space: space, creator: creator, reviewer: reviewer, champion: champion, project_attrs: project_attrs}
+  end
+
+  test "ProjectCreation operation creates project", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
 
     contributors = Projects.list_project_contributors(project)
 
@@ -50,21 +55,47 @@ defmodule Operately.Operations.ProjectCreationTest do
     assert Enum.member?(contributors, {ctx.champion.id, :champion})
   end
 
-  test "ProjectCreation operation creates activity and notification", ctx do
-    attrs = %Operately.Operations.ProjectCreation{
-      name: "my project",
-      champion_id: ctx.champion.id,
-      reviewer_id: ctx.reviewer.id,
-      creator_is_contributor: "yes",
-      creator_role: "developer",
-      visibility: "everyone",
-      creator_id: ctx.creator.id,
-      company_id: ctx.company.id,
-      group_id: ctx.group.id,
-    }
+  test "ProjectCreation operation creates bindings to company", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
 
+    context = Access.get_context!(project_id: project.id)
+
+    full_access = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
+    members = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    anonymous = Access.get_group!(company_id: ctx.company.id, tag: :anonymous)
+
+    assert Access.get_binding(group_id: full_access.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: members.id, context_id: context.id, access_level: Binding.comment_access())
+    assert Access.get_binding(group_id: anonymous.id, context_id: context.id, access_level: Binding.view_access())
+  end
+
+  test "ProjectCreation operation creates bindings to space", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
+
+    context = Access.get_context!(project_id: project.id)
+    full_access = Access.get_group!(group_id: ctx.space.id, tag: :full_access)
+    members = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+
+    assert Access.get_binding(group_id: full_access.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: members.id, context_id: context.id, access_level: Binding.edit_access())
+  end
+
+  test "ProjectCreation operation creates bindings to contributors", ctx do
+    {:ok, project} = Operately.Operations.ProjectCreation.run(ctx.project_attrs)
+
+    context = Access.get_context!(project_id: project.id)
+    creator = Access.get_group!(person_id: ctx.creator.id)
+    reviewer = Access.get_group!(person_id: ctx.reviewer.id)
+    champion = Access.get_group!(person_id: ctx.champion.id)
+
+    assert Access.get_binding(group_id: creator.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: reviewer.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: champion.id, context_id: context.id, access_level: Binding.full_access())
+  end
+
+  test "ProjectCreation operation creates activity and notification", ctx do
     {:ok, project} = Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.ProjectCreation.run(attrs)
+      Operately.Operations.ProjectCreation.run(ctx.project_attrs)
     end)
 
     activity = from(a in Activity, where: a.action == "project_created" and a.content["project_id"] == ^project.id) |> Repo.one()

--- a/test/operately/projects_test.exs
+++ b/test/operately/projects_test.exs
@@ -2,6 +2,7 @@ defmodule Operately.ProjectsTest do
   use Operately.DataCase
 
   alias Operately.Projects
+  alias Operately.Access.Binding
 
   import Operately.ProjectsFixtures
   import Operately.GroupsFixtures
@@ -48,6 +49,8 @@ defmodule Operately.ProjectsTest do
         champion_id: ctx.champion.id,
         reviewer_id: ctx.reviewer.id,
         creator_id: ctx.champion.id,
+        company_access_level: Binding.view_access(),
+        space_access_level: Binding.comment_access(),
       }
 
       assert {:ok, %Project{} = project} = Projects.create_project(project_attrs)

--- a/test/operately_email/project_created_email_test.exs
+++ b/test/operately_email/project_created_email_test.exs
@@ -6,6 +6,8 @@ defmodule OperatelyEmail.ProjectCreatedEmailTest do
   import Operately.GroupsFixtures
   import Operately.CompaniesFixtures
 
+  alias Operately.Access.Binding
+
   setup do
     company = company_fixture()
 
@@ -21,11 +23,13 @@ defmodule OperatelyEmail.ProjectCreatedEmailTest do
       champion_id: champion.id,
       reviewer_id: reviewer.id,
       group_id: group.id,
+      company_access_level: Binding.view_access(),
+      space_access_level: Binding.comment_access(),
     })
 
     {:ok, %{
-      company: company, 
-      project: project, 
+      company: company,
+      project: project,
       champion: champion,
       reviewer: reviewer,
     }}

--- a/test/operately_web/api/queries/get_companies_test.exs
+++ b/test/operately_web/api/queries/get_companies_test.exs
@@ -1,4 +1,4 @@
-defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
+defmodule OperatelyWeb.Api.Queries.GetCompaniesTest do
   use OperatelyWeb.TurboCase
 
   import Operately.CompaniesFixtures
@@ -52,11 +52,11 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
       assert length(res.companies) == 3
 
       # reload companies with member count so that we can compare the serialized response
-      [c1, c2, c3] = 
-        [ctx.company, company1, company2] 
+      [c1, c2, c3] =
+        [ctx.company, company1, company2]
         |> Enum.map(fn c -> Operately.Companies.get_company!(c.id) end)
         |> Company.load_member_count()
-      
+
       assert find_in_response(res, ctx.company) == Serializer.serialize(c1, level: :full)
       assert find_in_response(res, company1) == Serializer.serialize(c2, level: :full)
       assert find_in_response(res, company2) == Serializer.serialize(c3, level: :full)

--- a/test/operately_web/api/queries/get_project_test.exs
+++ b/test/operately_web/api/queries/get_project_test.exs
@@ -3,7 +3,6 @@ defmodule OperatelyWeb.Api.Queries.GetProjectTest do
 
   import OperatelyWeb.Api.Serializer
   import Operately.ProjectsFixtures
-  import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import Operately.GoalsFixtures
   import Operately.GroupsFixtures
@@ -17,9 +16,8 @@ defmodule OperatelyWeb.Api.Queries.GetProjectTest do
       ctx = register_and_log_in_account(ctx)
       project = create_project(ctx)
 
-      other_company = company_fixture()
-      other_person = person_fixture(company_id: other_company.id)
-      other_project = create_project(ctx, company_id: other_company.id, creator_id: other_person.id)
+      other_ctx = register_and_log_in_account(ctx)
+      other_project = create_project(other_ctx, company_id: other_ctx.company.id, creator_id: other_ctx.person.id)
 
       assert {404, "Not found"} = query(ctx.conn, :get_project, %{id: other_project.id})
       assert {200, _} = query(ctx.conn, :get_project, %{id: project.id})
@@ -146,12 +144,12 @@ defmodule OperatelyWeb.Api.Queries.GetProjectTest do
 
   def create_project(ctx, attrs \\ %{}) do
     attrs = Map.merge(%{
-      company_id: ctx.company.id, 
-      name: "Project 1", 
-      creator_id: ctx.person.id, 
+      company_id: ctx.company.id,
+      name: "Project 1",
+      creator_id: ctx.person.id,
       group_id: ctx.company.company_space_id
     }, Enum.into(attrs, %{}))
 
     project_fixture(attrs)
   end
-end 
+end

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -1,5 +1,6 @@
 defmodule Operately.Support.Features.ProjectSteps do
   use Operately.FeatureCase
+  alias Operately.Access.Binding
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.EmailSteps
   alias Operately.Support.Features.NotificationsSteps
@@ -57,6 +58,8 @@ defmodule Operately.Support.Features.ProjectSteps do
       creator_role: nil,
       visibility: "everyone",
       group_id: group.id,
+      company_access_level: Binding.view_access(),
+      space_access_level: Binding.comment_access(),
     }
 
     {:ok, project} = Operately.Projects.create_project(params)

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -1,4 +1,6 @@
 defmodule Operately.ProjectsFixtures do
+  alias Operately.Access.Binding
+
   @moduledoc """
   This module defines test helpers for creating
   entities via the `Operately.Projects` context.
@@ -14,7 +16,9 @@ defmodule Operately.ProjectsFixtures do
       name: "some name",
       visibility: "everyone",
       champion_id: attrs[:champion_id] || attrs[:creator_id],
-      reviewer_id: attrs[:reviewer_id] || attrs[:creator_id]
+      reviewer_id: attrs[:reviewer_id] || attrs[:creator_id],
+      company_access_level: Binding.view_access(),
+      space_access_level: Binding.comment_access(),
     }, attrs)
 
     attrs = struct!(Operately.Operations.ProjectCreation, attrs)

--- a/test/support/notifications.ex
+++ b/test/support/notifications.ex
@@ -23,6 +23,10 @@ defmodule Operately.Support.Notifications do
     from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.one()
   end
 
+  def fetch_notifications(activity_id) do
+    from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.all()
+  end
+
   def notification_message(%Person{id: id, full_name: full_name}) do
     %{
       type: :doc,


### PR DESCRIPTION
I've updated ProjectCreation operation so that it also creates `access bindings` between the project's `access context` and the company's, space's and contributors' `access groups`.

Updating the frontend side for the new operation was tricky because all the information related to the permission was inside the `PermissionsProvider`, however, the function that submits the form was in the `useForm` hook, which was outside of the provider.

I couldn't just move `useForm` into the `PermissionsProvider` because the provider takes the space as a prop which was coming from the `useForm` hook.

I've created two different solutions and I'm submitting them as drafts. 

In this one, I'm passing the permissions information as an argument to the submit function. The implementation is not perfectly clean, but at least we get to keep `space` as part of the context provider and we don't have to drill it down to all the components that need it, unlike in https://github.com/operately/operately/pull/696.