### PR TITLE
feat: GroupCreation operation creates activity

### DIFF
--- a/lib/operately/activities/content/space_added.ex
+++ b/lib/operately/activities/content/space_added.ex
@@ -1,0 +1,19 @@
+defmodule Operately.Activities.Content.SpaceAdded do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    field :name, :string
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -29,6 +29,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
   @space_actions [
     "space_joining",
     "space_permissions_edited",
+    "space_added",
 
     "goal_archived",
 

--- a/lib/operately/activities/notifications/space_added.ex
+++ b/lib/operately/activities/notifications/space_added.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.SpaceAdded do
+  def dispatch(_activity) do
+    # Notification dispatcher for SpaceAdded not implemented yet
+    {:ok, []}
+  end
+end

--- a/test/operately/operations/group_creation_test.exs
+++ b/test/operately/operations/group_creation_test.exs
@@ -7,6 +7,7 @@ defmodule Operately.Operations.GroupCreationTest do
   alias Operately.Groups
   alias Operately.Access
   alias Operately.Access.Binding
+  alias Operately.Activities.Activity
 
   @group_attrs %{
     name: "my group",
@@ -110,5 +111,14 @@ defmodule Operately.Operations.GroupCreationTest do
     managers = Access.get_group(group_id: group.id, tag: :full_access)
 
     assert Access.get_group_membership!(group_id: managers.id, person_id: ctx.creator.id)
+  end
+
+  test "GroupCreation operation creates activity", ctx do
+    {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, @group_attrs)
+
+    activity = from(a in Activity, where: a.action == "space_added" and a.content["space_id"] == ^group.id) |> Repo.one!()
+
+    assert activity.content["company_id"] == ctx.company.id
+    assert activity.content["name"] == group.name
   end
 end


### PR DESCRIPTION
I've updated `Operately.Operations.GroupCreation` to also insert an activity record as described in https://github.com/operately/operately/issues/584.

I didn't update the feed to show this activity because I wasn't sure if it should appear there. However, if it should, I can make the necessary changes before merging this pull request.