### PR TITLE
feat: Add permissions filter to SearchPotentialSpaceMembers query

### DIFF
--- a/lib/operately_web/api/queries/search_potential_space_members.ex
+++ b/lib/operately_web/api/queries/search_potential_space_members.ex
@@ -2,6 +2,11 @@ defmodule OperatelyWeb.Api.Queries.SearchPotentialSpaceMembers do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
+  alias Operately.People.Person
+  alias Operately.Groups.{Group, Member}
+
   inputs do
     field :group_id, :string
     field :query, :string
@@ -13,15 +18,41 @@ defmodule OperatelyWeb.Api.Queries.SearchPotentialSpaceMembers do
     field :people, list_of(:person)
   end
 
-  def call(_conn, inputs) do
+  def call(conn, inputs) do
     {:ok, space_id} = decode_id(inputs.group_id)
 
-    query = inputs[:query] || ""
-    excluded_ids = inputs[:exclude_ids] || []
+    if has_permissions?(me(conn), space_id) do
+      people = load_members(inputs, space_id)
+      {:ok, %{people: Serializer.serialize(people)}}
+    else
+      {:ok, %{people: []}}
+    end
+  end
+
+  defp has_permissions?(person, space_id) do
+    from(g in Group, where: g.id == ^space_id)
+    |> filter_by_view_access(person.id)
+    |> Repo.exists?()
+  end
+
+  defp load_members(inputs, space_id) do
     limit = inputs[:limit] || 10
 
-    people = Operately.Groups.list_potential_members(space_id, query, excluded_ids, limit)
+    from(p in Person,
+      left_join: m in Member, on: p.id == m.person_id and m.group_id == ^space_id,
+      where: is_nil(m) and not p.suspended,
+      limit: ^limit
+    )
+    |> exclude_ids(inputs[:exclude_ids])
+    |> string_query(inputs[:query])
+    |> Repo.all()
+  end
 
-    {:ok, %{people: Serializer.serialize(people)}}
+  defp exclude_ids(q, nil), do: q
+  defp exclude_ids(q, exclude_ids), do: from(p in q, where: p.id not in ^exclude_ids)
+
+  defp string_query(q, nil), do: q
+  defp string_query(q, str) do
+    from(p in q, where: ilike(p.full_name, ^"%#{str}%") or ilike(p.title, ^"%#{str}%"))
   end
 end

--- a/test/operately_web/api/queries/search_potential_space_members_test.exs
+++ b/test/operately_web/api/queries/search_potential_space_members_test.exs
@@ -1,0 +1,175 @@
+defmodule OperatelyWeb.Api.Queries.SearchPotentialSpaceMembersTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias OperatelyWeb.Paths
+  alias Operately.People
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :search_potential_space_members, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      member = person_fixture(company_id: ctx.company.id)
+
+      Map.merge(ctx, %{member: member})
+    end
+
+    test "company member has access", ctx do
+      space = group_fixture(ctx.company_creator, [
+        company_id: ctx.company.id,
+        company_permissions: Binding.view_access(),
+      ])
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+
+      assert length(res.people) == 2
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.member)))
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person)))
+    end
+
+    test "company member has no access", ctx do
+      space = group_fixture(ctx.company_creator, [
+        company_id: ctx.company.id,
+        company_permissions: Binding.no_access(),
+      ])
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+      assert length(res.people) == 0
+    end
+
+    test "space member has no access", ctx do
+      space = group_fixture(ctx.company_creator, [
+        company_id: ctx.company.id,
+        company_permissions: Binding.no_access(),
+      ])
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+      assert length(res.people) == 0
+
+      add_person_to_space(ctx.person, space)
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.member)))
+    end
+
+    test "suspended people don't have access", ctx do
+      space = group_fixture(ctx.company_creator, [
+        company_id: ctx.company.id,
+        company_permissions: Binding.view_access(),
+      ])
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+      assert length(res.people) == 2
+
+      People.update_person(ctx.person, %{suspended_at: DateTime.utc_now()})
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(space)})
+      assert length(res.people) == 0
+    end
+  end
+
+  describe "search_potential_space_members functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+
+      space = group_fixture(ctx.person, company_id: ctx.company.id)
+      add_person_to_space(ctx.company_creator, space)
+
+      person1 = person_fixture(full_name: "John Doe", title: "CEO", company_id: ctx.company.id)
+      person2 = person_fixture(full_name: "Mike Smith", title: "CTO", company_id: ctx.company.id)
+
+      Map.merge(ctx, %{space: space, person1: person1, person2: person2})
+    end
+
+    test "returns all petential members", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+
+      assert length(res.people) == 2
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person1)))
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person2)))
+    end
+
+    test "query members by name", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{
+        group_id: Paths.space_id(ctx.space),
+        query: "Mike",
+      })
+
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person2)))
+    end
+
+    test "query members by title", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{
+        group_id: Paths.space_id(ctx.space),
+        query: "CEO",
+      })
+
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person1)))
+    end
+
+    test "exlude_ids excludes members from result", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{
+        group_id: Paths.space_id(ctx.space),
+        exclude_ids: [ctx.person1.id],
+      })
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person2)))
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{
+        group_id: Paths.space_id(ctx.space),
+        exclude_ids: [ctx.person2.id],
+      })
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person1)))
+    end
+
+    test "existing members excluded from result", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+      assert length(res.people) == 2
+
+      add_person_to_space(ctx.person1, ctx.space)
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person2)))
+
+      add_person_to_space(ctx.person2, ctx.space)
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+      assert length(res.people) == 0
+    end
+
+    test "suspended people excluded from result", ctx do
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+      assert length(res.people) == 2
+
+      People.update_person(ctx.person1, %{suspended: true})
+
+      assert {200, res} = query(ctx.conn, :search_potential_space_members, %{group_id: Paths.space_id(ctx.space)})
+      assert length(res.people) == 1
+      assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person2)))
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp add_person_to_space(person, space) do
+    Operately.Groups.add_members(person, space.id, [%{
+      id: person.id,
+      permissions: Binding.view_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Queries.SearchPotentialSpaceMembers` query.