### PR TITLE
feat: Add tag field to access_binding schema

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -126,12 +126,13 @@ defmodule Operately.Access do
     |> insert_binding(:space_members_binding, standard, members_access_level)
   end
 
-  def insert_binding(multi, name, access_group, access_level) do
+  def insert_binding(multi, name, access_group, access_level, tag \\ nil) do
     Multi.insert(multi, name, fn %{context: context} ->
       Binding.changeset(%{
         group_id: access_group.id,
         context_id: context.id,
         access_level: access_level,
+        tag: tag,
       })
     end)
   end

--- a/lib/operately/access/access_binding.ex
+++ b/lib/operately/access/access_binding.ex
@@ -4,7 +4,9 @@ defmodule Operately.Access.Binding do
   schema "access_bindings" do
     belongs_to :group, Operately.Access.Group
     belongs_to :context, Operately.Access.Context
+
     field :access_level, :integer
+    field :tag, Ecto.Enum, values: [:champion, :reviewer]
 
     timestamps()
   end
@@ -23,7 +25,7 @@ defmodule Operately.Access.Binding do
 
   def changeset(binding, attrs) do
     binding
-    |> cast(attrs, [:group_id, :context_id, :access_level])
+    |> cast(attrs, [:group_id, :context_id, :access_level, :tag])
     |> validate_inclusion(:access_level, @valid_access_levels, message: "invalid access level")
     |> validate_required([:group_id, :context_id, :access_level])
   end

--- a/lib/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings.ex
+++ b/lib/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings.ex
@@ -1,0 +1,59 @@
+defmodule Operately.Data.Change023AddTagToReviewersAndChampionsBindings do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Goals.Goal
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(g in Goal, preload: [:reviewer, :champion])
+      |> Repo.all()
+      |> update_tags()
+
+      from(p in Project, preload: [:reviewer, :champion])
+      |> Repo.all()
+      |> update_tags()
+    end)
+  end
+
+  defp update_tags(resources) do
+    Enum.each(resources, fn resource ->
+      context = get_context(resource)
+
+      update_tag(context, resource.reviewer, :reviewer)
+      update_tag(context, resource.champion, :champion)
+    end)
+  end
+
+  defp update_tag(context, person, tag) do
+    binding = get_binding(context, person, tag)
+
+    case binding.tag do
+      nil -> Access.update_binding(binding, %{tag: tag})
+      _ -> :ok
+    end
+  end
+
+  defp get_binding(context, person, tag) do
+    group = Access.get_group!(person_id: person.id)
+
+    case Access.get_binding(context_id: context.id, group_id: group.id) do
+      nil ->
+        {:ok, binding} = Access.create_binding(%{
+          context_id: context.id,
+          group_id: group.id,
+          access_level: Binding.full_access(),
+          tag: tag,
+        })
+        binding
+      binding ->
+        binding
+    end
+  end
+
+  defp get_context(%Goal{} = resource), do: Access.get_context!(goal_id: resource.id)
+  defp get_context(%Project{} = resource), do: Access.get_context!(project_id: resource.id)
+end

--- a/lib/operately/operations/goal_creation.ex
+++ b/lib/operately/operations/goal_creation.ex
@@ -50,8 +50,8 @@ defmodule Operately.Operations.GoalCreation do
     multi
     |> Access.insert_bindings_to_company(creator.company_id, attrs.company_access_level, attrs.anonymous_access_level)
     |> maybe_insert_bindings_to_space(creator, attrs)
-    |> Access.insert_binding(:reviewer_binding, reviewer_group, Binding.full_access())
-    |> Access.insert_binding(:champion_binding, champion_group, Binding.full_access())
+    |> Access.insert_binding(:reviewer_binding, reviewer_group, Binding.full_access(), :reviewer)
+    |> Access.insert_binding(:champion_binding, champion_group, Binding.full_access(), :champion)
   end
 
   defp maybe_insert_bindings_to_space(multi, creator, attrs) do

