### PR TITLE
feat: Add permissions filter to Project queries

### DIFF
--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -3,9 +3,23 @@ defmodule Operately.Access.Filters do
 
   alias Operately.Access.Binding
 
-  def filter_by_view_access(query, person_id), do: filter(query, person_id, Binding.view_access())
+  def filter_by_view_access(query, person_id, opts \\ []) do
+    filter(query, person_id, Binding.view_access(), opts)
+  end
 
-  defp filter(query, person_id, access_level) do
+  defp filter(query, person_id, access_level, project_child: true) do
+    from(item in query,
+      join: p in assoc(item, :project),
+      join: c in assoc(p, :access_context),
+      join: b in assoc(c, :bindings),
+      join: g in assoc(b, :group),
+      join: m in assoc(g, :memberships),
+      where: m.person_id == ^person_id and b.access_level >= ^access_level,
+      distinct: true
+    )
+  end
+
+  defp filter(query, person_id, access_level, _) do
     from(item in query,
       join: c in assoc(item, :access_context),
       join: b in assoc(c, :bindings),

--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -7,9 +7,9 @@ defmodule Operately.Access.Filters do
     filter(query, person_id, Binding.view_access(), opts)
   end
 
-  defp filter(query, person_id, access_level, project_child: true) do
+  defp filter(query, person_id, access_level, join_parent: parent) do
     from(item in query,
-      join: p in assoc(item, :project),
+      join: p in assoc(item, ^parent),
       join: c in assoc(p, :access_context),
       join: b in assoc(c, :bindings),
       join: g in assoc(b, :group),

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias Operately.Projects.Project
   alias OperatelyWeb.Api.Serializer
 
@@ -51,6 +53,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     |> Project.scope_visibility(person.id)
     |> include_requested(include_filters)
     |> load_contributors_access_level(inputs[:include_contributors_access_levels], id)
+    |> filter_by_view_access(person.id)
     |> Repo.one(with_deleted: true)
     |> Project.after_load_hooks()
     |> include_permissions(person, include_filters)
@@ -77,6 +80,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     end)
   end
 
+  def include_permissions(nil, _, _), do: nil
   def include_permissions(project, person, include_filters) do
     if Enum.member?(include_filters, :include_permissions) do
       Project.set_permissions(project, person)

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 3]
+
   alias Operately.Projects.CheckIn
 
   inputs do
@@ -17,7 +19,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
 
   def call(conn, inputs) do
     case decode_id(inputs[:id]) do
-      {:ok, id} -> 
+      {:ok, id} ->
         project_check_in = load(me(conn), id, inputs)
 
         if nil == project_check_in do
@@ -32,12 +34,13 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   defp load(person, id, inputs) do
     requested = extract_include_filters(inputs)
 
-    query = from p in CheckIn, 
-      where: p.id == ^id, 
+    query = from p in CheckIn,
+      where: p.id == ^id,
       preload: [:acknowledged_by]
 
     query
     |> include_requested(requested)
+    |> filter_by_view_access(person.id, project_child: true)
     |> Repo.one()
     |> preload_project_permissions(person)
   end

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -2,7 +2,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_view_access: 3]
+  import Operately.Access.Filters
 
   alias Operately.Projects.CheckIn
 
@@ -40,7 +40,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
 
     query
     |> include_requested(requested)
-    |> filter_by_view_access(person.id, project_child: true)
+    |> filter_by_view_access(person.id, join_parent: :project)
     |> Repo.one()
     |> preload_project_permissions(person)
   end

--- a/lib/operately_web/api/queries/get_project_check_ins.ex
+++ b/lib/operately_web/api/queries/get_project_check_ins.ex
@@ -2,7 +2,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIns do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_view_access: 3]
+  import Operately.Access.Filters
 
   alias Operately.Projects.CheckIn
 
@@ -33,7 +33,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIns do
 
     query
     |> include_requested(requested)
-    |> filter_by_view_access(person.id, project_child: true)
+    |> filter_by_view_access(person.id, join_parent: :project)
     |> Repo.all()
   end
 

--- a/lib/operately_web/api/queries/get_projects.ex
+++ b/lib/operately_web/api/queries/get_projects.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetProjects do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias OperatelyWeb.Api.Serializer
   alias Operately.Projects.Project
 
@@ -43,13 +45,14 @@ defmodule OperatelyWeb.Api.Queries.GetProjects do
     |> Project.scope_visibility(person.id)
     |> Project.scope_space(space_id)
     |> Project.scope_goal(goal_id)
+    |> filter_by_view_access(person.id)
     |> apply_role_filter(person, inputs)
     |> include_requested(include_filters)
     |> Project.order_by_name()
     |> Repo.all(with_deleted: inputs[:include_archived] == true)
     |> Project.after_load_hooks()
   end
-  
+
   defp apply_role_filter(query, person, inputs) do
     cond do
       inputs[:only_reviewed_by_me] -> Project.scope_role(query, person.id, [:reviewer])
@@ -70,7 +73,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjects do
         :include_champion -> from p in q, preload: [:champion]
         :include_reviewer -> from p in q, preload: [:reviewer]
         :include_milestones -> from p in q, preload: [milestones: :project]
-        _ -> q 
+        _ -> q
       end
     end)
   end

