### PR TITLE
chore: Remove pgweb container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - dev
 
   pgweb:
-    container_name: pgweb
     restart: always
     image: sosedoff/pgweb:0.15.0
     command: [ "pgweb", "--bind=0.0.0.0" ]


### PR DESCRIPTION
I'm testing the DX of local development setup, and I'm cloning multiple instances of the operately codebase (e.g. operately1, operately2). One thing that blocks starting up multiple of them is this container name for the pgweb.

AFAIK it is not needed for our development setup, and the reason it is there is pure copy/paste from the pgweb docs.