### PR TITLE
fix: Replace add_members/2 by add_members/3

### DIFF
--- a/test/operately_web/api/queries/get_activity_test.exs
+++ b/test/operately_web/api/queries/get_activity_test.exs
@@ -45,7 +45,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
     end
 
     test "space members have no access", ctx do
-      Groups.add_members(ctx.space.id, [%{
+      Groups.add_members(ctx.person, ctx.space.id, [%{
         id: ctx.person.id,
         permissions: Binding.edit_access(),
       }])
@@ -60,7 +60,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
     end
 
     test "space members have access", ctx do
-      Groups.add_members(ctx.space.id, [%{
+      Groups.add_members(ctx.person, ctx.space.id, [%{
         id: ctx.person.id,
         permissions: Binding.edit_access(),
       }])


### PR DESCRIPTION
I've replaced `Operately.Groups.add_members/2` by `Operately.Groups.add_members/3` in the get_activity tests.