### PR TITLE
Mock: Project page message board, resources, improved milestones

### DIFF
--- a/assets/js/pages/ProjectPage/NextMilestone.tsx
+++ b/assets/js/pages/ProjectPage/NextMilestone.tsx
@@ -30,14 +30,12 @@ function MilestonesZeroState({ project }) {
   const editPath = Paths.projectEditTimelinePath(project.id!);
 
   const editLink = (
-    <GhostButton linkTo={editPath} testId="add-milestones-link" size="xs" type="secondary">
-      Edit Timeline
-    </GhostButton>
+    <a href="" class="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">Edit timeline</a>
   );
 
   return (
     <div className="text-sm">
-      No milestones defined yet.
+      Outline your project timeline with milestones.
       {project.permissions.canEditMilestone && <div className="mt-2 flex">{editLink}</div>}
     </div>
   );

--- a/assets/js/pages/ProjectPage/Timeline.tsx
+++ b/assets/js/pages/ProjectPage/Timeline.tsx
@@ -19,7 +19,8 @@ export default function Timeline({ project }) {
         <Progress project={project} />
       </div>
 
-      <NextMilestone project={project} />
+      {false ? <NextMilestone project={project} /> : "" }
+      <MilestoneList />
     </div>
   );
 }
@@ -91,6 +92,82 @@ function Progress({ project }: { project: Projects.Project }) {
           <>Not yet started</>
         )}
       </div>
