### PR TITLE
feat: Discussion page updates when there are changes in the comments

### DIFF
--- a/assets/js/api/socket.tsx
+++ b/assets/js/api/socket.tsx
@@ -1,6 +1,8 @@
 import { Socket } from "phoenix";
 import * as React from "react";
 
+type Payload = {[ key: string ]: any};
+
 var socket: Socket | null = null;
 
 function connect(): Socket {
@@ -13,10 +15,10 @@ function connect(): Socket {
   return newSocket;
 }
 
-function useSubscription(channelName: string, callback: (payload: any) => void) {
+function useSubscription(channelName: string, callback: () => void, payload: Payload={}) {
   React.useEffect(() => {
     let socket = connect();
-    const channel = socket.channel(channelName, {});
+    const channel = socket.channel(channelName, payload);
 
     channel.on("event", callback);
 
@@ -34,10 +36,14 @@ function useSubscription(channelName: string, callback: (payload: any) => void) 
   }, [channelName, callback]);
 }
 
-export function useAssignmentsCount(callback: (payload: any) => void) {
+export function useAssignmentsCount(callback: () => void) {
   return useSubscription("api:assignments_count", callback);
 }
 
-export function useUnreadNotificationCount(callback: (payload: any) => void) {
+export function useDiscussionCommentsChangeSignal(callback: () => void, payload: { discussionId: string }) {
+  return useSubscription("api:discussion_comments", callback, payload);
+}
+
+export function useUnreadNotificationCount(callback: () => void) {
   return useSubscription("api:unread_notifications_count", callback);
 }

--- a/assets/js/models/comments/index.tsx
+++ b/assets/js/models/comments/index.tsx
@@ -4,6 +4,7 @@ import * as Time from "@/utils/time";
 export type Comment = api.Comment;
 
 export { useCreateComment, useEditComment, useGetComments } from "@/api";
+export { useDiscussionCommentsChangeSignal } from "@/api/socket";
 
 export function splitComments(comments: Comment[], timestamp: string): { before: Comment[]; after: Comment[] } {
   const before = comments.filter((comment) => {

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -16,8 +16,10 @@ import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useForDiscussion } from "@/features/CommentSection";
 
 import { useRefresh, useLoadedData } from "./loader";
+import { useDiscussionCommentsChangeSignal } from "@/models/comments";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths, compareIds } from "@/routes/paths";
+
 
 export function Page() {
   const me = useMe();
@@ -25,6 +27,7 @@ export function Page() {
 
   const refresh = useRefresh();
   const commentsForm = useForDiscussion(discussion);
+  useDiscussionCommentsChangeSignal(refresh, {discussionId: discussion.id!});
 
   return (
     <Pages.Page title={discussion.title!}>

--- a/lib/operately/operations/comment_adding.ex
+++ b/lib/operately/operations/comment_adding.ex
@@ -20,6 +20,13 @@ defmodule Operately.Operations.CommentAdding do
     |> insert_activity(creator, action, entity)
     |> Repo.transaction()
     |> Repo.extract_result(:comment)
+    |> case do
+      {:ok, comment} ->
+        OperatelyWeb.ApiSocket.broadcast!("api:discussion_comments:#{comment.entity_id}")
+        {:ok, comment}
+
+      error -> error
+    end
   end
 
   def insert_activity(multi, creator, action = :discussion_comment_submitted, entity) do

--- a/lib/operately/operations/comment_editing.ex
+++ b/lib/operately/operations/comment_editing.ex
@@ -7,5 +7,12 @@ defmodule Operately.Operations.CommentEditing do
     changeset = Comment.changeset(comment, %{content: %{"message" => new_content}})
 
     Repo.update(changeset)
+    |> case do
+      {:ok, comment} ->
+        OperatelyWeb.ApiSocket.broadcast!("api:discussion_comments:#{comment.entity_id}")
+        {:ok, comment}
+
+      error -> error
+    end
   end
 end

--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -118,5 +118,6 @@ defmodule OperatelyWeb.Api do
   mutation :update_task_status, M.UpdateTaskStatus
 
   subscription :assignments_count, S.AssignmentsCount
+  subscription :discussion_comments, S.DiscussionComments
   subscription :unread_notifications_count, S.UnreadNotificationsCount
 end

--- a/lib/operately_web/api/subscriptions/discussion_comments.ex
+++ b/lib/operately_web/api/subscriptions/discussion_comments.ex
@@ -1,0 +1,11 @@
+defmodule OperatelyWeb.Api.Subscriptions.DiscussionComments do
+  use TurboConnect.Subscription
+  use OperatelyWeb.Api.Helpers
+
+  def join(_name, payload, socket) do
+    {:ok, discussion_id} = decode_id(payload["discussionId"])
+
+    {:ok, socket, [discussion_id]}
+  end
+
+end


### PR DESCRIPTION
I've handled the issue described in https://github.com/operately/operately/issues/607.

Now the page automatically refreshes the comments when a new comment is posted or an existing comment is edited.

Demo:

https://github.com/user-attachments/assets/9b5fc535-e895-405a-a474-f91513d0640b
