### PR TITLE
chore: Implement wait for db and create db in Elixir

### DIFF
--- a/lib/operately/release.ex
+++ b/lib/operately/release.ex
@@ -5,24 +5,57 @@ defmodule Operately.Release do
   """
   @app :operately
 
-  def migrate do
-    load_app()
+  def create_db do
+    IO.write("Waiting for database to be ready ")
+    :ok = wait_until_db_ready(attempts: 10, timeout: 1000)
 
-    for repo <- repos() do
-      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    IO.puts("Creating database")
+    case repo().__adapter__.storage_up(repo().config) do
+      :ok -> :ok
+      {:error, :already_up} -> :ok
+      {:error, term} -> raise term
     end
   end
 
-  def rollback(repo, version) do
+  def migrate do
+    IO.puts("Running migrations")
     load_app()
-    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo(), &Ecto.Migrator.run(&1, :up, all: true))
   end
 
-  defp repos do
-    Application.fetch_env!(@app, :ecto_repos)
+  def rollback(version) do
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo(), &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  #
+  # Private
+  #
+
+  defp repo do
+    Application.fetch_env!(@app, :ecto_repos) |> hd()
   end
 
   defp load_app do
     Application.load(@app)
+  end
+
+  def wait_until_db_ready(attempts: attempts, timeout: timeout) do
+    host = Keyword.get(repo().config, :hostname) |> String.to_charlist()
+    port = Keyword.get(repo().config, :port) || 5432
+
+    if attempts > 0 do
+      case :gen_tcp.connect(host, port, []) do
+        {:ok, _} -> 
+          IO.puts("")
+          :ok
+        {:error, _error} -> 
+          IO.write(".")
+          :timer.sleep(timeout)
+          wait_until_db_ready(attempts: attempts - 1, timeout: timeout)
+      end
+    else
+      :timeout
+    end
   end
 end

--- a/rel/overlays/bin/create_db
+++ b/rel/overlays/bin/create_db
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+exec ./operately eval Operately.Release.create_db


### PR DESCRIPTION
So far this was done with postgres specific tools manually. With these additions the create_db and migrate can be part of the docker compose entry point.

The entry point I have in mind (for next PR) is:

```
#/bin/sh

/app/bin/create_db
/app/bin/migrate
/app/bin/server
```

The create_db has a built in mechanism to wait for the postgres server to fully boot up.