### PR TITLE
fix: Add margin-top to "Join this Space" button

### DIFF
--- a/assets/js/pages/SpacePage/page.tsx
+++ b/assets/js/pages/SpacePage/page.tsx
@@ -71,7 +71,7 @@ function JoinButton({ space }) {
   };
 
   return (
-    <div className="flex justify-center mb-8">
+    <div className="flex justify-center mb-8 mt-6">
       <FilledButton type="primary" size="sm" onClick={handleClick} testId="join-space-button">
         Join this Space
       </FilledButton>


### PR DESCRIPTION
I've noticed that there was no space between the "Join this Space" and the "Manage Access" buttons.

Previously:
![bug](https://github.com/user-attachments/assets/60dfd001-52f9-4d71-8534-e329be1da07b)

Now:
![bug-fixed](https://github.com/user-attachments/assets/c59bc83a-549c-442b-9616-408be9c3c9d6)
