### PR TITLE
feat: Update GoalCreation operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1445,6 +1445,9 @@ export interface CreateGoalInput {
   targets?: CreateTargetInput[] | null;
   description?: string | null;
   parentGoalId?: string | null;
+  anonymousAccessLevel?: number | null;
+  companyAccessLevel?: number | null;
+  spaceAccessLevel?: number | null;
 }
 
 export interface CreateGoalResult {

--- a/assets/js/features/Permissions/PermissionSelector.tsx
+++ b/assets/js/features/Permissions/PermissionSelector.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import PrivacyLevel from "./PrivacyLevel";
 import { AccessLevel, ResourceAccessLevel } from "./AccessLevel";
 import { ReducerActions, usePermissionsContext } from "./PermissionsContext";
+import { compareIds } from "@/routes/paths";
 
 
 export enum PermissionOptions {
@@ -34,7 +35,7 @@ export function SpacePermissionSelector() {
 export function ResourcePermissionSelector() {
   const { space, company, dispatch } = usePermissionsContext();
 
-  const companySpaceSelected = company.companySpaceId === space?.id;
+  const companySpaceSelected = (!company.companySpaceId || !space?.id) ? false : compareIds(company.companySpaceId, space.id);
 
   useEffect(() => {
     dispatch({type: ReducerActions.SET_SECRET});

--- a/assets/js/features/goals/GoalForm/Form.tsx
+++ b/assets/js/features/goals/GoalForm/Form.tsx
@@ -13,10 +13,12 @@ import { AddTarget, Target, TargetHeader } from "./Target";
 import { FormState } from "./useForm";
 import { GoalSelectorDropdown } from "@/features/goals/GoalTree/GoalSelectorDropdown";
 import { TimeframeSelector } from "@/components/TimeframeSelector";
+import { ResourcePermissionSelector } from "@/features/Permissions";
+
 
 export function Form({ form }: { form: FormState }) {
   return (
-    <Forms.Form onSubmit={form.submit} loading={form.submitting} onCancel={form.cancel} isValid={true}>
+    <Forms.Form onSubmit={()=>{}} loading={form.submitting} onCancel={form.cancel} isValid={true}>
       <FormMain form={form} />
       <FormFooter form={form} />
     </Forms.Form>
@@ -121,6 +123,10 @@ function FormFooter({ form }: { form: FormState }) {
             <SpaceSelector form={form} />
           </div>
         )}
+      </div>
+
+      <div className="flex flex-col gap-4 mt-10">
+        <ResourcePermissionSelector />
       </div>
     </Paper.DimmedSection>
   );

--- a/assets/js/pages/GoalAddPage/page.tsx
+++ b/assets/js/pages/GoalAddPage/page.tsx
@@ -20,7 +20,7 @@ export function Page() {
     mode: "create",
     company: company,
     me: me,
-    allowSpaceSelection: isCompanyWide || false,
+    allowSpaceSelection: Boolean(isCompanyWide || !space),
     space: space,
     spaces: spaces,
     parentGoal,

--- a/assets/js/pages/GoalAddPage/page.tsx
+++ b/assets/js/pages/GoalAddPage/page.tsx
@@ -9,30 +9,38 @@ import { useLoadedData } from "./loader";
 import { FormState, useForm, Form } from "@/features/goals/GoalForm";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths } from "@/routes/paths";
+import { PermissionsProvider, usePermissionsContext } from "@/features/Permissions/PermissionsContext";
+
 
 export function Page() {
-  const { spaceID } = useLoadedData();
-
-  if (spaceID) {
-    return <NewGoalForSpacePage />;
-  } else {
-    return <NewGoalPage />;
-  }
-}
-
-function NewGoalForSpacePage() {
   const me = useMe();
-  const { company, space, parentGoal, goals } = useLoadedData();
+  const { spaceID, space, spaces, company, parentGoal, goals, isCompanyWide } = useLoadedData();
 
   const form = useForm({
     mode: "create",
     company: company,
     me: me,
-    allowSpaceSelection: false,
+    allowSpaceSelection: isCompanyWide || false,
     space: space,
+    spaces: spaces,
     parentGoal,
     parentGoalOptions: goals,
+    isCompanyWide,
   });
+
+  return (
+    <PermissionsProvider company={company} space={space || form.fields.space} >
+      {spaceID ?
+        <NewGoalForSpacePage form={form} />
+      :
+        <NewGoalPage form={form} />
+      }
+    </PermissionsProvider>
+  );
+}
+
+function NewGoalForSpacePage({ form }: { form: FormState }) {
+  const { space } = useLoadedData();
 
   return (
     <Pages.Page title="New Goal">
@@ -53,20 +61,8 @@ function NewGoalForSpacePage() {
   );
 }
 
-function NewGoalPage() {
-  const me = useMe();
-  const { company, spaces, parentGoal, goals, isCompanyWide } = useLoadedData();
-
-  const form = useForm({
-    mode: "create",
-    company: company,
-    me: me,
-    allowSpaceSelection: true,
-    spaces: spaces,
-    parentGoal,
-    parentGoalOptions: goals,
-    isCompanyWide,
-  });
+function NewGoalPage({ form }: { form: FormState }) {
+  const { isCompanyWide } = useLoadedData();
 
   return (
     <Pages.Page title="New Goal">
@@ -90,6 +86,12 @@ function NewGoalPage() {
 }
 
 function SubmitButton({ form }: { form: FormState }) {
+  const { permissions } = usePermissionsContext();
+
+  const handleSubmit = () => {
+    form.submit(permissions);
+  }
+
   return (
     <div className="mt-8">
       {form.errors.length > 0 && (
@@ -99,7 +101,7 @@ function SubmitButton({ form }: { form: FormState }) {
       <div className="flex items-center justify-center gap-4">
         <FilledButton
           type="primary"
-          onClick={form.submit}
+          onClick={handleSubmit}
           loading={form.submitting}
           size="lg"
           testId="add-goal-button"

--- a/assets/js/pages/GoalEditPage/page.tsx
+++ b/assets/js/pages/GoalEditPage/page.tsx
@@ -7,6 +7,8 @@ import { FilledButton } from "@/components/Button";
 import { useLoadedData } from "./loader";
 import { FormState, useForm, Form } from "@/features/goals/GoalForm";
 import { useMe } from "@/contexts/CurrentUserContext";
+import { PermissionsProvider } from "@/features/Permissions/PermissionsContext";
+
 
 export function Page() {
   const me = useMe();
@@ -24,9 +26,11 @@ export function Page() {
     <Pages.Page title={["Edit", goal.name!]}>
       <Paper.Root size="medium">
         <Paper.Body minHeight="300px">
-          <Header form={form} />
-          <ErrorMessage form={form} />
-          <Form form={form} />
+          <PermissionsProvider company={company} space={goal.space} >
+            <Header form={form} />
+            <ErrorMessage form={form} />
+            <Form form={form} />
+          </PermissionsProvider>
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>

--- a/lib/operately_web/api/mutations/create_goal.ex
+++ b/lib/operately_web/api/mutations/create_goal.ex
@@ -11,6 +11,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
     field :targets, list_of(:create_target_input)
     field :description, :string
     field :parent_goal_id, :string
+    field :anonymous_access_level, :integer
+    field :company_access_level, :integer
+    field :space_access_level, :integer
   end
 
   outputs do
@@ -20,7 +23,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
   def call(conn, inputs) do
     {:ok, space_id} = decode_id(inputs.space_id)
     inputs = Map.put(inputs, :space_id, space_id)
-    
+
     {:ok, goal} = Operately.Operations.GoalCreation.run(me(conn), inputs)
     {:ok, %{goal: Serializer.serialize(goal, level: :essential)}}
   end

--- a/test/operately/access/contexts_test.exs
+++ b/test/operately/access/contexts_test.exs
@@ -127,6 +127,7 @@ defmodule Operately.AccessContextsTest do
 
     Access.create_group(%{company_id: company.id, tag: :full_access})
     Access.create_group(%{company_id: company.id, tag: :standard})
+    Access.create_group(%{company_id: company.id, tag: :anonymous})
 
     company
   end

--- a/test/operately/goals_test.exs
+++ b/test/operately/goals_test.exs
@@ -3,6 +3,7 @@ defmodule Operately.GoalsTest do
 
   alias Operately.Goals
   alias Operately.Goals.Goal
+  alias Operately.Access.Binding
 
   import Operately.GroupsFixtures
   import Operately.PeopleFixtures
@@ -29,7 +30,7 @@ defmodule Operately.GoalsTest do
 
     test "create_goal/2 with valid data creates a goal", ctx do
       valid_attrs = %{
-        name: "some name", 
+        name: "some name",
         space_id: ctx.group.id,
         champion_id: ctx.person.id,
         reviewer_id: ctx.person.id,
@@ -38,6 +39,9 @@ defmodule Operately.GoalsTest do
           end_date: ~D[2020-12-31],
           type: "year",
         },
+        company_access_level: Binding.comment_access(),
+        space_access_level: Binding.edit_access(),
+        anonymous_access_level: Binding.view_access(),
       }
 
       assert {:ok, %Goal{} = goal} = Goals.create_goal(ctx.person, valid_attrs)
@@ -47,6 +51,11 @@ defmodule Operately.GoalsTest do
     test "create_goal/2 with invalid data returns error changeset", ctx do
       assert {:error, :goal, %Ecto.Changeset{}, _} = Goals.create_goal(ctx.person, %{
         space_id: ctx.group.id,
+        champion_id: ctx.person.id,
+        reviewer_id: ctx.person.id,
+        company_access_level: Binding.comment_access(),
+        space_access_level: Binding.edit_access(),
+        anonymous_access_level: Binding.view_access(),
       })
     end
 

--- a/test/operately/operations/goal_creation_test.exs
+++ b/test/operately/operations/goal_creation_test.exs
@@ -1,0 +1,74 @@
+defmodule Operately.Operations.GoalCreationTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Access
+  alias Operately.Goals
+  alias Operately.Activities.Activity
+
+  @target_attrs %{ name: "First response time", from: 30, to: 15, unit: "minutes", index: 0 }
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+
+    attrs = %{
+      space_id: space.id,
+      name: "some name",
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+      timeframe: %{ type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 2) },
+      targets: [ @target_attrs ],
+    }
+
+    {:ok, attrs: attrs, creator: creator}
+  end
+
+  test "GoalCreation operation creates goal and context", ctx do
+    assert Goals.list_goals() == []
+
+    {:ok, goal} = Operately.Operations.GoalCreation.run(ctx.creator, ctx.attrs)
+
+    assert Goals.list_goals() == [goal]
+    assert Access.get_context(goal_id: goal.id)
+  end
+
+  test "GoalCreation operation creates targets", ctx do
+    {:ok, goal} = Operately.Operations.GoalCreation.run(ctx.creator, ctx.attrs)
+
+    targets = Goals.list_targets(goal.id)
+
+    assert length(targets) == 1
+
+    target = hd(targets)
+
+    assert target.name == @target_attrs[:name]
+    assert target.from == @target_attrs[:from]
+    assert target.to == @target_attrs[:to]
+    assert target.unit == @target_attrs[:unit]
+    assert target.index == @target_attrs[:index]
+  end
+
+  test "GoalCreation operation creates activity and notification", ctx do
+    {:ok, goal} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalCreation.run(ctx.creator, ctx.attrs)
+    end)
+
+    activity = from(a in Activity, where: a.action == "goal_created" and a.content["goal_id"] == ^goal.id) |> Repo.one()
+
+    assert activity
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert 2 == notifications_count() # 1 reviewer + 1 champion = 2
+    assert fetch_notifications(activity.id)
+  end
+end

--- a/test/support/features/goal_check_in_steps.ex
+++ b/test/support/features/goal_check_in_steps.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Support.Features.GoalCheckInSteps do
   use Operately.FeatureCase
 
+  alias Operately.Access.Binding
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.FeedSteps
   alias Operately.Support.Features.EmailSteps
@@ -42,7 +43,10 @@ defmodule Operately.Support.Features.GoalCheckInSteps do
           unit: "percent",
           index: 1
         }
-      ]
+      ],
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     ctx = Map.merge(ctx, %{company: company, champion: champion, reviewer: reviewer, group: group, goal: goal})
@@ -83,8 +87,8 @@ defmodule Operately.Support.Features.GoalCheckInSteps do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{
       where: ctx.goal.name,
-      to: ctx.reviewer, 
-      author: ctx.champion, 
+      to: ctx.reviewer,
+      author: ctx.champion,
       action: "updated the progress"
     })
   end
@@ -94,7 +98,7 @@ defmodule Operately.Support.Features.GoalCheckInSteps do
     |> UI.login_as(ctx.reviewer)
     |> NotificationsSteps.visit_notifications_page()
     |> NotificationsSteps.assert_activity_notification(%{
-      author: ctx.champion, 
+      author: ctx.champion,
       action: "updated the progress"
     })
   end

--- a/test/support/features/goal_steps.ex
+++ b/test/support/features/goal_steps.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Support.Features.GoalSteps do
   use Operately.FeatureCase
 
+  alias Operately.Access.Binding
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.FeedSteps
   alias Operately.Support.Features.EmailSteps
@@ -44,7 +45,10 @@ defmodule Operately.Support.Features.GoalSteps do
           unit: "percent",
           index: 1
         }
-      ]
+      ],
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     Map.merge(ctx, %{company: company, champion: champion, reviewer: reviewer, group: group, goal: goal})
@@ -70,7 +74,10 @@ defmodule Operately.Support.Features.GoalSteps do
           unit: goal_params.unit,
           index: 0
         }
-      ]
+      ],
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     ctx
@@ -84,7 +91,7 @@ defmodule Operately.Support.Features.GoalSteps do
   end
 
   step :assert_goal_parent_changed, ctx, parent_goal_name do
-    ctx 
+    ctx
     |> UI.assert_page(Paths.goal_path(ctx.company, ctx.goal))
     |> UI.assert_text(parent_goal_name)
   end
@@ -117,8 +124,8 @@ defmodule Operately.Support.Features.GoalSteps do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{
       where: ctx.group.name,
-      to: ctx.reviewer, 
-      author: ctx.champion, 
+      to: ctx.reviewer,
+      author: ctx.champion,
       action: "archived the #{ctx.goal.name} goal"
     })
   end
@@ -134,7 +141,7 @@ defmodule Operately.Support.Features.GoalSteps do
 
   step :edit_goal, ctx do
     values = %{
-      name: "New Goal Name", 
+      name: "New Goal Name",
       new_champion: person_fixture_with_account(%{company_id: ctx.company.id, full_name: "John New Champion"}),
       new_reviewer: person_fixture_with_account(%{company_id: ctx.company.id, full_name: "Leonardo New Reviewer"}),
       new_targets: [%{name: "Sold 1000 units", current: 0, target: 1000, unit: "units"}]
@@ -180,7 +187,7 @@ defmodule Operately.Support.Features.GoalSteps do
       end)
     end)
   end
-  
+
   step :assert_goal_edited_email_sent, ctx do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{
@@ -223,7 +230,7 @@ defmodule Operately.Support.Features.GoalSteps do
   step :assert_goal_timeframe_edited_feed_posted, ctx do
     ctx
     |> FeedSteps.assert_feed_item_exists(%{
-      author: ctx.champion, 
+      author: ctx.champion,
       title: "extended the timeframe",
       subtitle: "Extending the timeframe by 1 month to allow for more time to complete it."
     })
@@ -348,7 +355,7 @@ defmodule Operately.Support.Features.GoalSteps do
     assert goal.closed_by_id == ctx.champion.id
     assert goal.success == success
 
-    ctx 
+    ctx
     |> UI.assert_page(Paths.goal_path(ctx.company, ctx.goal))
     |> UI.assert_text("This goal was closed on")
   end
@@ -359,7 +366,7 @@ defmodule Operately.Support.Features.GoalSteps do
     refute goal.closed_at
     refute goal.closed_by_id
 
-    ctx 
+    ctx
     |> UI.assert_page(Paths.goal_path(ctx.company, ctx.goal))
     |> UI.refute_text("This goal was closed on")
   end

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Support.Features.ProjectCreationSteps do
   use Operately.FeatureCase
 
+  alias Operately.Access.Binding
   alias Operately.People.Person
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.EmailSteps
@@ -30,7 +31,10 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
         type: "year",
         start_date: ~D[2021-01-01],
         end_date: ~D[2021-12-31]
-      }
+      },
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     ctx = Map.merge(ctx, %{

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -37,7 +37,10 @@ defmodule Operately.Support.Features.ProjectSteps do
           unit: "percent",
           index: 1
         }
-      ]
+      ],
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     Map.put(ctx, :goal, goal)

--- a/test/support/fixtures/goals_fixtures.ex
+++ b/test/support/fixtures/goals_fixtures.ex
@@ -1,4 +1,6 @@
 defmodule Operately.GoalsFixtures do
+  alias Operately.Access.Binding
+
   def goal_fixture(creator, attrs \\ %{}) do
     attrs = Enum.into(attrs, %{
       name: "some name",
@@ -20,7 +22,10 @@ defmodule Operately.GoalsFixtures do
           unit: "percent",
           index: 1
         }
-      ]
+      ],
+      company_access_level: Binding.comment_access(),
+      space_access_level: Binding.edit_access(),
+      anonymous_access_level: Binding.view_access(),
     })
 
     {:ok, goal} = Operately.Goals.create_goal(creator, attrs)


### PR DESCRIPTION
I've updated `Operately.Operations.GoalCreation` so that it also creates access bindings between the goal's access context and the company's, space's and contributors' access groups.