--- a/test/operately_web/api/queries/get_project_check_in_test.exs
+++ b/test/operately_web/api/queries/get_project_check_in_test.exs
@@ -1,3 +1,115 @@
 defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import OperatelyWeb.Api.Serializer
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_project_check_in, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{space: space, creator: creator})
+    end
+
+    test "company members have no access", ctx do
+      check_in = create_check_in(ctx, company_access: Binding.no_access())
+
+      assert {404, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members have access", ctx do
+      check_in = create_check_in(ctx, company_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.project_check_in == check_in
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      check_in = create_check_in(ctx, space_access: Binding.no_access())
+
+      assert {404, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      check_in = create_check_in(ctx, space_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.project_check_in == check_in
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      check_in = create_check_in(ctx, champion_id: champion.id)
+
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # champion's request
+      assert {200, res} = query(conn, :get_project_check_in, %{id: check_in.id})
+      assert res.project_check_in == check_in
+
+      # another user's request
+      assert {404, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      check_in = create_check_in(ctx, reviewer_id: reviewer.id)
+
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # reviewer's request
+      assert {200, res} = query(conn, :get_project_check_in, %{id: check_in.id})
+      assert res.project_check_in == check_in
+
+      # another user's request
+      assert {404, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
+      assert res.message == "The requested resource was not found"
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_check_in(ctx, opts) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      group_id: ctx.space.id,
+      creator_id: ctx.creator.id,
+      champion_id: Keyword.get(opts, :champion_id, ctx.creator.id),
+      reviewer_id: Keyword.get(opts, :reviewer_id, ctx.creator.id),
+      company_access_level: Keyword.get(opts, :company_access, Binding.no_access()),
+      space_access_level: Keyword.get(opts, :space_access, Binding.no_access()),
+    })
+
+    check_in_fixture(%{author_id: ctx.creator.id, project_id: project.id})
+    |> serialize(level: :full)
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+end

--- a/test/operately_web/api/queries/get_project_check_ins_test.exs
+++ b/test/operately_web/api/queries/get_project_check_ins_test.exs
@@ -1,0 +1,126 @@
+defmodule OperatelyWeb.Api.Queries.GetProjectCheckInsTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_project_check_ins, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+      space_id = Paths.space_id(space)
+
+      Map.merge(ctx, %{space: space, space_id: space_id, creator: creator})
+    end
+
+    test "company members have no access", ctx do
+      {project_id, _} = create_project_and_check_ins(ctx, company_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert length(res.project_check_ins) == 0
+    end
+
+    test "company members have access", ctx do
+      {project_id, check_ins} = create_project_and_check_ins(ctx, company_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert_check_ins(res, check_ins)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      {project_id, _} = create_project_and_check_ins(ctx, space_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert length(res.project_check_ins) == 0
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      {project_id, check_ins} = create_project_and_check_ins(ctx, space_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert_check_ins(res, check_ins)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      {project_id, check_ins} = create_project_and_check_ins(ctx, champion_id: champion.id)
+
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # champion's request
+      assert {200, res} = query(conn, :get_project_check_ins, %{project_id: project_id})
+      assert assert_check_ins(res, check_ins)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert length(res.project_check_ins) == 0
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      {project_id, check_ins} = create_project_and_check_ins(ctx, reviewer_id: reviewer.id)
+
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # reviewer's request
+      assert {200, res} = query(conn, :get_project_check_ins, %{project_id: project_id})
+      assert assert_check_ins(res, check_ins)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :get_project_check_ins, %{project_id: project_id})
+      assert length(res.project_check_ins) == 0
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project_and_check_ins(ctx, opts) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      group_id: ctx.space.id,
+      creator_id: ctx.creator.id,
+      champion_id: Keyword.get(opts, :champion_id, ctx.creator.id),
+      reviewer_id: Keyword.get(opts, :reviewer_id, ctx.creator.id),
+      company_access_level: Keyword.get(opts, :company_access, Binding.no_access()),
+      space_access_level: Keyword.get(opts, :space_access, Binding.no_access()),
+    })
+    check_ins = Enum.map(1..3, fn _ ->
+      check_in_fixture(%{author_id: ctx.creator.id, project_id: project.id})
+    end)
+
+    project_id = Paths.project_id(project)
+
+    {project_id, check_ins}
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp assert_check_ins(res, check_ins) do
+    assert length(res.project_check_ins) == length(check_ins)
+    Enum.each(res.project_check_ins, fn c ->
+      assert Enum.find(check_ins, &(Paths.project_check_in_id(&1) == c.id))
+    end)
+  end
+end

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -20,6 +20,10 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     project_manager = person_fixture_with_account(%{company_id: company.id, full_name: "Project Manager"})
 
     group = group_fixture(champion, %{company_id: company.id, name: "Test Group"})
+    Operately.Groups.add_members(non_contributor, group.id, [%{
+      id: non_contributor.id,
+      permissions: Binding.full_access(),
+    }])
 
     {:ok, goal} = Operately.Goals.create_goal(champion, %{
       company_id: company.id,


### PR DESCRIPTION
I've added a permissions filter to the following queries:

- OperatelyWeb.Api.Queries.GetProject
- OperatelyWeb.Api.Queries.GetProjects
- OperatelyWeb.Api.Queries.GetProjectCheckIn
- OperatelyWeb.Api.Queries.GetProjectCheckIns