### PR TITLE
feat: Add ProjectContributorEditing operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -697,6 +697,7 @@ export interface ProjectContributor {
   responsibility?: string | null;
   role?: string | null;
   person?: Person | null;
+  accessLevel?: number | null;
 }
 
 export interface ProjectHealth {
@@ -1139,6 +1140,7 @@ export interface GetProjectInput {
   includeReviewer?: boolean | null;
   includeSpace?: boolean | null;
   includeAccessLevels?: boolean | null;
+  includeContributorsAccessLevels?: boolean | null;
 }
 
 export interface GetProjectResult {

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1937,6 +1937,7 @@ export interface UpdateProjectContributorInput {
   contribId?: string | null;
   personId?: string | null;
   responsibility?: string | null;
+  permissions?: number | null;
 }
 
 export interface UpdateProjectContributorResult {

--- a/assets/js/features/Permissions/index.tsx
+++ b/assets/js/features/Permissions/index.tsx
@@ -30,6 +30,7 @@ export const PERMISSIONS_LIST = [
   {value: PermissionLevels.EDIT_ACCESS, label: "Can Edit"},
   {value: PermissionLevels.COMMENT_ACCESS, label: "Can Comment"},
   VIEW_ACCESS,
+  {value: PermissionLevels.NO_ACCESS, label: "No Access"},
 ]
 
 export const PUBLIC_PERMISSIONS_LIST = [

--- a/assets/js/models/projectContributors/index.tsx
+++ b/assets/js/models/projectContributors/index.tsx
@@ -17,6 +17,17 @@ export function responsibility(contributor: ProjectContributor | undefined, role
   }
 }
 
+export function isPermissionsEditable(role: ContributorRole) {
+  switch (role) {
+    case "champion":
+      return false;
+    case "reviewer":
+      return false;
+    default:
+      return true;
+  }
+}
+
 export function isResponsibilityEditable(role: ContributorRole) {
   return role !== "champion" && role !== "reviewer";
 }

--- a/assets/js/pages/ProjectContributorsPage/ContributorItem.tsx
+++ b/assets/js/pages/ProjectContributorsPage/ContributorItem.tsx
@@ -114,6 +114,7 @@ function EditAssignment({ contributor, project, onSave, onRemove, onClose }) {
       contribId: contributor.id,
       personId: personID,
       responsibility: newResp,
+      permissions: permissions?.value || 0,
     });
 
     onSave();

--- a/assets/js/pages/ProjectContributorsPage/ContributorItem.tsx
+++ b/assets/js/pages/ProjectContributorsPage/ContributorItem.tsx
@@ -5,12 +5,14 @@ import * as Projects from "@/models/projects";
 
 import ContributorAvatar from "@/components/ContributorAvatar";
 
-import { ContributorSearch, RemoveButton, SaveButton, CancelButton, ResponsibilityInput } from "./FormElements";
+import { PERMISSIONS_LIST } from "@/features/Permissions";
+import { ContributorSearch, RemoveButton, SaveButton, CancelButton, ResponsibilityInput, PermissionsInput } from "./FormElements";
 import { createTestId } from "@/utils/testid";
+
 
 interface Props {
   project: Projects.Project;
-  contributor?: ProjectContributors.ProjectContributor;
+  contributor: ProjectContributors.ProjectContributor;
   refetch: any;
 }
 
@@ -22,15 +24,7 @@ export default function ContributorItem({ project, contributor, refetch }: Props
   );
 }
 
-function ContributorItemContent({
-  contributor,
-  project,
-  refetch,
-}: {
-  contributor?: ProjectContributors.ProjectContributor;
-  project: Projects.Project;
-  refetch: any;
-}) {
+function ContributorItemContent({ contributor, project, refetch }: Props) {
   const [state, setState] = React.useState<"view" | "edit">("view");
 
   const activateEdit = () => setState("edit");
@@ -109,6 +103,7 @@ function EditAssignment({ contributor, project, onSave, onRemove, onClose }) {
 
   const responsibility = ProjectContributors.responsibility(contributor, contributor.role);
 
+  const [permissions, setPermissions] = React.useState(PERMISSIONS_LIST.find(p => p.value === contributor.accessLevel));
   const [personID, setPersonID] = React.useState<any>(contributor.person.id);
   const [newResp, setNewResp] = React.useState(responsibility);
 
@@ -140,6 +135,10 @@ function EditAssignment({ contributor, project, onSave, onRemove, onClose }) {
 
       {ProjectContributors.isResponsibilityEditable(contributor.role) && (
         <ResponsibilityInput value={newResp} onChange={setNewResp} />
+      )}
+
+      {ProjectContributors.isPermissionsEditable(contributor.role) && (
+        <PermissionsInput value={permissions} onChange={setPermissions} />
       )}
 
       <div className="flex justify-between mt-8">

--- a/assets/js/pages/ProjectContributorsPage/loader.tsx
+++ b/assets/js/pages/ProjectContributorsPage/loader.tsx
@@ -12,7 +12,7 @@ export async function loader({ params }): Promise<LoaderData> {
       includeSpace: true,
       includeChampion: true,
       includePermissions: true,
-      includeContributors: true,
+      includeContributorsAccessLevels: true,
     }).then((data) => data.project!),
   };
 }

--- a/lib/operately/activities/content/project_contributor_edited.ex
+++ b/lib/operately/activities/content/project_contributor_edited.ex
@@ -1,22 +1,35 @@
 defmodule Operately.Activities.Content.ProjectContributorEdited do
   use Operately.Activities.Content
 
+  defmodule Contributor do
+    use Operately.Activities.Content
+
+    embedded_schema do
+      field :person_id, :string
+      field :role, :string
+      field :permissions, :integer
+    end
+
+    def changeset(update, attrs) do
+      update
+      |> cast(attrs, __schema__(:fields))
+    end
+  end
+
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
     belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
 
-    belongs_to :previous_contributor, Operately.People.Person
-    field :previous_role, :string
-
-    belongs_to :new_contributor, Operately.People.Person
-    field :new_role, :string
-    field :new_permissions, :integer
+    embeds_one :previous_contributor, Contributor
+    embeds_one :updated_contributor, Contributor
   end
 
   def changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, __schema__(:fields))
+    |> cast(attrs, [:company_id, :space_id, :project_id])
+    |> cast_embed(:previous_contributor)
+    |> cast_embed(:updated_contributor)
     |> validate_required(__schema__(:fields))
   end
 

--- a/lib/operately/activities/content/project_contributor_edited.ex
+++ b/lib/operately/activities/content/project_contributor_edited.ex
@@ -1,0 +1,26 @@
+defmodule Operately.Activities.Content.ProjectContributorEdited do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :project, Operately.Projects.Project
+
+    belongs_to :previous_contributor, Operately.People.Person
+    field :previous_role, :string
+
+    belongs_to :new_contributor, Operately.People.Person
+    field :new_role, :string
+    field :new_permissions, :integer
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -81,6 +81,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "project_permissions_edited",
     "project_resuming",
     "project_timeline_edited",
+    "project_contributor_edited",
   ]
 
   @task_actions [

--- a/lib/operately/activities/notifications/project_contributor_edited.ex
+++ b/lib/operately/activities/notifications/project_contributor_edited.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.ProjectContributorEdited do
+  def dispatch(_activity) do
+    # Notification dispatcher for ProjectContributorEdited not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/operations/project_contributor_editing.ex
+++ b/lib/operately/operations/project_contributor_editing.ex
@@ -1,0 +1,84 @@
+defmodule Operately.Operations.ProjectContributorEditing do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Projects
+  alias Operately.Projects.Contributor
+  alias Operately.Activities
+
+  def run(creator, contributor, attrs) do
+    Multi.new()
+    |> Multi.update(:contributor, Contributor.changeset(contributor, attrs))
+    |> Multi.run(:context, fn _, _ ->
+      {:ok, Access.get_context!(project_id: contributor.project_id)}
+    end)
+    |> update_bindings(contributor, attrs)
+    |> insert_activity(creator, contributor, attrs)
+    |> Repo.transaction()
+    |> Repo.extract_result(:contributor)
+  end
+
+  defp update_bindings(multi, contributor, attrs) when contributor.person_id == attrs.person_id do
+    if is_reviewer_or_contributor?(contributor) do
+      multi
+    else
+      group = Access.get_group!(person_id: contributor.person_id)
+      Access.update_or_insert_binding(multi, :contributor_binding, group, attrs.permissions)
+    end
+  end
+
+  defp update_bindings(multi, contributor, attrs) when contributor.person_id != attrs.person_id do
+    previous_group = Access.get_group!(person_id: contributor.person_id)
+    new_group = Access.get_group!(person_id: attrs.person_id)
+    permissions = find_permissions(contributor, attrs)
+
+    multi
+    |> delete_binding(previous_group)
+    |> Access.update_or_insert_binding(:contributor_binding, new_group, permissions)
+  end
+
+  defp insert_activity(multi, creator, contributor, attrs) do
+    project = Projects.get_project!(contributor.project_id)
+
+    Activities.insert_sync(multi, creator.id, :project_contributor_edited, fn changes ->
+      %{
+        company_id: project.company_id,
+        space_id: project.group_id,
+        project_id: project.id,
+        previous_contributor_id: contributor.person_id,
+        previous_role: Atom.to_string(contributor.role),
+        new_contributor_id: changes.contributor.person_id,
+        new_role: Atom.to_string(changes.contributor.role),
+        new_permissions: find_permissions(changes.contributor, attrs),
+      }
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp delete_binding(multi, group) do
+    Multi.run(multi, :deleted_binding, fn _, changes ->
+      Access.get_binding!(context_id: changes.context.id, group_id: group.id)
+      |> Repo.delete()
+    end)
+  end
+
+  defp find_permissions(contributor, attrs) do
+    if is_reviewer_or_contributor?(contributor) do
+      Binding.full_access()
+    else
+      attrs.permissions
+    end
+  end
+
+  defp is_reviewer_or_contributor?(contributor) do
+    case contributor.role do
+      :champion -> true
+      :reviewer -> true
+      :contributor -> false
+    end
+  end
+end

--- a/lib/operately/operations/project_contributor_editing.ex
+++ b/lib/operately/operations/project_contributor_editing.ex
@@ -46,11 +46,15 @@ defmodule Operately.Operations.ProjectContributorEditing do
         company_id: project.company_id,
         space_id: project.group_id,
         project_id: project.id,
-        previous_contributor_id: contributor.person_id,
-        previous_role: Atom.to_string(contributor.role),
-        new_contributor_id: changes.contributor.person_id,
-        new_role: Atom.to_string(changes.contributor.role),
-        new_permissions: find_permissions(changes.contributor, attrs),
+        previous_contributor: %{
+          person_id: contributor.person_id,
+          role: Atom.to_string(contributor.role),
+        },
+        updated_contributor: %{
+          person_id: changes.contributor.person_id,
+          role: Atom.to_string(changes.contributor.role),
+          permissions: find_permissions(changes.contributor, attrs),
+        }
       }
     end)
   end

