### PR TITLE
feat: Add activities and notifications for adding and removing space members

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -384,6 +384,11 @@ export interface ActivityContentSpaceJoining {
   space?: Space | null;
 }
 
+export interface ActivityContentSpaceMemberRemoved {
+  space?: Space | null;
+  member?: Person | null;
+}
+
 export interface ActivityContentSpaceMembersAdded {
   space?: Space | null;
   members?: Person[] | null;

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -384,6 +384,11 @@ export interface ActivityContentSpaceJoining {
   space?: Space | null;
 }
 
+export interface ActivityContentSpaceMembersAdded {
+  space?: Space | null;
+  members?: Person[] | null;
+}
+
 export interface ActivityContentTaskAdding {
   name?: string | null;
   taskId?: string | null;

--- a/assets/js/features/activities/SpaceMemberRemoved/index.tsx
+++ b/assets/js/features/activities/SpaceMemberRemoved/index.tsx
@@ -1,0 +1,65 @@
+import { Activity, ActivityContentSpaceMemberRemoved } from "@/api";
+import { ActivityHandler } from "../interfaces";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+import { Paths } from "@/routes/paths";
+import { shortName } from "@/models/people";
+
+
+const SpaceMemberRemoved: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    return Paths.spacePath(content(activity).space!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const person = shortName(content(activity).member!);
+    const space = spaceLink(content(activity).space!);
+    
+    if (page === "space") {
+      return feedTitle(activity, "removed", person, "from the space");
+    } else {
+      return feedTitle(activity, "removed", person, "from the", space, "space");
+    }
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+};
+
+export default SpaceMemberRemoved;
+
+function content(activity: Activity): ActivityContentSpaceMemberRemoved {
+  return activity.content as ActivityContentSpaceMemberRemoved;
+}

--- a/assets/js/features/activities/SpaceMembersAdded/index.tsx
+++ b/assets/js/features/activities/SpaceMembersAdded/index.tsx
@@ -1,0 +1,80 @@
+import { Activity, ActivityContentSpaceMembersAdded } from "@/api";
+import { ActivityHandler } from "../interfaces";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+import { Paths } from "@/routes/paths";
+import { shortName, Person } from "@/models/people";
+
+
+const SpaceMembersAdded: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    return Paths.spacePath(content(activity).space!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const names = formatNames(content(activity).members!);
+    const space = spaceLink(content(activity).space!);
+
+    if (page === "space") {
+      return feedTitle(activity, "added", names, "to the space");
+    } else {
+      return feedTitle(activity, "added", names, "to the", space, "space");
+    }
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+};
+
+export default SpaceMembersAdded;
+
+function content(activity: Activity): ActivityContentSpaceMembersAdded {
+  return activity.content as ActivityContentSpaceMembersAdded;
+}
+
+function formatNames(members: Person[]) {
+  const names = members.map(person => shortName(person));
+
+  if (names.length === 2) {
+    return `${names[0]} and ${names[1]}`;
+  } 
+  else if (names.length > 2) {
+    const last = names.pop();
+    return `${names.join(', ')} and ${last}`;
+  }
+  else {
+    return names[0]!;
+  }
+}

--- a/assets/js/features/activities/SpaceMembersAdded/index.tsx
+++ b/assets/js/features/activities/SpaceMembersAdded/index.tsx
@@ -2,7 +2,7 @@ import { Activity, ActivityContentSpaceMembersAdded } from "@/api";
 import { ActivityHandler } from "../interfaces";
 import { feedTitle, spaceLink } from "../feedItemLinks";
 import { Paths } from "@/routes/paths";
-import { shortName, Person } from "@/models/people";
+import { shortName, Person, firstName } from "@/models/people";
 
 
 const SpaceMembersAdded: ActivityHandler = {
@@ -49,12 +49,12 @@ const SpaceMembersAdded: ActivityHandler = {
     throw new Error("Not implemented");
   },
 
-  NotificationTitle(_props: { activity: Activity }) {
-    throw new Error("Not implemented");
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return firstName(activity.author!) + " added you to the " + content(activity).space?.name + " space"
   },
 
-  NotificationLocation(_props: { activity: Activity }) {
-    throw new Error("Not implemented");
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).space!.name!;
   },
 };
 

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -88,6 +88,7 @@ export const DISPLAYED_IN_FEED = [
   "project_resuming",
   "project_timeline_edited",
   "space_joining",
+  "space_member_removed",
   "space_members_added",
 ];
 
@@ -128,6 +129,7 @@ import ProjectRenamed from "@/features/activities/ProjectRenamed";
 import ProjectResuming from "@/features/activities/ProjectResuming";
 import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import SpaceJoining from "@/features/activities/SpaceJoining";
+import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
 import SpaceMembersAdded from "@/features/activities/SpaceMembersAdded";
 
 function handler(activity: Activity) {
@@ -161,6 +163,7 @@ function handler(activity: Activity) {
     .with("project_resuming", () => ProjectResuming)
     .with("project_timeline_edited", () => ProjectTimelineEdited)
     .with("space_joining", () => SpaceJoining)
+    .with("space_member_removed", () => SpaceMemberRemoved)
     .with("space_members_added", () => SpaceMembersAdded)
     .otherwise(() => {
       throw new Error("Unknown activity action: " + activity.action);

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -88,6 +88,7 @@ export const DISPLAYED_IN_FEED = [
   "project_resuming",
   "project_timeline_edited",
   "space_joining",
+  "space_members_added",
 ];
 
 //
@@ -127,6 +128,7 @@ import ProjectRenamed from "@/features/activities/ProjectRenamed";
 import ProjectResuming from "@/features/activities/ProjectResuming";
 import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import SpaceJoining from "@/features/activities/SpaceJoining";
+import SpaceMembersAdded from "@/features/activities/SpaceMembersAdded";
 
 function handler(activity: Activity) {
   return match(activity.action)
@@ -159,6 +161,7 @@ function handler(activity: Activity) {
     .with("project_resuming", () => ProjectResuming)
     .with("project_timeline_edited", () => ProjectTimelineEdited)
     .with("space_joining", () => SpaceJoining)
+    .with("space_members_added", () => SpaceMembersAdded)
     .otherwise(() => {
       throw new Error("Unknown activity action: " + activity.action);
     });

--- a/lib/operately/activities/content/space_member_removed.ex
+++ b/lib/operately/activities/content/space_member_removed.ex
@@ -1,0 +1,19 @@
+defmodule Operately.Activities.Content.SpaceMemberRemoved do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :member, Operately.People.Person
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/content/space_members_added.ex
+++ b/lib/operately/activities/content/space_members_added.ex
@@ -6,6 +6,7 @@ defmodule Operately.Activities.Content.SpaceMembersAdded do
 
     embedded_schema do
       field :person_id, :string
+      field :person_name, :string
       field :access_level, :integer
     end
 

--- a/lib/operately/activities/content/space_members_added.ex
+++ b/lib/operately/activities/content/space_members_added.ex
@@ -1,0 +1,36 @@
+defmodule Operately.Activities.Content.SpaceMembersAdded do
+  use Operately.Activities.Content
+
+  defmodule Member do
+    use Operately.Activities.Content
+
+    embedded_schema do
+      field :person_id, :string
+      field :access_level, :integer
+    end
+
+    def changeset(update, attrs) do
+      update
+      |> cast(attrs, __schema__(:fields))
+      |> validate_required(__schema__(:fields))
+    end
+  end
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+
+    embeds_many :members, Member
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:company_id, :space_id])
+    |> cast_embed(:members)
+    |> validate_required([:company_id, :space_id])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -32,6 +32,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "space_added",
     "space_members_permissions_edited",
     "space_members_added",
+    "space_member_removed",
 
     "goal_archived",
 

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -31,6 +31,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "space_permissions_edited",
     "space_added",
     "space_members_permissions_edited",
+    "space_members_added",
 
     "goal_archived",
 

--- a/lib/operately/activities/notifications/space_member_removed.ex
+++ b/lib/operately/activities/notifications/space_member_removed.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.SpaceMemberRemoved do
+  def dispatch(_activity) do
+    # Notification dispatcher for SpaceMemberRemoved not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/activities/notifications/space_members_added.ex
+++ b/lib/operately/activities/notifications/space_members_added.ex
@@ -1,6 +1,12 @@
 defmodule Operately.Activities.Notifications.SpaceMembersAdded do
-  def dispatch(_activity) do
-    # Notification dispatcher for SpaceMembersAdded not implemented yet
-    {:ok, []}
+  def dispatch(activity) do
+    Enum.map(activity.content["members"], fn m ->
+      %{
+        person_id: m["person_id"],
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/activities/notifications/space_members_added.ex
+++ b/lib/operately/activities/notifications/space_members_added.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.SpaceMembersAdded do
+  def dispatch(_activity) do
+    # Notification dispatcher for SpaceMembersAdded not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -136,7 +136,7 @@ defmodule Operately.Groups do
     Repo.one(query) != nil
   end
 
-  defdelegate add_members(group_id, people_ids), to: Operately.Operations.GroupMembersAdding, as: :run
+  defdelegate add_members(author, group_id, people_ids), to: Operately.Operations.GroupMembersAdding, as: :run
 
   def add_contact(group, name, value, type) do
     contact = %Contact{

--- a/lib/operately_email/emails/space_members_added_email.ex
+++ b/lib/operately_email/emails/space_members_added_email.ex
@@ -1,0 +1,21 @@
+defmodule OperatelyEmail.Emails.SpaceMembersAddedEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+  alias Operately.{Repo, Groups}
+
+  def send(person, activity) do
+    author = Repo.preload(activity, :author).author
+    space = Groups.get_group!(activity.content["space_id"])
+    company = Repo.preload(space, :company).company
+    link = OperatelyWeb.Paths.space_path(company, space) |> OperatelyWeb.Paths.to_url()
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: space.name, who: author, action: "added you to the #{space.name} space")
+    |> assign(:author, author)
+    |> assign(:space, space)
+    |> assign(:link, link)
+    |> render("space_members_added")
+  end
+end

--- a/lib/operately_email/templates/space_members_added.html.eex
+++ b/lib/operately_email/templates/space_members_added.html.eex
@@ -1,0 +1,7 @@
+<%= title("#{short_name(@author)} added you to the #{@space.name} space") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@link, "View Space") %>
+<% end %>

--- a/lib/operately_email/templates/space_members_added.text.eex
+++ b/lib/operately_email/templates/space_members_added.text.eex
@@ -1,0 +1,3 @@
+<%= short_name(@author) %> added yout to the <%= @space.name %> space.
+
+Link: <%= @link %>

--- a/lib/operately_email/templates/space_members_added.text.eex
+++ b/lib/operately_email/templates/space_members_added.text.eex
@@ -1,3 +1,3 @@
-<%= short_name(@author) %> added yout to the <%= @space.name %> space.
+<%= short_name(@author) %> added you to the <%= @space.name %> space.
 
 Link: <%= @link %>

--- a/lib/operately_web/api/mutations/add_group_members.ex
+++ b/lib/operately_web/api/mutations/add_group_members.ex
@@ -7,11 +7,11 @@ defmodule OperatelyWeb.Api.Mutations.AddGroupMembers do
     field :members, list_of(:add_member_input)
   end
 
-  def call(_conn, inputs) do
+  def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.group_id)
     inputs = decode_member_ids(inputs)
 
-    Operately.Operations.GroupMembersAdding.run(id, inputs.members)
+    Operately.Operations.GroupMembersAdding.run(me(conn), id, inputs.members)
 
     {:ok, %{}}
   end

--- a/lib/operately_web/api/mutations/remove_group_member.ex
+++ b/lib/operately_web/api/mutations/remove_group_member.ex
@@ -7,11 +7,11 @@ defmodule OperatelyWeb.Api.Mutations.RemoveGroupMember do
     field :member_id, :string
   end
 
-  def call(_, inputs) do
-    {:ok, id} = decode_id(inputs.group_id)
+  def call(conn, inputs) do
+    {:ok, group_id} = decode_id(inputs.group_id)
     {:ok, member_id} = decode_id(inputs.member_id)
 
-    {:ok, _} = Operately.Operations.GroupMemberRemoving.run(id, member_id)
+    {:ok, _} = Operately.Operations.GroupMemberRemoving.run(me(conn), group_id, member_id)
 
 
     {:ok, %{}}

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -309,6 +309,13 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
+  def serialize_content("space_members_added", content) do
+    %{
+      space: serialize_space(content["space"]),
+      members: Enum.map(content["members"], fn m -> %{id: m.person_id, full_name: m.person_name} end),
+    }
+  end
+
   def serialize_content("task_adding", _content) do
     %{}
   end
@@ -386,20 +393,20 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
   end
 
   def serialize_added_targets(content) do
-    Enum.map(content["added_targets"], fn target -> 
-      %{id: target["id"], name: target["name"]} 
+    Enum.map(content["added_targets"], fn target ->
+      %{id: target["id"], name: target["name"]}
     end)
   end
 
   def serialize_updated_targets(content) do
-    Enum.map(content["updated_targets"], fn target -> 
-      %{id: target["id"], old_name: target["old_name"], new_name: target["new_name"]} 
+    Enum.map(content["updated_targets"], fn target ->
+      %{id: target["id"], old_name: target["old_name"], new_name: target["new_name"]}
     end)
   end
 
   def serialize_deleted_targets(content) do
-    Enum.map(content["deleted_targets"], fn target -> 
-      %{id: target["id"], name: target["name"]} 
+    Enum.map(content["deleted_targets"], fn target ->
+      %{id: target["id"], name: target["name"]}
     end)
   end
 

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -309,6 +309,13 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
+  def serialize_content("space_member_removed", content) do
+    %{
+      space: serialize_space(content["space"]),
+      member: %{id: content["member"].id, full_name: content["member"].full_name},
+    }
+  end
+
   def serialize_content("space_members_added", content) do
     %{
       space: serialize_space(content["space"]),

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -13,6 +13,11 @@ defmodule OperatelyWeb.Api.Types do
     field :space, :space
   end
 
+  object :activity_content_space_member_removed do
+    field :space, :space
+    field :member, :person
+  end
+
   object :activity_content_space_members_added do
     field :space, :space
     field :members, list_of(:person)

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -13,6 +13,11 @@ defmodule OperatelyWeb.Api.Types do
     field :space, :space
   end
 
+  object :activity_content_space_members_added do
+    field :space, :space
+    field :members, list_of(:person)
+  end
+
   object :activity_content_goal_archived do
     field :goal, :goal
   end

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -18,15 +18,11 @@ defmodule Operately.Features.DiscussionsTest do
 
     space = group_fixture(author, %{name: "Marketing", mission: "Let the world know about our products"})
 
-    Operately.Groups.add_members(space.id, [
+    Operately.Groups.add_members(author, space.id, [
       %{
         id: reader.id,
         permissions: Binding.view_access(),
       },
-      %{
-        id: author.id,
-        permissions: Binding.full_access(),
-      }
     ])
 
     ctx = Map.merge(ctx, %{company: company, author: author, reader: reader, space: space})

--- a/test/features/spaces_test.exs
+++ b/test/features/spaces_test.exs
@@ -100,8 +100,7 @@ defmodule Operately.Features.SpacesTest do
     |> UI.click(testid: "add-remove-members")
     |> UI.assert_text(person.full_name)
     |> UI.click(testid: "remove-member-#{Paths.person_id(person)}")
-    |> UI.sleep(100)
-    |> UI.refute_text(person.full_name)
+    |> UI.refute_text(person.full_name, attempts: [50, 150, 250, 500])
   end
 
   feature "listing projects in a space", ctx do

--- a/test/features/spaces_test.exs
+++ b/test/features/spaces_test.exs
@@ -134,15 +134,15 @@ defmodule Operately.Features.SpacesTest do
 
   feature "adding space members (access management page)", ctx do
     group = group_fixture(ctx.person, %{name: "Marketing"})
-
-    name = "Mati Aharoni"
-    person_fixture(%{full_name: name, company_id: ctx.company.id})
+    member = person_fixture_with_account(%{full_name: "Mati Aharoni", company_id: ctx.company.id})
 
     ctx
     |> Steps.visit_home()
     |> Steps.visit_access_management(group.name)
-    |> Steps.add_new_member(search: "Mati", name: name)
-    |> Steps.assert_member_added(name)
+    |> Steps.add_new_member(search: "Mati", name: member.full_name)
+    |> Steps.assert_member_added(member.full_name)
+    |> Steps.assert_members_added_notification_sent(member: member, title: group.name)
+    |> Steps.assert_members_added_email_sent(member: member, title: group.name)
   end
 
   feature "removing space members (access management page)", ctx do

--- a/test/features/spaces_test.exs
+++ b/test/features/spaces_test.exs
@@ -38,7 +38,7 @@ defmodule Operately.Features.SpacesTest do
     group = group_fixture(ctx.person, %{name: "Marketing"})
     person = person_fixture(%{full_name: "Mati Aharoni", company_id: ctx.company.id})
 
-    Operately.Groups.add_members(group.id, [%{
+    Operately.Groups.add_members(ctx.person, group.id, [%{
       id: person.id,
       permissions: Binding.edit_access(),
     }])
@@ -88,7 +88,7 @@ defmodule Operately.Features.SpacesTest do
     group = group_fixture(ctx.person, %{name: "Marketing"})
     person = person_fixture(%{full_name: "Mati Aharoni", company_id: ctx.company.id})
 
-    Operately.Groups.add_members(group.id, [%{
+    Operately.Groups.add_members(ctx.person, group.id, [%{
       id: person.id,
       permissions: Binding.edit_access(),
     }])

--- a/test/operately/operations/group_member_removing_test.exs
+++ b/test/operately/operations/group_member_removing_test.exs
@@ -16,7 +16,7 @@ defmodule Operately.Operations.GroupMemberRemovingTest do
 
     member = person_fixture_with_account(%{company_id: company.id})
 
-    Operately.Operations.GroupMembersAdding.run(group.id, [%{
+    Groups.add_members(creator, group.id, [%{
       id: member.id,
       permissions: Binding.comment_access(),
     }])

--- a/test/operately/operations/group_members_adding_test.exs
+++ b/test/operately/operations/group_members_adding_test.exs
@@ -106,5 +106,11 @@ defmodule Operately.Operations.GroupMembersAddingTest do
 
     assert length(g1) == 3
     assert length(g2) == 3
+
+    member = hd(g1)
+
+    assert Map.has_key?(member, "person_id")
+    assert Map.has_key?(member, "person_name")
+    assert Map.has_key?(member, "access_level")
   end
 end

--- a/test/operately/operations/group_members_adding_test.exs
+++ b/test/operately/operations/group_members_adding_test.exs
@@ -8,6 +8,7 @@ defmodule Operately.Operations.GroupMembersAddingTest do
   alias Operately.Groups
   alias Operately.Access
   alias Operately.Access.Binding
+  alias Operately.Activities.Activity
 
   setup do
     company = company_fixture()
@@ -31,11 +32,11 @@ defmodule Operately.Operations.GroupMembersAddingTest do
       }
     end)
 
-    {:ok, group: group, creator: creator, members: members, managers: managers}
+    {:ok, company: company, group: group, creator: creator, members: members, managers: managers}
   end
 
   test "GroupMembersAdding operation adds members to group", ctx do
-    Operately.Operations.GroupMembersAdding.run(ctx.group.id, ctx.members)
+    Operately.Operations.GroupMembersAdding.run(ctx.creator, ctx.group.id, ctx.members)
 
     members = Groups.list_members(ctx.group)
     people_ids = [ctx.creator.id | Enum.map(ctx.members, fn %{id: id} -> id end)]
@@ -58,8 +59,8 @@ defmodule Operately.Operations.GroupMembersAddingTest do
       refute Access.get_group_membership(group_id: managers.id, person_id: person_id)
     end)
 
-    Operately.Operations.GroupMembersAdding.run(ctx.group.id, ctx.members)
-    Operately.Operations.GroupMembersAdding.run(ctx.group.id, ctx.managers)
+    Operately.Operations.GroupMembersAdding.run(ctx.creator, ctx.group.id, ctx.members)
+    Operately.Operations.GroupMembersAdding.run(ctx.creator, ctx.group.id, ctx.managers)
 
     Enum.each(ctx.members, fn %{id: person_id} ->
       assert Access.get_group_membership(group_id: members.id, person_id: person_id)
@@ -81,7 +82,7 @@ defmodule Operately.Operations.GroupMembersAddingTest do
       refute Access.get_binding(group_id: access_group.id, context_id: access_context.id)
     end)
 
-    Operately.Operations.GroupMembersAdding.run(ctx.group.id, all_members)
+    Operately.Operations.GroupMembersAdding.run(ctx.creator, ctx.group.id, all_members)
 
     Enum.each(all_members, fn %{id: person_id, permissions: permissions} ->
       access_group = Access.get_group!(person_id: person_id)
@@ -89,5 +90,21 @@ defmodule Operately.Operations.GroupMembersAddingTest do
       assert Access.get_binding(group_id: access_group.id, context_id: access_context.id, access_level: permissions)
       assert Access.get_binding(group_id: access_group.id, context_id: access_context.id)
     end)
+  end
+
+  test "GroupMembersAdding operation creates activity", ctx do
+    all_members = ctx.members ++ ctx.managers
+
+    {:ok, _} = Operately.Operations.GroupMembersAdding.run(ctx.creator, ctx.group.id, all_members)
+
+    activity = from(a in Activity, where: a.action == "space_members_added" and a.content["space_id"] == ^ctx.group.id) |> Repo.one!()
+
+    assert activity.content["company_id"] == ctx.company.id
+    assert length(activity.content["members"]) == 6
+
+    [g1, g2] = Enum.chunk_by(activity.content["members"], &(&1["access_level"]))
+
+    assert length(g1) == 3
+    assert length(g2) == 3
   end
 end

--- a/test/operately/operations/group_members_permissions_editing_test.exs
+++ b/test/operately/operations/group_members_permissions_editing_test.exs
@@ -16,9 +16,9 @@ defmodule Operately.Operations.GroupMembersPermissionsEditingTest do
     space = group_fixture(creator)
 
     members = [
-      create_group_member(space, Binding.comment_access()),
-      create_group_member(space, Binding.edit_access()),
-      create_group_member(space, Binding.full_access()),
+      create_group_member(creator, space, Binding.comment_access()),
+      create_group_member(creator, space, Binding.edit_access()),
+      create_group_member(creator, space, Binding.full_access()),
     ]
 
     {:ok, space: space, creator: creator, members: members}
@@ -75,10 +75,10 @@ defmodule Operately.Operations.GroupMembersPermissionsEditingTest do
   # Helpers
   #
 
-  defp create_group_member(space, permissions) do
+  defp create_group_member(creator, space, permissions) do
     person = person_fixture(%{company_id: space.company_id})
 
-    Groups.add_members(space.id, [%{
+    Groups.add_members(creator, space.id, [%{
       id: person.id,
       permissions: permissions,
     }])

--- a/test/operately_web/api/queries/get_activities_test.exs
+++ b/test/operately_web/api/queries/get_activities_test.exs
@@ -57,7 +57,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
     end
 
     test "space members have no access", ctx do
-      Groups.add_members(ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
+      Groups.add_members(ctx.champion, ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
       goal_fixture(ctx.champion, %{
         space_id: ctx.space.id,
         space_access_level: Binding.no_access(),
@@ -70,7 +70,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
     end
 
     test "space members have access", ctx do
-      Groups.add_members(ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
+      Groups.add_members(ctx.champion, ctx.space.id, [%{id: ctx.person.id, permissions: Binding.edit_access()}])
       goal = goal_fixture(ctx.champion, %{
         space_id: ctx.space.id,
         space_access_level: Binding.view_access(),

--- a/test/operately_web/api/queries/get_space_test.exs
+++ b/test/operately_web/api/queries/get_space_test.exs
@@ -63,7 +63,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpaceTest do
       m3 = person_fixture(company_id: ctx.company.id, full_name: "Charlie Smith")
 
       members = [m1, m2, m3] |> Enum.map(fn person -> %{id: person.id, permissions: Binding.comment_access()} end)
-      Operately.Groups.add_members(space.id, members)
+      Operately.Groups.add_members(ctx.person, space.id, members)
 
       assert {200, res} = query(ctx.conn, :get_space, %{id: Paths.space_id(space), include_members: true})
       assert length(res.space.members) == 4 # 3 members + current user

--- a/test/support/features/email_steps.ex
+++ b/test/support/features/email_steps.ex
@@ -60,6 +60,10 @@ defmodule Operately.Support.Features.EmailSteps do
     ctx |> assert_sent_to_all_project_contributors(subject: "#{Person.short_name(author)} posted an check-in for #{ctx.project.name}", except: [author])
   end
 
+  def assert_space_members_added_sent(ctx, author: author, to: to, title: title) do
+    ctx |> assert_sent(to: to, subject: "(#{title}) #{Person.short_name(author)} added you to the #{title} space")
+  end
+
   #
   # Private
   #

--- a/test/support/features/notifications_steps.ex
+++ b/test/support/features/notifications_steps.ex
@@ -116,4 +116,7 @@ defmodule Operately.Support.Features.NotificationsSteps do
     ctx |> assert_notification_exists(author: author, subject: "#{Person.first_name(author)} re-opened: #{title}")
   end
 
+  def assert_space_members_added_sent(ctx, author: author, title: title) do
+    ctx |> assert_notification_exists(author: author, subject: "#{Person.first_name(author)} added you to the #{title} space")
+  end
 end

--- a/test/support/features/space_steps.ex
+++ b/test/support/features/space_steps.ex
@@ -36,7 +36,7 @@ defmodule Operately.Support.Features.SpaceSteps do
     space = group_fixture(ctx.person, %{name: attrs.space_name})
     member = person_fixture_with_account(%{full_name: attrs.person_name, company_id: ctx.company.id})
 
-    Operately.Groups.add_members(space.id, [%{
+    Operately.Groups.add_members(ctx.person, space.id, [%{
       id: member.id,
       permissions: Operately.Access.Binding.comment_access(),
     }])

--- a/test/support/features/space_steps.ex
+++ b/test/support/features/space_steps.ex
@@ -2,6 +2,8 @@ defmodule Operately.Support.Features.SpaceSteps do
   use Operately.FeatureCase
 
   alias Operately.Support.Features.UI
+  alias Operately.Support.Features.NotificationsSteps
+  alias Operately.Support.Features.EmailSteps
 
   import Operately.CompaniesFixtures
   import Operately.GroupsFixtures
@@ -112,5 +114,16 @@ defmodule Operately.Support.Features.SpaceSteps do
   step :assert_member_removed, ctx, person do
     ctx
     |> UI.refute_text(person.full_name, testid: "members-list")
+  end
+
+  step :assert_members_added_notification_sent, ctx, params do
+    ctx
+    |> UI.login_as(params[:member])
+    |> NotificationsSteps.assert_space_members_added_sent(author: ctx.person, title: params[:title])
+  end
+
+  step :assert_members_added_email_sent, ctx, params do
+    ctx
+    |> EmailSteps.assert_space_members_added_sent(author: ctx.person, to: params[:member], title: params[:title])
   end
 end

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -84,7 +84,7 @@ defmodule Operately.Support.Features.UI do
 
   defp list_all_testids(state) do
     script = """
-      return Array.from(document.querySelectorAll('[data-test-id]')).map(function(e) { 
+      return Array.from(document.querySelectorAll('[data-test-id]')).map(function(e) {
         return e.attributes['data-test-id'].value;
       })
     """
@@ -107,7 +107,7 @@ defmodule Operately.Support.Features.UI do
     end)
   end
 
-  def send_keys(state, keys) do 
+  def send_keys(state, keys) do
     execute(state, fn session ->
       session |> Browser.send_keys(keys)
     end)
@@ -250,6 +250,21 @@ defmodule Operately.Support.Features.UI do
     end)
   end
 
+  def refute_text(state, text, attempts: [delay | attempts]) do
+    execute(state, fn session ->
+      :timer.sleep(delay)
+
+      visible_text = session |> Browser.text()
+      text_found = String.contains?(visible_text, text)
+
+      cond do
+        not text_found -> session
+        attempts == [] -> refute_text(state, text)
+        true -> refute_text(state, text, attempts: attempts)
+      end
+    end)
+  end
+
   def assert_page(state, path) do
     execute(state, fn session ->
       require ExUnit.Assertions
@@ -282,7 +297,7 @@ defmodule Operately.Support.Features.UI do
 
   def find(state, %Wallaby.Query{} = query, callback) do
     execute(state, fn session ->
-      session 
+      session
       |> Browser.find(query, fn element ->
         callback.(%{state | session: element})
       end)
@@ -302,7 +317,7 @@ defmodule Operately.Support.Features.UI do
           {:error, :not_yet}
         end
       end)
-      
+
       session
     end)
   end
@@ -315,12 +330,12 @@ defmodule Operately.Support.Features.UI do
         {:delivered_email, _} -> true
         _ -> false
       end
-    end) 
+    end)
     |> Enum.map(fn {:delivered_email, email} -> email end)
   end
 
   def assert_email_sent(state, title, to: to) do
-    emails = 
+    emails =
       state
       |> list_sent_emails()
       |> Enum.map(fn email -> {email.subject, elem(hd(email.to), 1)} end)


### PR DESCRIPTION
I've handled the issue described in https://github.com/operately/operately/issues/671.

Now adding members to a space or removing them from it creates an activity record. These records are going to be displayed in the Feed.
Also, members who are added to a space should receive an email notification.