### PR TITLE
feat: Add permissions filter to AcknowledgeGoalProgressUpdate mutation

### DIFF
--- a/lib/operately_web/api/mutations/acknowledge_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/acknowledge_goal_progress_update.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdate do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [forbidden_or_not_found: 3]
+
   inputs do
     field :id, :string
   end
@@ -11,11 +13,31 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdate do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.id)
     person = me(conn)
-    update = Operately.Updates.get_update!(id)
+    {:ok, id} = decode_id(inputs.id)
 
-    {:ok, update} = Operately.Updates.acknowledge_update(person, update)
-    {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(update)}}
+    case load_update(person.id, id) do
+      nil ->
+        query(id)
+        |> forbidden_or_not_found(person.id, named_binding: :goal)
+
+      update ->
+        {:ok, update} = Operately.Updates.acknowledge_update(person, update)
+        {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(update)}}
+    end
+  end
+
+  defp load_update(person_id, update_id) do
+    q = query(update_id)
+
+    from([goal: goal] in q, where: goal.reviewer_id == ^person_id)
+    |> Repo.one()
+  end
+
+  defp query(update_id) do
+    from(u in Operately.Updates.Update,
+      join: g in Operately.Goals.Goal, on: u.updatable_id == g.id, as: :goal,
+      where: u.id == ^update_id
+    )
   end
 end

--- a/test/operately_web/api/mutations/acknowledge_goal_check_in_test.exs
+++ b/test/operately_web/api/mutations/acknowledge_goal_check_in_test.exs
@@ -1,3 +1,0 @@
-defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalCheckInTest do
-  use OperatelyWeb.ConnCase
-end 

--- a/test/operately_web/api/mutations/acknowledge_goal_progress_update_test.exs
+++ b/test/operately_web/api/mutations/acknowledge_goal_progress_update_test.exs
@@ -1,0 +1,129 @@
+defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdateTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.GoalsFixtures
+  import Operately.UpdatesFixtures
+
+  alias OperatelyWeb.Paths
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :acknowledge_goal_progress_update, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator, space_id: space.id})
+    end
+
+    test "company members without view access can't see an update", ctx do
+      update = create_update(ctx, company_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, update)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members can't acknowledge an update", ctx do
+      update = create_update(ctx, company_access_level: Binding.edit_access())
+
+      assert {403, res} = request(ctx.conn, update)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members without view access can't see an update", ctx do
+      add_person_to_space(ctx)
+      update = create_update(ctx, space_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, update)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space members can't acknowledge an update", ctx do
+      add_person_to_space(ctx)
+      update = create_update(ctx, space_access_level: Binding.edit_access())
+
+      assert {403, res} = request(ctx.conn, update)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "champion can't acknowledge an update", ctx do
+      update = create_update(ctx, champion_id: ctx.person.id)
+
+      assert {403, res} = request(ctx.conn, update)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "reviewers can acknowledge an update", ctx do
+      update = create_update(ctx, reviewer_id: ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, update)
+      assert_response(res, update)
+    end
+  end
+
+  describe "acknowledge_goal_progress_update functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    test "acknowledges goal update", ctx do
+      update = create_update(ctx, reviewer_id: ctx.person.id)
+
+      refute update.acknowledged
+      refute update.acknowledged_at
+      refute update.acknowledging_person_id
+
+      assert {200, res} = mutation(ctx.conn, :acknowledge_goal_progress_update, %{id: Paths.goal_update_id(update)})
+      assert_response(res, update)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, update) do
+    mutation(conn, :acknowledge_goal_progress_update, %{id: Paths.goal_update_id(update)})
+  end
+
+  defp assert_response(res, update) do
+    update = Repo.reload(update)
+
+    assert update.acknowledged
+    assert update.acknowledged_at
+    assert update.acknowledging_person_id
+    assert res.update == Serializer.serialize(update)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_update(ctx, opts) do
+    goal = goal_fixture(ctx.creator, Enum.into(opts, %{
+      space_id: ctx[:space_id] || ctx.company.company_space_id,
+      company_access_level: Keyword.get(opts, :company_access_level, Binding.no_access()),
+      space_access_level: Keyword.get(opts, :space_access_level, Binding.no_access()),
+    }))
+    update_fixture(%{type: :goal_check_in, updatable_id: goal.id, updatable_type: :goal, author_id: ctx.creator.id})
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdate` mutation.