### PR TITLE
fix: Sort reviews using DateTime.compare/2

### DIFF
--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -27,7 +27,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
     |> load_due_project_check_ins(person)
     |> load_due_goal_updates(person)
     |> convert_id()
-    |> Enum.sort(&(&1.due > &2.due))
+    |> Enum.sort(&(DateTime.compare(&1.due, &2.due) == :gt))
   end
 
   defp load_projects(person) do


### PR DESCRIPTION
I've fixed the issue describe in https://github.com/operately/operately/issues/789 by using `DateTime.compare/2` instead of `>` to sort the dates.