### PR TITLE
feat: Move "close project" to the action menu

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -759,6 +759,7 @@ export interface ProjectPermissions {
   canEditName?: boolean | null;
   canEditSpace?: boolean | null;
   canEditPermissions?: boolean | null;
+  canClose?: boolean | null;
   canPause?: boolean | null;
   canCheckIn?: boolean | null;
   canAcknowledgeCheckIn?: boolean | null;

--- a/assets/js/pages/ProjectPage/Options.tsx
+++ b/assets/js/pages/ProjectPage/Options.tsx
@@ -61,6 +61,15 @@ export default function Options({ project }) {
           dataTestId="move-project-link"
         />
       )}
+
+      {project.permissions.canClose && project.status !== "closed" && (
+        <PageOptions.Link
+          icon={Icons.IconCircleCheck}
+          title="Close the project"
+          to={Paths.projectClosePath(project.id)}
+          dataTestId="close-project"
+        />
+      )}
     </PageOptions.Root>
   );
 }

--- a/assets/js/pages/ProjectPage/Overview.tsx
+++ b/assets/js/pages/ProjectPage/Overview.tsx
@@ -1,22 +1,16 @@
 import React from "react";
 
-import { DimmedLabel } from "./Label";
-
 import * as Projects from "@/models/projects";
-import { GhostButton } from "@/components/Button";
 import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { MiniPieChart } from "@/components/MiniPieChart";
-import { Paths } from "@/routes/paths";
+import { DimmedLabel } from "./Label";
+
 
 export default function Overview({ project }) {
   return (
-    <div className="flex items-center justify-between">
-      <div className="flex items-start gap-12 text-sm">
-        <Status project={project} />
-        <Completion project={project} />
-      </div>
-
-      <CloseButton project={project} />
+    <div className="flex items-start gap-12 text-sm">
+      <Status project={project} />
+      <Completion project={project} />
     </div>
   );
 }
@@ -67,19 +61,5 @@ function CompletionPieChart({ done, total }) {
         {done}/{total} milestones completed
       </span>
     </div>
-  );
-}
-
-function CloseButton({ project }: { project: Projects.Project }) {
-  if (project.status === "closed") return null;
-  if (project.isArchived) return null;
-
-  const type = Projects.allMilestonesCompleted(project) ? "primary" : "secondary";
-  const linkTo = Paths.projectClosePath(project.id!);
-
-  return (
-    <GhostButton type={type} linkTo={linkTo} size="sm" testId="close-project-button">
-      Close Project
-    </GhostButton>
   );
 }

--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -12,6 +12,7 @@ defmodule Operately.Projects.Permissions do
     :can_edit_space,
     :can_edit_contributors,
     :can_edit_permissions,
+    :can_close,
     :can_pause,
     :can_check_in,
     :can_acknowledge_check_in
@@ -35,6 +36,7 @@ defmodule Operately.Projects.Permissions do
       can_edit_contributors: is_contributor?(project, user),
       can_edit_permissions: is_contributor?(project, user),
 
+      can_close: is_contributor?(project, user),
       can_pause: is_contributor?(project, user),
       can_check_in: is_contributor?(project, user),
       can_acknowledge_check_in: is_reviewer?(project, user)

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -395,6 +395,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Permissions do
       can_edit_space: permissions.can_edit_space,
       can_edit_contributors: permissions.can_edit_contributors,
       can_edit_permissions: permissions.can_edit_permissions,
+      can_close: permissions.can_close,
       can_pause: permissions.can_pause,
       can_check_in: permissions.can_check_in,
       can_acknowledge_check_in: permissions.can_acknowledge_check_in,

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -399,6 +399,7 @@ defmodule OperatelyWeb.Api.Types do
     field :can_edit_name, :boolean
     field :can_edit_space, :boolean
     field :can_edit_permissions, :boolean
+    field :can_close, :boolean
     field :can_pause, :boolean
     field :can_check_in, :boolean
     field :can_acknowledge_check_in, :boolean

--- a/test/features/project_retrospectives_test.exs
+++ b/test/features/project_retrospectives_test.exs
@@ -21,7 +21,7 @@ defmodule Operately.Features.ProjectRetrospectivesTest do
 
     ctx
     |> ProjectSteps.visit_project_page()
-    |> UI.click(testid: "close-project-button")
+    |> ProjectSteps.visit_close_project_page()
     |> fill_rich_text_in("what-went-well", "We built the thing")
     |> fill_rich_text_in("what-could-ve-gone-better", "We built the thing")
     |> fill_rich_text_in("what-did-you-learn", "We learned the thing")
@@ -40,8 +40,8 @@ defmodule Operately.Features.ProjectRetrospectivesTest do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{
       where: ctx.project.name,
-      to: ctx.reviewer, 
-      author: ctx.champion, 
+      to: ctx.reviewer,
+      author: ctx.champion,
       action: "closed the project and submitted a retrospective"
     })
 
@@ -59,7 +59,7 @@ defmodule Operately.Features.ProjectRetrospectivesTest do
   feature "can't close a project with an emtpy retrospective", ctx do
     ctx
     |> ProjectSteps.visit_project_page()
-    |> UI.click(testid: "close-project-button")
+    |> ProjectSteps.visit_close_project_page()
     |> UI.click(testid: "submit")
     |> UI.assert_text("Please fill in this field")
   end
@@ -87,5 +87,4 @@ defmodule Operately.Features.ProjectRetrospectivesTest do
       UI.fill_rich_text(el, content)
     end)
   end
-
 end

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -252,6 +252,12 @@ defmodule Operately.Support.Features.ProjectSteps do
     ctx |> UI.visit(Paths.project_path(ctx.company, ctx.project))
   end
 
+  step :visit_close_project_page, ctx do
+    ctx
+    |> UI.click(testid: "project-options-button")
+    |> UI.click(testid: "close-project")
+  end
+
   def visit_project_milestones_page(ctx, milestone_name) do
     {:ok, milestone} = Operately.Projects.get_milestone_by_name(ctx.project, milestone_name)
 


### PR DESCRIPTION
I've moved the "Close project" button to the action menu as described in https://github.com/operately/operately/issues/669.

Unlike the other actions, the "Close Project" action was shown to anyone. So, I've added "can close" to permissions and used it to display this action only contributors.