### PR TITLE
feat: Add get_assignments query

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -470,12 +470,8 @@ export interface AddMemberInput {
 }
 
 export interface Assignment {
-  id?: string | null;
-  name?: string | null;
-  due?: string | null;
   type?: string | null;
-  championId?: string | null;
-  championName?: string | null;
+  due?: string | null;
   resource?: AssignmentResource | null;
 }
 
@@ -785,6 +781,15 @@ export interface Reaction {
   person?: Person | null;
 }
 
+export interface ReviewAssignment {
+  id?: string | null;
+  name?: string | null;
+  due?: string | null;
+  type?: string | null;
+  championId?: string | null;
+  championName?: string | null;
+}
+
 export interface Space {
   id?: string | null;
   name?: string | null;
@@ -989,7 +994,7 @@ export interface GetAssignmentsInput {
 }
 
 export interface GetAssignmentsResult {
-  assignments?: Assignment[] | null;
+  assignments?: ReviewAssignment[] | null;
 }
 
 

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -470,8 +470,12 @@ export interface AddMemberInput {
 }
 
 export interface Assignment {
-  type?: string | null;
+  id?: string | null;
+  name?: string | null;
   due?: string | null;
+  type?: string | null;
+  championId?: string | null;
+  championName?: string | null;
   resource?: AssignmentResource | null;
 }
 
@@ -977,6 +981,15 @@ export interface GetActivityInput {
 
 export interface GetActivityResult {
   activity?: Activity | null;
+}
+
+
+export interface GetAssignmentsInput {
+
+}
+
+export interface GetAssignmentsResult {
+  assignments?: Assignment[] | null;
 }
 
 
@@ -2091,6 +2104,10 @@ export class ApiClient {
     return axios.get(this.getBasePath() + "/get_activity", { params: toSnake(input)}).then(({ data }) => toCamel(data));
   }
 
+  async getAssignments(input: GetAssignmentsInput): Promise<GetAssignmentsResult> {
+    return axios.get(this.getBasePath() + "/get_assignments", { params: toSnake(input)}).then(({ data }) => toCamel(data));
+  }
+
   async getAssignmentsCount(input: GetAssignmentsCountInput): Promise<GetAssignmentsCountResult> {
     return axios.get(this.getBasePath() + "/get_assignments_count", { params: toSnake(input)}).then(({ data }) => toCamel(data));
   }
@@ -2497,11 +2514,12 @@ export async function getActivities(input: GetActivitiesInput) : Promise<GetActi
 export async function getActivity(input: GetActivityInput) : Promise<GetActivityResult> {
   return defaultApiClient.getActivity(input);
 }
-
+export async function getAssignments(input: GetAssignmentsInput) : Promise<GetAssignmentsResult> {
+  return defaultApiClient.getAssignments(input);
+}
 export async function getAssignmentsCount(input: GetAssignmentsCountInput) : Promise<GetAssignmentsCountResult> {
   return defaultApiClient.getAssignmentsCount(input);
 }
-
 export async function getComments(input: GetCommentsInput) : Promise<GetCommentsResult> {
   return defaultApiClient.getComments(input);
 }
@@ -2803,6 +2821,10 @@ export function useGetActivities(input: GetActivitiesInput) : UseQueryHookResult
 
 export function useGetActivity(input: GetActivityInput) : UseQueryHookResult<GetActivityResult> {
   return useQuery<GetActivityResult>(() => defaultApiClient.getActivity(input));
+}
+
+export function useGetAssignments(input: GetAssignmentsInput) : UseQueryHookResult<GetAssignmentsResult> {
+  return useQuery<GetAssignmentsResult>(() => defaultApiClient.getAssignments(input));
 }
 
 export function useGetAssignmentsCount(input: GetAssignmentsCountInput) : UseQueryHookResult<GetAssignmentsCountResult> {
@@ -3208,6 +3230,8 @@ export default {
   useGetActivities,
   getActivity,
   useGetActivity,
+  getAssignments,
+  useGetAssignments,
   getAssignmentsCount,
   useGetAssignmentsCount,
   getComments,

--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -16,6 +16,7 @@ defmodule OperatelyWeb.Api do
   query :get_activities, Q.GetActivities
   query :get_activity, Q.GetActivity
   query :get_assignments_count, Q.GetAssignmentsCount
+  query :get_assignments, Q.GetAssignments
   query :get_comments, Q.GetComments
   query :get_companies, Q.GetCompanies
   query :get_company, Q.GetCompany

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -9,8 +9,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
 
   def get_due_projects(person) do
     from(p in Operately.Projects.Project,
-      join: a in assoc(p, :contributors),
-      where: a.person_id == ^person.id and a.role == :champion,
+      join: c in assoc(p, :contributors),
+      where: c.person_id == ^person.id and c.role == :champion,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
       where: p.status == "active",
       select: p
@@ -24,6 +24,17 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
       where: is_nil(g.closed_at),
       where: g.champion_id == ^person.id,
       select: g
+    )
+    |> Repo.all()
+  end
+
+  def get_due_project_check_ins(person) do
+    from(c in Operately.Projects.CheckIn,
+      join: p in assoc(c, :project),
+      join: contrib in assoc(p, :contributors),
+      where: contrib.person_id == ^person.id and contrib.role == :reviewer,
+      where: is_nil(c.acknowledged_by_id),
+      select: c
     )
     |> Repo.all()
   end

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -1,0 +1,20 @@
+defmodule OperatelyWeb.Api.Queries.GetAssignments do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  # def call() do
+
+  # end
+
+  def get_due_projects(person) do
+    from(p in Operately.Projects.Project,
+      join: a in assoc(p, :contributors),
+      where: a.person_id == ^person.id and a.role == :champion,
+      where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
+      where: p.status == "active",
+      select: p
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -38,4 +38,14 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
     )
     |> Repo.all()
   end
+
+  def get_due_goal_updates(person) do
+    from(u in Operately.Updates.Update,
+      join: g in Operately.Goals.Goal, on: u.updatable_id == g.id,
+      where: g.reviewer_id == ^person.id,
+      where: u.type == :goal_check_in and is_nil(u.acknowledging_person_id),
+      select: u
+    )
+    |> Repo.all()
+  end
 end

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -7,7 +7,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
   import Ecto.Query, only: [from: 2]
 
   outputs do
-    field :assignments, list_of(:assignment)
+    field :assignments, list_of(:review_assignment)
   end
 
   def call(conn, _inputs) do

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -17,4 +17,14 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
     )
     |> Repo.all()
   end
+
+  def get_due_goals(person) do
+    from(g in Operately.Goals.Goal,
+      where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
+      where: is_nil(g.closed_at),
+      where: g.champion_id == ^person.id,
+      select: g
+    )
+    |> Repo.all()
+  end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -30,6 +30,15 @@ defmodule OperatelyWeb.Api.Types do
     field :check_in, :project_check_in
   end
 
+  object :assignment do
+    field :id, :string
+    field :name, :string
+    field :due, :date
+    field :type, :string
+    field :champion_id, :string
+    field :champion_name, :string
+  end
+
   union :update_content, types: [
     :update_content_project_created,
     :update_content_project_start_time_changed,

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -30,7 +30,7 @@ defmodule OperatelyWeb.Api.Types do
     field :check_in, :project_check_in
   end
 
-  object :assignment do
+  object :review_assignment do
     field :id, :string
     field :name, :string
     field :due, :date

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -1,0 +1,79 @@
+defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Projects.Project
+
+  describe "get_due_assignments" do
+    setup :register_and_log_in_account
+
+    test "get_due_projects", ctx do
+      # Projects for one person
+      today_project = create_project(ctx, DateTime.utc_now())
+      due_project = create_project(ctx, past_date())
+      create_project(ctx, upcoming_date())
+
+      # Projects for one person
+      another_person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+      another_due_project = create_project(ctx, past_date(), %{creator_id: another_person.id})
+      create_project(ctx, upcoming_date(), %{creator_id: another_person.id})
+
+      assert [today_project, due_project] == OperatelyWeb.Api.Queries.GetAssignments.get_due_projects(ctx.person)
+
+      assert [another_due_project] == OperatelyWeb.Api.Queries.GetAssignments.get_due_projects(another_person)
+    end
+
+    test "get_due_projects ignores closed projects", ctx do
+      create_project(ctx, upcoming_date())
+      create_project(ctx, past_date()) |> close_project()
+      due_project = create_project(ctx, past_date())
+
+      assert [due_project] == OperatelyWeb.Api.Queries.GetAssignments.get_due_projects(ctx.person)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp upcoming_date do
+    Date.utc_today()
+    |> Date.add(3)
+    |> Operately.Time.as_datetime()
+  end
+
+  defp past_date do
+    Date.utc_today()
+    |> Date.add(-3)
+    |> Operately.Time.as_datetime()
+  end
+
+  defp create_project(ctx, date, attrs \\ %{}) do
+    {:ok, project} =
+      project_fixture(Map.merge(%{
+        creator_id: ctx.person.id,
+        company_id: ctx.company.id,
+        group_id: ctx.company.company_space_id,
+      }, attrs))
+      |> Project.changeset(%{next_check_in_scheduled_at: date})
+      |> Repo.update()
+
+    project
+  end
+
+  defp close_project(project) do
+    {:ok, project} =
+      Project.changeset(project, %{
+        status: "closed",
+        closed_at: DateTime.utc_now(),
+        closed_by_id: project.creator_id,
+      })
+      |> Repo.update()
+
+    project
+  end
+end

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -59,6 +59,22 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       assert [due_goal] == OperatelyWeb.Api.Queries.GetAssignments.get_due_goals(ctx.person)
     end
+
+    test "get_due_project_check_ins", ctx do
+      another_person = person_fixture_with_account(%{company_id: ctx.company.id})
+      project = create_project(ctx, upcoming_date(), %{reviewer_id: another_person.id})
+
+      c1 = create_check_in(project)
+      c2 = create_check_in(project)
+
+      another_project = create_project(ctx, upcoming_date(), %{champion_id: another_person.id, reviewer_id: ctx.person.id})
+
+      c3 = create_check_in(another_project)
+      c4 = create_check_in(another_project)
+
+      assert [c1, c2] == OperatelyWeb.Api.Queries.GetAssignments.get_due_project_check_ins(another_person)
+      assert [c3, c4] == OperatelyWeb.Api.Queries.GetAssignments.get_due_project_check_ins(ctx.person)
+    end
   end
 
   #
@@ -120,5 +136,13 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
       |> Repo.update()
 
     goal
+  end
+
+  defp create_check_in(project) do
+    project = Repo.preload(project, :champion)
+    check_in_fixture(%{
+      author_id: project.champion.id,
+      project_id: project.id,
+    })
   end
 end

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -6,6 +6,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
   import Operately.GoalsFixtures
   import Operately.UpdatesFixtures
 
+  alias OperatelyWeb.Paths
   alias Operately.Repo
   alias Operately.Goals.Goal
   alias Operately.Updates.Update
@@ -37,11 +38,11 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [p1, p2] = assignments
 
-      assert p1.id == today_project.id
+      assert p1.id == Paths.project_id(today_project)
       assert p1.name == "today"
       assert p1.due
       assert p1.type == "project"
-      assert p2.id == due_project.id
+      assert p2.id == Paths.project_id(due_project)
       assert p2.name == "3 days ago"
       assert p2.due
       assert p2.type == "project"
@@ -59,7 +60,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [p] = assignments
 
-      assert p.id == due_project.id
+      assert p.id == Paths.project_id(due_project)
       assert p.name == "single project"
       assert p.due
       assert p.type == "project"
@@ -82,11 +83,11 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [g1, g2] = assignments
 
-      assert g1.id == today_goal.id
+      assert g1.id == Paths.goal_id(today_goal)
       assert g1.name == "today"
       assert g1.due
       assert g1.type == "goal"
-      assert g2.id == due_goal.id
+      assert g2.id == Paths.goal_id(due_goal)
       assert g2.name == "3 days ago"
       assert g2.due
       assert g2.type == "goal"
@@ -104,7 +105,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [g] = assignments
 
-      assert g.id == due_goal.id
+      assert g.id == Paths.goal_id(due_goal)
       assert g.name == "single goal"
       assert g.due
       assert g.type == "goal"
@@ -132,14 +133,14 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [c1, c2] = assignments
 
-      assert c1.id == check_in2.id
+      assert c1.id == Paths.project_check_in_id(check_in2)
       assert c1.name == "project"
       assert c1.due
       assert c1.type == "check_in"
       assert c1.champion_id == another_person.id
       assert c1.champion_name == "champion"
 
-      assert c2.id == check_in1.id
+      assert c2.id == Paths.project_check_in_id(check_in1)
       assert c2.name == "project"
       assert c2.due
       assert c2.type == "check_in"
@@ -170,14 +171,14 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [u1, u2] = assignments
 
-      assert u1.id == update2.id
+      assert u1.id == Paths.goal_update_id(update2)
       assert u1.name == "goal"
       assert u1.due
       assert u1.type == "goal_update"
       assert u1.champion_id == another_person.id
       assert u1.champion_name == "champion"
 
-      assert u2.id == update1.id
+      assert u2.id == Paths.goal_update_id(update1)
       assert u2.name == "goal"
       assert u2.due
       assert u2.type == "goal_update"

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -37,12 +37,12 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [p1, p2] = assignments
 
-      assert p1.id == due_project.id
-      assert p1.name == "3 days ago"
+      assert p1.id == today_project.id
+      assert p1.name == "today"
       assert p1.due
       assert p1.type == "project"
-      assert p2.id == today_project.id
-      assert p2.name == "today"
+      assert p2.id == due_project.id
+      assert p2.name == "3 days ago"
       assert p2.due
       assert p2.type == "project"
     end
@@ -82,12 +82,12 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [g1, g2] = assignments
 
-      assert g1.id == due_goal.id
-      assert g1.name == "3 days ago"
+      assert g1.id == today_goal.id
+      assert g1.name == "today"
       assert g1.due
       assert g1.type == "goal"
-      assert g2.id == today_goal.id
-      assert g2.name == "today"
+      assert g2.id == due_goal.id
+      assert g2.name == "3 days ago"
       assert g2.due
       assert g2.type == "goal"
     end


### PR DESCRIPTION
I've added the `OperatelyWeb.Api.Queries.GetAssignments` query, which will be used in the new Review page to fetch all the due assignments for a specific person.

This query is a little different from the others and I found it very difficult to use our serializer to handle it. 

The thing is that we need to fetch information from many different tables, but just a few fields from each table. So, to use the serializer as it is, I would have to fetch way more data than we needed. 
Furthermore, the current `essential` and `full` levels for the structures I was working with didn't meet some of the requirements for the data, so there wasn't a straightforward way of using the serializer without extending it.

So, rather than fetching much more data than we needed and extending the serializer to handle a single use case, I decided to optimize the queries to fetch only the data we need and already in the required format.