### PR TITLE
feat: Add ProjectSpaceMoving operation

### DIFF
--- a/lib/operately/operations/project_space_moving.ex
+++ b/lib/operately/operations/project_space_moving.ex
@@ -1,0 +1,72 @@
+defmodule Operately.Operations.ProjectSpaceMoving do
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Activities
+  alias Operately.Projects.Project
+
+  def run(author, project, space_id) do
+    context = Access.get_context!(project_id: project.id)
+
+    Multi.new()
+    |> Multi.update(:project, Project.changeset(project, %{group_id: space_id}))
+    |> Multi.run(:context, fn _, _ -> {:ok, context} end)
+    |> update_bindings(context, project, space_id)
+    |> insert_activity(author, project)
+    |> Repo.transaction()
+    |> Repo.extract_result(:project)
+  end
+
+  defp insert_activity(multi, author, project) do
+    Activities.insert_sync(multi, author.id, :project_moved, fn changes -> %{
+      company_id: project.company_id,
+      project_id: project.id,
+      old_space_id: project.group_id,
+      new_space_id: changes.project.group_id
+    } end)
+  end
+
+  defp update_bindings(multi, context, project, new_space_id) do
+    company_space_id = Repo.one!(from(c in Operately.Companies.Company, where: c.id == ^project.company_id, select: c.company_space_id))
+    previous_space_id = project.group_id
+
+    binding = get_current_binding(context, previous_space_id, company_space_id)
+
+    multi
+    |> maybe_delete_binding_to_space(binding)
+    |> maybe_update_binding_to_space(new_space_id, company_space_id, get_current_access_level(binding))
+  end
+
+  defp maybe_update_binding_to_space(multi, space_id, company_space_id, access_level) do
+    if space_id != company_space_id do
+      Access.update_bindings_to_space(multi, space_id, access_level)
+    else
+      multi
+    end
+  end
+
+  defp maybe_delete_binding_to_space(multi, binding) do
+    if binding do
+      Multi.delete(multi, :deleted_space_binding, binding)
+    else
+      multi
+    end
+  end
+
+  defp get_current_binding(context, space_id, company_space_id) do
+    if space_id != company_space_id do
+      group = Access.get_group!(group_id: space_id, tag: :standard)
+      Access.get_binding!(context_id: context.id, group_id: group.id)
+    end
+  end
+
+  defp get_current_access_level(binding) do
+    case binding do
+      nil -> Binding.no_access()
+      binding -> binding.access_level
+    end
+  end
+end

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -42,19 +42,6 @@ defmodule Operately.Projects do
     |> Repo.update()
   end
 
-  def move_project_to_space(author, project, space_id) do
-    Multi.new()
-    |> Multi.update(:project, change_project(project, %{group_id: space_id}))
-    |> Activities.insert_sync(author.id, :project_moved, fn _ -> %{
-      company_id: project.company_id,
-      project_id: project.id,
-      old_space_id: project.group_id,
-      new_space_id: space_id
-    } end)
-    |> Repo.transaction()
-    |> Repo.extract_result(:project)
-  end
-
   def rename_project(author, project, new_name) do
     Multi.new()
     |> Multi.update(:project, change_project(project, %{name: new_name}))

--- a/lib/operately_web/api/mutations/move_project_to_space.ex
+++ b/lib/operately_web/api/mutations/move_project_to_space.ex
@@ -14,7 +14,7 @@ defmodule OperatelyWeb.Api.Mutations.MoveProjectToSpace do
     {:ok, space_id} = decode_id(inputs.space_id)
 
     project = Operately.Projects.get_project!(project_id)
-    {:ok, _project} = Operately.Projects.move_project_to_space(author, project, space_id)
+    {:ok, _project} = Operately.Operations.ProjectSpaceMoving.run(author, project, space_id)
 
     {:ok, %{}}
   end

