### PR TITLE
feat: Add permissions filter to AddCompanyAdmins mutation

### DIFF
--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -85,29 +85,8 @@ defmodule Operately.Companies do
     end
   end
 
-  def add_admin(admin, person_id) do
-    person = Operately.People.get_person!(person_id)
-
-    cond do
-      person == nil ->
-        {:error, "Person not found"}
-
-      admin.company_role != :admin ->
-        {:error, "Only admins can add other admins"}
-
-      admin.company_id != person.company_id ->
-        {:error, "Person is not in the same company"}
-
-      true ->
-        {:ok, _} = Operately.People.update_person(person, %{company_role: :admin})
-    end
-  end
-
-  def add_admins(admin, people_ids) do
-    Enum.map(people_ids, fn person_id ->
-      add_admin(admin, person_id)
-    end)
-  end
+  def add_admin(admin, person_id), do: add_admins(admin, [person_id])
+  defdelegate add_admins(admin, people_ids), to: Operately.Operations.CompanyAdminAdding, as: :run
 
   def add_trusted_email_domain(company, admin, domain) do
     cond do

--- a/lib/operately_web/api/mutations/add_company_admins.ex
+++ b/lib/operately_web/api/mutations/add_company_admins.ex
@@ -2,14 +2,28 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyAdmins do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_full_access: 2]
+
+  alias Operately.Companies.Company
+
   inputs do
     field :people_ids, list_of(:string)
   end
 
   def call(conn, inputs) do
     {:ok, ids} = decode_id(inputs.people_ids)
-    Operately.Companies.add_admins(me(conn), ids)
 
-    {:ok, %{}}
+    if has_permissions?(me(conn), company(conn)) do
+      {:ok, _} = Operately.Operations.CompanyAdminAdding.run(me(conn), ids)
+      {:ok, %{}}
+    else
+      {:error, :forbidden}
+    end
+  end
+
+  defp has_permissions?(person, company) do
+    from(c in Company, where: c.id == ^company.id)
+    |> filter_by_full_access(person.id)
+    |> Repo.exists?()
   end
 end

--- a/test/features/company_admin_test.exs
+++ b/test/features/company_admin_test.exs
@@ -8,13 +8,7 @@ defmodule Operately.Features.CompanyAdminTest do
 
   setup ctx do
     company = company_fixture(%{name: "Dunder Mifflin"})
-
-    admin = person_fixture_with_account(%{
-      full_name: "Dwight Schrute",
-      company_id: company.id,
-      title: "Assistant to the Regional Manager",
-      company_role: "admin"
-    })
+    admin = Operately.Companies.list_admins(company.id) |> hd()
 
     ctx = Map.put(ctx, :company, company)
     ctx = Map.put(ctx, :admin, admin)
@@ -65,8 +59,9 @@ defmodule Operately.Features.CompanyAdminTest do
 
     ctx
     |> UI.click(testid: "manage-company-administrators")
+    |> UI.assert_text("Michael Scott")
     |> UI.click(testid: "remove-michael-scott")
-    |> UI.sleep(300)
+    |> UI.refute_text("Michael Scott", attempts: [50, 150, 250, 400])
 
     person = Operately.People.get_person_by_name!(ctx.company, "Michael Scott")
 
@@ -93,8 +88,9 @@ defmodule Operately.Features.CompanyAdminTest do
 
     ctx
     |> UI.click(testid: "manage-trusted-email-domains")
+    |> UI.assert_text("@dmif.com")
     |> UI.click(testid: "remove-trusted-email-domain--dmif-com")
-    |> UI.sleep(300)
+    |> UI.refute_text("@dmif.com", attempts: [50, 150, 250, 400])
 
     company = Operately.Companies.get_company!(ctx.company.id)
 
@@ -103,13 +99,14 @@ defmodule Operately.Features.CompanyAdminTest do
   end
 
   feature "remove members from the company", ctx do
+    person_fixture(%{full_name: "Dwight Schrute", company_id: ctx.company.id})
+
     ctx
     |> UI.click(testid: "add-remove-people-manually")
     |> UI.assert_text("Dwight Schrute")
     |> UI.click(testid: "remove-dwight-schrute")
     |> UI.click(testid: "remove-member")
-    |> UI.sleep(300)
-    |> UI.refute_text("Dwight Schrute")
+    |> UI.refute_text("Dwight Schrute", attempts: [50, 150, 250, 400])
 
     person = Operately.People.get_person_by_name!(ctx.company, "Dwight Schrute")
 

--- a/test/operately_web/api/mutations/add_company_admins_test.exs
+++ b/test/operately_web/api/mutations/add_company_admins_test.exs
@@ -1,3 +1,79 @@
 defmodule OperatelyWeb.Api.Mutations.AddCompanyAdminsTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+
+  alias OperatelyWeb.Paths
+  alias Operately.Repo
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :add_company_admins, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup :register_and_log_in_account
+
+    test "company members without full access can't add admins", ctx do
+      person = person_fixture(%{company_id: ctx.company.id})
+
+      assert {403, res} = mutation(ctx.conn, :add_company_admins, %{
+        people_ids: [Paths.person_id(person)],
+      })
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with full access can add admins", ctx do
+      person = person_fixture(%{company_id: ctx.company.id})
+      account = Repo.preload(ctx.company_creator, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      refute person.company_role == :admin
+
+      assert {200, _} = mutation(conn, :add_company_admins, %{
+        people_ids: [Paths.person_id(ctx.person)],
+      })
+
+      person = Repo.reload(ctx.person)
+      assert person.company_role == :admin
+    end
+  end
+
+  describe "add_company_admins functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      account = Repo.preload(ctx.company_creator, :account).account
+
+      %{ctx | conn: log_in_account(ctx.conn, account)}
+    end
+
+    test "adds one admin", ctx do
+      refute ctx.person.company_role == :admin
+
+      assert {200, _} = mutation(ctx.conn, :add_company_admins, %{
+        people_ids: [Paths.person_id(ctx.person)],
+      })
+
+      person = Repo.reload(ctx.person)
+      assert person.company_role == :admin
+    end
+
+    test "adds multiple members", ctx do
+      people = Enum.map(1..3, fn _ -> person_fixture(%{company_id: ctx.company.id}) end)
+
+      Enum.each(people, fn p ->
+        refute p.company_role == :admin
+      end)
+
+      assert {200, _} = mutation(ctx.conn, :add_company_admins, %{
+        people_ids: Enum.map(people, &(Paths.person_id(&1))),
+      })
+
+      Enum.each(people, fn p ->
+        person = Repo.reload(p)
+        assert person.company_role == :admin
+      end)
+    end
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.AddCompanyAdmins` mutation.