### PR TITLE
feat: Update GoalEditing operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1569,6 +1569,9 @@ export interface EditGoalInput {
   addedTargets?: CreateTargetInput[] | null;
   updatedTargets?: UpdateTargetInput[] | null;
   description?: string | null;
+  anonymousAccessLevel?: number | null;
+  companyAccessLevel?: number | null;
+  spaceAccessLevel?: number | null;
 }
 
 export interface EditGoalResult {

--- a/assets/js/features/goals/GoalForm/useForm.tsx
+++ b/assets/js/features/goals/GoalForm/useForm.tsx
@@ -286,6 +286,9 @@ function useSubmit(fields: Fields, config: FormConfig): [(permissions: Permissio
             unit: t.unit,
             index: index,
           })),
+        anonymousAccessLevel: permissions.public,
+        companyAccessLevel: permissions.company,
+        spaceAccessLevel: permissions.space,
       });
 
       navigate(Paths.goalPath(res.goal.id!));

--- a/assets/js/pages/GoalEditPage/page.tsx
+++ b/assets/js/pages/GoalEditPage/page.tsx
@@ -7,7 +7,7 @@ import { FilledButton } from "@/components/Button";
 import { useLoadedData } from "./loader";
 import { FormState, useForm, Form } from "@/features/goals/GoalForm";
 import { useMe } from "@/contexts/CurrentUserContext";
-import { PermissionsProvider } from "@/features/Permissions/PermissionsContext";
+import { PermissionsProvider, usePermissionsContext } from "@/features/Permissions/PermissionsContext";
 
 
 export function Page() {
@@ -38,6 +38,12 @@ export function Page() {
 }
 
 function Header({ form }: { form: FormState }) {
+  const { permissions } = usePermissionsContext();
+
+  const handleSubmit = () => {
+    form.submit(permissions);
+  }
+
   return (
     <Paper.Header className="bg-surface-dimmed">
       <div className="flex items-end justify-between my-2">
@@ -50,7 +56,7 @@ function Header({ form }: { form: FormState }) {
 
           <FilledButton
             type="primary"
-            onClick={form.submit}
+            onClick={handleSubmit}
             loading={form.submitting}
             size="sm"
             testId="save-changes"

--- a/lib/operately_web/api/mutations/edit_goal.ex
+++ b/lib/operately_web/api/mutations/edit_goal.ex
@@ -11,6 +11,9 @@ defmodule OperatelyWeb.Api.Mutations.EditGoal do
     field :added_targets, list_of(:create_target_input)
     field :updated_targets, list_of(:update_target_input)
     field :description, :string
+    field :anonymous_access_level, :integer
+    field :company_access_level, :integer
+    field :space_access_level, :integer
   end
 
   outputs do

--- a/test/operately/operations/goal_editing_test.exs
+++ b/test/operately/operations/goal_editing_test.exs
@@ -1,0 +1,87 @@
+defmodule Operately.Operations.GoalEditingTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.GoalsFixtures
+
+  alias Operately.Goals
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+
+    goal = goal_fixture(creator, %{
+      name: "some name",
+      space_id: space.id,
+      champion_id: creator.id,
+      reviewer_id: creator.id,
+      targets: [
+        %{
+          name: "Some target",
+          from: 80,
+          to: 90,
+          unit: "percent",
+          index: 0
+        }
+      ],
+    })
+
+    attrs = %{
+      name: "new name",
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+      timeframe: %{ type: "days", start_date: Date.utc_today(), end_date: Date.add(Date.utc_today(), 2) },
+      added_targets: [ %{ name: "new target", from: 30, to: 15, unit: "minutes", index: 1 } ],
+      updated_targets: [],
+    }
+
+    {:ok, attrs: attrs, company: company, space: space, goal: goal, creator: creator, champion: champion, reviewer: reviewer}
+  end
+
+  test "GoalEditing operation edits goal", ctx do
+    assert ctx.goal.name == "some name"
+    assert ctx.goal.champion_id == ctx.creator.id
+    assert ctx.goal.reviewer_id == ctx.creator.id
+
+    targets = Goals.list_targets(ctx.goal.id)
+    target = hd(targets)
+
+    assert length(targets) == 1
+    assert target.name == "Some target"
+
+    attrs = Map.merge(ctx.attrs, %{updated_targets: [ %{ id: target.id, name: "updated target" } ]})
+
+    {:ok, goal} = Operately.Operations.GoalEditing.run(ctx.creator, ctx.goal, attrs)
+
+    target = Repo.reload(target)
+
+    assert goal.name == "new name"
+    assert goal.champion_id == ctx.champion.id
+    assert goal.reviewer_id == ctx.reviewer.id
+    assert length(Goals.list_targets(goal.id)) == 2
+    assert target.name == "updated target"
+  end
+
+  test "GoalEditing operation creates activity and notification", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.GoalEditing.run(ctx.creator, ctx.goal, ctx.attrs)
+    end)
+
+    activity = from(a in Activity, where: a.action == "goal_editing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
+
+    assert activity
+    assert 0 == notifications_count()
+
+    perform_job(activity.id)
+
+    assert 2 == notifications_count() # 1 reviewer + 1 champion = 2
+    assert fetch_notifications(activity.id)
+  end
+end


### PR DESCRIPTION
I've updated `Operately.Operations.GoalEditing` so that it also updates the access level of bindings between the goal's access context and the company's and space's access groups.

I decided to submit this PR as it is since everything should be working. However, I'd say that the user experience is not that good because we are not loading the current permissions of the goal. So, the user can set new permissions, but they don't know what the current ones are.

In the near future, we should probably update the way goals are loaded, so that it includes permissions information as well.