### PR TITLE
feat: GoalEditing updates champion's and reviewer's bindings

### DIFF
--- a/lib/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings.ex
+++ b/lib/operately/data/change_023_add_tag_to_reviewers_and_champions_bindings.ex
@@ -28,6 +28,8 @@ defmodule Operately.Data.Change023AddTagToReviewersAndChampionsBindings do
     end)
   end
 
+  defp update_tag(_, nil, _), do: :ok
+
   defp update_tag(context, person, tag) do
     binding = get_binding(context, person, tag)
 


### PR DESCRIPTION
I've updated the `Operately.Operations.GoalEditing` operation so that it also updates the champion's and reviewer's bindings. 