### PR TITLE
fix: login redirects to previously visited page

### DIFF
--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -27,7 +27,7 @@ defmodule OperatelyWeb.AccountAuth do
   """
   def log_in_account(conn, account, params \\ %{}) do
     token = People.generate_account_session_token(account)
-    path = after_login_path(account)
+    path = get_session(conn, :redirect_to) || after_login_path(account)
 
     conn
     |> renew_session()

--- a/lib/operately_web/controllers/page_controller.ex
+++ b/lib/operately_web/controllers/page_controller.ex
@@ -39,6 +39,7 @@ defmodule OperatelyWeb.PageController do
       render(conn, :home)
     else
       conn
+      |> put_session(:redirect_to, conn.request_path)
       |> redirect(to: ~p"/accounts/log_in")
       |> halt()
     end


### PR DESCRIPTION
I've fixed the bug described in https://github.com/operately/operately/issues/728 by adding a `redirect_to` key to the session with the current path as value before the user is redirected to the login page. When the user logs in, if `redirect_to` is present in the session, `OperatelyWeb.AccountAuth.log_in_account/3` redirects them to that path.

I've tested it extensively on localhost and wrote some unit tests for it as well. 
Unfortunately, I couldn't test it with OAuth, but since it also uses `OperatelyWeb.AccountAuth.log_in_account/3`, it should be working, too.