### PR TITLE
chore: Add logs around assigning contexts to track which one failed

### DIFF
--- a/lib/operately/data/change_013_create_activities_access_context.ex
+++ b/lib/operately/data/change_013_create_activities_access_context.ex
@@ -97,6 +97,8 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
   end
 
   defp assign_context(activity) do
+    Logger.info("Assigning access context to activity: #{activity.id}")
+
     cond do
       activity.action in Activity.deprecated_actions() -> :ok
       activity.action in @company_actions -> assign_company_context(activity)


### PR DESCRIPTION
One of the activities is failing to be converted. This is the first step in the fix: to add a bit more logging around the problem.