--- a/lib/operately_web/api/mutations/update_project_contributor.ex
+++ b/lib/operately_web/api/mutations/update_project_contributor.ex
@@ -6,20 +6,18 @@ defmodule OperatelyWeb.Api.Mutations.UpdateProjectContributor do
     field :contrib_id, :string
     field :person_id, :string
     field :responsibility, :string
+    field :permissions, :integer
   end
 
   outputs do
     field :contributor, :project_contributor
   end
 
-  def call(_conn, inputs) do
+  def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.contrib_id)
     contrib = Operately.Projects.get_contributor!(id)
 
-    {:ok, contrib} = Operately.Projects.update_contributor(contrib, %{
-      person_id: inputs.person_id,
-      responsibility: inputs.responsibility
-    })
+    {:ok, contrib} = Operately.Operations.ProjectContributorEditing.run(me(conn), contrib, inputs)
 
     {:ok, %{contributor: OperatelyWeb.Api.Serializer.serialize(contrib)}}
   end

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -89,20 +89,6 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
   defp load_access_levels(project, true), do: Project.preload_access_levels(project)
   defp load_access_levels(project, _), do: project
 
-  defp load_contributors_access_level(query, true, project_id) do
-    subquery = from(b in Operately.Access.Binding,
-      join: c in assoc(b, :context),
-      where: c.project_id == ^project_id,
-      select: b
-    )
-
-    from(p in query,
-      join: contribs in assoc(p, :contributors),
-      join: person in assoc(contribs, :person),
-      join: group in assoc(person, :access_group),
-      where: p.id == ^project_id,
-      preload: [contributors: {contribs, [person: {person, [access_group: {group, [bindings: ^subquery]}]}]}]
-    )
-  end
+  defp load_contributors_access_level(query, true, project_id), do: Project.preload_contributors_access_level(query, project_id)
   defp load_contributors_access_level(query, _, _), do: query
 end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -301,12 +301,23 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.KeyResource do
 end
 
 defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Contributor do
