### PR TITLE
feat: Add permissions filter to Goal queries

### DIFF
--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -7,7 +7,7 @@ defmodule Operately.Access.Filters do
 
   defp filter(query, person_id, access_level) do
     from(item in query,
-      join: c in assoc(item, :context),
+      join: c in assoc(item, :access_context),
       join: b in assoc(c, :bindings),
       join: g in assoc(b, :group),
       join: m in assoc(g, :memberships),

--- a/lib/operately/activities/activity.ex
+++ b/lib/operately/activities/activity.ex
@@ -17,7 +17,7 @@ defmodule Operately.Activities.Activity do
     belongs_to :author, Operately.People.Person
     belongs_to :comment_thread, Operately.Comments.CommentThread
 
-    belongs_to :context, Operately.Access.Context, foreign_key: :context_id
+    belongs_to :access_context, Operately.Access.Context, foreign_key: :access_context_id
 
     field :action, :string
     field :content, :map
@@ -33,7 +33,7 @@ defmodule Operately.Activities.Activity do
   end
 
   def changeset(activity, attrs) do
-    activity |> cast(attrs, [:author_id, :action, :content, :comment_thread_id, :context_id])
+    activity |> cast(attrs, [:author_id, :action, :content, :comment_thread_id, :access_context_id])
   end
 
   def deprecated_actions, do: @deprecated_actions

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -101,7 +101,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     |> Multi.update(:updated_activity, fn %{activity: activity} ->
       context_id = fetch_context(activity)
 
-      Activity.changeset(activity, %{context_id: context_id})
+      Activity.changeset(activity, %{access_context_id: context_id})
     end)
   end
 
@@ -195,7 +195,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
       join: t in Operately.Comments.CommentThread,
       on: a.id == t.parent_id,
       where: t.id == ^comment.entity_id,
-      select: a.context_id
+      select: a.access_context_id
     )
     |> Repo.one()
   end

--- a/lib/operately/data/change_013_create_activities_access_context.ex
+++ b/lib/operately/data/change_013_create_activities_access_context.ex
@@ -18,7 +18,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
 
   defp query do
     from(a in Activity,
-      where: is_nil(a.context_id),
+      where: is_nil(a.access_context_id),
       where: a.action not in ^Activity.deprecated_actions(),
       order_by: [asc: a.inserted_at])
   end
@@ -183,7 +183,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
 
   defp update_activity(parent, activity) do
     activity
-    |> Activity.changeset(%{context_id: parent.access_context.id})
+    |> Activity.changeset(%{access_context_id: parent.access_context.id})
     |> Repo.update()
   end
 
@@ -196,7 +196,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
     |> Repo.one!()
 
     activity
-    |> Activity.changeset(%{context_id: parent.context_id})
+    |> Activity.changeset(%{access_context_id: parent.access_context_id})
     |> Repo.update()
   end
 end

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias OperatelyWeb.Api.Serializer
   alias Operately.Goals.Goal
 
@@ -46,6 +48,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
     query
     |> Goal.scope_company(person.company_id)
     |> include_requested(include_filters)
+    |> filter_by_view_access(person.id)
     |> Repo.one(with_deleted: true)
     |> load_last_check_in(inputs[:include_last_check_in])
     |> load_permissions(person, inputs[:include_permissions])

--- a/lib/operately_web/api/queries/get_goal_progress_update.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_update.ex
@@ -2,8 +2,10 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
+  alias Operately.Repo
   alias Operately.Goals.Goal
-  alias Operately.Updates.Update
 
   inputs do
     field :id, :string
@@ -16,19 +18,37 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
 
   def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.id)
-    update = Operately.Updates.get_update!(id)
-    update = Operately.Repo.preload(update, [:author, :acknowledging_person, reactions: [:person]])
 
-    if update do
-      update = Update.preload_goal(update)
-      update = load_goal_permissions(update, me(conn))
-
-      {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(update, level: :full)}}
-    else
-      {:error, :not_found}
+    case load(me(conn), id) do
+      nil ->
+        {:error, :not_found}
+      update ->
+        {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(update, level: :full)}}
     end
   end
 
+  defp load(person, id) do
+    goal_query = from(g in Goal, select: g) |> filter_by_view_access(person.id)
+
+    from(u in Operately.Updates.Update,
+      join: g in subquery(goal_query), on: g.id == u.updatable_id,
+      where: u.id == ^id,
+      order_by: [desc: u.inserted_at],
+      select: %{update: u, goal: g}
+    )
+    |> Repo.one()
+    |> preload_resources()
+    |> load_goal_permissions(person)
+  end
+
+  defp preload_resources(nil), do: nil
+  defp preload_resources(%{update: update, goal: goal}) do
+    update = Repo.preload(update, [:author, :acknowledging_person, reactions: [:person]])
+
+    %{update | goal: goal}
+  end
+
+  defp load_goal_permissions(nil, _), do: nil
   defp load_goal_permissions(update, person) do
     goal = Goal.preload_permissions(update.goal, person)
     Map.put(update, :goal, goal)

