### PR TITLE
docs: Use docker compose without dashes

### DIFF
--- a/docs/installation/single-host.md
+++ b/docs/installation/single-host.md
@@ -79,7 +79,7 @@ openssl rand -hex 32
 Start Operately with Docker Compose:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Operately should now be running on your server. You can access it by navigating to the domain you


### PR DESCRIPTION
docker-compose is the old standard and might not be available on new machines.