### PR TITLE
feat: Clean up GroupCreation and GroupMemberAdding operations

### DIFF
--- a/test/operately/operations/group_creation_test.exs
+++ b/test/operately/operations/group_creation_test.exs
@@ -44,17 +44,17 @@ defmodule Operately.Operations.GroupCreationTest do
     access_groups = Access.list_groups()
     context = Access.get_context!(group_id: group.id)
 
-    assert nil != context
+    assert context
     assert 6 == length(access_groups) # 2 company's + 2 space's + 1 user's + 1 anonymous
 
-    assert nil != Access.get_group(group_id: group.id, tag: :standard)
-    assert nil != Access.get_group(group_id: group.id, tag: :full_access)
+    assert Access.get_group(group_id: group.id, tag: :standard)
+    assert Access.get_group(group_id: group.id, tag: :full_access)
 
     company_members = Access.get_group(company_id: group.company_id, tag: :standard)
     company_admins = Access.get_group(company_id: group.company_id, tag: :full_access)
 
-    assert nil != Access.get_binding(group_id: company_members.id, context_id: context.id, access_level: Binding.comment_access())
-    assert nil != Access.get_binding(group_id: company_admins.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: company_members.id, context_id: context.id, access_level: Binding.comment_access())
+    assert Access.get_binding(group_id: company_admins.id, context_id: context.id, access_level: Binding.full_access())
   end
 
   test "GroupCreation operation creates full_access binding with creator", ctx do
@@ -63,7 +63,23 @@ defmodule Operately.Operations.GroupCreationTest do
     context = Access.get_context!(group_id: group.id)
     access_group = Access.get_group!(person_id: ctx.creator.id)
 
-    assert nil != Access.get_binding(group_id: access_group.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: access_group.id, context_id: context.id, access_level: Binding.full_access())
+  end
+
+  test "GroupCreation operation can create no_access binding to company members", ctx do
+    attrs = Map.merge(@group_attrs, %{ company_permissions: Binding.no_access() })
+
+    {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, attrs)
+
+    context = Access.get_context!(group_id: group.id)
+    standard = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    full_access = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
+
+    assert Access.get_binding(group_id: standard.id, context_id: context.id)
+    assert Access.get_binding(group_id: standard.id, context_id: context.id, access_level: Binding.no_access())
+
+    assert Access.get_binding(group_id: full_access.id, context_id: context.id)
+    assert Access.get_binding(group_id: full_access.id, context_id: context.id, access_level: Binding.full_access())
   end
 
   test "GroupCreation operation creates only view_access for anonymours users", ctx do
@@ -72,20 +88,20 @@ defmodule Operately.Operations.GroupCreationTest do
     {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, @group_attrs)
     context = Access.get_context!(group_id: group.id)
 
-    assert nil == Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
+    refute Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
 
     attrs = Map.merge(@group_attrs, %{public_permissions: Binding.comment_access()})
     {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, attrs)
     context = Access.get_context!(group_id: group.id)
 
-    assert nil == Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
-    assert nil == Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.comment_access())
+    refute Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
+    refute Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.comment_access())
 
     attrs = Map.merge(@group_attrs, %{public_permissions: Binding.view_access()})
     {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, attrs)
     context = Access.get_context!(group_id: group.id)
 
-    assert nil != Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
+    assert Access.get_binding(group_id: anonymous_group.id, context_id: context.id, access_level: Binding.view_access())
   end
 
   test "GroupCreation operation adds creator to managers group", ctx do
@@ -93,6 +109,6 @@ defmodule Operately.Operations.GroupCreationTest do
 
     managers = Access.get_group(group_id: group.id, tag: :full_access)
 
-    assert nil != Access.get_group_membership!(group_id: managers.id, person_id: ctx.creator.id)
+    assert Access.get_group_membership!(group_id: managers.id, person_id: ctx.creator.id)
   end
 end

--- a/test/operately/operations/group_members_adding_test.exs
+++ b/test/operately/operations/group_members_adding_test.exs
@@ -50,24 +50,24 @@ defmodule Operately.Operations.GroupMembersAddingTest do
     managers = Access.get_group(group_id: ctx.group.id, tag: :full_access)
 
     Enum.each(ctx.members, fn %{id: person_id} ->
-      assert nil == Access.get_group_membership(group_id: members.id, person_id: person_id)
-      assert nil == Access.get_group_membership(group_id: managers.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: members.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: managers.id, person_id: person_id)
     end)
     Enum.each(ctx.managers, fn %{id: person_id} ->
-      assert nil == Access.get_group_membership(group_id: members.id, person_id: person_id)
-      assert nil == Access.get_group_membership(group_id: managers.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: members.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: managers.id, person_id: person_id)
     end)
 
     Operately.Operations.GroupMembersAdding.run(ctx.group.id, ctx.members)
     Operately.Operations.GroupMembersAdding.run(ctx.group.id, ctx.managers)
 
     Enum.each(ctx.members, fn %{id: person_id} ->
-      assert nil != Access.get_group_membership(group_id: members.id, person_id: person_id)
-      assert nil == Access.get_group_membership(group_id: managers.id, person_id: person_id)
+      assert Access.get_group_membership(group_id: members.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: managers.id, person_id: person_id)
     end)
     Enum.each(ctx.managers, fn %{id: person_id} ->
-      assert nil == Access.get_group_membership(group_id: members.id, person_id: person_id)
-      assert nil != Access.get_group_membership(group_id: managers.id, person_id: person_id)
+      refute Access.get_group_membership(group_id: members.id, person_id: person_id)
+      assert Access.get_group_membership(group_id: managers.id, person_id: person_id)
     end)
   end
 
@@ -75,10 +75,10 @@ defmodule Operately.Operations.GroupMembersAddingTest do
     all_members = ctx.members ++ ctx.managers
     access_context = Access.get_context!(group_id: ctx.group.id)
 
-    Enum.each(all_members, fn %{id: person_id, permissions: permissions} ->
+    Enum.each(all_members, fn %{id: person_id} ->
       access_group = Access.get_group!(person_id: person_id)
 
-      assert nil == Access.get_binding(group_id: access_group.id, context_id: access_context.id, access_level: permissions)
+      refute Access.get_binding(group_id: access_group.id, context_id: access_context.id)
     end)
 
     Operately.Operations.GroupMembersAdding.run(ctx.group.id, all_members)
@@ -86,7 +86,8 @@ defmodule Operately.Operations.GroupMembersAddingTest do
     Enum.each(all_members, fn %{id: person_id, permissions: permissions} ->
       access_group = Access.get_group!(person_id: person_id)
 
-      assert nil != Access.get_binding(group_id: access_group.id, context_id: access_context.id, access_level: permissions)
+      assert Access.get_binding(group_id: access_group.id, context_id: access_context.id, access_level: permissions)
+      assert Access.get_binding(group_id: access_group.id, context_id: access_context.id)
     end)
   end
 end


### PR DESCRIPTION
I've removed some repeated code that was being used to create access bindings in `Operately.Operations.GroupCreation` and `Operately.Operations.GroupMembersAdding`. 

Now, they use the same functions to create access bindings as `Operately.Operations.ProjectCreation` and `Operately.Operations.GroupMembersAdding`.