### PR TITLE
fix: Project list avatars no longer flow out of container

### DIFF
--- a/assets/js/features/ProjectListItem/index.tsx
+++ b/assets/js/features/ProjectListItem/index.tsx
@@ -103,7 +103,7 @@ function NextMilestone({ project }) {
   return (
     <div className="flex items-center gap-2">
       <MilestoneIcon milestone={project.nextMilestone} />
-      <div className="flex-1 truncate pr-2 w-96">
+      <div className="flex-1 truncate">
         <FormattedTime time={project.nextMilestone.deadlineAt} format="short-date" />: {project.nextMilestone.title}
       </div>
     </div>

--- a/assets/js/features/ProjectListItem/index.tsx
+++ b/assets/js/features/ProjectListItem/index.tsx
@@ -114,7 +114,7 @@ function ContribList({ project, size }) {
   const sortedContributors = Projects.sortContributorsByRole(project.contributors as Projects.ProjectContributor[]);
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 mb-3">
       {sortedContributors.map((contributor) => (
         <Avatar key={contributor!.id} person={contributor!.person!} size={size} />
       ))}


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/456. 

The problem was that the "next-milestone-info" container had a hard-coded width. Removing it was enough to fix it.
I've also added some margin-bottom to the avatars so that they wouldn't flow over the text.

Before:
![before](https://github.com/user-attachments/assets/8a855a0c-0344-4aaf-849c-8fcec2777869)

Now:
![after](https://github.com/user-attachments/assets/c96808e9-bb07-4844-9a68-f075af091268)