--- a/lib/operately_web/api/queries/get_goal_progress_updates.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_updates.ex
@@ -2,7 +2,6 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdates do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Ecto.Query, only: [from: 2]
   import Operately.Access.Filters, only: [filter_by_view_access: 2]
 
   alias Operately.Repo

--- a/lib/operately_web/api/queries/get_goals.ex
+++ b/lib/operately_web/api/queries/get_goals.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetGoals do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias OperatelyWeb.Api.Serializer
   alias Operately.Goals.Goal
 
@@ -38,6 +40,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoals do
     |> Goal.scope_space(inputs[:space_id])
     |> Goal.scope_company(person.company_id)
     |> include_requested(include_filters)
+    |> filter_by_view_access(person.id)
     |> Repo.all()
     |> Goal.preload_last_check_in()
   end
@@ -51,7 +54,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoals do
         :include_champion -> from p in q, preload: [:champion]
         :include_reviewer -> from p in q, preload: [:reviewer]
         :include_last_check_in -> q # this is done after the load
-        _ -> q 
+        _ -> q
       end
     end)
   end

--- a/priv/repo/migrations/20240730162256_rename_activity_context_id_to_activity_access_context_id.exs
+++ b/priv/repo/migrations/20240730162256_rename_activity_context_id_to_activity_access_context_id.exs
@@ -1,0 +1,7 @@
+defmodule Operately.Repo.Migrations.RenameActivityContextIdToActivityAccessContextId do
+  use Ecto.Migration
+
+  def change do
+    rename table(:activities), :context_id, to: :access_context_id
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -307,7 +307,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
 
       activity = Repo.reload(activity)
 
-      assert activity.context_id == ctx.goal.access_context.id
+      assert activity.access_context_id == ctx.goal.access_context.id
     end
 
     test "goal_discussion_editing action", ctx do
@@ -344,7 +344,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       )
       |> Repo.one()
 
-      assert activity.context_id == ctx.goal.access_context.id
+      assert activity.access_context_id == ctx.goal.access_context.id
     end
 
     test "goal_timeframe_editing action", ctx do
@@ -366,7 +366,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       )
       |> Repo.one()
 
-      assert activity.context_id == ctx.goal.access_context.id
+      assert activity.access_context_id == ctx.goal.access_context.id
     end
   end
 
@@ -622,7 +622,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
         content: %{
           project_id: ctx.project.id,
         },
-        context_id: ctx.project.access_context.id,
+        access_context_id: ctx.project.access_context.id,
       }
 
       parent_activity = activity_fixture(attrs)
@@ -687,6 +687,6 @@ defmodule Operately.AccessActivityContextAssignerTest do
   def assert_context_assigned(result, context_id) do
     {:ok, activity} = result
 
-    assert activity.context_id == context_id
+    assert activity.access_context_id == context_id
   end
 end

--- a/test/operately/data/change_013_create_activities_access_context_test.exs
+++ b/test/operately/data/change_013_create_activities_access_context_test.exs
@@ -910,7 +910,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContextTest do
 
   def assert_no_context(activities) do
     Enum.each(activities, fn activity ->
-      assert activity.context_id == nil
+      assert activity.access_context_id == nil
     end)
     activities
   end
@@ -925,7 +925,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContextTest do
 
   def assert_context_assigned(activities, context_id) do
     Enum.each(activities, fn activity ->
-      assert activity.context_id == context_id
+      assert activity.access_context_id == context_id
     end)
   end
 end

--- a/test/operately_web/api/queries/get_goal_progress_update_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_update_test.exs
@@ -92,6 +92,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdateTest do
     assert update.author
     assert update.goal
     assert update.goal.permissions
+    assert update.goal.targets
   end
 
   defp forbidden_request(conn, update_id) do

