### PR TITLE
feat: Add permissions filter to SearchProjectContributorCandidates query

### DIFF
--- a/lib/operately_web/api/queries/search_project_contributor_candidates.ex
+++ b/lib/operately_web/api/queries/search_project_contributor_candidates.ex
@@ -2,7 +2,10 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidates do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias Operately.Projects
+  alias Operately.Projects.Project
 
   inputs do
     field :project_id, :string
@@ -13,11 +16,20 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidates do
     field :people, list_of(:person)
   end
 
-  def call(_conn, inputs) do
+  def call(conn, inputs) do
     {:ok, project_id} = decode_id(inputs.project_id)
 
-    people = Projects.list_project_contributor_candidates(project_id, inputs.query, [], 10)
+    if has_permissions?(me(conn), project_id) do
+      people = Projects.list_project_contributor_candidates(project_id, inputs.query, [], 10)
+      {:ok, %{people: Serializer.serialize(people)}}
+    else
+      {:ok, %{people: []}}
+    end
+  end
 
-    {:ok, %{people: Serializer.serialize(people)}}
+  defp has_permissions?(person, project_id) do
+    from(p in Project, where: p.id == ^project_id)
+    |> filter_by_view_access(person.id)
+    |> Repo.exists?()
   end
 end

--- a/test/operately_web/api/queries/search_project_contributor_candidates_test.exs
+++ b/test/operately_web/api/queries/search_project_contributor_candidates_test.exs
@@ -2,11 +2,130 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
   use OperatelyWeb.TurboCase
 
   import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
   import Operately.ProjectsFixtures
+
+  alias Operately.{Repo, People}
+  alias Operately.Access.Binding
 
   describe "security" do
     test "it requires authentication", ctx do
       assert {401, _} = query(ctx.conn, :search_project_contributor_candidates, %{})
+    end
+  end
+
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      space = group_fixture(ctx.company_creator, %{company_id: ctx.company.id})
+      member = person_fixture(%{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{space: space, creator: ctx.company_creator, member: member})
+    end
+
+    test "company members have no access", ctx do
+      project = create_project(ctx, company_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert length(res.people) == 0
+    end
+
+    test "company members have access", ctx do
+      project = create_project(ctx, company_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert_response(res, ctx)
+    end
+
+    test "space members have no access", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access: Binding.no_access())
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert length(res.people) == 0
+    end
+
+    test "space members have access", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert_response(res, ctx)
+    end
+
+    test "champions have access", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      project = create_project(ctx, champion_id: champion.id)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert_response(res, ctx)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert length(res.people) == 0
+    end
+
+    test "reviewers have access", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      project = create_project(ctx, reviewer_id: reviewer.id)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = query(conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert_response(res, ctx)
+
+      # another user's request
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert length(res.people) == 0
+    end
+
+    test "suspended people don't have access", ctx do
+      project = create_project(ctx, company_access: Binding.view_access())
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert_response(res, ctx)
+
+      People.update_person(ctx.person, %{suspended_at: DateTime.utc_now()})
+
+      assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
+        project_id: Paths.project_id(project),
+        query: "",
+      })
+      assert length(res.people) == 0
     end
   end
 
@@ -15,7 +134,7 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
 
     test "returns people based on query", ctx do
       project = project_fixture(%{
-        company_id: ctx.company.id, 
+        company_id: ctx.company.id,
         creator_id: ctx.person.id,
         group_id: ctx.company.company_space_id
       })
@@ -23,7 +142,7 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
       person = person_fixture(company_id: ctx.company.id)
 
       assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
-        project_id: Paths.project_id(project), 
+        project_id: Paths.project_id(project),
         query: person.full_name
       })
 
@@ -38,7 +157,7 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
 
     test "doesn't return suspended people", ctx do
       project = project_fixture(%{
-        company_id: ctx.company.id, 
+        company_id: ctx.company.id,
         creator_id: ctx.person.id,
         group_id: ctx.company.company_space_id
       })
@@ -50,11 +169,41 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
       })
 
       assert {200, res} = query(ctx.conn, :search_project_contributor_candidates, %{
-        project_id: Paths.project_id(project), 
+        project_id: Paths.project_id(project),
         query: suspended_person.full_name
       })
 
       assert res.people == []
     end
   end
-end 
+
+  #
+  # Helpers
+  #
+
+  defp assert_response(res, ctx) do
+    assert length(res.people) == 2
+    assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.member)))
+    assert Enum.find(res.people, &(&1 == Serializer.serialize(ctx.person)))
+  end
+
+  defp create_project(ctx, opts) do
+    project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      champion_id: Keyword.get(opts, :champion_id, ctx.creator.id),
+      reviewer_id: Keyword.get(opts, :reviewer_id, ctx.creator.id),
+      group_id: ctx.space.id,
+      company_access_level: Keyword.get(opts, :company_access, Binding.no_access()),
+      space_access_level: Keyword.get(opts, :space_access, Binding.no_access()),
+    })
+  end
+
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: Binding.view_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Queries.SearchProjectContributorCandidates` query.