### PR TITLE
fix: Add 3 columns to goal creation footer

### DIFF
--- a/assets/js/features/goals/GoalForm/Form.tsx
+++ b/assets/js/features/goals/GoalForm/Form.tsx
@@ -84,7 +84,8 @@ function Description({ form }: { form: FormState }) {
 function FormFooter({ form }: { form: FormState }) {
   const bottomGridStyle = classnames({
     "grid grid-cols-1 sm:grid-cols-2 gap-4": true,
-    "lg:grid-cols-2": !form.config.allowSpaceSelection,
+    "lg:grid-cols-2": !form.config.allowSpaceSelection && form.config.mode !== "create",
+    "lg:grid-cols-3": !form.config.allowSpaceSelection && form.config.mode === "create",
     "lg:grid-cols-4": form.config.allowSpaceSelection,
   });
 


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/550.

Previously:

![before](https://github.com/user-attachments/assets/a4b60931-da8a-4423-a74d-c95ec83c3531)


Now:

![after](https://github.com/user-attachments/assets/ea97d840-b3f3-41be-bd8c-195936f5f2ed)