--- a/test/operately/operations/project_space_moving_test.exs
+++ b/test/operately/operations/project_space_moving_test.exs
@@ -1,0 +1,114 @@
+defmodule Operately.Operations.ProjectSpaceMovingTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Ecto.Query, only: [from: 2]
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+    new_space = group_fixture(creator)
+
+    attrs = %{
+      company_id: company.id,
+      creator_id: creator.id,
+      group_id: space.id,
+      space_access_level: Binding.edit_access(),
+    }
+
+    {:ok, company: company, space: space, new_space: new_space, creator: creator, attrs: attrs}
+  end
+
+  test "ProjectSpaceMoving operation changes project's space", ctx do
+    project = project_fixture(ctx.attrs)
+
+    {:ok, updated_project} = Operately.Operations.ProjectSpaceMoving.run(ctx.creator, project, ctx.new_space.id)
+
+    assert project.group_id == ctx.space.id
+    assert updated_project.group_id == ctx.new_space.id
+  end
+
+  test "ProjectSpaceMoving operation creates binding to new space and deletes old binding", ctx do
+    project = project_fixture(ctx.attrs)
+    context = Access.get_context!(project_id: project.id)
+
+    old_space_group = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+    new_space_group = Access.get_group!(group_id: ctx.new_space.id, tag: :standard)
+
+    assert Access.get_binding(context_id: context.id, group_id: old_space_group.id, access_level: Binding.edit_access())
+    refute Access.get_binding(context_id: context.id, group_id: new_space_group.id)
+
+    Operately.Operations.ProjectSpaceMoving.run(ctx.creator, project, ctx.new_space.id)
+
+    refute Access.get_binding(context_id: context.id, group_id: old_space_group.id)
+    assert Access.get_binding(context_id: context.id, group_id: new_space_group.id, access_level: Binding.edit_access())
+  end
+
+  test "ProjectSpaceMoving operation ignores new space when it's the company's space and deletes old binding", ctx do
+    project = project_fixture(ctx.attrs)
+    context = Access.get_context!(project_id: project.id)
+
+    unused_space_group = Access.get_group!(group_id: ctx.new_space.id, tag: :standard)
+    old_space_group = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+
+    refute Access.get_binding(context_id: context.id, group_id: unused_space_group.id)
+    assert Access.get_binding(context_id: context.id, group_id: old_space_group.id, access_level: Binding.edit_access())
+
+    Operately.Operations.ProjectSpaceMoving.run(ctx.creator, project, ctx.company.company_space_id)
+
+    refute Access.get_binding(context_id: context.id, group_id: unused_space_group.id)
+    refute Access.get_binding(context_id: context.id, group_id: old_space_group.id)
+  end
+
+  test "ProjectSpaceMoving operation creates binding to new space and ignores old space when it's the company's space", ctx do
+    project = project_fixture(Map.merge(ctx.attrs, %{group_id: ctx.company.company_space_id}))
+    context = Access.get_context!(project_id: project.id)
+
+    unused_space_group = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+    new_space_group = Access.get_group!(group_id: ctx.new_space.id, tag: :standard)
+
+    refute Access.get_binding(context_id: context.id, group_id: unused_space_group.id)
+    refute Access.get_binding(context_id: context.id, group_id: new_space_group.id)
+
+    Operately.Operations.ProjectSpaceMoving.run(ctx.creator, project, ctx.new_space.id)
+
+    refute Access.get_binding(context_id: context.id, group_id: unused_space_group.id)
+    assert Access.get_binding(context_id: context.id, group_id: new_space_group.id, access_level: Binding.no_access())
+  end
+
+  test "ProjectSpaceMoving operation creates activity and notification", ctx do
+    champion = person_fixture_with_account(%{company_id: ctx.company.id})
+    reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    attrs = Map.merge(ctx.attrs, %{
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+      creator_is_contributor: "no",
+    })
+
+    {:ok, project} = Oban.Testing.with_testing_mode(:manual, fn ->
+      project = project_fixture(attrs)
+      Operately.Operations.ProjectSpaceMoving.run(ctx.creator, project, ctx.new_space.id)
+    end)
+
+    activity = from(a in Activity, where: a.action == "project_moved" and a.content["project_id"] == ^project.id) |> Repo.one()
+
+    assert notifications_count() == 0
+
+    perform_job(activity.id)
+
+    assert fetch_notifications(activity.id)
+    assert notifications_count() == 2
+  end
+end


### PR DESCRIPTION
I've added the `ProjectSpaceMoving` operation, which moves a project to another space and updates the project's access bindings.