### PR TITLE
fix: "New invitation" button only shown to invited members

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -669,6 +669,7 @@ export interface Person {
   reports?: Person[] | null;
   peers?: Person[] | null;
   theme?: string | null;
+  hasOpenInvitation?: boolean | null;
 }
 
 export interface Project {

--- a/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/NewInvitationToken.tsx
@@ -6,6 +6,7 @@ import { GhostButton } from "@/components/Button";
 import Modal from "@/components/Modal";
 import { createInvitationUrl } from "@/features/CompanyAdmin";
 import { createTestId } from "@/utils/testid";
+import { CopyToClipboard } from "@/components/CopyToClipboard";
 
 export default function NewInvitationToken({ person }: { person: People.Person }) {
   const newTokenTestId = createTestId("new-token", person.fullName!);
@@ -47,7 +48,16 @@ export default function NewInvitationToken({ person }: { person: People.Person }
       </GhostButton>
 
       <Modal title="New Invitation URL" isOpen={showToken} hideModal={handleHideModal} minHeight="120px">
-        {error ? <div>{error}</div> : <div>{url}</div>}
+        {error ?
+          <div>{error}</div>
+        :
+          <div className="text-content-primary border border-surface-outline rounded-lg px-3 py-1 font-medium flex items-center justify-between">
+            <span className="break-all">
+              {url}
+            </span>
+            <CopyToClipboard text={url} size={25} padding={1} containerClass="" />
+          </div>
+        }
       </Modal>
     </>
   );

--- a/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/PeopleList.tsx
@@ -31,7 +31,9 @@ function PersonRow({ person }: { person: People.Person }) {
 
       <div className="flex flex-col gap-2">
         <RemoveMember person={person} />
-        <NewInvitationToken person={person} />
+        {person.hasOpenInvitation && (
+          <NewInvitationToken person={person} />
+        )}
       </div>
     </div>
   );

--- a/lib/operately/operations/company_member_adding.ex
+++ b/lib/operately/operations/company_member_adding.ex
@@ -37,7 +37,8 @@ defmodule Operately.Operations.CompanyMemberAdding do
         account_id: changes[:account].id,
         full_name: attrs.full_name,
         email: attrs.email,
-        title: attrs.title
+        title: attrs.title,
+        has_open_invitation: true,
       })
     end)
   end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -32,6 +32,7 @@ defmodule Operately.People.Person do
     field :suspended_at, :utc_datetime
 
     field :avatar_blob_id, :binary_id
+    field :has_open_invitation, :boolean, default: false
 
     timestamps()
   end
@@ -59,7 +60,8 @@ defmodule Operately.People.Person do
       :theme,
       :suspended,
       :suspended_at,
-      :avatar_blob_id
+      :avatar_blob_id,
+      :has_open_invitation
     ])
     |> validate_required([:full_name, :company_id])
     |> foreign_key_constraint(:avatar_blob_id, name: :people_avatar_blob_id_fkey)

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -52,6 +52,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
       full_name: data.full_name,
       avatar_url: data.avatar_url,
       title: data.title,
+      has_open_invitation: data.has_open_invitation,
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -605,6 +605,7 @@ defmodule OperatelyWeb.Api.Types do
     field :reports, list_of(:person)
     field :peers, list_of(:person)
     field :theme, :string
+    field :has_open_invitation, :boolean
   end
 
   object :project_health do

--- a/priv/repo/migrations/20240725091444_add_has_open_invitation_field_to_people.exs
+++ b/priv/repo/migrations/20240725091444_add_has_open_invitation_field_to_people.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddHasOpenInvitationFieldToPeople do
+  use Ecto.Migration
+
+  def change do
+    alter table(:people) do
+      add :has_open_invitation, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/operately/operations/company_member_adding_test.exs
+++ b/test/operately/operations/company_member_adding_test.exs
@@ -41,6 +41,7 @@ defmodule Operately.Operations.CompanyMemberAddingTest do
     assert person.company_role == :member
     assert person.full_name == "John Doe"
     assert person.title == "Developer"
+    assert person.has_open_invitation
   end
 
   test "CompanyMemberAdding operation creates members's access group and membership", ctx do

--- a/test/operately/operations/password_first_time_changing_test.exs
+++ b/test/operately/operations/password_first_time_changing_test.exs
@@ -1,0 +1,52 @@
+defmodule Operately.Operations.PasswordFirstTimeChangingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.InvitationsFixtures
+
+  alias Operately.People.Account
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    admin = person_fixture_with_account(%{company_id: company.id, company_role: :admin})
+    member = person_fixture_with_account(%{company_id: company.id, has_open_invitation: true})
+    invitation = invitation_fixture(%{member_id: member.id, admin_id: admin.id})
+
+    attrs = %{
+      password: "AaBb12345@#cC",
+      password_confirmation: "AaBb12345@#cC",
+    }
+
+    {:ok, company: company, member: member, invitation: invitation, attrs: attrs}
+  end
+
+  test "PasswordFirstTimeChanging operation changes password", ctx do
+    member_account = Repo.preload(ctx.member, :account).account
+    refute Account.valid_password?(member_account, ctx.attrs.password)
+
+    {:ok, _} = Operately.Operations.PasswordFirstTimeChanging.run(ctx.attrs, ctx.invitation)
+
+    member_account = Repo.reload(member_account)
+    assert Account.valid_password?(member_account, ctx.attrs.password)
+  end
+
+  test "PasswordFirstTimeChanging operation sets has_open_invitation to false", ctx do
+    assert ctx.member.has_open_invitation
+
+    {:ok, _} = Operately.Operations.PasswordFirstTimeChanging.run(ctx.attrs, ctx.invitation)
+
+    member = Repo.reload(ctx.member)
+    refute member.has_open_invitation
+  end
+
+  test "PasswordFirstTimeChanging operation creates activity", ctx do
+    {:ok, _} = Operately.Operations.PasswordFirstTimeChanging.run(ctx.attrs, ctx.invitation)
+
+    activity = from(a in Activity, where: a.action == "password_first_time_changed" and a.content["member_email"] == ^ctx.member.email) |> Repo.one()
+
+    assert activity.content["company_id"] == ctx.company.id
+    assert activity.content["invitatition_id"] == ctx.invitation.id
+  end
+end

--- a/test/operately_web/api/queries/get_space_test.exs
+++ b/test/operately_web/api/queries/get_space_test.exs
@@ -73,7 +73,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpaceTest do
       |> Enum.with_index()
       |> Enum.map(fn {m, i} -> {m, Enum.at(res.space.members, i)} end)
       |> Enum.each(fn {m, res} ->
-        assert res == %{id: Paths.person_id(m), full_name: m.full_name, avatar_url: m.avatar_url, title: m.title}
+        assert res == %{id: Paths.person_id(m), full_name: m.full_name, avatar_url: m.avatar_url, title: m.title, has_open_invitation: false}
       end)
     end
 


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/520 and https://github.com/operately/operately/issues/642.

Now the "New invitation" button is displayed only for members who received an invitation (link with token) and haven't set their password for the first time.

This is how it looks when a member was invited, but hasn't set their password yet:
![with-invitations](https://github.com/user-attachments/assets/1f56efa3-d2a6-4ee5-9d57-17cdf294aeb8)

And here is how it looks after they have set their password:
![without-invitations](https://github.com/user-attachments/assets/00d834ab-746b-40f4-b87d-4f9463b66cf5)
