### PR TITLE
fix: Adding and editing tasks with assignees were broken

### DIFF
--- a/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
+++ b/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
@@ -105,6 +105,7 @@ export function MultiPeopleSearch(props: MultiPeopleSearchProps) {
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
           value={searchTerm}
+          id="task-assignees-input"
         />
 
         <div className="absolute flex items-center justify-center z-[1000]" style={{ top: "30px", left: 0 }}>

--- a/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
+++ b/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
@@ -6,6 +6,8 @@ import * as People from "@/models/people";
 import * as Icons from "@tabler/icons-react";
 
 import Avatar from "@/components/Avatar";
+import { createTestId } from "@/utils/testid";
+
 
 interface MultiPeopleSearchProps {
   addedPeople: People.Person[];
@@ -92,6 +94,7 @@ export function MultiPeopleSearch(props: MultiPeopleSearchProps) {
             size={12}
             onClick={() => props.setAddedPeople((people) => people.filter((p) => p.id !== person.id))}
             className="cursor-pointer ml-1"
+            data-test-id={createTestId("remove", person.fullName!)}
           />
         </div>
       ))}

--- a/assets/js/features/Tasks/NewTaskModal/index.tsx
+++ b/assets/js/features/Tasks/NewTaskModal/index.tsx
@@ -89,7 +89,7 @@ export function NewTaskModal({ isOpen, hideModal, modalTitle, milestone, onSubmi
             Cancel
           </FilledButton>
 
-          <FilledButton size="base" type="primary" onClick={form.submit}>
+          <FilledButton size="base" type="primary" onClick={form.submit} testId="submit-new-task" >
             Add Task
           </FilledButton>
         </div>
@@ -117,7 +117,7 @@ function Form({ form }: { form: ReturnType<typeof useForm> }) {
               })}
               placeholder="Title of the task"
               value={form.fields.name}
-              data-test-id="new-milestone-title"
+              data-test-id="new-task-title"
               onChange={(e) => form.fields.setName(e.target.value)}
             />
           </div>