--- a/test/operately_web/api/queries/get_goal_progress_update_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_update_test.exs
@@ -1,0 +1,127 @@
+defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdateTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.UpdatesFixtures
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_goal_progress_update, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+      space_id = Paths.space_id(space)
+
+      Map.merge(ctx, %{space: space, space_id: space_id, creator: creator})
+    end
+
+    test "company members have no access", ctx do
+      update_id = create_update(ctx, company_access: Binding.no_access())
+
+      forbidden_request(ctx.conn, update_id)
+    end
+
+    test "company members have access", ctx do
+      update_id = create_update(ctx, company_access: Binding.view_access())
+
+      allowed_request(ctx.conn, update_id)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      update_id = create_update(ctx, space_access: Binding.no_access())
+
+      forbidden_request(ctx.conn, update_id)
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      update_id = create_update(ctx, space_access: Binding.view_access())
+
+      allowed_request(ctx.conn, update_id)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      update_id = create_update(ctx, champion_id: champion.id)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      allowed_request(conn, update_id)
+
+      # other user's request
+      forbidden_request(ctx.conn, update_id)
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      update_id = create_update(ctx, reviewer_id: reviewer.id)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      allowed_request(conn, update_id)
+
+      # other user's request
+      forbidden_request(ctx.conn, update_id)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp allowed_request(conn, update_id) do
+    assert {200, %{update: update} = _res} = query(conn, :get_goal_progress_update, %{id: update_id})
+
+    assert update.id == update_id
+    assert update.author
+    assert update.goal
+    assert update.goal.permissions
+  end
+
+  defp forbidden_request(conn, update_id) do
+    assert {404, %{message: msg} = _res} = query(conn, :get_goal_progress_update, %{id: update_id})
+    assert msg == "The requested resource was not found"
+  end
+
+  defp create_update(ctx, opts) do
+    company_access = Keyword.get(opts, :company_access, Binding.no_access())
+    space_access = Keyword.get(opts, :space_access, Binding.no_access())
+    champion_id = Keyword.get(opts, :champion_id, ctx.creator.id)
+    reviewer_id = Keyword.get(opts, :reviewer_id, ctx.creator.id)
+
+    goal = goal_fixture(ctx.creator, %{
+      space_id: ctx.space.id,
+      champion_id: champion_id,
+      reviewer_id: reviewer_id,
+      company_access_level: company_access,
+      space_access_level: space_access,
+    })
+    update = update_fixture(%{type: :goal_check_in, updatable_id: goal.id, updatable_type: :goal, author_id: ctx.creator.id})
+    update_id = Paths.goal_update_id(update)
+
+    update_id
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+end

