### PR TITLE
fix: Suspended people excluded from space and project queries

### DIFF
--- a/lib/operately/groups/member.ex
+++ b/lib/operately/groups/member.ex
@@ -3,7 +3,7 @@ defmodule Operately.Groups.Member do
 
   schema "members" do
     belongs_to :group, Operately.Groups.Group
-    belongs_to :person, Operately.People.Person
+    belongs_to :person, Operately.People.Person, where: [suspended_at: nil]
 
     timestamps()
   end

--- a/lib/operately/projects/contributor.ex
+++ b/lib/operately/projects/contributor.ex
@@ -6,7 +6,7 @@ defmodule Operately.Projects.Contributor do
   @foreign_key_type :binary_id
   schema "project_contributors" do
     belongs_to :project, Operately.Projects.Project, foreign_key: :project_id
-    belongs_to :person, Operately.People.Person, foreign_key: :person_id
+    belongs_to :person, Operately.People.Person, foreign_key: :person_id, where: [suspended_at: nil]
 
     field :responsibility, :string
     field :role, Ecto.Enum, values: [:champion, :reviewer, :contributor], default: :contributor
@@ -28,7 +28,7 @@ defmodule Operately.Projects.Contributor do
   end
 
   def changeset(contributor, attrs) do
-    contributor 
+    contributor
     |> cast(attrs, [:responsibility, :project_id, :person_id, :role])
     |> validate_required([:project_id, :person_id])
   end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -370,13 +370,20 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       reviewer: OperatelyWeb.Api.Serializer.serialize(project.reviewer),
       goal: OperatelyWeb.Api.Serializer.serialize(project.goal),
       milestones: OperatelyWeb.Api.Serializer.serialize(project.milestones),
-      contributors: OperatelyWeb.Api.Serializer.serialize(project.contributors),
+      contributors: OperatelyWeb.Api.Serializer.serialize(exclude_suspended(project)),
       last_check_in: OperatelyWeb.Api.Serializer.serialize(project.last_check_in),
       next_milestone: OperatelyWeb.Api.Serializer.serialize(project.next_milestone),
       permissions: OperatelyWeb.Api.Serializer.serialize(project.permissions),
       key_resources: OperatelyWeb.Api.Serializer.serialize(project.key_resources),
       access_levels: OperatelyWeb.Api.Serializer.serialize(project.access_levels, level: :full),
     }
+  end
+
+  defp exclude_suspended(project) do
+    case project.contributors do
+      %Ecto.Association.NotLoaded{} -> []
+      contributors -> Enum.filter(contributors, &(not is_nil(&1.person)))
+    end
   end
 end
 


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/651.

Now both project and space queries exclude members who have been suspended.