### PR TITLE
feat: Add data migration for removing private project access bindings

### DIFF
--- a/lib/operately/data/change_024_remove_private_projects_bindings.ex
+++ b/lib/operately/data/change_024_remove_private_projects_bindings.ex
@@ -1,0 +1,44 @@
+defmodule Operately.Data.Change024RemovePrivateProjectsBindings do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.{Repo, Access}
+  alias Operately.Access.Binding
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(p in Project, where: p.private, preload: :access_context)
+      |> Repo.all()
+      |> remove_bindings()
+    end)
+  end
+
+  defp remove_bindings(projects) when is_list(projects) do
+    Enum.each(projects, fn p ->
+      remove_bindings(p)
+    end)
+  end
+
+  defp remove_bindings(%{access_context: context, company_id: company_id, group_id: space_id}) do
+    fetch_groups(company_id, space_id)
+    |> Enum.each(fn g ->
+      remove_binding(context.id, g.id)
+    end)
+  end
+
+  defp remove_binding(context_id, group_id) do
+    case Access.get_binding(context_id: context_id, group_id: group_id) do
+      nil -> :ok
+      binding ->
+        Access.update_binding(binding, %{access_level: Binding.no_access()})
+    end
+  end
+
+  defp fetch_groups(company_id, space_id) do
+    [
+      Access.get_group!(company_id: company_id, tag: :anonymous),
+      Access.get_group!(company_id: company_id, tag: :standard),
+      Access.get_group!(group_id: space_id, tag: :standard),
+    ]
+  end
+end

--- a/test/operately/data/change_024_remove_private_projects_bindings_test.exs
+++ b/test/operately/data/change_024_remove_private_projects_bindings_test.exs
@@ -1,0 +1,106 @@
+defmodule Operately.Data.Change024RemovePrivateProjectsBindingsTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator, %{company_id: company.id})
+
+    {:ok, company: company, creator: creator, space: space}
+  end
+
+  test "removes private projects bindings", ctx do
+    private = Enum.map(1..3, fn _ ->
+      create_project(ctx, "no one")
+    end)
+    public = Enum.map(1..3, fn _ ->
+      create_project(ctx, "everyone")
+    end)
+
+    assert_has_access(private)
+    assert_has_access(public)
+
+    Operately.Data.Change024RemovePrivateProjectsBindings.run()
+
+    private = reload_project(private)
+    public = reload_project(public)
+
+    assert_no_access(private)
+    assert_has_access(public)
+  end
+
+  #
+  # Assertions
+  #
+
+  defp assert_has_access(projects) do
+    Enum.each(projects, fn p ->
+      context = Access.get_context!(project_id: p.id)
+
+      fetch_groups(p.company_id, p.group_id)
+      |> Enum.each(fn g ->
+        assert Access.get_binding(context_id: context.id, group_id: g.id)
+        refute Access.get_binding(context_id: context.id, group_id: g.id, access_level: Binding.no_access())
+      end)
+    end)
+  end
+
+  defp assert_no_access(projects) do
+    Enum.each(projects, fn p ->
+      context = Access.get_context!(project_id: p.id)
+
+      fetch_groups(p.company_id, p.group_id)
+      |> Enum.each(fn g ->
+        assert Access.get_binding(context_id: context.id, group_id: g.id)
+        assert Access.get_binding(context_id: context.id, group_id: g.id, access_level: Binding.no_access())
+      end)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project(ctx, visibility) do
+    project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: ctx.space.id,
+      visibility: visibility,
+    })
+    |> create_anonymous_binding()
+  end
+
+  defp create_anonymous_binding(project) do
+    context = Access.get_context!(project_id: project.id)
+    group = Access.get_group!(company_id: project.company_id, tag: :anonymous)
+
+    {:ok, _} = Access.create_binding(%{
+      context_id: context.id,
+      group_id: group.id,
+      access_level: Binding.view_access(),
+    })
+
+    project
+  end
+
+  defp reload_project(projects) do
+    Enum.map(projects, &(Repo.reload(&1)))
+  end
+
+  defp fetch_groups(company_id, space_id) do
+    [
+      Access.get_group!(company_id: company_id, tag: :anonymous),
+      Access.get_group!(company_id: company_id, tag: :standard),
+      Access.get_group!(group_id: space_id, tag: :standard),
+    ]
+  end
+end


### PR DESCRIPTION
I've added a data migration which removes any access binding that a private project may have to a space's or company's access group.

After running this migration, only contributors, company admins and space admins should have permissions to access private projects.