### PR TITLE
fix: get_assignments query excludes soft-deleted items

### DIFF
--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -3,7 +3,7 @@ defmodule Operately.Projects.CheckIn do
 
   schema "project_check_ins" do
     belongs_to :author, Operately.People.Person, foreign_key: :author_id
-    belongs_to :project, Operately.Projects.Project, foreign_key: :project_id
+    belongs_to :project, Operately.Projects.Project, foreign_key: :project_id, where: [deleted_at: nil]
 
     field :status, :string
     field :description, :map

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -88,6 +88,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
       join: g in Operately.Goals.Goal, on: u.updatable_id == g.id,
       join: champion in assoc(g, :champion),
       where: g.reviewer_id == ^person.id,
+      where: is_nil(g.deleted_at),
       where: u.type == :goal_check_in and is_nil(u.acknowledging_person_id),
       select: %{
         id: u.id,


### PR DESCRIPTION
I've fixed the issue described it https://github.com/operately/operately/issues/792.

The problem was that our `Repo.all()` handles the exclusion of soft-deleted items from queries only when it's querying them directly, but it does not handle it when it comes to relationships.

So, it would exclude soft-deleted goals and projects, but it would still load their outstanding check-ins and updates that hadn't been acknowledged yet. However, if we clicked on these check-ins and updates, we would be redirected to their pages and get a 500 because `Repo` can't load soft-deleted goals and projects directly.