### PR TITLE
fix: People.insert_person/2 creates access membership with company group

### DIFF
--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -12,8 +12,8 @@ defmodule Operately.Companies do
 
   def list_companies(account = %Operately.People.Account{}) do
     Repo.all(
-      from c in Company, 
-        join: p in assoc(c, :people), 
+      from c in Company,
+        join: p in assoc(c, :people),
         where: p.account_id == ^account.id)
   end
 
@@ -34,6 +34,15 @@ defmodule Operately.Companies do
   end
 
   def get_company_by_name(name), do: Repo.get_by(Company, name: name)
+
+  def get_company_space!(company_id) do
+    from(c in Company,
+      join: g in Operately.Groups.Group, on: g.id == c.company_space_id,
+      where: c.id == ^company_id,
+      select: g
+    )
+    |> Repo.one!()
+  end
 
   defdelegate create_company(attrs \\ %{}),to: Operately.Operations.CompanyAdding, as: :run
 

--- a/lib/operately/operations/company_adding.ex
+++ b/lib/operately/operations/company_adding.ex
@@ -111,7 +111,9 @@ defmodule Operately.Operations.CompanyAdding do
     create_admin = Keyword.get(opts, :create_admin, false)
 
     if create_admin do
-      Operately.People.insert_person(multi, fn changes ->
+      multi
+      |> Multi.run(:company_space, fn _, changes -> {:ok, changes.group} end)
+      |> Operately.People.insert_person(fn changes ->
         Person.changeset(%{
           company_id: changes[:company].id,
           account_id: changes[:account].id,

--- a/lib/operately/operations/company_member_adding.ex
+++ b/lib/operately/operations/company_member_adding.ex
@@ -31,7 +31,11 @@ defmodule Operately.Operations.CompanyMemberAdding do
     attrs = Map.put(attrs, :company_id, admin.company_id)
     attrs = Map.put(attrs, :company_role, :member)
 
-    Operately.People.insert_person(multi, fn changes ->
+    multi
+    |> Multi.run(:company_space, fn _, _ ->
+      {:ok, Operately.Companies.get_company_space!(admin.company_id)}
+    end)
+    |> Operately.People.insert_person(fn changes ->
       Operately.People.Person.changeset(%{
         company_id: admin.company_id,
         account_id: changes[:account].id,

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -35,6 +35,7 @@ defmodule Operately.People do
     |> Multi.insert(:person, fn changes -> callback.(changes) end)
     |> insert_person_access_group()
     |> insert_membership_with_company_group()
+    |> insert_company_space_member()
   end
 
   defp insert_person_access_group(multi) do
@@ -58,6 +59,16 @@ defmodule Operately.People do
     |> Multi.insert(:company_access_membership, fn changes ->
       Access.GroupMembership.changeset(%{
         group_id: changes.company_access_group.id,
+        person_id: changes.person.id,
+      })
+    end)
+  end
+
+  defp insert_company_space_member(multi) do
+    multi
+    |> Multi.insert(:company_space_member, fn changes ->
+      Operately.Groups.Member.changeset(%{
+        group_id: changes.company_space.id,
         person_id: changes.person.id,
       })
     end)

--- a/lib/operately/people/insert_person_into_operation.ex
+++ b/lib/operately/people/insert_person_into_operation.ex
@@ -1,0 +1,48 @@
+defmodule Operately.People.InsertPersonIntoOperation do
+  alias Ecto.Multi
+  alias Operately.Access
+
+  def insert(multi, callback) when is_function(callback, 1) do
+    multi
+    |> Multi.insert(:person, fn changes -> callback.(changes) end)
+    |> insert_person_access_group()
+    |> insert_membership_with_company_group()
+    |> insert_company_space_member()
+  end
+
+  defp insert_person_access_group(multi) do
+    multi
+    |> Multi.insert(:person_access_group, fn changes ->
+      Access.Group.changeset(%{person_id: changes.person.id})
+    end)
+    |> Multi.insert(:person_access_membership, fn changes ->
+      Access.GroupMembership.changeset(%{
+        group_id: changes.person_access_group.id,
+        person_id: changes.person.id,
+      })
+    end)
+  end
+
+  defp insert_membership_with_company_group(multi) do
+    multi
+    |> Multi.run(:company_access_group, fn _, %{person: person} ->
+      {:ok, Access.get_group!(company_id: person.company_id, tag: :standard)}
+    end)
+    |> Multi.insert(:company_access_membership, fn changes ->
+      Access.GroupMembership.changeset(%{
+        group_id: changes.company_access_group.id,
+        person_id: changes.person.id,
+      })
+    end)
+  end
+
+  defp insert_company_space_member(multi) do
+    multi
+    |> Multi.insert(:company_space_member, fn changes ->
+      Operately.Groups.Member.changeset(%{
+        group_id: changes.company_space.id,
+        person_id: changes.person.id,
+      })
+    end)
+  end
+end

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -24,7 +24,7 @@ defmodule Operately.Operations.CompanyAddingTest do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
 
     assert 1 == Companies.count_companies()
-    assert nil != Companies.get_company_by_name("Acme Co.")
+    assert Companies.get_company_by_name("Acme Co.")
     assert [] == People.list_people(company.id)
   end
 
@@ -35,23 +35,22 @@ defmodule Operately.Operations.CompanyAddingTest do
     person = People.get_person_by_email(company, @email)
 
     assert 1 == Companies.count_companies()
-    assert nil != Companies.get_company_by_name("Acme Co.")
+    assert Companies.get_company_by_name("Acme Co.")
 
     assert 1 == length(People.list_people(company.id))
     assert person.company_role == :admin
     assert person.full_name == "John Doe"
     assert person.title == "CEO"
 
-    assert nil != People.get_account_by_email(@email)
+    assert People.get_account_by_email(@email)
   end
 
   test "CompanyAdding operation creates company group" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
 
-    assert nil != company.company_space_id
-    assert nil != Groups.get_group(company.company_space_id)
+    assert company.company_space_id
+    assert Groups.get_group(company.company_space_id)
   end
-
 
   test "CompanyAdding operation creates admin user's access group and membership" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs, create_admin: true)
@@ -59,8 +58,7 @@ defmodule Operately.Operations.CompanyAddingTest do
     person = People.get_person_by_email(company, @email)
     group = Access.get_group!(person_id: person.id)
 
-    assert nil != group
-    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: group.id, person_id: person.id)
   end
 
   test "CompanyAdding operation creates access groups, bindings and group_memberships for admins and members" do
@@ -69,23 +67,19 @@ defmodule Operately.Operations.CompanyAddingTest do
     person = People.get_person_by_email(company, @email)
     full_access = Access.get_group!(company_id: company.id, tag: :full_access)
     standard = Access.get_group!(company_id: company.id, tag: :standard)
-    anonymous = Access.get_group!(company_id: company.id, tag: :anonymous)
 
-    assert nil != full_access
-    assert nil != standard
-    assert nil != anonymous
+    assert Access.get_group(company_id: company.id, tag: :anonymous)
+    assert Access.get_binding!(group_id: full_access.id, access_level: Binding.full_access())
+    assert Access.get_binding!(group_id: standard.id, access_level: Binding.view_access())
 
-    assert nil != Access.get_binding!(group_id: full_access.id, access_level: Binding.full_access())
-    assert nil != Access.get_binding!(group_id: standard.id, access_level: Binding.view_access())
-
-    assert nil != Access.get_group_membership(group_id: full_access.id, person_id: person.id)
-    assert nil == Access.get_group_membership(group_id: standard.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: full_access.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: standard.id, person_id: person.id)
   end
 
   test "CompanyAdding operation creates company and group access contexts" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
 
-    assert nil != Access.get_context!(company_id: company.id)
-    assert nil != Access.get_context!(group_id: company.company_space_id)
+    assert Access.get_context!(company_id: company.id)
+    assert Access.get_context!(group_id: company.company_space_id)
   end
 end

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -82,4 +82,13 @@ defmodule Operately.Operations.CompanyAddingTest do
     assert Access.get_context!(company_id: company.id)
     assert Access.get_context!(group_id: company.company_space_id)
   end
+
+  test "CompanyAdding operation creates company company space member" do
+    {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs, create_admin: true)
+
+    members = Groups.get_group!(company.company_space_id) |> Groups.list_members()
+
+    assert length(members) == 1
+    assert hd(members).full_name == @company_attrs.full_name
+  end
 end

--- a/test/operately/operations/company_member_adding_test.exs
+++ b/test/operately/operations/company_member_adding_test.exs
@@ -34,7 +34,7 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
     Operately.Operations.CompanyMemberAdding.run(ctx.admin, @member_attrs)
 
     assert 2 == Repo.aggregate(Person, :count, :id)
-    assert nil != People.get_account_by_email(@email)
+    assert People.get_account_by_email(@email)
 
     person = People.get_person_by_email(ctx.company, @email)
 
@@ -49,8 +49,11 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
     person = People.get_person_by_email(ctx.company, @email)
     group = Access.get_group!(person_id: person.id)
 
-    assert nil != group
-    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: group.id, person_id: person.id)
+
+    company_group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+
+    assert Access.get_group_membership(group_id: company_group.id, person_id: person.id)
   end
 
   test "CompanyMemberAdding operation creates invitation for person", ctx do
@@ -59,7 +62,7 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
     person = People.get_person_by_email(ctx.company, @email)
 
     assert 1 == Repo.aggregate(Invitation, :count, :id)
-    assert nil != Invitations.get_invitation_by_member(person)
+    assert Invitations.get_invitation_by_member(person)
   end
 
   test "CompanyMemberAdding operation creates activity", ctx do

--- a/test/operately/operations/company_member_adding_test.exs
+++ b/test/operately/operations/company_member_adding_test.exs
@@ -9,6 +9,7 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
   alias Operately.Access
   alias Operately.People
   alias Operately.People.Person
+  alias Operately.Groups
   alias Operately.Invitations
   alias Operately.Invitations.Invitation
   alias Operately.Activities.Activity
@@ -63,6 +64,16 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
 
     assert 1 == Repo.aggregate(Invitation, :count, :id)
     assert Invitations.get_invitation_by_member(person)
+  end
+
+  test "CompanyMemberAdding operation creates company space member", ctx do
+    company_space = Groups.get_group!(ctx.company.company_space_id)
+
+    assert length(Groups.list_members(company_space)) == 0
+
+    {:ok, _} = Operately.Operations.CompanyMemberAdding.run(ctx.admin, @member_attrs)
+
+    assert length(Groups.list_members(company_space)) == 1
   end
 
   test "CompanyMemberAdding operation creates activity", ctx do

--- a/test/operately/operations/fetch_or_create_account_test.exs
+++ b/test/operately/operations/fetch_or_create_account_test.exs
@@ -21,7 +21,7 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
   end
 
   test "FetchOrCreateAccountOperation creates person and account", ctx do
-    assert nil == People.get_person_by_email(ctx.company, @email)
+    refute People.get_person_by_email(ctx.company, @email)
 
     Operately.People.FetchOrCreateAccountOperation.call(ctx.company, @attrs)
 
@@ -30,7 +30,7 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
     assert person.full_name == "John Doe"
     assert person.email == @email
     assert person.company_role == :member
-    assert nil != People.get_account_by_email(@email)
+    assert People.get_account_by_email(@email)
   end
 
   test "FetchOrCreateAccountOperation creates person's access group", ctx do
@@ -39,8 +39,11 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
     person = People.get_person_by_email(ctx.company, @email)
     group = Access.get_group!(person_id: person.id)
 
-    assert nil != group
-    assert nil != Access.get_group_membership(group_id: group.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: group.id, person_id: person.id)
+
+    company_group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+
+    assert Access.get_group_membership(group_id: company_group.id, person_id: person.id)
   end
 
   test "FetchOrCreateAccountOperation doesn't create account for non-trusted email domain", ctx do
@@ -52,6 +55,6 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
       :image => "",
     })
 
-    assert nil == People.get_person_by_email(ctx.company, email)
+    refute People.get_person_by_email(ctx.company, email)
   end
 end

--- a/test/operately/operations/fetch_or_create_account_test.exs
+++ b/test/operately/operations/fetch_or_create_account_test.exs
@@ -4,6 +4,7 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
   import Operately.CompaniesFixtures
 
   alias Operately.People
+  alias Operately.Groups
   alias Operately.Access
 
   @email "john@allowed_email.com"
@@ -56,5 +57,15 @@ defmodule Operately.Operations.FetchOrCreateAccountTest do
     })
 
     refute People.get_person_by_email(ctx.company, email)
+  end
+
+  test "FetchOrCreateAccountOperation creates company space member", ctx do
+    company_space = Groups.get_group!(ctx.company.company_space_id)
+
+    assert length(Groups.list_members(company_space)) == 0
+
+    {:ok, _} = Operately.People.FetchOrCreateAccountOperation.call(ctx.company, @attrs)
+
+    assert length(Groups.list_members(company_space)) == 1
   end
 end


### PR DESCRIPTION
I've updated `Operately.People.insert_person/2`. Now it also creates an access membership between the new person and the company's access group.

If we come across errors or bugs that suggest that there is no access membership between an existing person and the company's access group, running the data migration 015 should fix the problem.