--- a/lib/operately/operations/project_creation.ex
+++ b/lib/operately/operations/project_creation.ex
@@ -131,8 +131,8 @@ defmodule Operately.Operations.ProjectCreation do
     champion_group = Access.get_group!(person_id: params.champion_id)
 
     multi
-    |> Access.insert_binding(:reviewer_binding, reviewer_group, Binding.full_access())
-    |> Access.insert_binding(:champion_binding, champion_group, Binding.full_access())
+    |> Access.insert_binding(:reviewer_binding, reviewer_group, Binding.full_access(), :reviewer)
+    |> Access.insert_binding(:champion_binding, champion_group, Binding.full_access(), :champion)
   end
 
   defp maybe_insert_binding_to_creator(multi, params) do

--- a/priv/repo/migrations/20240712101332_add_tag_property_to_bindings_table.exs
+++ b/priv/repo/migrations/20240712101332_add_tag_property_to_bindings_table.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddTagPropertyToBindingsTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:access_bindings) do
+      add :tag, :string
+    end
+  end
+end

--- a/test/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings_test.exs
+++ b/test/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings_test.exs
@@ -1,0 +1,168 @@
+defmodule Operately.Data.Change023AddTagToReviewersAndChampionsBindingsTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+  import Operately.GoalsFixtures
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+  alias Operately.Goals.Goal
+  alias Operately.Projects.{Project, Contributor}
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+
+    {:ok, company: company, creator: creator, reviewer: reviewer, champion: champion}
+  end
+
+  test "creates tags for projects reviewers' and champions' bindings", ctx do
+    project_with_tags = Enum.map(1..3, fn _ ->
+      create_project_with_tags(ctx.company, ctx.creator, ctx.reviewer, ctx.champion)
+    end)
+    project_without_tags = Enum.map(1..3, fn _ ->
+      create_project_without_tags(ctx.company, ctx.creator, ctx.reviewer, ctx.champion)
+    end)
+
+    assert_has_tag(project_with_tags, ctx.reviewer, ctx.champion)
+    refute_has_tag(project_without_tags, ctx.reviewer, ctx.champion)
+
+    Operately.Data.Change023AddTagToReviewersAndChampionsBindings.run()
+
+    all_projects = project_with_tags ++ project_without_tags
+
+    assert_has_tag(all_projects, ctx.reviewer, ctx.champion)
+  end
+
+  test "creates tags for goals reviewers' and champions' bindings", ctx do
+    goals_with_tags = Enum.map(1..3, fn _ ->
+      create_goal_with_tags(ctx.company, ctx.creator, ctx.reviewer, ctx.champion)
+    end)
+    goals_without_tags = Enum.map(1..3, fn _ ->
+      create_goal_without_tags(ctx.company, ctx.creator, ctx.reviewer, ctx.champion)
+    end)
+
+    assert_has_tag(goals_with_tags, ctx.reviewer, ctx.champion)
+    refute_has_tag(goals_without_tags, ctx.reviewer, ctx.champion)
+
+    Operately.Data.Change023AddTagToReviewersAndChampionsBindings.run()
+
+    all_goals = goals_with_tags ++ goals_without_tags
+
+    assert_has_tag(all_goals, ctx.reviewer, ctx.champion)
+  end
+
+  #
+  # Steps
+  #
+
+  defp assert_has_tag(resources, reviewer, champion) do
+    Enum.each(resources, fn resource ->
+      context = get_context(resource)
+      reviewer_group = Access.get_group!(person_id: reviewer.id)
+      champion_group = Access.get_group!(person_id: champion.id)
+
+      assert Access.get_binding(context_id: context.id, group_id: reviewer_group.id)
+      assert Access.get_binding(tag: :reviewer, context_id: context.id, group_id: reviewer_group.id)
+
+      assert Access.get_binding(context_id: context.id, group_id: champion_group.id)
+      assert Access.get_binding(tag: :champion, context_id: context.id, group_id: champion_group.id)
+    end)
+  end
+
+  defp refute_has_tag(resources, reviewer, champion) do
+    Enum.each(resources, fn resource ->
+      context = get_context(resource)
+      reviewer_group = Access.get_group!(person_id: reviewer.id)
+      champion_group = Access.get_group!(person_id: champion.id)
+
+      assert Access.get_binding(context_id: context.id, group_id: reviewer_group.id)
+      refute Access.get_binding(tag: :reviewer, context_id: context.id, group_id: reviewer_group.id)
+
+      assert Access.get_binding(context_id: context.id, group_id: champion_group.id)
+      refute Access.get_binding(tag: :champion, context_id: context.id, group_id: champion_group.id)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project_with_tags(company, creator, reviewer, champion) do
+    project_fixture(%{
+      company_id: company.id,
+      creator_id: creator.id,
+      reviewer_id: reviewer.id,
+      champion_id: champion.id,
+      group_id: company.company_space_id,
+      creator_is_contributor: "yes",
+    })
+  end
+
+  defp create_project_without_tags(company, creator, reviewer, champion) do
+    {:ok, project} = Project.changeset(%{
+      name: "some name",
+      company_id: company.id,
+      group_id: company.company_space_id,
+      creator_id: creator.id,
+      reviewer_id: reviewer.id,
+      champion_id: champion.id,
+    })
+    |> Repo.insert()
+
+    {:ok, context} = Access.create_context(%{project_id: project.id})
+
+    create_contributor(%{project_id: project.id, person_id: reviewer.id, role: :reviewer})
+    create_contributor(%{project_id: project.id, person_id: champion.id, role: :champion})
+
+    create_binding(context, reviewer)
+    create_binding(context, champion)
+
+    project
+  end
+
+  defp create_goal_with_tags(company, creator, reviewer, champion) do
+    goal_fixture(creator, %{
+      space_id: company.company_space_id,
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+    })
+  end
+
+  defp create_goal_without_tags(company, creator, reviewer, champion) do
+    {:ok, goal} = Goal.changeset(%{
+      company_id: company.id,
+      name: "some name",
+      group_id: company.company_space_id,
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+      creator_id: creator.id,
+    })
+    |> Repo.insert()
+
+    {:ok, context} = Access.create_context(%{goal_id: goal.id})
+
+    create_binding(context, reviewer)
+    create_binding(context, champion)
+
+    goal
+  end
+
+  defp create_binding(context, person) do
+    group = Access.get_group!(person_id: person.id)
+
+    Access.create_binding(%{context_id: context.id, group_id: group.id, access_level: Binding.full_access()})
+  end
+
+  defp create_contributor(attrs) do
+    Contributor.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  defp get_context(%Goal{} = resource), do: Access.get_context!(goal_id: resource.id)
+  defp get_context(%Project{} = resource), do: Access.get_context!(project_id: resource.id)
+end

--- a/test/operately/operations/goal_creation_test.exs
+++ b/test/operately/operations/goal_creation_test.exs
@@ -109,6 +109,20 @@ defmodule Operately.Operations.GoalCreationTest do
     assert Access.get_binding(context_id: context.id, group_id: champion_group.id, access_level: Binding.full_access())
   end
 
+  test "GoalCreation operation adds tags to reviewer's and champion's bindings", ctx do
+    {:ok, goal} = Operately.Operations.GoalCreation.run(ctx.creator, ctx.attrs)
+
+    context = Access.get_context!(goal_id: goal.id)
+    reviewer_group = Access.get_group!(person_id: ctx.reviewer.id)
+    champion_group = Access.get_group!(person_id: ctx.champion.id)
+
+    assert Access.get_binding(context_id: context.id, group_id: reviewer_group.id)
+    assert Access.get_binding(tag: :reviewer, context_id: context.id, group_id: reviewer_group.id, access_level: Binding.full_access())
+
+    assert Access.get_binding(context_id: context.id, group_id: champion_group.id)
+    assert Access.get_binding(tag: :champion, context_id: context.id, group_id: champion_group.id, access_level: Binding.full_access())
+  end
+
   test "GoalCreation operation creates activity and notification", ctx do
     {:ok, goal} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalCreation.run(ctx.creator, ctx.attrs)


### PR DESCRIPTION
I've added the `tag` field to the `access_binding` schema so that we can have a way to identify different bindings which would otherwise be identical.