### PR TITLE
fix: Make get_invitation and change_password_first_time public

### DIFF
--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -2,7 +2,9 @@ defmodule OperatelyWeb.Api do
   use TurboConnect.Api
 
   plug OperatelyWeb.Api.Plugs.RequireAuthenticatedAccount, except: [
-    {:mutation, :add_first_company}
+    {:query, :get_invitation},
+    {:mutation, :add_first_company},
+    {:mutation, :change_password_first_time}
   ]
 
   use_types OperatelyWeb.Api.Types


### PR DESCRIPTION
When we migrated to the new API, `get_invitation` and `change_password_first_time` ended up as private operations. Therefore, inviting a new member was not working. 