### PR TITLE
feat: Add permissions filter to GetComments query

### DIFF
--- a/assets/js/features/CommentSection/useForGoalCheckIn.tsx
+++ b/assets/js/features/CommentSection/useForGoalCheckIn.tsx
@@ -7,7 +7,7 @@ import { Item, ItemType } from "./form";
 export function useForGoalCheckIn(update: GoalCheckIns.Update) {
   const { data, loading, error, refetch } = Comments.useGetComments({
     entityId: update.id!,
-    entityType: "update",
+    entityType: "goal_update",
   });
 
   const [post, { loading: submittingPost }] = Comments.useCreateComment();

--- a/lib/operately_web/api/queries/get_comments.ex
+++ b/lib/operately_web/api/queries/get_comments.ex
@@ -4,7 +4,8 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
 
   import Operately.Access.Filters, only: [filter_by_view_access: 3]
 
-  alias Operately.Updates.Comment
+  alias Operately.Updates.{Update, Comment}
+  alias Operately.Goals.Goal
   alias Operately.Projects.CheckIn
 
   inputs do
@@ -33,6 +34,18 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
       order_by: [asc: c.inserted_at]
     )
     |> filter_by_view_access(person.id, named_binding: :project)
+    |> Repo.all()
+  end
+
+  defp load(person, id, :update) do
+    from(c in Comment,
+      join: u in Update, on: c.entity_id == u.id,
+      join: g in Goal, on: u.updatable_id == g.id, as: :goal,
+      where: c.entity_id == ^id and c.entity_type == :update,
+      preload: [:author, reactions: :person],
+      order_by: [asc: c.inserted_at]
+    )
+    |> filter_by_view_access(person.id, named_binding: :goal)
     |> Repo.all()
   end
 

--- a/lib/operately_web/api/queries/get_comments.ex
+++ b/lib/operately_web/api/queries/get_comments.ex
@@ -2,6 +2,11 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 3]
+
+  alias Operately.Updates.Comment
+  alias Operately.Projects.CheckIn
+
   inputs do
     field :entity_id, :string
     field :entity_type, :string
@@ -11,12 +16,28 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     field :comments, list_of(:comment)
   end
 
-  def call(_conn, inputs) do
+  def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.entity_id)
-    entity_type = String.to_existing_atom(inputs.entity_type)
-    comments = Operately.Updates.list_comments(id, entity_type)
-    comments = Operately.Repo.preload(comments, [:author, reactions: :person])  
+    type = String.to_existing_atom(inputs.entity_type)
+
+    comments = load(me(conn), id, type)
 
     {:ok, %{comments: Serializer.serialize(comments, level: :full)}}
+  end
+
+  defp load(person, id, :project_check_in) do
+    from(c in Comment,
+      join: check_in in CheckIn, on: c.entity_id == check_in.id,
+      join: p in assoc(check_in, :project), as: :project,
+      where: c.entity_id == ^id and c.entity_type == :project_check_in,
+      order_by: [asc: c.inserted_at]
+    )
+    |> filter_by_view_access(person.id, named_binding: :project)
+    |> Repo.all()
+  end
+
+  defp load(_person, id, type) do
+    Operately.Updates.list_comments(id, type)
+    |> Operately.Repo.preload([:author, reactions: :person])
   end
 end

--- a/lib/operately_web/api/queries/get_comments.ex
+++ b/lib/operately_web/api/queries/get_comments.ex
@@ -5,6 +5,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
   import Operately.Access.Filters, only: [filter_by_view_access: 3]
 
   alias Operately.Updates.{Update, Comment}
+  alias Operately.Groups.Group
   alias Operately.Goals.Goal
   alias Operately.Projects.CheckIn
   alias Operately.Comments.CommentThread
@@ -23,43 +24,77 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     {:ok, id} = decode_id(inputs.entity_id)
     type = String.to_existing_atom(inputs.entity_type)
 
-    comments = load(me(conn), id, type)
+    comments = load(id, type, me(conn), company(conn))
 
     {:ok, %{comments: Serializer.serialize(comments, level: :full)}}
   end
 
-  defp load(person, id, :project_check_in) do
+  defp load(id, :project_check_in, person, _) do
     from(c in Comment,
       join: check_in in CheckIn, on: c.entity_id == check_in.id,
       join: p in assoc(check_in, :project), as: :project,
-      where: c.entity_id == ^id and c.entity_type == :project_check_in,
-      order_by: [asc: c.inserted_at]
+      where: c.entity_id == ^id and c.entity_type == :project_check_in
     )
+    |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :project)
     |> Repo.all()
   end
 
-  defp load(person, id, :update) do
+  defp load(id, :goal_update, person, _) do
     from(c in Comment,
       join: u in Update, on: c.entity_id == u.id,
       join: g in Goal, on: u.updatable_id == g.id, as: :goal,
-      where: c.entity_id == ^id and c.entity_type == :update,
-      preload: [:author, reactions: :person],
-      order_by: [asc: c.inserted_at]
+      where: c.entity_id == ^id and c.entity_type == :update
     )
+    |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :goal)
     |> Repo.all()
   end
 
