### PR TITLE
feat: Add CompanyAdminRemoving operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -140,6 +140,11 @@ export interface ActivityContentCompanyAdminAdded {
   people?: Person[] | null;
 }
 
+export interface ActivityContentCompanyAdminRemoved {
+  company?: Company | null;
+  person?: Person | null;
+}
+
 export interface ActivityContentDiscussionCommentSubmitted {
   spaceId?: string | null;
   discussionId?: string | null;

--- a/assets/js/features/activities/CompanyAdminRemoved/index.tsx
+++ b/assets/js/features/activities/CompanyAdminRemoved/index.tsx
@@ -1,0 +1,60 @@
+import { Activity, ActivityContentCompanyAdminRemoved } from "@/api";
+import { ActivityHandler } from "../interfaces";
+import { feedTitle } from "../feedItemLinks";
+import { Paths } from "@/routes/paths";
+import { firstName } from "@/models/people";
+
+
+const SpaceMembersAdded: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(): string {
+    return Paths.orgChartPath();
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity; page: any }) {
+    const name = firstName(content(activity).person!);
+
+    return feedTitle(activity, `has revoked ${name}'s admin privileges`);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return firstName(activity.author!) + " has revoked your admin privileges"
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).company!.name!;
+  },
+};
+
+export default SpaceMembersAdded;
+
+function content(activity: Activity): ActivityContentCompanyAdminRemoved {
+  return activity.content as ActivityContentCompanyAdminRemoved;
+}

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -62,6 +62,7 @@ export default ActivityHandler;
 export const DISPLAYED_IN_FEED = [
   "comment_added",
   "company_admin_added",
+  "company_admin_removed",
   "discussion_posting",
   "goal_archived",
   "goal_check_in",
@@ -104,6 +105,7 @@ import { match } from "ts-pattern";
 
 import CommentAdded from "@/features/activities/CommentAdded";
 import CompanyAdminAdded from "@/features/activities/CompanyAdminAdded";
+import CompanyAdminRemoved from "@/features/activities/CompanyAdminRemoved";
 import DiscussionPosting from "@/features/activities/DiscussionPosting";
 import DiscussionCommentSubmitted from "@/features/activities/DiscussionCommentSubmitted";
 import GoalArchived from "@/features/activities/GoalArchived";
@@ -138,6 +140,7 @@ function handler(activity: Activity) {
   return match(activity.action)
     .with("comment_added", () => CommentAdded)
     .with("company_admin_added", () => CompanyAdminAdded)
+    .with("company_admin_removed", () => CompanyAdminRemoved)
     .with("discussion_posting", () => DiscussionPosting)
     .with("discussion_comment_submitted", () => DiscussionCommentSubmitted)
     .with("goal_archived", () => GoalArchived)

--- a/lib/operately/activities/content/company_admin_removed.ex
+++ b/lib/operately/activities/content/company_admin_removed.ex
@@ -1,0 +1,18 @@
+defmodule Operately.Activities.Content.CompanyAdminRemoved do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :person, Operately.People.Person
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -21,6 +21,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
 
   @company_actions [
     "company_admin_added",
+    "company_admin_removed",
     "company_member_removed",
     "password_first_time_changed",
     "company_invitation_token_created",

--- a/lib/operately/activities/notifications/company_admin_removed.ex
+++ b/lib/operately/activities/notifications/company_admin_removed.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.CompanyAdminRemoved do
+  def dispatch(_activity) do
+    # Notification dispatcher for CompanyAdminRemoved not implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/activities/notifications/company_admin_removed.ex
+++ b/lib/operately/activities/notifications/company_admin_removed.ex
@@ -1,6 +1,11 @@
 defmodule Operately.Activities.Notifications.CompanyAdminRemoved do
-  def dispatch(_activity) do
-    # Notification dispatcher for CompanyAdminRemoved not implemented yet
-    {:ok, []}
+  def dispatch(activity) do
+    Operately.Notifications.bulk_create([
+      %{
+        person_id: activity.content["person_id"],
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    ])
   end
 end

--- a/lib/operately/operations/company_admin_removing.ex
+++ b/lib/operately/operations/company_admin_removing.ex
@@ -10,6 +10,7 @@ defmodule Operately.Operations.CompanyAdminRemoving do
     |> insert_member_permissions(admin)
     |> insert_activity(admin)
     |> Repo.transaction()
+    |> Repo.extract_result(:person)
   end
 
   defp update_person(multi, person_id) do

--- a/lib/operately/operations/company_admin_removing.ex
+++ b/lib/operately/operations/company_admin_removing.ex
@@ -1,0 +1,76 @@
+defmodule Operately.Operations.CompanyAdminRemoving do
+  alias Ecto.Multi
+  alias Operately.{Repo, Access, Activities, People}
+  alias Operately.People.Person
+
+  def run(%Person{company_role: :admin} = admin, person_id) do
+    Multi.new()
+    |> update_person(person_id)
+    |> remove_admin_permissions(admin)
+    |> insert_member_permissions(admin)
+    |> insert_activity(admin)
+    |> Repo.transaction()
+  end
+
+  defp update_person(multi, person_id) do
+    multi
+    |> Multi.run(:person, fn _, _ ->
+      {:ok, People.get_person!(person_id)}
+    end)
+    |> Multi.update(:updated_person, fn %{person: person} ->
+      Person.changeset(person, %{company_role: :member})
+    end)
+  end
+
+  defp remove_admin_permissions(multi, admin) do
+    multi
+    |> Multi.run(:admins_group, fn _, _ ->
+      {:ok, Access.get_group!(company_id: admin.company_id, tag: :full_access)}
+    end)
+    |> Multi.run(:admins_membership, fn _, changes ->
+      maybe_delete_membership(changes.admins_group.id, changes.person.id)
+    end)
+  end
+
+  defp insert_member_permissions(multi, admin) do
+    multi
+    |> Multi.run(:members_group, fn _, _ ->
+      {:ok, Access.get_group!(company_id: admin.company_id, tag: :standard)}
+    end)
+    |> Multi.run(:members_membership, fn _, changes ->
+      maybe_create_membership(changes.members_group.id, changes.person.id)
+    end)
+  end
+
+  defp insert_activity(multi, admin) do
+    multi
+    |> Activities.insert_sync(admin.id, :company_admin_removed, fn %{person: person} ->
+      %{
+        company_id: person.company_id,
+        person_id: person.id,
+      }
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp maybe_create_membership(group_id, person_id) do
+    case Access.get_group_membership(group_id: group_id, person_id: person_id) do
+      nil ->
+        Access.create_group_membership(%{group_id: group_id, person_id: person_id})
+      membership ->
+        {:ok, membership}
+    end
+  end
+
+  defp maybe_delete_membership(group_id, person_id) do
+    case Access.get_group_membership(group_id: group_id, person_id: person_id) do
+      nil ->
+        {:ok, nil}
+      membership ->
+        Access.delete_group_membership(membership)
+    end
+  end
+end

--- a/lib/operately_email/emails/company_admin_removed_email.ex
+++ b/lib/operately_email/emails/company_admin_removed_email.ex
@@ -1,0 +1,21 @@
+defmodule OperatelyEmail.Emails.CompanyAdminRemovedEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+
+  def send(person, activity) do
+    activity = Repo.preload(activity, [author: :company])
+    author = activity.author
+    company = author.company
+    link = Paths.home_path(company) |> Paths.to_url()
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: company.name, who: author, action: "revoked your admin privileges")
+    |> assign(:author, author)
+    |> assign(:link, link)
+    |> render("company_admin_removed")
+  end
+end

--- a/lib/operately_email/templates/company_admin_removed.html.eex
+++ b/lib/operately_email/templates/company_admin_removed.html.eex
@@ -1,0 +1,7 @@
+<%= title("Your admin privileges have been revoked by #{short_name(@author)}") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@link, "View Company") %>
+<% end %>

--- a/lib/operately_email/templates/company_admin_removed.text.eex
+++ b/lib/operately_email/templates/company_admin_removed.text.eex
@@ -1,0 +1,3 @@
+Your admin privileges have been revoked by <%=  short_name(@author) %>.
+
+Link: <%= @link %>

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -59,8 +59,15 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
 
   def serialize_content("company_admin_added", content) do
     %{
-      company: serialize_company(content["company"]),
+      company: OperatelyWeb.Api.Serializer.serialize(content["company"], level: :essential),
       people: content["people"]
+    }
+  end
+
+  def serialize_content("company_admin_removed", content) do
+    %{
+      company: OperatelyWeb.Api.Serializer.serialize(content["company"], level: :essential),
+      person: OperatelyWeb.Api.Serializer.serialize(content["person"], level: :essential),
     }
   end
 
@@ -388,13 +395,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
       id: goal.id,
       name: goal.name,
       my_role: goal.my_role,
-    }
-  end
-
-  def serialize_company(company) do
-    %{
-      id: OperatelyWeb.Paths.company_id(company),
-      name: company.name,
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -817,6 +817,11 @@ defmodule OperatelyWeb.Api.Types do
     field :people, list_of(:person)
   end
 
+  object :activity_content_company_admin_removed do
+    field :company, :company
+    field :person, :person
+  end
+
   object :activity_content_project_renamed do
     field :project, :project
     field :old_name, :string

--- a/test/features/first_time_setup_test.exs
+++ b/test/features/first_time_setup_test.exs
@@ -43,7 +43,7 @@ defmodule Operately.Features.FirstTimeSetupTest do
     |> UI.fill(testid: "password", with: @company_info[:password])
     |> UI.fill(testid: "password-confirmation", with: @company_info[:passwordConfirmation])
     |> UI.click(testid: "submit-form")
-    |> UI.assert_page("/accounts/log_in")
+    |> UI.assert_page("/")
 
     account = Operately.People.get_account_by_email_and_password(@company_info[:email], @company_info[:password])
 

--- a/test/operately/operations/company_admin_removing_test.exs
+++ b/test/operately/operations/company_admin_removing_test.exs
@@ -1,0 +1,60 @@
+defmodule Operately.Operations.CompanyAdminRemovingTest do
+  use Operately.DataCase
+  # use Operately.Support.Notifications
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Access
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    company_creator = Operately.Companies.list_admins(company.id) |> hd()
+    admin = person_fixture_with_account(%{company_id: company.id, company_role: :admin})
+
+    {:ok, company: company, admin: admin, member: company_creator}
+  end
+
+  test "CompanyAdminRemoving operation updates admin to member", ctx do
+    assert ctx.member.company_role == :admin
+
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+
+    member = Repo.reload(ctx.member)
+    assert member.company_role == :member
+  end
+
+  test "CompanyAdminRemoving operation removes membership with admins group", ctx do
+    group = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
+
+    assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+
+    refute Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+  end
+
+  test "CompanyAdminRemoving operation adds membership with members group if it doesn't exist", ctx do
+    group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    {:ok, _} = Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+      |> Access.delete_group_membership()
+
+    refute Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
+  end
+
+  test "CompanyAdminRemoving operation creates activity", ctx do
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+
+    activity = from(a in Activity, where: a.action == "company_admin_removed" and a.content["company_id"] == ^ctx.company.id) |> Repo.one()
+
+    assert activity.author_id == ctx.admin.id
+    assert activity.content["person_id"] == ctx.member.id
+  end
+end


### PR DESCRIPTION
I've added the `Operately.Operations.CompanyAdminRemoving` operation which:

- Removes a person's admin status
- Revokes their admin privileges
- Sends them a notification
- Adds a record to the company feed