### PR TITLE
feat: Add permissions filter to get_activities query

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -197,10 +197,6 @@ defmodule Operately.Access do
 
   alias Operately.Access.GroupMembership
 
-  def list_group_memberships do
-    Repo.all(GroupMembership)
-  end
-
   def get_group_membership!(id) when is_binary(id), do: Repo.get!(GroupMembership, id)
 
   def get_group_membership!(attrs) when is_list(attrs), do: Repo.get_by!(GroupMembership, attrs)

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -1,11 +1,8 @@
 defmodule Operately.People do
   import Ecto.Query, warn: false
 
-<<<<<<< HEAD
   alias Operately.Repo
-=======
   alias Operately.Access
->>>>>>> e7310082 (Fix Operately.People.create_person/1)
   alias Operately.People.{Person, Account}
 
   def list_people(company_id) do

--- a/lib/operately_web/api/queries/get_activities.ex
+++ b/lib/operately_web/api/queries/get_activities.ex
@@ -25,8 +25,6 @@ defmodule OperatelyWeb.Api.Queries.GetActivities do
     {:ok, scope_type, scope_id} = decode_scope(inputs)
     activities = load_activities(me(conn), scope_type, scope_id, actions)
 
-    # IO.inspect(activities)
-
     {:ok, %{activities: OperatelyWeb.Api.Serializers.Activity.serialize(activities)}}
   end
 

--- a/test/operately/access/group_memberships_test.exs
+++ b/test/operately/access/group_memberships_test.exs
@@ -19,15 +19,6 @@ defmodule Operately.AccessGroupMembershipsTest do
       {:ok, %{person: person, group: group, company: company}}
     end
 
-    test "list_group_memberships/0 returns all group_memberships", ctx do
-      group_membership = group_membership_fixture(%{
-        person_id: ctx.person.id,
-        group_id: ctx.group.id,
-      })
-
-      assert Access.list_group_memberships() == [group_membership]
-    end
-
     test "get_group_membership!/1 returns the group_membership with given id", ctx do
       group_membership = group_membership_fixture(%{
         person_id: ctx.person.id,

--- a/test/operately_web/api/queries/get_activities_test.exs
+++ b/test/operately_web/api/queries/get_activities_test.exs
@@ -1,13 +1,124 @@
 defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
   use OperatelyWeb.TurboCase
 
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+
+  alias Operately.Repo
+  alias Operately.Groups
+  alias Operately.Access.Binding
+  alias OperatelyWeb.Paths
+
   describe "security" do
     test "it requires authentication", ctx do
       assert {401, _} = query(ctx.conn, :get_activities, %{})
     end
   end
 
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      space = group_fixture(champion)
+
+      attrs = %{
+        scope_type: "company",
+        scope_id: Paths.company_id(ctx.company),
+        actions: ["goal_created"]
+      }
+
+      Map.merge(ctx, %{space: space, champion: champion, reviewer: reviewer, attrs: attrs})
+    end
+
+    test "company members have no access", ctx do
+      goal_fixture(ctx.champion, %{
+        space_id: ctx.company.company_space_id,
+        company_access_level: Binding.no_access(),
+      })
+
+      assert {200, res} = query(ctx.conn, :get_activities, ctx.attrs)
+
+      assert res.activities == []
+    end
+
+    test "company members have access", ctx do
+      goal = goal_fixture(ctx.champion, %{
+        space_id: ctx.company.company_space_id,
+        company_access_level: Binding.view_access(),
+      })
+
+      assert {200, %{ activities: activities } = _res} = query(ctx.conn, :get_activities, ctx.attrs)
+
+      assert length(activities) == 1
+      assert goal.id == hd(activities).content.goal.id
+    end
+
+    test "space members have no access", ctx do
+      Groups.add_members(ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
+      goal_fixture(ctx.champion, %{
+        space_id: ctx.space.id,
+        space_access_level: Binding.no_access(),
+        company_access_level: Binding.no_access(),
+      })
+
+      assert {200, res} = query(ctx.conn, :get_activities, ctx.attrs)
+
+      assert res.activities == []
+    end
+
+    test "space members have access", ctx do
+      Groups.add_members(ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
+      goal = goal_fixture(ctx.champion, %{
+        space_id: ctx.space.id,
+        space_access_level: Binding.view_access(),
+        company_access_level: Binding.no_access(),
+      })
+
+      assert {200, %{ activities: activities } = _res} = query(ctx.conn, :get_activities, ctx.attrs)
+
+      assert length(activities) == 1
+      assert goal.id == hd(activities).content.goal.id
+    end
+
+    test "reviewers have access", ctx do
+      goal = goal_fixture(ctx.champion, %{
+        space_id: ctx.space.id,
+        reviewer_id: ctx.reviewer.id,
+        space_access_level: Binding.no_access(),
+        company_access_level: Binding.no_access(),
+      })
+
+      account = Repo.preload(ctx.reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, %{ activities: activities } = _res} = query(conn, :get_activities, ctx.attrs)
+
+      assert length(activities) == 1
+      assert goal.id == hd(activities).content.goal.id
+    end
+
+    test "champions have access", ctx do
+      goal = goal_fixture(ctx.reviewer, %{
+        space_id: ctx.space.id,
+        champion_id: ctx.champion.id,
+        space_access_level: Binding.no_access(),
+        company_access_level: Binding.no_access(),
+      })
+
+      account = Repo.preload(ctx.champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, %{ activities: activities } = _res} = query(conn, :get_activities, ctx.attrs)
+
+      assert length(activities) == 1
+      assert goal.id == hd(activities).content.goal.id
+    end
+  end
+
   describe "get_activities functionality" do
     setup :register_and_log_in_account
   end
-end 
+end


### PR DESCRIPTION
I've added a permissions filter `OperatelyWeb.Api.Queries.GetActivities` in order to load only the activities for which a person has view permissions.

I've added tests for several situations and everything seems to be working.

While I was testing this query, I found out that both `Operately.People.insert_person/2` and `Operately.People.create_person/1` are not creating an access group membership between the new person's access group and the company's access context.

Since `Operately.People.create_person/1` is used only for tests, I've already fixed it in this pull request.

I will fix `Operately.People.insert_person/2` in a separate pull request.