--- a/test/operately_web/api/queries/get_goal_progress_updates_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_updates_test.exs
@@ -1,0 +1,133 @@
+defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdatesTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.UpdatesFixtures
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_goal_progress_updates, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+      space_id = Paths.space_id(space)
+
+      Map.merge(ctx, %{space: space, space_id: space_id, creator: creator})
+    end
+
+    test "company members have no access", ctx do
+      {goal_id, _} = create_goal_and_updates(ctx, company_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 0
+    end
+
+    test "company members have access", ctx do
+      {goal_id, updates} = create_goal_and_updates(ctx, company_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 3
+      Enum.each(res.updates, fn u ->
+        assert Enum.find(updates, &(Paths.goal_update_id(&1) == u.id))
+      end)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      {goal_id, _} = create_goal_and_updates(ctx, space_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+
+      assert length(res.updates) == 0
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      {goal_id, updates} = create_goal_and_updates(ctx, space_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 3
+      Enum.each(res.updates, fn u ->
+        assert Enum.find(updates, &(Paths.goal_update_id(&1) == u.id))
+      end)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      {goal_id, updates} = create_goal_and_updates(ctx, champion_id: champion.id)
+
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 0
+
+      assert {200, res} = query(conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 3
+      Enum.each(res.updates, fn u ->
+        assert Enum.find(updates, &(Paths.goal_update_id(&1) == u.id))
+      end)
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      {goal_id, updates} = create_goal_and_updates(ctx, reviewer_id: reviewer.id)
+
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(ctx.conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 0
+
+      assert {200, res} = query(conn, :get_goal_progress_updates, %{goal_id: goal_id})
+      assert length(res.updates) == 3
+      Enum.each(res.updates, fn u ->
+        assert Enum.find(updates, &(Paths.goal_update_id(&1) == u.id))
+      end)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_goal_and_updates(ctx, opts) do
+    company_access = Keyword.get(opts, :company_access, Binding.no_access())
+    space_access = Keyword.get(opts, :space_access, Binding.no_access())
+    champion_id = Keyword.get(opts, :champion_id, ctx.creator.id)
+    reviewer_id = Keyword.get(opts, :reviewer_id, ctx.creator.id)
+
+    goal = goal_fixture(ctx.creator, %{
+      space_id: ctx.space.id,
+      champion_id: champion_id,
+      reviewer_id: reviewer_id,
+      company_access_level: company_access,
+      space_access_level: space_access,
+    })
+    updates = Enum.map(1..3, fn _ ->
+      update_fixture(%{type: :goal_check_in, updatable_id: goal.id, updatable_type: :goal, author_id: ctx.creator.id})
+    end)
+
+    goal_id = Paths.goal_id(goal)
+
+    {goal_id, updates}
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+end

--- a/test/operately_web/api/queries/get_goals_test.exs
+++ b/test/operately_web/api/queries/get_goals_test.exs
@@ -1,13 +1,141 @@
 defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
   use OperatelyWeb.TurboCase
 
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
   import Operately.GoalsFixtures
   import Operately.UpdatesFixtures
   import OperatelyWeb.Api.Serializer
 
+  alias OperatelyWeb.Paths
+  alias Operately.Access.Binding
+  alias Operately.{Repo, Groups}
+
   describe "security" do
     test "it requires authentication", ctx do
       assert {401, _} = query(ctx.conn, :get_goals, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+      space_id = Paths.space_id(space)
+
+      Map.merge(ctx, %{space: space, space_id: space_id, creator: creator})
+    end
+
+    test "company members have no access", ctx do
+      Enum.each(1..3, fn _ ->
+        goal_fixture(ctx.creator, %{
+          space_id: ctx.space.id,
+          company_access_level: Binding.no_access(),
+        })
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+      assert length(res.goals) == 0
+
+      goal_fixture(ctx.creator, %{
+        space_id: ctx.space.id,
+        company_access_level: Binding.view_access(),
+      })
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+      assert length(res.goals) == 1
+    end
+
+    test "company members have access", ctx do
+      goal_fixture(ctx.creator, %{
+        space_id: ctx.space.id,
+        company_access_level: Binding.no_access(),
+      })
+      goals = Enum.map(1..3, fn _ ->
+        goal_fixture(ctx.creator, %{
+          space_id: ctx.space.id,
+          company_access_level: Binding.view_access(),
+        })
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+
+      assert_goals(res, goals)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+
+      Enum.each(1..3, fn _ ->
+        goal_fixture(ctx.creator, %{
+          space_id: ctx.space.id,
+          company_access_level: Binding.no_access(),
+          space_access_level: Binding.no_access(),
+        })
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+      assert length(res.goals) == 0
+
+      goal_fixture(ctx.creator, %{
+        space_id: ctx.space.id,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.view_access(),
+      })
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+      assert length(res.goals) == 1
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+
+      goals = Enum.map(1..3, fn _ ->
+        goal_fixture(ctx.creator, %{
+          space_id: ctx.space.id,
+          company_access_level: Binding.no_access(),
+          space_access_level: Binding.view_access(),
+        })
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_goals, %{space_id: ctx.space_id})
+
+      assert_goals(res, goals)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = goal_fixture(ctx.creator, %{
+        space_id: ctx.space.id,
+        champion_id: champion.id,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.no_access(),
+      })
+
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(conn, :get_goals, %{space_id: ctx.space_id})
+
+      assert_goals(res, [goal])
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = goal_fixture(ctx.creator, %{
+        space_id: ctx.space.id,
+        reviewer_id: reviewer.id,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.no_access(),
+      })
+
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(conn, :get_goals, %{space_id: ctx.space_id})
+
+      assert_goals(res, [goal])
     end
   end
 
@@ -29,8 +157,28 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
 
       assert {200, res} = query(ctx.conn, :get_goals, %{include_last_check_in: true})
       assert length(res.goals) == 2
-      assert Enum.at(res.goals, 0).last_check_in == serialize(update1, level: :full)
-      assert Enum.at(res.goals, 1).last_check_in == serialize(update3, level: :full)
+
+      assert Enum.find(res.goals, &(&1.last_check_in == serialize(update1, level: :full)))
+      assert Enum.find(res.goals, &(&1.last_check_in == serialize(update3, level: :full)))
     end
   end
-end 
+
+  #
+  # Helpers
+  #
+
+  defp assert_goals(res, goals) do
+    assert length(res.goals) == length(goals)
+
+    Enum.each(goals, fn goal ->
+      assert Enum.find(res.goals, &(&1.id == Paths.goal_id(goal)))
+    end)
+  end
+
+  defp add_person_to_space(ctx) do
+    Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the following queries:

- OperatelyWeb.Api.Queries.GetGoal
- OperatelyWeb.Api.Queries.GetGoals
- OperatelyWeb.Api.Queries.GetGoalProgressUpdate
- OperatelyWeb.Api.Queries.GetGoalProgressUpdates