### PR TITLE
fix: Broken task list on milestones in_progress vs inProgress

### DIFF
--- a/assets/js/features/Tasks/TaskBoard.tsx
+++ b/assets/js/features/Tasks/TaskBoard.tsx
@@ -7,6 +7,7 @@ import { DivLink } from "@/components/Link";
 import { insertAt } from "@/utils/array";
 import { DragAndDropProvider, useDraggable, useDropZone, useDragAndDropContext } from "@/features/DragAndDrop";
 import { Paths, compareIds } from "@/routes/paths";
+import { match } from "ts-pattern";
 
 interface TaskBoardState {
   todoTasks: Tasks.Task[];
@@ -196,8 +197,14 @@ function orderTasksByKanbanState(tasks: Tasks.Task[], kanbanState: any, status: 
   return tasks
     .filter((t) => t.status === status)
     .sort((a, b) => {
-      const aIndex = kanbanState[status].findIndex((id: string) => compareIds(id, a.id!)) || 0;
-      const bIndex = kanbanState[status].findIndex((id: string) => compareIds(id, b.id!)) || 0;
+      const column = match(status)
+        .with("todo", () => kanbanState.todo)
+        .with("in_progress", () => kanbanState.inProgress)
+        .with("done", () => kanbanState.done)
+        .otherwise(() => []);
+
+      const aIndex = column.findIndex((id: string) => compareIds(id, a.id!)) || 0;
+      const bIndex = column.findIndex((id: string) => compareIds(id, b.id!)) || 0;
 
       return aIndex - bIndex;
     });


### PR DESCRIPTION
Previously, the kanban board state was transmitted as string JSON data, but I've converted it to be a proper API type last week. However, the JS API Client automatically converts every key from snake_case to camelCast which broke the lookup when the task.status was in_progress, but the kanbanState only contained the todo, inProgress, done states.

fixes: https://github.com/operately/operately/issues/726