### PR TITLE
feat: A single account can belong to multiple companies via people records

### DIFF
--- a/assets/js/window.d.ts
+++ b/assets/js/window.d.ts
@@ -10,7 +10,6 @@ declare global {
 
   interface AppConfig {
     environment: string;
-    companyID: string;
 
     sentry: SentryConfig;
     api: ApiConfig;

--- a/lib/operately/people.ex
+++ b/lib/operately/people.ex
@@ -161,12 +161,7 @@ defmodule Operately.People do
   def get_account_by_session_token(token) do
     {:ok, query} = AccountToken.verify_session_token_query(token)
 
-    case Repo.one(query) do
-      %Account{} = account ->
-        Repo.preload(account, [:person])
-      nil ->
-        nil
-    end
+    Repo.one(query)
   end
 
   def delete_account_session_token(token) do

--- a/lib/operately/people/account.ex
+++ b/lib/operately/people/account.ex
@@ -1,10 +1,8 @@
 defmodule Operately.People.Account do
-  use Ecto.Schema
-  import Ecto.Changeset
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
+  use Operately.Schema
+
   schema "accounts" do
-    has_one(:person, Operately.People.Person, foreign_key: :account_id)
+    has_many :people, Operately.People.Person, foreign_key: :account_id
 
     field :email, :string
     field :password, :string, virtual: true, redact: true

--- a/lib/operately/people/fetch_or_create_account_operation.ex
+++ b/lib/operately/people/fetch_or_create_account_operation.ex
@@ -26,11 +26,13 @@ defmodule Operately.People.FetchOrCreateAccountOperation do
     if account == nil do
       {:error, "Not found"}
     else
-      person = Operately.Repo.preload(account, :person).person
+      people = Operately.Repo.preload(account, :people).people
 
-      if person.avatar_url != image do
-        {:ok, _} = Operately.People.update_person(person, %{avatar_url: image})
-      end
+      Enum.each(people, fn person ->
+        if person.avatar_url != image do
+          {:ok, _} = Operately.People.update_person(person, %{avatar_url: image})
+        end
+      end)
 
       {:ok, account}
     end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -1,9 +1,5 @@
 defmodule Operately.People.Person do
-  use Ecto.Schema
-  import Ecto.Changeset
-
-  @primary_key {:id, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id
+  use Operately.Schema
 
   schema "people" do
     belongs_to(:account, Operately.People.Account)

--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -102,6 +102,7 @@ defmodule OperatelyWeb.AccountAuth do
   def fetch_current_account(conn, _opts) do
     {account_token, conn} = ensure_account_token(conn)
     account = account_token && People.get_account_by_session_token(account_token)
+
     assign(conn, :current_account, account)
   end
 

--- a/lib/operately_web/account_auth.ex
+++ b/lib/operately_web/account_auth.ex
@@ -106,6 +106,19 @@ defmodule OperatelyWeb.AccountAuth do
     assign(conn, :current_account, account)
   end
 
+  def fetch_current_company(conn, _opts) do
+    assign(conn, :current_company, nil)
+  end
+
+  def fetch_current_person(conn, _opts) do
+    if conn.assigns[:current_account] do
+      people = Operately.Repo.preload(conn.assigns.current_account, :people).people
+      assign(conn, :current_person, List.first(people))
+    else
+      conn
+    end
+  end
+
   defp ensure_account_token(conn) do
     if token = get_session(conn, :account_token) do
       {token, conn}

--- a/lib/operately_web/api/helpers.ex
+++ b/lib/operately_web/api/helpers.ex
@@ -10,10 +10,10 @@ defmodule OperatelyWeb.Api.Helpers do
   end
 
   def me(conn) do
-    if conn.assigns.current_account do
-      conn.assigns.current_account.person
+    if conn.assigns.current_person do
+      conn.assigns.current_person
     else
-      raise "No account associated with the connection, maybe you forgot to load the account in a plug?"
+      raise "No person associated with the connection, maybe you forgot to load the person in a plug?"
     end
   end
 

--- a/lib/operately_web/api/mutations/mark_all_notifications_as_read.ex
+++ b/lib/operately_web/api/mutations/mark_all_notifications_as_read.ex
@@ -1,9 +1,9 @@
 defmodule OperatelyWeb.Api.Mutations.MarkAllNotificationsAsRead do
   use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
 
   def call(conn, _inputs) do
-    me = conn.assigns.current_account.person
-    Operately.Notifications.mark_all_as_read(me)
+    Operately.Notifications.mark_all_as_read(me(conn))
     {:ok, %{}}
   end
 end

--- a/lib/operately_web/api/mutations/mark_notification_as_read.ex
+++ b/lib/operately_web/api/mutations/mark_notification_as_read.ex
@@ -1,17 +1,17 @@
 defmodule OperatelyWeb.Api.Mutations.MarkNotificationAsRead do
   use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
 
   inputs do
     field :id, :string
   end
 
   def call(conn, inputs) do
-    me = conn.assigns.current_account.person
     id = inputs.id
 
     notification = Operately.Notifications.get_notification!(id)
 
-    if notification.person_id == me.id do
+    if notification.person_id == me(conn).id do
       Operately.Notifications.mark_as_read(notification)
       {:ok, %{}}
     else

--- a/lib/operately_web/api/mutations/update_my_profile.ex
+++ b/lib/operately_web/api/mutations/update_my_profile.ex
@@ -1,5 +1,6 @@
 defmodule OperatelyWeb.Api.Mutations.UpdateMyProfile do
   use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
 
   inputs do
     field :full_name, :string
@@ -16,9 +17,7 @@ defmodule OperatelyWeb.Api.Mutations.UpdateMyProfile do
   end
 
   def call(conn, inputs) do
-    me = conn.assigns.current_account.person
-
-    {:ok, me} = Operately.People.update_person(me, inputs)
+    {:ok, me} = Operately.People.update_person(me(conn), inputs)
     {:ok, serialize(me)}
   end
 

--- a/lib/operately_web/api/queries/get_me.ex
+++ b/lib/operately_web/api/queries/get_me.ex
@@ -1,5 +1,6 @@
 defmodule OperatelyWeb.Api.Queries.GetMe do
   use TurboConnect.Query
+  use OperatelyWeb.Api.Helpers
 
   alias Operately.Repo
 
@@ -12,7 +13,7 @@ defmodule OperatelyWeb.Api.Queries.GetMe do
   end
 
   def call(conn, inputs) do
-    conn.assigns.current_account.person
+    me(conn)
     |> preload_manager(inputs[:include_manager])
     |> serialize(inputs[:include_manager])
     |> ok_tuple()

--- a/lib/operately_web/api/queries/get_notifications.ex
+++ b/lib/operately_web/api/queries/get_notifications.ex
@@ -1,5 +1,6 @@
 defmodule OperatelyWeb.Api.Queries.GetNotifications do
   use TurboConnect.Query
+  use OperatelyWeb.Api.Helpers
 
   alias Operately.Notifications.Notification
   alias Operately.Activities.Activity
@@ -19,11 +20,10 @@ defmodule OperatelyWeb.Api.Queries.GetNotifications do
   @default_per_page 100
 
   def call(conn, inputs) do
-    me = conn.assigns.current_account.person
     page = inputs[:page] || 1
     per_page = inputs[:per_page] || @default_per_page
 
-    notifications = load(page, per_page, me)
+    notifications = load(page, per_page, me(conn))
 
     {:ok, %{notifications: serialize(notifications)}}
   end

--- a/lib/operately_web/api/queries/get_spaces.ex
+++ b/lib/operately_web/api/queries/get_spaces.ex
@@ -9,8 +9,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpaces do
   end
 
   def call(conn, _inputs) do
-    me = conn.assigns.current_account.person
-    spaces = load(me)
+    spaces = load(me(conn))
 
     {:ok, %{spaces: Serializer.serialize(spaces, level: :full)}}
   end

--- a/lib/operately_web/api/queries/get_unread_notification_count.ex
+++ b/lib/operately_web/api/queries/get_unread_notification_count.ex
@@ -1,13 +1,13 @@
 defmodule OperatelyWeb.Api.Queries.GetUnreadNotificationCount do
   use TurboConnect.Query
+  use OperatelyWeb.Api.Helpers
 
   outputs do
     field :unread, :integer
   end
 
   def call(conn, _inputs) do
-    me = conn.assigns.current_account.person
-    count = Operately.Notifications.unread_notifications_count(me)
+    count = Operately.Notifications.unread_notifications_count(me(conn))
 
     {:ok, %{unread: count}}
   end

--- a/lib/operately_web/api/subscriptions/assignments_count.ex
+++ b/lib/operately_web/api/subscriptions/assignments_count.ex
@@ -2,7 +2,7 @@ defmodule OperatelyWeb.Api.Subscriptions.AssignmentsCount do
   use TurboConnect.Subscription
 
   def join(_name, _payload, socket) do
-    topic = socket.assigns.account.person.id
+    topic = socket.assigns.person.id
 
     {:ok, socket, [topic]}
   end

--- a/lib/operately_web/api/subscriptions/unread_notifications_count.ex
+++ b/lib/operately_web/api/subscriptions/unread_notifications_count.ex
@@ -2,7 +2,7 @@ defmodule OperatelyWeb.Api.Subscriptions.UnreadNotificationsCount do
   use TurboConnect.Subscription
 
   def join(_name, _payload, socket) do
-    topic = socket.assigns.account.person.id
+    topic = socket.assigns.person.id
 
     {:ok, socket, [topic]}
   end

--- a/lib/operately_web/channels/api_socket.ex
+++ b/lib/operately_web/channels/api_socket.ex
@@ -69,10 +69,12 @@ defmodule OperatelyWeb.ApiSocket do
 
   defp assign_current_account(account_id, socket) do
     account = Operately.People.get_account!(account_id)
-    account = Operately.Repo.preload(account, :person)
+    people = Operately.Repo.preload(account, :people).people
 
     if account do
       socket = assign(socket, :account, account)
+      socket = assign(socket, :person, List.first(people))
+
       {:ok, socket}
     else
       {:error, :unauthorized}

--- a/lib/operately_web/components/layouts/root.html.heex
+++ b/lib/operately_web/components/layouts/root.html.heex
@@ -25,9 +25,8 @@
 
       window.appConfig.environment = "<%= Application.get_env(:operately, :app_env) %>";
 
-      <%= if @current_account && @current_account.person do %>
-        window.appConfig.companyID = "<%= @current_account.person.company_id %>";
-        window.appConfig.api= {};
+      <%= if @current_account do %>
+        window.appConfig.api = {};
         window.appConfig.api.socketToken = "<%= OperatelyWeb.ApiSocket.gen_token(@conn) %>";
       <% end %>
 

--- a/lib/operately_web/router.ex
+++ b/lib/operately_web/router.ex
@@ -11,12 +11,16 @@ defmodule OperatelyWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_account
+    plug :fetch_current_company
+    plug :fetch_current_person
   end
 
   pipeline :api do
     plug :accepts, ["json"]
     plug :fetch_session
     plug :fetch_current_account
+    plug :fetch_current_company
+    plug :fetch_current_person
   end
 
   #

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -50,8 +50,8 @@ defmodule Operately.Features.FirstTimeSetupTest do
     assert Operately.Companies.count_companies() == 1
     assert account != nil
 
-    account = Operately.Repo.preload(account, :person)
+    person = Operately.Repo.preload(account, :people).people |> hd()
 
-    assert account.person.company_role == :admin
+    assert person.company_role == :admin
   end
 end

--- a/test/operately_web/api/mutations/add_first_company_test.exs
+++ b/test/operately_web/api/mutations/add_first_company_test.exs
@@ -23,8 +23,8 @@ defmodule OperatelyWeb.Api.Mutations.AddFirstCompanyTest do
       assert account
       assert group
 
-      account = Operately.Repo.preload(account, :person)
-      assert account.person.company_role == :admin
+      person = Operately.Repo.preload(account, :people).people |> hd()
+      assert person.company_role == :admin
     end
 
     test "allows company and admin account creation only once", ctx do

--- a/test/support/features/invite_member_steps.ex
+++ b/test/support/features/invite_member_steps.ex
@@ -30,7 +30,6 @@ defmodule Operately.Support.Features.InviteMemberSteps do
   step :reissue_invitation_token, ctx, params do
     ctx
     |> UI.click(testid: params[:newTokenTestId])
-
   end
 
   step :assert_member_invited, ctx do
@@ -48,10 +47,10 @@ defmodule Operately.Support.Features.InviteMemberSteps do
 
   step :assert_password_changed, ctx, params do
     account = Operately.People.get_account_by_email_and_password(params[:email], params[:password])
-    account = Operately.Repo.preload(account, :person)
+    person = Operately.Repo.preload(account, :people).people |> hd()
 
     assert is_struct(account, Operately.People.Account)
-    assert account.person.full_name == params[:fullName]
+    assert person.full_name == params[:fullName]
 
     ctx
   end


### PR DESCRIPTION
This is the first half of this change. It is preparing the backend system to be able to handle the `has_many` association between accounts and people, but it is still not handling having multiple companies for one account.

The [current code](https://github.com/operately/operately/pull/808/files#diff-0241219bc5ea0f0d413a0af274f3cc8978695cd5d439a5f484fb068c5900b868R116) uses `account.people |> List.first()` to look up the person in every request. This will be addressed in an upcoming PR.