### PR TITLE
feat: Add permissions filter to GetCompany query

### DIFF
--- a/lib/operately_web/api/queries/get_company.ex
+++ b/lib/operately_web/api/queries/get_company.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetCompany do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
+
   alias OperatelyWeb.Api.Serializer
   alias Operately.Companies.ShortId
   alias Operately.Companies.Company
@@ -44,10 +46,11 @@ defmodule OperatelyWeb.Api.Queries.GetCompany do
 
   defp load(person, id, inputs) do
     requested = extract_include_filters(inputs)
-    query = from c in Company, join: p in assoc(c, :people), where: c.short_id == ^id and p.id == ^person.id
-    query = include_requested(query, requested)
 
-    Repo.one(query)
+    (from c in Company, join: p in assoc(c, :people), where: c.short_id == ^id and p.id == ^person.id)
+    |> filter_by_view_access(person.id)
+    |> include_requested(requested)
+    |> Repo.one()
   end
 
   def include_requested(query, requested) do

--- a/test/operately_web/api/queries/get_company_test.exs
+++ b/test/operately_web/api/queries/get_company_test.exs
@@ -1,9 +1,57 @@
 defmodule OperatelyWeb.Api.Queries.GetCompanyTest do
   use OperatelyWeb.TurboCase
 
+  alias Operately.{Repo, People}
+
   describe "security" do
     test "it requires authentication", ctx do
       assert {401, _} = query(ctx.conn, :get_company, %{id: "1"})
     end
+
+    test "suspended people don't have access", ctx do
+      ctx = register_and_log_in_account(ctx)
+      company = Serializer.serialize(ctx.company, level: :full)
+
+      assert {200, res} = query(ctx.conn, :get_company, %{id: company.id})
+      assert res.company == company
+
+      People.update_person(ctx.person, %{suspended_at: DateTime.utc_now()})
+
+      assert {404, res} = query(ctx.conn, :get_company, %{id: company.id})
+      assert res.message == "The requested resource was not found"
+    end
   end
-end 
+
+  describe "get_company functionality" do
+    setup :register_and_log_in_account
+
+    test "only company", ctx do
+      company = Serializer.serialize(ctx.company, level: :full)
+
+      assert {200, res} = query(ctx.conn, :get_company, %{id: company.id})
+      assert res.company == company
+      refute res.company.admins
+      refute res.company.people
+    end
+
+    test "include_admins", ctx do
+      company =
+        Repo.preload(ctx.company, :admins)
+        |> Serializer.serialize(level: :full)
+
+      assert {200, res} = query(ctx.conn, :get_company, %{id: company.id, include_admins: true})
+      assert res.company == company
+      assert res.company.admins
+    end
+
+    test "include_people", ctx do
+      company =
+        Repo.preload(ctx.company, :people)
+        |> Serializer.serialize(level: :full)
+
+      assert {200, res} = query(ctx.conn, :get_company, %{id: company.id, include_people: true})
+      assert res.company == company
+      assert res.company.people
+    end
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Queries.GetCompany` query.