### PR TITLE
fix: Task columns titles were invisible in the dark mode

### DIFF
--- a/assets/js/features/Tasks/TaskBoard.tsx
+++ b/assets/js/features/Tasks/TaskBoard.tsx
@@ -3,6 +3,7 @@ import * as Tasks from "@/models/tasks";
 
 import Avatar from "@/components/Avatar";
 
+import { useIsDarkMode } from "@/theme";
 import { DivLink } from "@/components/Link";
 import { insertAt } from "@/utils/array";
 import { DragAndDropProvider, useDraggable, useDropZone, useDragAndDropContext } from "@/features/DragAndDrop";
@@ -105,6 +106,7 @@ interface TaskColumnProps {
 }
 
 function TaskColumn(props: TaskColumnProps) {
+  const isDarkMode = useIsDarkMode();
   const { draggedId } = useDragAndDropContext();
   const { ref, isOver, isSourceZone, dropIndex, draggedElementHeight } = useDropZone({ id: props.status });
 
@@ -147,7 +149,7 @@ function TaskColumn(props: TaskColumnProps) {
 
   return (
     <div className={columnClassName}>
-      <div className="text-xs uppercase font-semibold">
+      <div className={`text-xs uppercase font-semibold ${isDarkMode && "text-gray-800"}`}>
         {props.title} {props.tasks.length > 0 && <span>({props.tasks.length})</span>}
       </div>
 
@@ -188,8 +190,10 @@ function TaskItem({ task, zoneId, style }: { task: Tasks.Task; zoneId: string; s
 }
 
 function PlaceholderTask() {
+  const isDarkMode = useIsDarkMode();
+
   return (
-    <div className="text-sm rounded p-2 border-2 border-stroke-base flex items-start justify-between border-dashed h-8"></div>
+    <div className={`text-sm rounded p-2 border-2 flex items-start justify-between border-dashed h-8 ${!isDarkMode && "border-stroke-base"}`}></div>
   );
 }
 

--- a/assets/js/theme/index.tsx
+++ b/assets/js/theme/index.tsx
@@ -64,6 +64,12 @@ export function useColorMode() {
   return colorMode;
 }
 
+export function useIsDarkMode() {
+  const { colorMode } = React.useContext(ThemeContext);
+
+  return colorMode === "dark";
+}
+
 export function useTheme() {
   const { theme } = React.useContext(ThemeContext);
 


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/523. The task placeholder was also invisible in the dark mode, so I also fixed it.

Previously:

![previous](https://github.com/user-attachments/assets/cdfb5b22-2214-4559-979e-db6aa17503e3)


Now:

![after](https://github.com/user-attachments/assets/0ded6dca-8a30-4999-97ab-5a9805aecee4)