--- a/assets/js/features/Tasks/TaskBoard.tsx
+++ b/assets/js/features/Tasks/TaskBoard.tsx
@@ -154,8 +154,8 @@ function TaskColumn(props: TaskColumnProps) {
       </div>
 
       <div className="flex flex-col mt-2" ref={ref} style={style}>
-        {props.tasks.map((task) => (
-          <TaskItem key={task.id} task={task} zoneId={props.status} style={taskStyle(visibleIndexes[task.id!])} />
+        {props.tasks.map((task, idx) => (
+          <TaskItem key={task.id} task={task} zoneId={props.status} style={taskStyle(visibleIndexes[task.id!])} testId={`${props.status}_${idx}`} />
         ))}
 
         {props.tasks.length === 0 && <PlaceholderTask />}
@@ -164,12 +164,12 @@ function TaskColumn(props: TaskColumnProps) {
   );
 }
 
-function TaskItem({ task, zoneId, style }: { task: Tasks.Task; zoneId: string; style: React.CSSProperties }) {
+function TaskItem({ task, zoneId, style, testId }: { task: Tasks.Task; zoneId: string; style: React.CSSProperties; testId: string }) {
   const { ref, isDragging } = useDraggable({ id: task.id!, zoneId });
 
   return (
     <div className="w-full" ref={ref}>
-      <div className="my-1" style={isDragging ? {} : style}>
+      <div className="my-1" style={isDragging ? {} : style} data-test-id={testId}>
         <DivLink
           className="text-sm bg-surface rounded p-2 border border-stroke-base flex items-start justify-between cursor-pointer"
           to={Paths.taskPath(task.id!)}

--- a/assets/js/pages/ProjectMilestonePage/page.tsx
+++ b/assets/js/pages/ProjectMilestonePage/page.tsx
@@ -80,6 +80,7 @@ function AddTask({ onClick }) {
       <div
         className={"text-sm font-bold rounded-full p-1 hover:scale-110 transition cursor-pointer bg-sky-200"}
         onClick={onClick}
+        data-test-id="add-task"
       >
         <Icons.IconPlus size={14} />
       </div>

--- a/assets/js/pages/TaskPage/page.tsx
+++ b/assets/js/pages/TaskPage/page.tsx
@@ -77,6 +77,7 @@ function HeaderEditor({ form }: { form: FormState }) {
           onChange={form.headerForm.setName}
           placeholder="Task Name"
           error={form.headerForm.errors.includes("name")}
+          data-test-id="task-name-input"
         />
       </div>
 
@@ -94,7 +95,7 @@ function HeaderEditor({ form }: { form: FormState }) {
           Cancel
         </FilledButton>
 
-        <FilledButton size="sm" type="primary" onClick={form.headerForm.submit} bzzzOnClickFailure>
+        <FilledButton size="sm" type="primary" onClick={form.headerForm.submit} bzzzOnClickFailure testId="submit-edited-task">
           Save
         </FilledButton>
       </div>
@@ -133,7 +134,7 @@ function TopActions({ form }: { form: FormState }) {
     <div className="flex gap-2 items-center shrink-0">
       {form.fields.status !== "done" ? <MarkAsDoneButton form={form} /> : <ReopenButton form={form} />}
 
-      <FilledButton size="sm" type="secondary" onClick={form.headerForm.startEditing}>
+      <FilledButton size="sm" type="secondary" onClick={form.headerForm.startEditing} testId="edit-task">
         Edit
       </FilledButton>
     </div>
@@ -178,7 +179,7 @@ function DescriptionEditor({ form }: { form: FormState }) {
             Cancel
           </FilledButton>
 
-          <FilledButton size="xs" type="primary" onClick={form.descriptionForm.submit}>
+          <FilledButton size="xs" type="primary" onClick={form.descriptionForm.submit} testId="submit-edited-task-description">
             Save
           </FilledButton>
         </div>
@@ -216,7 +217,7 @@ function AssignedPeopleList({ form }: { form: FormState }) {
   }
 
   return (
-    <div className="flex items-center gap-2 flex-wrap mx-10">
+    <div className="flex items-center gap-2 flex-wrap mx-10" data-test-id="assignees-container">
       {form.fields.assignedPeople!.map((person) => (
         <div className="flex items-center gap-1" key={person.id}>
           <Avatar person={person} size={32} />
@@ -250,6 +251,7 @@ function EditDescription({ form, color }: { form: FormState; color: string }) {
           "text-sm font-bold rounded-full p-1 hover:scale-110 transition cursor-pointer" + " " + color + " " + textColor
         }
         onClick={form.descriptionForm.startEditing}
+        data-test-id="edit-description"
       >
         <Icons.IconPencil size={12} />
       </div>

--- a/lib/operately_web/api/mutations/create_task.ex
+++ b/lib/operately_web/api/mutations/create_task.ex
@@ -15,10 +15,21 @@ defmodule OperatelyWeb.Api.Mutations.CreateTask do
 
   def call(conn, inputs) do
     {:ok, milestone_id} = decode_id(inputs.milestone_id)
-    inputs = %{inputs | milestone_id: milestone_id}
+
+    inputs = Map.merge(inputs, %{
+      milestone_id: milestone_id,
+      assignee_ids: decode_assignees(inputs.assignee_ids),
+    })
 
     creator = me(conn)
     {:ok, task} = Operately.Operations.TaskAdding.run(creator, inputs)
     {:ok, %{task: Serializer.serialize(task, level: :essential)}}
+  end
+
+  defp decode_assignees(ids) do
+    Enum.map(ids, fn id ->
+      {:ok, id} = decode_id(id)
+      id
+    end)
   end
 end

--- a/lib/operately_web/api/mutations/update_task.ex
+++ b/lib/operately_web/api/mutations/update_task.ex
@@ -17,9 +17,16 @@ defmodule OperatelyWeb.Api.Mutations.UpdateTask do
 
     author = me(conn)
     name = inputs.name
-    assigned_ids = inputs.assigned_ids
+    assigned_ids = decode_assignees(inputs.assigned_ids)
 
     {:ok, task} = Operately.Operations.TaskUpdate.run(author, task_id, name, assigned_ids)
     {:ok, %{task: Serializer.serialize(task, level: :essential)}}
+  end
+
+  defp decode_assignees(ids) do
+    Enum.map(ids, fn id ->
+      {:ok, id} = decode_id(id)
+      id
+    end)
   end
 end

--- a/lib/operately_web/api/queries/search_people.ex
+++ b/lib/operately_web/api/queries/search_people.ex
@@ -44,6 +44,11 @@ defmodule OperatelyWeb.Api.Queries.SearchPeople do
   end
 
   defp ignore_ids(query, ignored_ids) do
+    ignored_ids = Enum.map(ignored_ids, fn id ->
+      {:ok, decoded_id} = decode_id(id)
+      decoded_id
+    end)
+
     from p in query, where: p.id not in ^ignored_ids
   end
 

--- a/test/features/project_tasks_test.exs
+++ b/test/features/project_tasks_test.exs
@@ -70,4 +70,69 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.add_task(attrs)
     |> Steps.assert_task_added(attrs)
   end
+
+  @tag login_as: :champion
+  feature "edit task name and description", ctx do
+    attrs = %{
+      title: "My task",
+      description: "Some description",
+      test_id: "todo_0",
+    }
+    name = "new name"
+    description = " - new description"
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs)
+    |> Steps.assert_task_added(attrs)
+    |> Steps.click_on_task(attrs)
+    |> UI.refute_text(name)
+    |> Steps.edit_task_name(name)
+    |> UI.assert_text(name)
+    |> UI.refute_text(description)
+    |> Steps.edit_task_description(description)
+    |> UI.assert_text(attrs.description <> description)
+  end
+
+  @tag login_as: :champion
+  feature "edit task assignees", ctx do
+    attrs = %{
+      title: "My task",
+      description: "Some description",
+      test_id: "todo_0",
+    }
+    assignees = [ ctx.champion.full_name, ctx.reviewer.full_name ]
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs)
+    |> Steps.assert_task_added(attrs)
+    |> Steps.click_on_task(attrs)
+    |> Steps.assert_no_assignee()
+    |> Steps.edit_task_assignees(assignees)
+    |> Steps.assert_assignees(assignees)
+  end
+
+  @tag login_as: :champion
+  feature "remove task assignees", ctx do
+    assignees = [ ctx.champion.full_name, ctx.reviewer.full_name ]
+    attrs = %{
+      title: "My task",
+      description: "Some description",
+      assignees: assignees,
+      test_id: "todo_0",
+    }
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs)
+    |> Steps.assert_task_added(attrs)
+    |> Steps.click_on_task(attrs)
+    |> Steps.assert_assignees(assignees)
+    |> Steps.remove_assignee(ctx.champion.full_name)
+    |> Steps.assert_assignees([ctx.reviewer.full_name])
+    |> Steps.assert_no_specific_assignee(ctx.champion.full_name)
+    |> Steps.remove_assignee(ctx.reviewer.full_name)
+    |> Steps.assert_no_assignee()
+  end
 end

--- a/test/features/project_tasks_test.exs
+++ b/test/features/project_tasks_test.exs
@@ -1,0 +1,73 @@
+defmodule Operately.Features.ProjectTasksTest do
+  use Operately.FeatureCase
+
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Support.Features.ProjectSteps
+  alias Operately.Support.Features.ProjectTaskSteps, as: Steps
+
+  setup ctx do
+    ctx = ProjectSteps.create_project(ctx, name: "Test Project")
+    ctx = ProjectSteps.login(ctx)
+
+    milestone = milestone_fixture(ctx.champion, %{project_id: ctx.project.id, title: "The Milestone"})
+
+    {:ok, Map.merge(ctx, %{milestone: milestone})}
+  end
+
+  @tag login_as: :champion
+  feature "create task", ctx do
+    attrs1 = %{
+      title: "Task 1",
+      description: "Some description",
+      assignees: [ctx.champion.full_name],
+      test_id: "todo_0",
+    }
+    attrs2 = Map.merge(attrs1, %{
+      title: "Task 2",
+      test_id: "todo_1",
+    })
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs1)
+    |> Steps.assert_task_added(attrs1)
+    |> Steps.add_task(attrs2)
+    |> Steps.assert_task_added(attrs2)
+  end
+
+  @tag login_as: :champion
+  feature "create task without assignee", ctx do
+    attrs = %{
+      title: "My task",
+      description: "Some description",
+      test_id: "todo_0",
+    }
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs)
+    |> Steps.assert_task_added(attrs)
+  end
+
+  @tag login_as: :champion
+  feature "create task with several assignees", ctx do
+    person = person_fixture_with_account(%{company_id: ctx.company.id})
+    attrs = %{
+      title: "My task",
+      description: "Some description",
+      assignees: [
+        ctx.champion.full_name,
+        ctx.reviewer.full_name,
+        person.full_name,
+      ],
+      test_id: "todo_0",
+    }
+
+    ctx
+    |> Steps.visit_milestone_page()
+    |> Steps.add_task(attrs)
+    |> Steps.assert_task_added(attrs)
+  end
+end

--- a/test/support/features/project_task_steps.ex
+++ b/test/support/features/project_task_steps.ex
@@ -22,16 +22,86 @@ defmodule Operately.Support.Features.ProjectTaskSteps do
     |> UI.click(testid: "submit-new-task")
   end
 
+  step :click_on_task, ctx, attrs do
+    ctx
+    |> UI.click(testid: attrs.test_id)
+  end
+
+  step :edit_task_name, ctx, name do
+    ctx
+    |> UI.click(testid: "edit-task")
+    |> UI.fill(testid: "task-name-input", with: name)
+    |> UI.click(testid: "submit-edited-task")
+    |> UI.sleep(50)
+    |> UI.refute_has(testid: "task-name-input")
+    |> UI.refute_has(testid: "submit-edited-task")
+  end
+
+  step :edit_task_description, ctx, description do
+    ctx
+    |> UI.click(testid: "edit-description")
+    |> UI.fill_rich_text(description)
+    |> UI.click(testid: "submit-edited-task-description")
+    |> UI.sleep(50)
+    |> UI.refute_has(testid: "submit-edited-task-description")
+  end
+
+  step :edit_task_assignees, ctx, assignees do
+    ctx
+    |> UI.click(testid: "edit-task")
+
+    Enum.each(assignees, fn name ->
+      ctx
+      |> UI.select_person_in(id: "task-assignees-input", name: name)
+    end)
+
+    ctx
+    |> UI.click(testid: "submit-edited-task")
+  end
+
+  step :remove_assignee, ctx, assignee do
+    testid = "remove-" <> String.replace(assignee, " ", "-") |> String.downcase()
+
+    ctx
+    |> UI.click(testid: "edit-task")
+    |> UI.click(testid: testid)
+    |> UI.click(testid: "submit-edited-task")
+  end
+
+  #
+  # Assertions
+  #
+
   step :assert_task_added, ctx, attrs do
     UI.find(ctx, UI.query(testid: attrs.test_id), fn ctx ->
-      ctx
-      |> UI.assert_text(attrs.title)
-
       Enum.each(attrs[:assignees] || [], fn name ->
         ctx
         |> UI.assert_has(title: name)
       end)
-    end)
 
+      ctx
+      |> UI.assert_text(attrs.title)
+    end)
+  end
+
+  step :assert_no_assignee, ctx do
+    ctx
+    |> UI.assert_text("No one is assigned to this task")
+  end
+
+  step :assert_assignees, ctx, assignees do
+    UI.find(ctx, UI.query(testid: "assignees-container"), fn ctx ->
+      Enum.each(assignees, fn name ->
+        ctx
+        |> UI.assert_has(title: name)
+      end)
+    end)
+  end
+
+  step :assert_no_specific_assignee, ctx, name do
+    UI.find(ctx, UI.query(testid: "assignees-container"), fn ctx ->
+      ctx
+      |> UI.refute_has(title: name)
+    end)
   end
 end

--- a/test/support/features/project_task_steps.ex
+++ b/test/support/features/project_task_steps.ex
@@ -1,0 +1,37 @@
+defmodule Operately.Support.Features.ProjectTaskSteps do
+  use Operately.FeatureCase
+
+  step :visit_milestone_page, ctx do
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+    |> UI.click_link(ctx.milestone.title)
+  end
+
+  step :add_task, ctx, attrs do
+    ctx
+    |> UI.click(testid: "add-task")
+    |> UI.fill(testid: "new-task-title", with: attrs.title)
+    |> UI.fill_rich_text(attrs.description)
+
+    Enum.each(attrs[:assignees] || [], fn name ->
+      ctx
+      |> UI.select_person_in(id: "task-assignees-input", name: name)
+    end)
+
+    ctx
+    |> UI.click(testid: "submit-new-task")
+  end
+
+  step :assert_task_added, ctx, attrs do
+    UI.find(ctx, UI.query(testid: attrs.test_id), fn ctx ->
+      ctx
+      |> UI.assert_text(attrs.title)
+
+      Enum.each(attrs[:assignees] || [], fn name ->
+        ctx
+        |> UI.assert_has(title: name)
+      end)
+    end)
+
+  end
+end


### PR DESCRIPTION
I've fixed the issue described in https://github.com/operately/operately/issues/796.

We didn't realize these APIs were broken earlier because we didn't have feature tests for Tasks, so I've decided to add them in this pull request.