### PR TITLE
fix: Migration for adding placeholder for goal updates without targets

### DIFF
--- a/lib/operately/data/change_026_add_placeholder_to_goal_check_ins_taget_update.ex
+++ b/lib/operately/data/change_026_add_placeholder_to_goal_check_ins_taget_update.ex
@@ -1,0 +1,27 @@
+defmodule Operately.Data.Change026AddPlaceholderToGoalCheckInsTagetUpdate do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.{Repo, Updates}
+  alias Operately.Updates.Update
+
+  def run do
+    Repo.transaction(fn ->
+      from(u in Update, where: u.type == :goal_check_in)
+      |> Repo.all()
+      |> add_placeholder()
+    end)
+  end
+
+  defp add_placeholder(check_ins) when is_list(check_ins) do
+    Enum.each(check_ins, fn c ->
+      add_placeholder(c)
+    end)
+  end
+
+  defp add_placeholder(check_in) do
+    unless Map.has_key?(check_in.content, "targets") do
+      content = Map.put_new(check_in.content, "targets", [])
+      Updates.update_update(check_in, %{content: content})
+    end
+  end
+end

--- a/test/operately/data/change_026_add_placeholder_to_goal_check_ins_taget_update_test.exs
+++ b/test/operately/data/change_026_add_placeholder_to_goal_check_ins_taget_update_test.exs
@@ -1,0 +1,78 @@
+defmodule Operately.Data.Change026AddPlaceholderToGoalCheckInsTagetUpdateTest do
+  use Operately.DataCase
+
+  import OperatelyWeb.Api.Serializer
+  import Operately.Support.RichText
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GoalsFixtures
+  import Operately.UpdatesFixtures
+
+  alias Operately.{Repo, Goals}
+
+  setup ctx do
+    company = company_fixture(%{})
+    creator = person_fixture_with_account(%{company_id: company.id})
+    goal = goal_fixture(creator, %{space_id: company.company_space_id})
+
+
+    Map.merge(ctx, %{creator: creator, goal: goal})
+  end
+
+  test "creates placeholder for goal check-in target update", ctx do
+    check_ins = Enum.map(1..3, fn _ ->
+      create_update(ctx.goal)
+    end)
+
+    Enum.each(check_ins, fn c ->
+      c = serialize(c, level: :full)
+      assert c.goal_target_updates == nil
+    end)
+
+    Operately.Data.Change026AddPlaceholderToGoalCheckInsTagetUpdate.run()
+
+    Enum.each(check_ins, fn c ->
+      c = Repo.reload(c) |> serialize(level: :full)
+      assert c.goal_target_updates == []
+    end)
+  end
+
+  test "migration ignores check-ins that have targets", ctx do
+    check_ins = Enum.map(1..3, fn _ ->
+      create_update(ctx.goal)
+    end)
+    check_ins_to_ignore = Enum.map(1..3, fn _ ->
+      create_update_with_targets(ctx)
+    end)
+
+    Operately.Data.Change026AddPlaceholderToGoalCheckInsTagetUpdate.run()
+
+    Enum.each(check_ins, fn c ->
+      updated_c = Repo.reload(c)
+      assert serialize(c, level: :full).goal_target_updates != serialize(updated_c, level: :full).goal_target_updates
+    end)
+    Enum.each(check_ins_to_ignore, fn c ->
+      ignored_c = Repo.reload(c)
+      assert serialize(c, level: :full).goal_target_updates == serialize(ignored_c, level: :full).goal_target_updates
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_update(goal) do
+    update_fixture(%{
+      type: :goal_check_in,
+      updatable_id: goal.id,
+      updatable_type: :goal,
+      author_id: goal.creator_id,
+    })
+  end
+
+  defp create_update_with_targets(ctx) do
+    targets = Enum.map(Goals.list_targets(ctx.goal.id), fn t ->%{"id" => t.id, "value" => t.value+10}end)
+    {:ok, check_in} = Operately.Operations.GoalCheckIn.run(ctx.creator, ctx.goal, rich_text("content"), targets)
+    check_in
+  end
+end


### PR DESCRIPTION
To solve the problem discussed in https://github.com/operately/operately/issues/818, I've created a data migration which adds a `[]` placeholder to goal updates which don't have `content["targets"]` set.

Hopefully, an empty list will be enough to solve the problem. If it isn't, I will try adding a list of mock "targets".