### PR TITLE
feat: Add possibility to update project's permissions

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -730,6 +730,7 @@ export interface ProjectPermissions {
   canEditGoal?: boolean | null;
   canEditName?: boolean | null;
   canEditSpace?: boolean | null;
+  canEditPermissions?: boolean | null;
   canPause?: boolean | null;
   canCheckIn?: boolean | null;
   canAcknowledgeCheckIn?: boolean | null;
@@ -1678,6 +1679,16 @@ export interface EditProjectNameResult {
 }
 
 
+export interface EditProjectPermissionsInput {
+  projectId?: string | null;
+  accessLevels?: AccessLevels | null;
+}
+
+export interface EditProjectPermissionsResult {
+  success?: boolean | null;
+}
+
+
 export interface EditProjectTimelineInput {
   projectId?: string | null;
   projectStartDate?: string | null;
@@ -2242,6 +2253,10 @@ export class ApiClient {
     return axios.post(this.getBasePath() + "/edit_project_name", toSnake(input)).then(({ data }) => toCamel(data));
   }
 
+  async editProjectPermissions(input: EditProjectPermissionsInput): Promise<EditProjectPermissionsResult> {
+    return axios.post(this.getBasePath() + "/edit_project_permissions", toSnake(input)).then(({ data }) => toCamel(data));
+  }
+
   async editProjectTimeline(input: EditProjectTimelineInput): Promise<EditProjectTimelineResult> {
     return axios.post(this.getBasePath() + "/edit_project_timeline", toSnake(input)).then(({ data }) => toCamel(data));
   }
@@ -2558,6 +2573,9 @@ export async function editProjectCheckIn(input: EditProjectCheckInInput) : Promi
 }
 export async function editProjectName(input: EditProjectNameInput) : Promise<EditProjectNameResult> {
   return defaultApiClient.editProjectName(input);
+}
+export async function editProjectPermissions(input: EditProjectPermissionsInput) : Promise<EditProjectPermissionsResult> {
+  return defaultApiClient.editProjectPermissions(input);
 }
 export async function editProjectTimeline(input: EditProjectTimelineInput) : Promise<EditProjectTimelineResult> {
   return defaultApiClient.editProjectTimeline(input);
@@ -2912,6 +2930,10 @@ export function useEditProjectName() : UseMutationHookResult<EditProjectNameInpu
   return useMutation<EditProjectNameInput, EditProjectNameResult>((input) => defaultApiClient.editProjectName(input));
 }
 
+export function useEditProjectPermissions() : UseMutationHookResult<EditProjectPermissionsInput, EditProjectPermissionsResult> {
+  return useMutation<EditProjectPermissionsInput, EditProjectPermissionsResult>((input) => defaultApiClient.editProjectPermissions(input));
+}
+
 export function useEditProjectTimeline() : UseMutationHookResult<EditProjectTimelineInput, EditProjectTimelineResult> {
   return useMutation<EditProjectTimelineInput, EditProjectTimelineResult>((input) => defaultApiClient.editProjectTimeline(input));
 }
@@ -3161,6 +3183,8 @@ export default {
   useEditProjectCheckIn,
   editProjectName,
   useEditProjectName,
+  editProjectPermissions,
+  useEditProjectPermissions,
   editProjectTimeline,
   useEditProjectTimeline,
   joinSpace,

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -676,6 +676,7 @@ export interface Project {
   archivedAt?: string | null;
   champion?: Person | null;
   reviewer?: Person | null;
+  accessLevels?: AccessLevels | null;
 }
 
 export interface ProjectCheckIn {
@@ -1134,6 +1135,7 @@ export interface GetProjectInput {
   includeChampion?: boolean | null;
   includeReviewer?: boolean | null;
   includeSpace?: boolean | null;
+  includeAccessLevels?: boolean | null;
 }
 
 export interface GetProjectResult {

--- a/assets/js/features/Permissions/PrivacyLevel.tsx
+++ b/assets/js/features/Permissions/PrivacyLevel.tsx
@@ -13,6 +13,11 @@ interface PrivacyLevelProps {
 }
 
 
+const parseTestId = (name: string) => {
+  return "privacy-level-" + name.split(" ")[0]?.toLocaleLowerCase();
+}
+
+
 export default function PrivacyLevel({description, options, defaultValue}: PrivacyLevelProps) {
   const { dispatch } = usePermissionsContext();
 
@@ -42,7 +47,7 @@ export default function PrivacyLevel({description, options, defaultValue}: Priva
 
       <RadioGroup name="privacy-level" onChange={handleChange} defaultValue={defaultValue} >
         {options.map((option, idx) => (
-          <Radio {...option} key={idx} />
+          <Radio {...option} key={idx} testId={parseTestId(option.label)} />
         ))}
       </RadioGroup>
     </div>

--- a/assets/js/pages/ProjectEditAccessLevelsPage/index.tsx
+++ b/assets/js/pages/ProjectEditAccessLevelsPage/index.tsx
@@ -1,0 +1,2 @@
+export { Page } from "./page";
+export { loader } from "./loader";

--- a/assets/js/pages/ProjectEditAccessLevelsPage/loader.tsx
+++ b/assets/js/pages/ProjectEditAccessLevelsPage/loader.tsx
@@ -1,0 +1,28 @@
+import * as Pages from "@/components/Pages";
+
+import { getCompany, getProject } from "@/api";
+import { Company } from "@/models/companies";
+import { Project } from "@/models/projects";
+
+
+interface LoaderResult {
+  project: Project;
+  company: Company;
+}
+
+export async function loader({ params }): Promise<LoaderResult> {
+  return {
+    project: await getProject({
+      id: params.projectID,
+      includeSpace: true,
+      includeAccessLevels: true,
+    }).then((data) => data.project!),
+    company: await getCompany({ 
+      id: params.companyId,
+    }).then((data) => data.company!)
+  };
+}
+
+export function useLoadedData(): LoaderResult {
+  return Pages.useLoadedData() as LoaderResult;
+}

--- a/assets/js/pages/ProjectEditAccessLevelsPage/page.tsx
+++ b/assets/js/pages/ProjectEditAccessLevelsPage/page.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import * as Icons from "@tabler/icons-react";
+
+import * as Paper from "@/components/PaperContainer";
+import * as Pages from "@/components/Pages";
+import * as Forms from "@/components/Form";
+
+import { useNavigateTo } from "@/routes/useNavigateTo";
+import { useLoadedData } from "./loader";
+import { Paths } from "@/routes/paths";
+import { Project } from "@/models/projects";
+import { PermissionsProvider, usePermissionsContext } from "@/features/Permissions/PermissionsContext";
+import { ResourcePermissionSelector } from "@/features/Permissions";
+import { useEditProjectPermissions } from "@/api";
+
+export function Page() {
+  const { project, company } = useLoadedData();
+  
+  return (
+    <Pages.Page title={["Edit Project Name", project.name!]}>
+      <Paper.Root>
+        <Paper.Navigation>
+          <Paper.NavItem linkTo={Paths.projectPath(project.id!)}>
+            <Icons.IconClipboardList size={16} />
+            {project.name}
+          </Paper.NavItem>
+        </Paper.Navigation>
+
+        <Paper.Body>
+          <h1 className="mb-8 font-extrabold text-content-accent text-3xl">Editing the project's permissions</h1>
+          <PermissionsProvider company={company} space={project.space} currentPermissions={project.accessLevels} >
+            <Form project={project} />
+          </PermissionsProvider>
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
+  );
+}
+
+function Form({ project }: { project: Project }) {
+  const navigateToProject = useNavigateTo(Paths.projectPath(project.id!));
+  const { permissions } = usePermissionsContext();
+  const [edit, { loading }] = useEditProjectPermissions();
+
+  const handleSubmit = async () => {
+    edit({
+      projectId: project.id,
+      accessLevels: permissions,
+    })
+    .then(() => {
+      navigateToProject();
+    })
+  };
+
+  const handleCancel = () => navigateToProject();
+
+  return (
+    <Forms.Form onSubmit={handleSubmit} loading={loading} isValid={true} onCancel={handleCancel} >
+      <div className="flex flex-col gap-6">
+        <ResourcePermissionSelector />
+      </div>
+
+      <Forms.SubmitArea>
+        <Forms.SubmitButton data-test-id="save">Save</Forms.SubmitButton>
+        <Forms.CancelButton>Cancel</Forms.CancelButton>
+      </Forms.SubmitArea>
+    </Forms.Form>
+  );
+}

--- a/assets/js/pages/ProjectPage/Options.tsx
+++ b/assets/js/pages/ProjectPage/Options.tsx
@@ -26,6 +26,15 @@ export default function Options({ project }) {
         />
       )}
 
+      {project.permissions.canEditPermissions && (
+        <PageOptions.Link
+          icon={Icons.IconLock}
+          title="Edit project permissions"
+          to={Paths.editProjectAccessLevelsPath(project.id)}
+          dataTestId="edit-project-permissions-button"
+        />
+      )}
+
       {project.permissions.canPause && Projects.isPausable(project) && (
         <PageOptions.Link
           icon={Icons.IconPlayerPauseFilled}

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -53,6 +53,7 @@ import * as ProjectCheckInPage from "./ProjectCheckInPage";
 import * as ProjectCheckInsPage from "./ProjectCheckInsPage";
 import * as ProjectClosePage from "./ProjectClosePage";
 import * as ProjectContributorsPage from "./ProjectContributorsPage";
+import * as ProjectEditAccessLevelsPage from "./ProjectEditAccessLevelsPage";
 import * as ProjectEditDescriptionPage from "./ProjectEditDescriptionPage";
 import * as ProjectEditGoalPage from "./ProjectEditGoalPage";
 import * as ProjectEditProjectNamePage from "./ProjectEditProjectNamePage";
@@ -280,6 +281,10 @@ export default {
   ProjectContributorsPage: {
     loader: ProjectContributorsPage.loader,
     Page: ProjectContributorsPage.Page
+  },
+  ProjectEditAccessLevelsPage: {
+    loader: ProjectEditAccessLevelsPage.loader,
+    Page: ProjectEditAccessLevelsPage.Page
   },
   ProjectEditDescriptionPage: {
     loader: ProjectEditDescriptionPage.loader,

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -99,6 +99,7 @@ export function createAppRoutes() {
         pageRoute("projects/:projectID/check-ins", pages.ProjectCheckInsPage),
         pageRoute("projects/:projectID/check-ins/new", pages.ProjectCheckInNewPage),
         pageRoute("projects/:projectID/edit/name", pages.ProjectEditProjectNamePage),
+        pageRoute("projects/:projectID/edit/permissions", pages.ProjectEditAccessLevelsPage),
         pageRoute("projects/:projectID/edit/timeline", pages.ProjectEditTimelinePage),
         pageRoute("projects/:projectID/edit/description", pages.ProjectEditDescriptionPage),
         pageRoute("projects/:projectID/edit/resources", pages.ProjectEditResourcesPage),

--- a/assets/js/routes/paths.tsx
+++ b/assets/js/routes/paths.tsx
@@ -123,6 +123,10 @@ export class Paths {
     return createCompanyPath(["projects", projectId, "edit", "name"]);
   }
 
+  static editProjectAccessLevelsPath(projectId: string) {
+    return createCompanyPath(["projects", projectId, "edit", "permissions"]);
+  }
+
   static moveProjectPath(projectId: string) {
     return createCompanyPath(["projects", projectId, "move"]);
   }

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -173,8 +173,10 @@ defmodule Operately.Access do
           |> repo.insert()
 
         binding ->
-          Binding.changeset(binding, %{access_level: access_level})
+          {:ok, updated} = Binding.changeset(binding, %{access_level: access_level})
           |> repo.update()
+
+          {:ok, %{previous: binding, updated: updated}}
       end
     end)
   end

--- a/lib/operately/activities/content/project_permissions_edited.ex
+++ b/lib/operately/activities/content/project_permissions_edited.ex
@@ -1,0 +1,39 @@
+defmodule Operately.Activities.Content.ProjectPermissionsEdited do
+  use Operately.Activities.Content
+
+  defmodule Permissions do
+    use Operately.Activities.Content
+
+    embedded_schema do
+      field :public, :integer
+      field :company, :integer
+      field :space, :integer
+    end
+
+    def changeset(update, attrs) do
+      update
+      |> cast(attrs, [:public, :company, :space])
+    end
+  end
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :project, Operately.Projects.Project
+
+    embeds_one :previous_permissions, Permissions
+    embeds_one :new_permissions, Permissions
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:company_id, :space_id, :project_id])
+    |> cast_embed(:previous_permissions)
+    |> cast_embed(:new_permissions)
+    |> validate_required([:company_id, :space_id, :project_id, :previous_permissions, :new_permissions])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -78,6 +78,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "project_moved",
     "project_pausing",
     "project_renamed",
+    "project_permissions_edited",
     "project_resuming",
     "project_timeline_edited",
   ]

--- a/lib/operately/activities/notifications/project_permissions_edited.ex
+++ b/lib/operately/activities/notifications/project_permissions_edited.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.ProjectPermissionsEdited do
+  def dispatch(_activity) do
+    # Notification dispatcher for ProjectPermissionsEdited not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/operations/project_permissions_editing.ex
+++ b/lib/operately/operations/project_permissions_editing.ex
@@ -1,0 +1,58 @@
+defmodule Operately.Operations.ProjectPermissionsEditing do
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Activities
+
+  def run(author, project, attrs) do
+    Multi.new()
+    |> Multi.run(:context, fn _, _ ->
+      {:ok, Access.get_context!(project_id: project.id)}
+    end)
+    |> Access.update_bindings_to_company(project.company_id, attrs.company, attrs.public)
+    |> maybe_update_bidings_to_space(project, attrs)
+    |> insert_activity(author, project)
+    |> Repo.transaction()
+  end
+
+  defp maybe_update_bidings_to_space(multi, project, attrs) do
+    company_space_id = Repo.one!(from(c in Operately.Companies.Company, where: c.id == ^project.company_id, select: c.company_space_id))
+
+    if project.group_id != company_space_id do
+      multi
+      |> Access.update_bindings_to_space(project.group_id, attrs.space)
+    else
+      multi
+    end
+  end
+
+  defp insert_activity(multi, author, project) do
+    multi
+    |> Activities.insert_sync(author.id, :project_permissions_edited, fn changes ->
+      %{
+        company_id: project.company_id,
+        space_id: project.group_id,
+        project_id: project.id,
+        previous_permissions: %{
+          public: find_access_level(changes, :anonymous_binding, :previous),
+          company: find_access_level(changes, :company_members_binding, :previous),
+          space: find_access_level(changes, :space_members_binding, :previous),
+        },
+        new_permissions: %{
+          public: find_access_level(changes, :anonymous_binding, :updated),
+          company: find_access_level(changes, :company_members_binding, :updated),
+          space: find_access_level(changes, :space_members_binding, :updated),
+        }
+      }
+    end)
+  end
+
+  defp find_access_level(changes, level, version) do
+    case Map.has_key?(changes, level) do
+      true -> Map.get(changes[level], version).access_level
+      false -> nil
+    end
+  end
+end

--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -11,6 +11,7 @@ defmodule Operately.Projects.Permissions do
     :can_edit_name,
     :can_edit_space,
     :can_edit_contributors,
+    :can_edit_permissions,
     :can_pause,
     :can_check_in,
     :can_acknowledge_check_in
@@ -32,6 +33,7 @@ defmodule Operately.Projects.Permissions do
       can_edit_name: is_contributor?(project, user),
       can_edit_space: is_contributor?(project, user),
       can_edit_contributors: is_contributor?(project, user),
+      can_edit_permissions: is_contributor?(project, user),
 
       can_pause: is_contributor?(project, user),
       can_check_in: is_contributor?(project, user),

--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -75,6 +75,7 @@ defmodule OperatelyWeb.Api do
   mutation :edit_key_resource, OperatelyWeb.Api.Mutations.EditKeyResource
   mutation :edit_project_check_in, OperatelyWeb.Api.Mutations.EditProjectCheckIn
   mutation :edit_project_name, OperatelyWeb.Api.Mutations.EditProjectName
+  mutation :edit_project_permissions, OperatelyWeb.Api.Mutations.EditProjectPermissions
   mutation :edit_project_timeline, OperatelyWeb.Api.Mutations.EditProjectTimeline
   mutation :join_space, OperatelyWeb.Api.Mutations.JoinSpace
   mutation :mark_all_notifications_as_read, OperatelyWeb.Api.Mutations.MarkAllNotificationsAsRead

--- a/lib/operately_web/api/mutations/edit_project_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_project_permissions.ex
@@ -16,7 +16,7 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectPermissions do
 
     project = Operately.Projects.get_project!(id)
 
-    # todo
+    Operately.Operations.ProjectPermissionsEditing.run(me(conn), project, inputs.access_levels)
 
     {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(project)}}
   end

--- a/lib/operately_web/api/mutations/edit_project_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_project_permissions.ex
@@ -1,0 +1,23 @@
+defmodule OperatelyWeb.Api.Mutations.EditProjectPermissions do
+  use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
+
+  inputs do
+    field :project_id, :string
+    field :access_levels, :access_levels
+  end
+
+  outputs do
+    field :success, :boolean
+  end
+
+  def call(conn, inputs) do
+    {:ok, id} = decode_id(inputs.project_id)
+
+    project = Operately.Projects.get_project!(id)
+
+    # todo
+
+    {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(project)}}
+  end
+end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -345,7 +345,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       last_check_in: OperatelyWeb.Api.Serializer.serialize(project.last_check_in),
       next_milestone: OperatelyWeb.Api.Serializer.serialize(project.next_milestone),
       permissions: OperatelyWeb.Api.Serializer.serialize(project.permissions),
-      key_resources: OperatelyWeb.Api.Serializer.serialize(project.key_resources)
+      key_resources: OperatelyWeb.Api.Serializer.serialize(project.key_resources),
+      access_levels: OperatelyWeb.Api.Serializer.serialize(project.access_levels, level: :full),
     }
   end
 end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -365,6 +365,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Permissions do
       can_edit_name: permissions.can_edit_name,
       can_edit_space: permissions.can_edit_space,
       can_edit_contributors: permissions.can_edit_contributors,
+      can_edit_permissions: permissions.can_edit_permissions,
       can_pause: permissions.can_pause,
       can_check_in: permissions.can_check_in,
       can_acknowledge_check_in: permissions.can_acknowledge_check_in,

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -150,6 +150,7 @@ defmodule OperatelyWeb.Api.Types do
     field :archived_at, :date
     field :champion, :person
     field :reviewer, :person
+    field :access_levels, :access_levels
   end
 
   object :discussion do

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -387,6 +387,7 @@ defmodule OperatelyWeb.Api.Types do
     field :can_edit_goal, :boolean
     field :can_edit_name, :boolean
     field :can_edit_space, :boolean
+    field :can_edit_permissions, :boolean
     field :can_pause, :boolean
     field :can_check_in, :boolean
     field :can_acknowledge_check_in, :boolean

--- a/test/operately/operations/project_permissions_editing_test.exs
+++ b/test/operately/operations/project_permissions_editing_test.exs
@@ -1,0 +1,84 @@
+defmodule Operately.Operations.ProjectPermissionsEditingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+
+    attrs = %{
+      company_id: company.id,
+      creator_id: creator.id,
+      group_id: space.id,
+      space_access_level: Binding.edit_access(),
+      company_access_level: Binding.comment_access(),
+      anonymous_access_level: Binding.view_access(),
+    }
+
+    {:ok, company: company, space: space, creator: creator, attrs: attrs}
+  end
+
+  test "ProjectPermissionsEditing operation edits bindings", ctx do
+    project = project_fixture(ctx.attrs)
+
+    Operately.Operations.ProjectPermissionsEditing.run(ctx.creator, project, %{
+      public: Binding.no_access(),
+      company: Binding.view_access(),
+      space: Binding.full_access(),
+    })
+
+    context = Access.get_context!(project_id: project.id)
+
+    public = Access.get_group!(company_id: ctx.company.id, tag: :anonymous)
+    company = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    space = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+
+    assert Access.get_binding(context_id: context.id, group_id: public.id, access_level: Binding.no_access())
+    assert Access.get_binding(context_id: context.id, group_id: company.id, access_level: Binding.view_access())
+    assert Access.get_binding(context_id: context.id, group_id: space.id, access_level: Binding.full_access())
+  end
+
+  test "ProjectPermissionsEditing operation ignores company space", ctx do
+    attrs = Map.merge(ctx.attrs, %{
+      group_id: ctx.company.company_space_id
+    })
+    project = project_fixture(attrs)
+
+    Operately.Operations.ProjectPermissionsEditing.run(ctx.creator, project, %{
+      public: Binding.no_access(),
+      company: Binding.view_access(),
+      space: Binding.full_access(),
+    })
+
+    refute Access.get_group(group_id: project.group_id, tag: :standard)
+  end
+
+  test "ProjectPermissionsEditing operation creates activity", ctx do
+    project = project_fixture(ctx.attrs)
+
+    Operately.Operations.ProjectPermissionsEditing.run(ctx.creator, project, %{
+      public: Binding.no_access(),
+      company: Binding.view_access(),
+      space: Binding.full_access(),
+    })
+
+    activity = from(a in Activity, where: a.action == "project_permissions_edited" and a.content["project_id"] == ^project.id) |> Repo.one!()
+
+    assert activity.content["previous_permissions"]["public"] == Binding.view_access()
+    assert activity.content["previous_permissions"]["company"] == Binding.comment_access()
+    assert activity.content["previous_permissions"]["space"] == Binding.edit_access()
+
+    assert activity.content["new_permissions"]["space"] == Binding.full_access()
+    assert activity.content["new_permissions"]["company"] == Binding.view_access()
+    assert activity.content["new_permissions"]["public"] == Binding.no_access()
+  end
+end

--- a/test/operately_web/api/queries/get_project_test.exs
+++ b/test/operately_web/api/queries/get_project_test.exs
@@ -147,6 +147,25 @@ defmodule OperatelyWeb.Api.Queries.GetProjectTest do
       assert {200, res} = query(ctx.conn, :get_project, %{id: Paths.project_id(project), include_key_resources: true})
       assert res.project.key_resources == [serialize(key_resource, level: :essential)]
     end
+
+    test "include_access_levels", ctx do
+      space = group_fixture(ctx.person)
+      project = create_project(ctx, %{
+        group_id: space.id,
+        anonymous_access_level: Binding.view_access(),
+        company_access_level: Binding.edit_access(),
+        space_access_level: Binding.full_access(),
+      })
+
+      assert {200, res} = query(ctx.conn, :get_project, %{id: Paths.project_id(project)})
+      refute res.project.access_levels
+
+      assert {200, res} = query(ctx.conn, :get_project, %{id: Paths.project_id(project), include_access_levels: true})
+
+      assert res.project.access_levels.public == Binding.view_access()
+      assert res.project.access_levels.company == Binding.edit_access()
+      assert res.project.access_levels.space == Binding.full_access()
+    end
   end
 
   def create_project(ctx, attrs \\ %{}) do


### PR DESCRIPTION
I've added `ProjectEditAccessLevelsPage` where the permissions of a project can be edited. I've also added the `EditProjectPermissions` mutation and the `ProjectPermissionsEditing` operation.