### PR TITLE
Update ProjectContributorAddition operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1285,6 +1285,7 @@ export interface AddProjectContributorInput {
   projectId?: string | null;
   personId?: string | null;
   responsibility?: string | null;
+  permissions?: number | null;
 }
 
 export interface AddProjectContributorResult {

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1282,11 +1282,13 @@ export interface AddKeyResourceResult {
 
 
 export interface AddProjectContributorInput {
-
+  projectId?: string | null;
+  personId?: string | null;
+  responsibility?: string | null;
 }
 
 export interface AddProjectContributorResult {
-
+  projectContributor?: ProjectContributor | null;
 }
 
 

--- a/assets/js/features/Permissions/index.tsx
+++ b/assets/js/features/Permissions/index.tsx
@@ -8,13 +8,23 @@ export enum PermissionLevels {
   NO_ACCESS=0,
 };
 
+export interface PermissionOption {
+  value: PermissionLevels,
+  label: string,
+}
+
+export const VIEW_ACCESS = {
+  value: PermissionLevels.VIEW_ACCESS,
+  label: "Can View",
+};
+
 export const PERMISSIONS_LIST = [
   {value: PermissionLevels.FULL_ACCESS, label: "Has Full Access"},
   {value: PermissionLevels.EDIT_ACCESS, label: "Can Edit"},
   {value: PermissionLevels.COMMENT_ACCESS, label: "Can Comment"},
-  {value: PermissionLevels.VIEW_ACCESS, label: "Can View"},
+  VIEW_ACCESS,
 ]
 
 export const PUBLIC_PERMISSIONS_LIST = [
-  {value: PermissionLevels.VIEW_ACCESS, label: "Can View"},
+  VIEW_ACCESS,
 ]

--- a/assets/js/gql/generated.tsx
+++ b/assets/js/gql/generated.tsx
@@ -448,7 +448,6 @@ export type RootMutationType = {
   addCompanyTrustedEmailDomain: Company;
   addFirstCompany: Company;
   addKeyResource: ProjectKeyResource;
-  addProjectContributor: ProjectContributor;
   addProjectMilestone: Milestone;
   addReaction?: Maybe<Reaction>;
   archiveGoal?: Maybe<Goal>;
@@ -530,14 +529,6 @@ export type RootMutationTypeAddFirstCompanyArgs = {
 
 export type RootMutationTypeAddKeyResourceArgs = {
   input: AddKeyResourceInput;
-};
-
-
-export type RootMutationTypeAddProjectContributorArgs = {
-  personId: Scalars['ID']['input'];
-  projectId: Scalars['ID']['input'];
-  responsibility: Scalars['String']['input'];
-  role: Scalars['String']['input'];
 };
 
 

--- a/assets/js/pages/ProjectContributorsPage/FormElements.tsx
+++ b/assets/js/pages/ProjectContributorsPage/FormElements.tsx
@@ -5,6 +5,8 @@ import * as Icons from "@tabler/icons-react";
 
 import Button from "@/components/Button";
 import PeopleSearch from "@/components/PeopleSearch";
+import { SelectBox } from "@/components/Form";
+import { PERMISSIONS_LIST } from "@/features/Permissions";
 
 export function ContributorSearch({ projectID, title, onSelect, defaultValue = undefined }) {
   const loader = Projects.useProjectContributorCandidatesQuery(projectID);
@@ -26,7 +28,7 @@ export function ContributorSearch({ projectID, title, onSelect, defaultValue = u
 
 export function ResponsibilityInput({ value, onChange }) {
   return (
-    <div className="">
+    <div className="mb-6">
       <label className="font-bold mb-1 block">What are the responsibilities of this contributor?</label>
       <div className="flex-1">
         <input
@@ -40,6 +42,17 @@ export function ResponsibilityInput({ value, onChange }) {
       </div>
     </div>
   );
+}
+
+export function PermissionsInput({value, onChange}) {
+  return (
+    <SelectBox
+      label="What are the permissions of this contributor"
+      onChange={onChange}
+      options={PERMISSIONS_LIST}
+      value={value}
+    />
+  )
 }
 
 export function RemoveButton({ onClick }) {
@@ -68,9 +81,9 @@ export function SaveButton({ disabled, onClick }) {
   );
 }
 
-export function AddContribButton({ disabled, onClick }) {
+export function AddContribButton({ disabled, onClick, loading }) {
   return (
-    <Button variant="success" disabled={disabled} onClick={onClick} data-test-id="save-contributor">
+    <Button loading={loading} variant="success" disabled={disabled} onClick={onClick} data-test-id="save-contributor">
       <Icons.IconPlus size={20} />
       Add Contributor
     </Button>

--- a/assets/js/pages/ProjectContributorsPage/page.tsx
+++ b/assets/js/pages/ProjectContributorsPage/page.tsx
@@ -6,12 +6,13 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 
 import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { ContributorSearch, ResponsibilityInput, CancelButton, AddContribButton } from "./FormElements";
+import { ContributorSearch, ResponsibilityInput, CancelButton, AddContribButton, PermissionsInput } from "./FormElements";
 import ContributorItem from "./ContributorItem";
 import { FilledButton } from "@/components/Button";
 
 import { useLoadedData, useRefresh } from "./loader";
-import { useForm } from "./useForm";
+import { useForm, FormState } from "./useForm";
+
 
 export function Page() {
   const { project } = useLoadedData();
@@ -33,7 +34,7 @@ export function Page() {
   );
 }
 
-function Title({ form }) {
+function Title({ form }: { form: FormState }) {
   return (
     <div className="rounded-t-[20px] pb-12">
       <div className="flex items-center justify-between">
@@ -50,15 +51,21 @@ function Title({ form }) {
   );
 }
 
-function AddContribForm({ form }) {
+function AddContribForm({ form }: { form: FormState }) {
   return (
     <div className="bg-surface-dimmed border-y border-surface-outline -mx-12 px-12 mt-4 py-8">
       <ContributorSearch title="Contributor" projectID={form.project.id} onSelect={form.addContrib.setPersonID} />
 
       <ResponsibilityInput value={form.addContrib.responsibility} onChange={form.addContrib.setResponsibility} />
 
+      <PermissionsInput value={form.addContrib.permissions} onChange={form.addContrib.setPermissions} />
+
       <div className="flex mt-8 gap-2">
-        <AddContribButton onClick={form.addContrib.submit} disabled={!form.addContrib.submittable} />
+        <AddContribButton
+          onClick={form.addContrib.submit}
+          loading={form.addContrib.submitting}
+          disabled={!form.addContrib.submittable}
+        />
         <CancelButton onClick={form.addContrib.deactivate} />
       </div>
     </div>

--- a/assets/js/pages/ProjectContributorsPage/useForm.tsx
+++ b/assets/js/pages/ProjectContributorsPage/useForm.tsx
@@ -3,6 +3,7 @@ import * as Projects from "@/models/projects";
 
 import { useRefresh } from "./loader";
 import { useAddProjectContributor } from "@/api";
+import { VIEW_ACCESS, PermissionOption } from "@/features/Permissions";
 
 
 export interface FormState {
@@ -29,6 +30,8 @@ interface AddColobState {
   setPersonID: (id: string) => void;
   responsibility: string;
   setResponsibility: (responsibility: string) => void;
+  permissions: PermissionOption,
+  setPermissions: (permission: PermissionOption) => void,
 
   submit: () => void;
   submittable: boolean;
@@ -46,6 +49,7 @@ function useAddContrib(project: Projects.Project): AddColobState {
 
   const [personID, setPersonID] = React.useState<string | null>(null);
   const [responsibility, setResponsibility] = React.useState("");
+  const [permissions, setPermissions] = React.useState(VIEW_ACCESS);
 
   const submittable = !!personID && !!responsibility;
 
@@ -58,6 +62,7 @@ function useAddContrib(project: Projects.Project): AddColobState {
       projectId: project.id,
       personId: personID,
       responsibility: responsibility,
+      permissions: permissions.value,
     });
 
     refresh();
@@ -74,6 +79,8 @@ function useAddContrib(project: Projects.Project): AddColobState {
     setPersonID,
     responsibility,
     setResponsibility,
+    permissions,
+    setPermissions,
 
     submit,
     submittable,

--- a/assets/js/pages/ProjectContributorsPage/useForm.tsx
+++ b/assets/js/pages/ProjectContributorsPage/useForm.tsx
@@ -2,8 +2,10 @@ import * as React from "react";
 import * as Projects from "@/models/projects";
 
 import { useRefresh } from "./loader";
+import { useAddProjectContributor } from "@/api";
 
-interface FormState {
+
+export interface FormState {
   project: Projects.Project;
   addContrib: AddColobState;
 }
@@ -30,6 +32,7 @@ interface AddColobState {
 
   submit: () => void;
   submittable: boolean;
+  submitting: boolean;
 }
 
 function useAddContrib(project: Projects.Project): AddColobState {
@@ -46,12 +49,17 @@ function useAddContrib(project: Projects.Project): AddColobState {
 
   const submittable = !!personID && !!responsibility;
 
-  const [addColab, _s] = Projects.useAddProjectContributorMutation(project.id!);
+  const [add, { loading: submitting }] = useAddProjectContributor();
 
   const submit = async () => {
     if (!submittable) return;
 
-    await addColab(personID, responsibility);
+    await add({
+      projectId: project.id,
+      personId: personID,
+      responsibility: responsibility,
+    });
+
     refresh();
     deactivate();
   };
@@ -69,5 +77,6 @@ function useAddContrib(project: Projects.Project): AddColobState {
 
     submit,
     submittable,
+    submitting,
   };
 }

--- a/lib/operately_web/api/mutations/add_project_contributor.ex
+++ b/lib/operately_web/api/mutations/add_project_contributor.ex
@@ -1,15 +1,26 @@
 defmodule OperatelyWeb.Api.Mutations.AddProjectContributor do
   use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
 
   inputs do
-    # TODO: Define input fields
+    field :project_id, :string
+    field :person_id, :string
+    field :responsibility, :string
   end
 
   outputs do
-    # TODO: Define output fields
+    field :project_contributor, :project_contributor
   end
 
-  def call(_conn, _inputs) do
-    raise "Not implemented"
+  def call(conn, inputs) do
+    person = me(conn)
+
+    {:ok, contributor} = Operately.Operations.ProjectContributorAddition.run(person, %{
+      project_id: inputs.project_id,
+      person_id: inputs.person_id,
+      responsibility: inputs.responsibility,
+    })
+
+    {:ok, %{contributor: Serializer.serialize(contributor, level: :essential)}}
   end
 end

--- a/lib/operately_web/api/mutations/add_project_contributor.ex
+++ b/lib/operately_web/api/mutations/add_project_contributor.ex
@@ -6,6 +6,7 @@ defmodule OperatelyWeb.Api.Mutations.AddProjectContributor do
     field :project_id, :string
     field :person_id, :string
     field :responsibility, :string
+    field :permissions, :integer
   end
 
   outputs do
@@ -19,6 +20,7 @@ defmodule OperatelyWeb.Api.Mutations.AddProjectContributor do
       project_id: inputs.project_id,
       person_id: inputs.person_id,
       responsibility: inputs.responsibility,
+      permissions: inputs.permissions,
     })
 
     {:ok, %{contributor: Serializer.serialize(contributor, level: :essential)}}

--- a/lib/operately_web/graphql/mutations/projects.ex
+++ b/lib/operately_web/graphql/mutations/projects.ex
@@ -225,24 +225,6 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
     # Contributors
     #
 
-    field :add_project_contributor, non_null(:project_contributor) do
-      arg :project_id, non_null(:id)
-      arg :person_id, non_null(:id)
-      arg :responsibility, non_null(:string)
-      arg :role, non_null(:string)
-
-      resolve fn args, %{context: context} ->
-        person = context.current_account.person
-
-        Operately.Operations.ProjectContributorAddition.run(person, %{
-          project_id: args.project_id,
-          person_id: args.person_id,
-          responsibility: args.responsibility,
-          role: args.role
-        })
-      end
-    end
-
     field :update_project_contributor, non_null(:project_contributor) do
       arg :contrib_id, non_null(:id)
       arg :person_id, non_null(:id)
@@ -318,7 +300,6 @@ defmodule OperatelyWeb.Graphql.Mutations.Projects do
         Operately.Operations.ProjectGoalDisconnection.run(person, project, goal)
       end
     end
-
   end
 
   defp parse_date(date) do

--- a/test/operately/operations/project_contributor_addition_test.exs
+++ b/test/operately/operations/project_contributor_addition_test.exs
@@ -1,0 +1,52 @@
+defmodule Operately.Operations.ProjectContributorAdditionTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Projects
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    contributor = person_fixture_with_account(%{company_id: company.id})
+    project = project_fixture(%{company_id: company.id, creator_id: creator.id, group_id: company.company_space_id})
+
+    {:ok, company: company, creator: creator, contributor: contributor, project: project}
+  end
+
+  test "ProjectContributorAddition operation creates contributor", ctx do
+    Operately.Operations.ProjectContributorAddition.run(ctx.creator, %{
+      project_id: ctx.project.id,
+      person_id: ctx.contributor.id,
+      responsibility: "Developer",
+    })
+
+    contributors = Projects.list_project_contributors(ctx.project) |> Enum.map(fn c -> {c.person_id, c.role} end)
+
+    assert 3 == length(contributors)
+    assert Enum.member?(contributors, {ctx.contributor.id, :contributor})
+  end
+
+  test "ProjectContributorAddition operation creates activity and notification", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectContributorAddition.run(ctx.creator, %{
+        project_id: ctx.project.id,
+        person_id: ctx.contributor.id,
+        responsibility: "Developer",
+      })
+    end)
+
+    activity = from(a in Activity, where: a.action == "project_contributor_addition" and a.content["project_id"] == ^ctx.project.id) |> Repo.one()
+
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert fetch_notification(activity.id)
+    assert 1 == notifications_count()
+  end
+end


### PR DESCRIPTION
I've updated `Operately.Operations.ProjectContributorAddition` so that it will also create an access binding between the new contributor's access group and the project's access context.

I've also updated the UI so that the access level for the new contributor can be selected when the contributor is being added.