-  defp load(person, id, :comment_thread) do
+  defp load(id, :discussion, person, company) do
+    group_id = from(g in Group,
+        join: u in Update, on: u.updatable_id == g.id,
+        where: u.id == ^id,
+        select: g.id
+      )
+      |> Repo.one!()
+
+    query = from(c in Comment,
+        join: u in Update, on: c.entity_id == u.id,
+        join: g in Group, on: u.updatable_id == g.id, as: :group,
+        where: c.entity_id == ^id and c.entity_type == :update
+      )
+      |> preload_resources()
+
+    if group_id == company.company_space_id do
+      query
+      |> filter_by_view_access(person.id, [
+        join_parent: :company,
+        named_binding: :group,
+      ])
+      |> Repo.all()
+    else
+      query
+      |> filter_by_view_access(person.id, named_binding: :group)
+      |> Repo.all()
+    end
+  end
+
+  defp load(id, :comment_thread, person, _) do
     from(c in Comment,
       join: t in CommentThread, on: c.entity_id == t.id,
       join: a in Activity, on: t.parent_id == a.id, as: :activity,
-      where: c.entity_id == ^id and c.entity_type == :comment_thread,
+      where: c.entity_id == ^id and c.entity_type == :comment_thread
+    )
+    |> preload_resources()
+    |> filter_by_view_access(person.id, named_binding: :activity)
+    |> Repo.all()
+  end
+
+  defp preload_resources(query) do
+    from(c in query,
       preload: [:author, reactions: :person],
       order_by: [asc: c.inserted_at]
     )
-    |> filter_by_view_access(person.id, named_binding: :activity)
-    |> Repo.all()
   end
 end

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -152,6 +152,12 @@ defmodule OperatelyWeb.Paths do
     OperatelyWeb.Api.Helpers.id_with_comments(date, id)
   end
 
+  def comment_thread_id(comment_thread) do
+    id = Operately.ShortUuid.encode!(comment_thread.id)
+    date = comment_thread.inserted_at |> NaiveDateTime.to_date() |> Date.to_string()
+    OperatelyWeb.Api.Helpers.id_with_comments(date, id)
+  end
+
   def milestone_id(milestone) do
     milestone_id(milestone.id, milestone.title)
   end

--- a/test/operately_web/api/queries/get_comments_test.exs
+++ b/test/operately_web/api/queries/get_comments_test.exs
@@ -1,3 +1,184 @@
 defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import OperatelyWeb.Api.Serializer
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  # import Operately.UpdatesFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_comments, %{})
+    end
+  end
+
+  describe "permissions - project check-in" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator, space: space})
+    end
+
+    test "company members have no access", ctx do
+      check_in = create_check_in(ctx, company_access: Binding.no_access())
+      Enum.each(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert length(res.comments) == 0
+    end
+
+    test "company members have access", ctx do
+      check_in = create_check_in(ctx, company_access: Binding.view_access())
+      comments = Enum.map(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert_comments(res, comments)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      check_in = create_check_in(ctx, space_access: Binding.no_access())
+      Enum.each(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert length(res.comments) == 0
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      check_in = create_check_in(ctx, space_access: Binding.view_access())
+      comments = Enum.map(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert_comments(res, comments)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      check_in = create_check_in(ctx, champion_id: champion.id)
+      comments = Enum.map(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # champion's request
+      assert {200, res} = query(conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert_comments(res, comments)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert length(res.comments) == 0
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      check_in = create_check_in(ctx, reviewer_id: reviewer.id)
+      comments = Enum.map(1..3, fn _ ->
+        add_comment(ctx, check_in.id, "project_check_in")
+      end)
+
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      # reviewer's request
+      assert {200, res} = query(conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert_comments(res, comments)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :get_comments, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+      })
+      assert length(res.comments) == 0
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp assert_comments(res, comments) do
+    assert length(res.comments) == length(comments)
+    assert Enum.each(res.comments, fn c ->
+      Enum.find(comments, &(&1 == c))
+    end)
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp create_check_in(ctx, opts) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      group_id: ctx.space.id,
+      creator_id: ctx.creator.id,
+      champion_id: Keyword.get(opts, :champion_id, ctx.creator.id),
+      reviewer_id: Keyword.get(opts, :reviewer_id, ctx.creator.id),
+      company_access_level: Keyword.get(opts, :company_access, Binding.no_access()),
+      space_access_level: Keyword.get(opts, :space_access, Binding.no_access()),
+    })
+
+    check_in_fixture(%{author_id: ctx.creator.id, project_id: project.id})
+  end
+
+  defp create_discussion(ctx, attrs) do
+    update_fixture(%{
+      author_id: ctx.creator.id,
+      updatable_id: Keyword.get(attrs, :space_id, ctx.company.company_space_id),
+      updatable_type: :space,
+      type: :project_discussion,
+      content: %{
+        title: "Hello World",
+        body: "How are you doing?"
+      }
+    })
+  end
+
+  defp add_comment(ctx, entity_id, entity_type, content \\ "Hello World") do
+    {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.person, entity_id, entity_type, RichText.rich_text(content))
+    Repo.preload(comment, :author)
+    |> serialize(level: :full)
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Queries.GetComments` query.