+  def serialize(%{person: %{access_group: %{bindings: bindings}}} = contributor, level: :essential) when length(bindings) > 0 do
+    %{
+      id: contributor.id,
+      role: Atom.to_string(contributor.role),
+      responsibility: contributor.responsibility,
+      person: OperatelyWeb.Api.Serializer.serialize(contributor.person),
+      access_level: Enum.max_by(bindings, &(&1.access_level)).access_level,
+    }
+  end
+
   def serialize(contributor, level: :essential) do
     %{
       id: contributor.id,
       role: Atom.to_string(contributor.role),
       responsibility: contributor.responsibility,
       person: OperatelyWeb.Api.Serializer.serialize(contributor.person),
+      access_level: 0,
     }
   end
 end
@@ -460,7 +471,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.Project
   def serialize(milestone, level: :essential) do
     %{
       id: OperatelyWeb.Paths.milestone_id(milestone.milestone_id, milestone.new_title),
-      title: milestone.new_title, 
+      title: milestone.new_title,
       deadline_at: OperatelyWeb.Api.Serializer.serialize(milestone.new_due_date),
     }
   end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -868,6 +868,7 @@ defmodule OperatelyWeb.Api.Types do
     field :responsibility, :string
     field :role, :string
     field :person, :person
+    field :access_level, :integer
   end
 
   object :create_target_input do

