### PR TITLE
feat: Add migration for creating binding between projects and contributors

### DIFF
--- a/lib/operately/data/change_020_create_project_contributors_bindings.ex
+++ b/lib/operately/data/change_020_create_project_contributors_bindings.ex
@@ -1,0 +1,51 @@
+defmodule Operately.Data.Change020CreateProjectContributorsBindings do
+  import Ecto.Query, only: [from: 1]
+
+  alias Operately.Repo
+  alias Operately.Projects
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  def run do
+    Repo.transaction(fn ->
+      projects = from(p in Projects.Project) |> Repo.all()
+
+      Enum.each(projects, fn project ->
+        create_bindings(project)
+      end)
+    end)
+  end
+
+  defp create_bindings(project) do
+    context = Access.get_context!(project_id: project.id)
+    contributors = Projects.list_project_contributors(project)
+
+    Enum.each(contributors, fn contributor ->
+      group = Access.get_group!(person_id: contributor.person_id)
+      access_level = get_access_level(contributor.role)
+
+      create_binding(context, group, access_level)
+    end)
+  end
+
+  defp create_binding(context, group, access_level) do
+    case Access.get_binding(context_id: context.id, group_id: group.id) do
+      nil ->
+        Access.create_binding(%{
+          context_id: context.id,
+          group_id: group.id,
+          access_level: access_level,
+        })
+      _ ->
+        :ok
+    end
+  end
+
+  defp get_access_level(role) do
+    case role do
+      :champion -> Binding.full_access()
+      :reviewer -> Binding.full_access()
+      :contributor -> Binding.edit_access()
+    end
+  end
+end

--- a/test/operately/data/change_020_create_project_contributors_bindings_test.exs
+++ b/test/operately/data/change_020_create_project_contributors_bindings_test.exs
@@ -1,0 +1,131 @@
+defmodule Operately.Data.Change020CreateProjectContributorsBindingsTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Projects
+  alias Operately.Projects.{Project, Contributor}
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(creator)
+
+    project_with_bindings = Enum.map(1..3, fn _ ->
+      create_project_with_bindings(%{
+        company_id: company.id,
+        creator_id: creator.id,
+        group_id: group.id,
+      })
+    end)
+
+    project_without_bindings = Enum.map(1..3, fn _ ->
+      create_project_without_bindings(%{
+        company_id: company.id,
+        creator_id: creator.id,
+        group_id: group.id,
+      })
+    end)
+
+    {:ok, project_with_bindings: project_with_bindings, project_without_bindings: project_without_bindings}
+  end
+
+  test "creates access binding to existing contributors", ctx do
+    Enum.each(ctx.project_with_bindings, fn project ->
+      context = Access.get_context!(project_id: project.id)
+
+      Projects.list_project_contributors(project)
+      |> Enum.each(fn contributor ->
+        group = Access.get_group!(person_id: contributor.person_id)
+
+        assert Access.get_binding(context_id: context.id, group_id: group.id)
+      end)
+    end)
+
+    Enum.each(ctx.project_without_bindings, fn project ->
+      context = Access.get_context!(project_id: project.id)
+
+      Projects.list_project_contributors(project)
+      |> Enum.each(fn contributor ->
+        group = Access.get_group!(person_id: contributor.person_id)
+
+        refute Access.get_binding(context_id: context.id, group_id: group.id)
+      end)
+    end)
+
+    Operately.Data.Change020CreateProjectContributorsBindings.run()
+
+    Enum.each(ctx.project_without_bindings, fn project ->
+      context = Access.get_context!(project_id: project.id)
+
+      Projects.list_project_contributors(project)
+      |> Enum.each(fn contributor ->
+        group = Access.get_group!(person_id: contributor.person_id)
+
+        case contributor.role do
+          :contributor ->
+            assert Access.get_binding(context_id: context.id, group_id: group.id)
+            assert Access.get_binding(context_id: context.id, group_id: group.id, access_level: Binding.edit_access())
+
+          _ ->
+            assert Access.get_binding(context_id: context.id, group_id: group.id)
+            assert Access.get_binding(context_id: context.id, group_id: group.id, access_level: Binding.full_access())
+        end
+      end)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project_with_bindings(attrs) do
+    reviewer = person_fixture_with_account(%{company_id: attrs.company_id})
+    champion = person_fixture_with_account(%{company_id: attrs.company_id})
+
+    project_fixture(%{
+      company_id: attrs.company_id,
+      creator_id: attrs.creator_id,
+      reviewer_id: reviewer.id,
+      champion_id: champion.id,
+      group_id: attrs.group_id,
+      creator_is_contributor: "yes",
+    })
+  end
+
+  defp create_project_without_bindings(attrs) do
+    {:ok, project} = Project.changeset(%{
+      name: "some name",
+      company_id: attrs.company_id,
+      group_id: attrs.group_id,
+      creator_id: attrs.creator_id,
+    })
+    |> Repo.insert()
+
+    Access.create_context(%{project_id: project.id})
+
+    reviewer = person_fixture_with_account(%{company_id: attrs.company_id})
+    champion = person_fixture_with_account(%{company_id: attrs.company_id})
+
+    create_contributor(project.id, attrs.creator_id, :contributor)
+    create_contributor(project.id, reviewer.id, :reviewer)
+    create_contributor(project.id, champion.id, :champion)
+
+    project
+  end
+
+  defp create_contributor(project_id, person_id, role) do
+    Contributor.changeset(%{
+      project_id: project_id,
+      person_id: person_id,
+      role: role,
+    })
+    |> Repo.insert()
+  end
+end


### PR DESCRIPTION
I've added a data migration for creating access bindings between projects and its contributors. 