### PR TITLE
feat: Clicking on avatar in Goal page redirects to person's profile

### DIFF
--- a/assets/js/components/InlinePeopleList/index.tsx
+++ b/assets/js/components/InlinePeopleList/index.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import * as People from "@/models/people";
 
+import { Paths } from "@/routes/paths";
+import { DivLink } from "@/components/Link";
 import Avatar from "@/components/Avatar";
+
 
 interface InlinePeopleListProps {
   people: People.Person[];
@@ -22,11 +25,15 @@ export function InlinePeopleList({ people, nameFormat }: InlinePeopleListProps) 
 }
 
 function PersonWithAvatarAndName({ person, nameFormat }: { person: People.Person; nameFormat?: People.NameFormat }) {
+  const profilePath = Paths.profilePath(person.id!);
+
   return (
-    <div className="flex items-center gap-1 shrink-0">
-      <Avatar person={person} size={18} />
-      {People.formattedName(person, nameFormat || "first")}
-    </div>
+    <DivLink to={profilePath}>
+      <div className="flex items-center gap-1 shrink-0">
+        <Avatar person={person} size={18} />
+        {People.formattedName(person, nameFormat || "first")}
+      </div>
+    </DivLink>
   );
 }
 

--- a/assets/js/features/goals/GoalCheckIn/index.tsx
+++ b/assets/js/features/goals/GoalCheckIn/index.tsx
@@ -24,10 +24,13 @@ export function LastCheckInMessage({ goal }) {
   const message = goal.lastCheckIn.message;
   const path = Paths.goalProgressUpdatePath(goal.lastCheckIn.id);
   const author = goal.lastCheckIn.author;
+  const championProfilePath = Paths.profilePath(author.id!)
 
   return (
     <div className="flex items-start gap-4">
-      <Avatar person={author} size={40} />
+      <DivLink to={championProfilePath}>
+        <Avatar person={author} size={40} />
+      </DivLink>
       <div className="flex flex-col gap-1 -mt-1">
         <div className="font-semibold">
           Last progress update from <FormattedTime time={goal.lastCheckIn.insertedAt} format="short-date" />

--- a/assets/js/pages/GoalAboutPage/page.tsx
+++ b/assets/js/pages/GoalAboutPage/page.tsx
@@ -10,6 +10,9 @@ import RichContent from "@/components/RichContent";
 
 import { useLoadedData } from "./loader";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
+import { Paths } from "@/routes/paths";
+import { DivLink } from "@/components/Link";
+
 
 export function Page() {
   const { goal } = useLoadedData();
@@ -35,12 +38,18 @@ const DimmedLabel = ({ children }) => (
   <div className="text-xs uppercase font-medium mb-1 tracking-wider">{children}</div>
 );
 
-const AvatarAndName = ({ person }) => (
-  <div className="flex items-center gap-1.5">
-    <Avatar person={person} size="tiny" />
-    <div className="font-medium">{person.fullName}</div>
-  </div>
-);
+const AvatarAndName = ({ person }) => {
+  const profilePath = Paths.profilePath(person.id)
+
+  return (
+    <DivLink to={profilePath}>
+      <div className="flex items-center gap-1.5">
+          <Avatar person={person} size="tiny" />
+        <div className="font-medium">{person.fullName}</div>
+      </div>
+    </DivLink>
+  );
+};
 
 function Description({ goal }) {
   return (

--- a/assets/js/pages/GoalDiscussionsPage/index.tsx
+++ b/assets/js/pages/GoalDiscussionsPage/index.tsx
@@ -81,6 +81,7 @@ function ActivityList() {
 
 function ActivityItem({ activity }: { activity: Activities.Activity }) {
   const path = ActivityHandler.pagePath(activity);
+  const authorProfilePath = Paths.profilePath(activity.author!.id!);
 
   return (
     <div className="flex items-start border-t border-stroke-base py-6">
@@ -94,7 +95,9 @@ function ActivityItem({ activity }: { activity: Activities.Activity }) {
       </div>
 
       <div className="flex items-start gap-3 flex-1">
-        <Avatar person={activity.author!} size={40} />
+        <DivLink to={authorProfilePath}>
+          <Avatar person={activity.author!} size={40} />
+        </DivLink>
 
         <div className="flex items-start justify-between gap-4 flex-1">
           <div className="flex flex-col gap-1 w-full">


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/639. 

Now, clicking on a person's avatar in the Goal page redirects to that person's profile.