### PR TITLE
feat: Add permissions filter to GetPeople query

### DIFF
--- a/lib/operately/access/access_group_membership.ex
+++ b/lib/operately/access/access_group_membership.ex
@@ -3,7 +3,7 @@ defmodule Operately.Access.GroupMembership do
 
   schema "access_group_memberships" do
     belongs_to :group, Operately.Access.Group
-    belongs_to :person, Operately.People.Person
+    belongs_to :person, Operately.People.Person, where: [suspended_at: nil]
 
     timestamps()
   end

--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -14,7 +14,9 @@ defmodule Operately.Access.Filters do
       join: b in assoc(c, :bindings),
       join: g in assoc(b, :group),
       join: m in assoc(g, :memberships),
+      join: p in assoc(m, :person),
       where: m.person_id == ^person_id and b.access_level >= ^access_level,
+      where: is_nil(p.suspended_at),
       distinct: true
     )
   end

--- a/lib/operately_web/api/queries/get_people.ex
+++ b/lib/operately_web/api/queries/get_people.ex
@@ -2,6 +2,11 @@ defmodule OperatelyWeb.Api.Queries.GetPeople do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
+  alias Operately.People.Person
+  alias Operately.Companies.Company
+
   inputs do
     field :include_suspended, :boolean
     field :include_manager, :boolean
@@ -12,29 +17,35 @@ defmodule OperatelyWeb.Api.Queries.GetPeople do
   end
 
   def call(conn, inputs) do
-    company_id = me(conn).company_id
-    people = load_people(company_id, inputs)
+    people = load(me(conn), inputs)
 
     {:ok, %{people: Serializer.serialize(people, level: :full)}}
   end
 
-  defp load_people(company_id, inputs) do
-    query = from p in Operately.People.Person, where: p.company_id == ^company_id
-
-    query = if inputs[:include_suspended] do 
-      query
-    else 
-      from p in query, where: is_nil(p.suspended_at)
-    end
-
-    query = if inputs[:include_manager] do
-      from p in query, preload: [:manager]
-    else
-      query
-    end
-
-    query = from p in query, order_by: [asc: p.full_name]
-
-    Repo.all(query)
+  defp load(person, inputs) do
+    from(c in Company,
+      where: c.id == ^person.company_id,
+      select: c.id
+    )
+    |> filter_by_view_access(person.id)
+    |> Repo.one()
+    |> load_people(inputs)
   end
+
+  defp load_people(nil, _), do: []
+  defp load_people(company_id, inputs) do
+    from(p in Person,
+      where: p.company_id == ^company_id,
+      order_by: [asc: p.full_name]
+    )
+    |> include_suspended(inputs[:include_suspended])
+    |> include_manager(inputs[:include_manager])
+    |> Repo.all()
+  end
+
+  defp include_suspended(q, true), do: q
+  defp include_suspended(q, _), do: from(p in q, where: is_nil(p.suspended_at))
+
+  defp include_manager(q, true), do: from(p in q, preload: [:manager])
+  defp include_manager(q, _), do: q
 end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Queries.GetPeople` query.

I noticed that the `filter_by_view_access` function was allowing suspended people to use the API. This issue is also handled in this PR. 