+    </div>
+  );
+}
+
+function MilestoneList() {
+  const milestones = [
+    {
+      id: 1,
+      title: "Design Phase Completion",
+      dueDate: "Aug 19",
+      isOverdue: false,
+      commentCount: 5,
+      pendingTasks: 3,
+      description: "Finalize all UI/UX designs and get stakeholder approval for the new dashboard layout."
+    },
+    {
+      id: 2,
+      title: "Backend API Development",
+      dueDate: "Sep 5",
+      isOverdue: true,
+      commentCount: 8,
+      pendingTasks: 12,
+      description: "Complete the development of RESTful APIs for user authentication, data retrieval, and real-time updates."
+    },
+    {
+      id: 3,
+      title: "User Testing",
+      dueDate: "Oct 1",
+      isOverdue: false,
+      commentCount: 2,
+      pendingTasks: 7,
+      description: ""
+    }
+  ];
+
+
+  return (
+    <div className="rounded-lg shadow-sm">
+      <DimmedLabel><a href="" className="underline underline-offset-2 hover:text-link-hover">Upcoming Milestones</a> (4)</DimmedLabel>
+      <ul role="list" className="divide-y divide-gray-200">
+        {milestones.map((milestone, index) => (
+          <li key={milestone.id} className={`py-4 pr-4 sm:pr-6 ${index === 0 ? 'rounded-t-lg' : ''} ${index === milestones.length - 1 ? 'rounded-b-lg' : ''} hover:bg-white transition duration-150 ease-in-out`}>
+            <div className="space-y-2">
+              <div className="flex items-center space-x-3">
+                <span className={`${milestone.isOverdue ? 'text-red-500' : 'text-gray-400'}`}>
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"></path>
+                  </svg>
+                </span>
+                <a href="#" className="text-sm font-medium text-blue-600 hover:underline underline-offset-2 decoration-blue-300">{milestone.title}</a>
+              </div>
+              <div className="flex items-center justify-between text-sm text-gray-500 pl-8">
+                <div className="flex space-x-4">
+                  <span>Due {milestone.dueDate}</span>
+                  <span className="flex items-center">
+                    <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
+                    </svg>
+                    {milestone.commentCount}
+                  </span>
+                  <span className="flex items-center">
+                    <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 3.055A9.001 9.001 0 1020.945 13H11V3.055z"></path>
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20.488 9H15V3.512A9.025 9.025 0 0120.488 9z"></path>
+                    </svg>
+                    {milestone.pendingTasks} pending tasks
+                  </span>
+                </div>
+              </div>
+              {milestone.description && (
+                <p className="text-sm text-gray-600 line-clamp-2 pl-8">{milestone.description}</p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/assets/js/pages/ProjectPage/page.tsx
+++ b/assets/js/pages/ProjectPage/page.tsx
@@ -296,6 +296,11 @@ function ResourcesListv2() {
             </div>
           </li>
         </ul>
+        <div className="mt-2 text-xs text-gray-500 flex justify-end items-center space-x-2 mr-2">
+          <span>Showing 3 most recent</span>
+          <span>•</span>
+          <a href="#" className="text-link-base hover:text-link-hover">View all</a>
+        </div>
       </dd>
     </div>
   )

--- a/assets/js/pages/ProjectPage/page.tsx
+++ b/assets/js/pages/ProjectPage/page.tsx
@@ -9,7 +9,7 @@ import Header from "./Header";
 import Overview from "./Overview";
 import Timeline from "./Timeline";
 import Navigation from "./Navigation";
-import { GhostButton } from "@/components/Button";
+import Button, { GhostButton } from "@/components/Button";
 
 import FormattedTime from "@/components/FormattedTime";
 import Avatar from "@/components/Avatar";
@@ -71,7 +71,7 @@ export function Page() {
             <div className="border-t border-stroke-base py-6">
               <div className="flex items-start gap-4">
                 <div className="w-1/5">
-                  <div className="font-bold text-sm">Timeline</div>
+                  <div className="font-bold text-sm"><a href="" className="text-black underline underline-offset-2 hover:text-link-hover transition-colors">Timeline</a></div>
 
                   <div className="text-sm">
                     {showEditMilestones(project) && (
@@ -90,10 +90,12 @@ export function Page() {
 
             <CheckInSection project={project} />
 
+            <MessageBoard />
+
             <div className="border-t border-stroke-base py-6">
               <div className="flex items-start gap-4">
                 <div className="w-1/5">
-                  <div className="font-bold text-sm">Resources</div>
+                  <div className="font-bold text-sm"><a href="" className="text-black hover:text-link-hover underline">Resources</a> (4)</div>
 
                   <div className="text-sm">
                     {showEditResource(project) && (
@@ -135,9 +137,7 @@ function LastCheckIn({ project }) {
 
   const checkInNowLink = (
     <div className="flex">
-      <GhostButton linkTo={newCheckInPath} testId="check-in-now" size="xs" type="secondary">
-        Check-In Now
-      </GhostButton>
+      <ButtonSecondaryRounded title="Check-in now" url={newCheckInPath} />
     </div>
   );
 
@@ -197,9 +197,10 @@ function LastCheckIn({ project }) {
 
 function Resources({ project }) {
   if (project.keyResources.length === 0) {
-    return <ResourcesZeroState project={project} />;
+    return <ResourcesListv2 />;
+    //return <ResourcesZeroState project={project} />;
   } else {
-    return <ResourcesList project={project} />;
+    return <ResourcesListv2 />;
   }
 }
 
@@ -207,14 +208,12 @@ function ResourcesZeroState({ project }) {
   const editPath = Paths.projectEditResourcesPath(project.id!);
 
   const editLink = (
-    <GhostButton linkTo={editPath} testId="add-resources-link" size="xs" type="secondary">
-      Add Resources
-    </GhostButton>
+    <ButtonSecondaryRounded title="Add Resources" url={editPath} />
   );
 
   return (
     <div className="text-sm">
-      No resources have been added yet.
+      Store and organize files, rich text documents, and links to external resources.
       {project.permissions.canEditResources && <div className="mt-2 flex">{editLink}</div>}
     </div>
   );
@@ -233,6 +232,73 @@ function ResourcesList({ project }: { project: Projects.Project }) {
       ))}
     </div>
   );
+}
+
+function ResourcesListv2() {
+  return (
+    <div className="px-4 pb-6 sm:grid sm:gap-4 sm:px-0">
+      <dd className="mt-2 text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+        <ul role="list" className="divide-y divide-gray-100 rounded-md border border-gray-200">
+          <li className="flex items-center justify-between py-4 pl-4 pr-5 text-sm leading-6">
+            <div className="flex w-0 flex-1 items-center">
+            <span className="w-4 h-4 text-gray-600"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+</svg>
+</span>
+              <div className="ml-4 flex min-w-0 flex-1 gap-2">
+                <span className="truncate font-medium">
+                  <a href="" className="text-black hover:underline">Budget v2</a>
+                </span>
+                <span className="flex-shrink-0 text-gray-400">Google Spreadsheet</span>
+              </div>
+            </div>
+            <div className="ml-4 flex-shrink-0">
+              <a href="#" className="font-medium text-link-base hover:text-link-hover">
+                Open
+              </a>
+            </div>
+          </li>
+          <li className="flex items-center justify-between py-4 pl-4 pr-5 text-sm leading-6">
+            <div className="flex w-0 flex-1 items-center">
+            <span className="w-4 h-4 text-gray-600"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
+</svg></span>
+              <div className="ml-4 flex min-w-0 flex-1 gap-2">
+                <span className="truncate font-medium">
+                  <a href="" className="text-black hover:underline">how_to_win_friends_and_influence_people.pdf</a>
+                </span>
+                <span className="flex-shrink-0 text-gray-400">4.5mb</span>
+              </div>
+            </div>
+            <div className="ml-4 flex-shrink-0">
+              <a href="#" className="font-medium text-link-base hover:text-link-hover">
+                Download
+              </a>
+            </div>
+          </li>
+          <li className="flex items-center justify-between py-4 pl-4 pr-5 text-sm leading-6">
+            <div className="flex w-0 flex-1 items-center">
+            <span className="w-4 h-4 text-gray-600"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+</svg>
+</span>
+              <div className="ml-4 flex min-w-0 flex-1 gap-2">
+                <span className="truncate font-medium">
+                  <a href="" className="text-black hover:underline">Project Iteration #5 Brief</a>
+                </span>
+                <span className="flex-shrink-0 text-gray-400">doc</span>
+              </div>
+            </div>
+            <div className="ml-4 flex-shrink-0">
+              <a href="#" className="font-medium text-link-base hover:text-link-hover">
+                Open
+              </a>
+            </div>
+          </li>
+        </ul>
+      </dd>
+    </div>
+  )
 }
 
 function Resource({ icon, title, href }) {
@@ -288,14 +354,12 @@ function DescriptionZeroState({ project }) {
   const writePath = Paths.projectEditDescriptionPath(project.id!);
 
   const editLink = (
-    <GhostButton linkTo={writePath} testId="write-project-description-link" size="xs" type="secondary">
-      Write project description
-    </GhostButton>
+    <ButtonSecondaryRounded title="Write project description" url={writePath} />
   );
 
   return (
     <div className="text-sm">
-      Project description is not yet set.
+      Describe your project to provide context and clarity.
       {project.permissions.canEditDescription && <div className="mt-2 flex">{editLink}</div>}
     </div>
   );
@@ -323,12 +387,13 @@ function showEditMilestones(project: Projects.Project) {
   return milestones.length > 0;
 }
 
+
 function CheckInSection({ project }) {
   return (
     <div className="border-t border-stroke-base py-6">
       <div className="flex items-start gap-4">
         <div className="w-1/5">
-          <div className="font-bold text-sm">Check-Ins</div>
+          <div className="font-bold text-sm"><a href="" className="text-black underline underline-offset-2 hover:text-link-hover transition-colors">Check-Ins</a> (3)</div>
           {project.lastCheckIn && (
             <div className="text-sm">
               <Link to={Paths.projectCheckInsPath(project.id!)}>View all</Link>
@@ -336,10 +401,213 @@ function CheckInSection({ project }) {
           )}
         </div>
 
-        <div className="w-4/5">
+        <div className="w-">
           <LastCheckIn project={project} />
         </div>
       </div>
     </div>
   );
+}
+
+function MessageBoard() {
+  return (
+    <div className="border-t border-stroke-base py-6">
+      <div className="flex items-start gap-4">
+        <div className="w-1/5">
+          <div className="font-bold text-sm mb-6">
+            <a href="" className="text-black underline underline-offset-2 hover:text-link-hover transition-colors">Message Board</a> (5)
+          </div>
+        </div>
+
+        <div className="w-4/5">
+          <Discussions />
+          <div className="flex flex-col items-start gap-2 mb-4">
+            <ButtonSecondaryRounded title="Write a new message" url="" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CircleWithNumber({totalComments}) {
+  return (
+    <div className="w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center">
+      <span className="text-white-1 text-xs font-bold">{totalComments}</span>
+    </div>
+  );
+}
+
+function ButtonSecondaryRounded({title, url}) {
+  return (
+    <a href={url} class="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">{title}</a>
+  );
+}
+
+const discussions = [
+  {
+    id: 1,
+    title: 'Atque perspiciatis et et aut ut porro voluptatem blanditiis?',
+    href: '#',
+    author: { name: 'Leslie A.', href: '#' },
+    date: '2d ago',
+    dateTime: '2023-01-23T22:34Z',
+    status: 'active',
+    totalComments: 24,
+    commenters: [
+      {
+        id: 12,
+        name: 'Emma Dorsey',
+        imageUrl:
+          'https://images.unsplash.com/photo-1505840717430-882ce147ef2d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 6,
+        name: 'Tom Cook',
+        imageUrl:
+          'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 4,
+        name: 'Lindsay Walton',
+        imageUrl:
+          'https://images.unsplash.com/photo-1517841905240-472988babdf9?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 16,
+        name: 'Benjamin Russel',
+        imageUrl:
+          'https://images.unsplash.com/photo-1531427186611-ecfd6d936c79?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 23,
+        name: 'Hector Gibbons',
+        imageUrl:
+          'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+    ],
+  },
+  {
+    id: 2,
+    title: 'Et ratione distinctio nesciunt recusandae vel ab?',
+    href: '#',
+    author: { name: 'Michael F.', href: '#' },
+    date: '2d ago',
+    dateTime: '2023-01-23T19:20Z',
+    status: 'active',
+    totalComments: 6,
+    commenters: [
+      {
+        id: 13,
+        name: 'Alicia Bell',
+        imageUrl:
+          'https://images.unsplash.com/photo-1509783236416-c9ad59bae472?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 16,
+        name: 'Benjamin Russel',
+        imageUrl:
+          'https://images.unsplash.com/photo-1531427186611-ecfd6d936c79?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 3,
+        name: 'Dries Vincent',
+        imageUrl:
+          'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+    ],
+  },
+  {
+    id: 3,
+    title: 'Blanditiis perferendis fugiat optio dolor minus ut?',
+    href: '#',
+    author: { name: 'Dries V.', href: '#' },
+    date: '3d ago',
+    dateTime: '2023-01-22T12:59Z',
+    status: 'resolved',
+    totalComments: 22,
+    commenters: [
+      {
+        id: 19,
+        name: 'Lawrence Hunter',
+        imageUrl:
+          'https://images.unsplash.com/photo-1513910367299-bce8d8a0ebf6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 21,
+        name: 'Angela Fisher',
+        imageUrl:
+          'https://images.unsplash.com/photo-1501031170107-cfd33f0cbdcc?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 14,
+        name: 'Jenny Wilson',
+        imageUrl:
+          'https://images.unsplash.com/photo-1507101105822-7472b28e22ac?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+      {
+        id: 16,
+        name: 'Benjamin Russel',
+        imageUrl:
+          'https://images.unsplash.com/photo-1531427186611-ecfd6d936c79?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80',
+      },
+    ],
+  }
+]
+
+export default function Discussions() {
+  return (
+    <ul role="list" className="divide-y divide-gray-100">
+      {discussions.map((discussion) => (
+        <li
+          key={discussion.id}
+          className="flex flex-wrap items-center justify-between gap-x-6 gap-y-4 pb-5 sm:flex-nowrap"
+        >
+          <div>
+            <p className="text-sm font-semibold leading-6 text-gray-900">
+              <a href={discussion.href} className="text-link-base underline underline-offset-2 hover:text-link-hover transition-colors">
+                {discussion.title}
+              </a>
+            </p>
+            <p className="mt-1 text-sm leading-6 text-gray-700">
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+            <div className="mt-1 flex items-center gap-x-2 text-xs leading-5 text-gray-500">
+              <p>
+                <a href={discussion.author.href} className="hover:underline">
+                  {discussion.author.name}
+                </a>
+              </p>
+              <svg viewBox="0 0 2 2" className="h-0.5 w-0.5 fill-current">
+                <circle r={1} cx={1} cy={1} />
+              </svg>
+              <p>
+                <time dateTime={discussion.dateTime}>{discussion.date}</time>
+              </p>
+            </div>
+          </div>
+          <dl className="flex w-full flex-none justify-between gap-x-8 sm:w-auto">
+            <div className="flex -space-x-0.5">
+              <dt className="sr-only">Commenters</dt>
+              {discussion.commenters.map((commenter) => (
+                <dd key={commenter.id}>
+                  <img
+                    alt={commenter.name}
+                    src={commenter.imageUrl}
+                    className="h-6 w-6 rounded-full bg-gray-50 ring-2 ring-white"
+                  />
+                </dd>
+              ))}
+            </div>
+            <div className="flex w-16 gap-x-2.5">
+              <dt>
+                <span className="sr-only">Total comments</span>
+              </dt>
+              <dd className="text-sm leading-6 text-gray-900"><CircleWithNumber totalComments={discussion.totalComments} /></dd>
+            </div>
+          </dl>
+        </li>
+      ))}
+    </ul>
+  )
 }


### PR DESCRIPTION
This branch is for reference, not to be merged.

Contains a modification of the project page to serve as a mockup for #598 and #813.

what's new/different:
- added message board
- resources as a mix of files, docs, links
- milestones redesigned
- using (x) numbers next to things to communicate how alive/large a project is and eliminate "View all" links
- replaced zero state copy from neutral/negative to positive/descriptive (eg. "No milestones defined yet." → "Outline your project timeline with milestones.")
- replaced secondary buttons with those from Tailwind UI package. this is a tiny step in the direction of reusing well developed components from an established system instead of reinventing the wheel.

![image](https://github.com/user-attachments/assets/938b5470-1be9-4c02-95b3-fac1f86925bd)