--- a/test/operately/operations/project_contributor_editing_test.exs
+++ b/test/operately/operations/project_contributor_editing_test.exs
@@ -125,8 +125,11 @@ defmodule Operately.Operations.ProjectContributorEditingTest do
 
     activity = from(a in Activity, where: a.action == "project_contributor_edited" and a.content["project_id"] == ^ctx.project.id) |> Repo.one()
 
-    assert activity.content["previous_contributor_id"] == contributor.person_id
-    assert activity.content["new_contributor_id"] == new_person.id
-    assert activity.content["new_permissions"] == Binding.view_access()
+    assert activity.content["previous_contributor"]["person_id"] == contributor.person_id
+    assert activity.content["previous_contributor"]["role"] == "contributor"
+
+    assert activity.content["updated_contributor"]["person_id"] == new_person.id
+    assert activity.content["updated_contributor"]["permissions"] == Binding.view_access()
+    assert activity.content["updated_contributor"]["role"] == "contributor"
   end
 end

--- a/test/operately/operations/project_contributor_editing_test.exs
+++ b/test/operately/operations/project_contributor_editing_test.exs
@@ -1,0 +1,132 @@
+defmodule Operately.Operations.ProjectContributorEditingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Projects
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+    contributor = person_fixture_with_account(%{company_id: company.id})
+
+    project = project_fixture(%{
+      company_id: company.id,
+      creator_id: creator.id,
+      champion_id: champion.id,
+      group_id: company.company_space_id,
+    })
+
+    attrs = %{
+      project_id: project.id,
+      responsibility: "Developer",
+      permissions: Binding.edit_access(),
+    }
+
+    {:ok, company: company, creator: creator, champion: champion, contributor: contributor, project: project, attrs: attrs}
+  end
+
+  test "ProjectContributorEditing operation updates reviewer/champion with the same person", ctx do
+    champion = Projects.get_contributor!(person_id: ctx.champion.id, project_id: ctx.project.id)
+
+    assert champion.role == :champion
+
+    {:ok, updated} = Operately.Operations.ProjectContributorEditing.run(ctx.creator, champion, %{
+      person_id: ctx.champion.id,
+      role: :reviewer,
+    })
+
+    assert updated.role == :reviewer
+  end
+
+  test "ProjectContributorEditing operation updates contributor with the same person", ctx do
+    {:ok, contributor} = Projects.create_contributor(ctx.creator, Map.merge(ctx.attrs, %{
+      person_id: ctx.contributor.id,
+    }))
+    group = Access.get_group!(person_id: ctx.contributor.id)
+    context = Access.get_context!(project_id: ctx.project.id)
+
+    assert Access.get_binding(context_id: context.id, group_id: group.id, access_level: Binding.edit_access())
+    assert contributor.responsibility == "Developer"
+
+    {:ok, updated} = Operately.Operations.ProjectContributorEditing.run(ctx.creator, contributor, %{
+      person_id: ctx.contributor.id,
+      responsibility: "Manager",
+      permissions: Binding.full_access(),
+    })
+
+    assert updated.responsibility == "Manager"
+    assert Access.get_binding(context_id: context.id, group_id: group.id, access_level: Binding.full_access())
+  end
+
+  test "ProjectContributorEditing operation updates reviewer/champion with another person", ctx do
+    champion_person = Projects.get_champion(ctx.project)
+    new_champion_person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    context = Access.get_context!(project_id: ctx.project.id)
+    champion_group = Access.get_group!(person_id: champion_person.id)
+    new_champion_group = Access.get_group!(person_id: new_champion_person.id)
+
+    assert Access.get_binding(context_id: context.id, group_id: champion_group.id, access_level: Binding.full_access())
+    refute Access.get_binding(context_id: context.id, group_id: new_champion_group.id)
+
+    champion = Projects.get_contributor!(person_id: ctx.champion.id, project_id: ctx.project.id)
+    assert champion_person == ctx.champion
+
+    {:ok, _} = Operately.Operations.ProjectContributorEditing.run(ctx.creator, champion, %{
+      person_id: new_champion_person.id,
+    })
+
+    assert new_champion_person == Projects.get_champion(ctx.project)
+
+    refute Access.get_binding(context_id: context.id, group_id: champion_group.id)
+    assert Access.get_binding(context_id: context.id, group_id: new_champion_group.id, access_level: Binding.full_access())
+  end
+
+  test "ProjectContributorEditing operation updates contributor with a different person", ctx do
+    {:ok, contributor} = Projects.create_contributor(ctx.creator, Map.merge(ctx.attrs, %{
+      person_id: ctx.contributor.id,
+    }))
+    new_person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    context = Access.get_context!(project_id: ctx.project.id)
+    contributor_group = Access.get_group!(person_id: ctx.contributor.id)
+    new_person_group = Access.get_group!(person_id: new_person.id)
+
+    assert Access.get_binding(context_id: context.id, group_id: contributor_group.id, access_level: Binding.edit_access())
+    refute Access.get_binding(context_id: context.id, group_id: new_person_group.id)
+
+    {:ok, _} = Operately.Operations.ProjectContributorEditing.run(ctx.creator, contributor, %{
+      person_id: new_person.id,
+      responsibility: "Manager",
+      permissions: Binding.comment_access(),
+    })
+
+    refute Access.get_binding(context_id: context.id, group_id: contributor_group.id)
+    assert Access.get_binding(context_id: context.id, group_id: new_person_group.id, access_level: Binding.comment_access())
+  end
+
+  test "ProjectContributorEditing operation creates activity", ctx do
+    {:ok, contributor} = Projects.create_contributor(ctx.creator, Map.merge(ctx.attrs, %{
+      person_id: ctx.contributor.id,
+    }))
+    new_person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    Operately.Operations.ProjectContributorEditing.run(ctx.creator, contributor, %{
+      person_id: new_person.id,
+      permissions: Binding.view_access(),
+    })
+
+    activity = from(a in Activity, where: a.action == "project_contributor_edited" and a.content["project_id"] == ^ctx.project.id) |> Repo.one()
+
+    assert activity.content["previous_contributor_id"] == contributor.person_id
+    assert activity.content["new_contributor_id"] == new_person.id
+    assert activity.content["new_permissions"] == Binding.view_access()
+  end
+end

--- a/test/operately_web/api/queries/get_project_test.exs
+++ b/test/operately_web/api/queries/get_project_test.exs
@@ -166,6 +166,22 @@ defmodule OperatelyWeb.Api.Queries.GetProjectTest do
       assert res.project.access_levels.company == Binding.edit_access()
       assert res.project.access_levels.space == Binding.full_access()
     end
+
+    test "include_contributors_access_levels", ctx do
+      project = create_project(ctx)
+
+      assert {200, res} = query(ctx.conn, :get_project, %{id: Paths.project_id(project)})
+
+      refute Map.has_key?(res.project, :contributor)
+
+      assert {200, res} = query(ctx.conn, :get_project, %{id: Paths.project_id(project), include_contributors_access_levels: true})
+
+      assert length(res.project.contributors) > 0
+
+      Enum.each(res.project.contributors, fn contributor ->
+        assert Map.has_key?(contributor, :access_level)
+      end)
+    end
   end
 
   def create_project(ctx, attrs \\ %{}) do


### PR DESCRIPTION
I've update the `ProjectContributorsPage` page to show a project contributor's current permission.

Then, I've updated the `UpdateProjectContributor` mutation and added the `Operately.Operations.ProjectContributorEditing` operation to update project contributors and their permissions. 