### PR TITLE
fix: Clear form after adding contributor

### DIFF
--- a/assets/js/pages/ProjectContributorsPage/useForm.tsx
+++ b/assets/js/pages/ProjectContributorsPage/useForm.tsx
@@ -55,18 +55,22 @@ function useAddContrib(project: Projects.Project): AddColobState {
 
   const [add, { loading: submitting }] = useAddProjectContributor();
 
-  const submit = async () => {
+  const submit = () => {
     if (!submittable) return;
 
-    await add({
+    add({
       projectId: project.id,
       personId: personID,
       responsibility: responsibility,
       permissions: permissions.value,
+    })
+    .then(() => {
+      setPersonID(null);
+      setResponsibility("");
+      setPermissions(VIEW_ACCESS);
+      refresh();
+      deactivate();
     });
-
-    refresh();
-    deactivate();
   };
 
   return {


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/678.

Now, after adding a contributor to a project, the form is cleared.