### PR TITLE
fix: search_people query encodes people IDs and mutations decode them

### DIFF
--- a/lib/operately_web/api/mutations/create_goal.ex
+++ b/lib/operately_web/api/mutations/create_goal.ex
@@ -21,13 +21,19 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
   end
 
   def call(conn, inputs) do
-    {:ok, parent_goal_id} = decode_id(inputs[:parent_goal_id], :allow_nil)
     {:ok, space_id} = decode_id(inputs.space_id)
+    {:ok, champion_id} = decode_id(inputs[:champion_id], :allow_nil)
+    {:ok, reviewer_id} = decode_id(inputs[:reviewer_id], :allow_nil)
+    {:ok, parent_goal_id} = decode_id(inputs[:parent_goal_id], :allow_nil)
 
-    inputs = Map.put(inputs, :space_id, space_id)
-    inputs = Map.put(inputs, :parent_goal_id, parent_goal_id)
+    attrs = Map.merge(inputs, %{
+      space_id: space_id,
+      champion_id: champion_id,
+      reviewer_id: reviewer_id,
+      parent_goal_id: parent_goal_id,
+    })
 
-    {:ok, goal} = Operately.Operations.GoalCreation.run(me(conn), inputs)
+    {:ok, goal} = Operately.Operations.GoalCreation.run(me(conn), attrs)
     {:ok, %{goal: Serializer.serialize(goal, level: :essential)}}
   end
 end

--- a/lib/operately_web/api/mutations/create_project.ex
+++ b/lib/operately_web/api/mutations/create_project.ex
@@ -25,11 +25,13 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
 
     {:ok, goal_id} = decode_id(inputs[:goal_id], :allow_nil)
     {:ok, space_id} = decode_id(inputs[:space_id], :allow_nil)
+    {:ok, champion_id} = decode_id(inputs[:champion_id], :allow_nil)
+    {:ok, reviewer_id} = decode_id(inputs[:reviewer_id], :allow_nil)
 
     args = %Operately.Operations.ProjectCreation{
       name: inputs.name,
-      champion_id: inputs.champion_id,
-      reviewer_id: inputs.reviewer_id,
+      champion_id: champion_id,
+      reviewer_id: reviewer_id,
       creator_is_contributor: inputs[:creator_is_contributor],
       creator_role: inputs[:creator_role],
       visibility: inputs.visibility,

--- a/lib/operately_web/api/mutations/edit_goal.ex
+++ b/lib/operately_web/api/mutations/edit_goal.ex
@@ -23,7 +23,16 @@ defmodule OperatelyWeb.Api.Mutations.EditGoal do
   def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.goal_id)
     goal = Operately.Goals.get_goal!(id)
-    {:ok, goal} = Operately.Operations.GoalEditing.run(me(conn), goal, inputs)
+
+    {:ok, champion_id} = decode_id(inputs.champion_id)
+    {:ok, reviewer_id} = decode_id(inputs.reviewer_id)
+
+    attrs = Map.merge(inputs, %{
+      champion_id: champion_id,
+      reviewer_id: reviewer_id,
+    })
+
+    {:ok, goal} = Operately.Operations.GoalEditing.run(me(conn), goal, attrs)
 
     {:ok, %{goal: Serializer.serialize(goal, level: :essential)}}
   end

--- a/lib/operately_web/api/mutations/update_project_contributor.ex
+++ b/lib/operately_web/api/mutations/update_project_contributor.ex
@@ -15,9 +15,12 @@ defmodule OperatelyWeb.Api.Mutations.UpdateProjectContributor do
 
   def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.contrib_id)
+    {:ok, person_id} = decode_id(inputs.person_id)
     contrib = Operately.Projects.get_contributor!(id)
 
-    {:ok, contrib} = Operately.Operations.ProjectContributorEditing.run(me(conn), contrib, inputs)
+    attrs = Map.merge(inputs, %{person_id: person_id})
+
+    {:ok, contrib} = Operately.Operations.ProjectContributorEditing.run(me(conn), contrib, attrs)
 
     {:ok, %{contributor: OperatelyWeb.Api.Serializer.serialize(contrib)}}
   end

--- a/test/operately_web/api/queries/search_people_test.exs
+++ b/test/operately_web/api/queries/search_people_test.exs
@@ -76,11 +76,6 @@ defmodule OperatelyWeb.Api.Queries.SearchPeopleTest do
   end
 
   def serialized(person) do
-    %{
-      id: person.id,
-      full_name: person.full_name,
-      title: person.title,
-      avatar_url: person.avatar_url
-    }
+    OperatelyWeb.Api.Serializer.serialize(person, level: :essential)
   end
-end 
+end


### PR DESCRIPTION
The mutations `update_project_contributor`, `edit_goal` and `create_project` weren't working because some of the IDs were not being decoded.