### PR TITLE
fix: Make notifications white to increate contrast

### DIFF
--- a/assets/js/layouts/DefaultLayout/Bell.tsx
+++ b/assets/js/layouts/DefaultLayout/Bell.tsx
@@ -31,7 +31,7 @@ function UnreadIndicator({ count }: { count: number }) {
 
   return (
     <div
-      className="absolute -top-1 -right-1 rounded-full bg-orange-600 flex items-center justify-center text-content-accent leading-none group-hover:bg-orange-500 transition-all"
+      className="absolute -top-1 -right-1 rounded-full bg-orange-600 flex items-center justify-center text-white-1 leading-none group-hover:bg-orange-500 transition-all"
       style={{
         height: "17px",
         width: "17px",

--- a/assets/js/layouts/DefaultLayout/Review.tsx
+++ b/assets/js/layouts/DefaultLayout/Review.tsx
@@ -33,7 +33,7 @@ function AssignmentsCount({ count }: { count: number }) {
 
   return (
     <div
-      className="absolute -top-1 -right-3 rounded-full bg-orange-600 flex items-center justify-center text-content-accent leading-none group-hover:bg-orange-500 transition-all"
+      className="absolute -top-1 -right-3 rounded-full bg-orange-600 flex items-center justify-center text-white-1 leading-none group-hover:bg-orange-500 transition-all"
       style={{
         height: "17px",
         width: "17px",


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/790 by making the notifications white for both the light and dark theme.

Light:
![light](https://github.com/user-attachments/assets/b73dee3b-7697-4133-9641-59ae6db2e193)

Dark:
![dark](https://github.com/user-attachments/assets/b24aec83-cc9a-427e-8b2a-cde195de03e2)
