### PR TITLE
fix: Migration for assigning context to activities

### DIFF
--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -51,7 +51,6 @@ defmodule Operately.Activities.ContextAutoAssigner do
 
     # exceptions
     "group_edited",
-    "goal_reparent",
   ]
 
   @goal_actions [
@@ -66,6 +65,9 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "goal_editing",
     "goal_reopening",
     "goal_timeframe_editing",
+
+    # exceptions
+    "goal_reparent",
   ]
 
   @project_actions [
@@ -112,7 +114,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
       activity.action in @deprecated_actions -> :ok
       activity.action in @company_actions -> fetch_company_context(activity.content.company_id)
       activity.action in @space_actions -> fetch_space_context(activity)
-      activity.action in @goal_actions -> fetch_goal_context(activity.content.goal_id)
+      activity.action in @goal_actions -> fetch_goal_context(activity.content)
       activity.action in @project_actions -> fetch_project_context(activity.content.project_id)
       activity.action in @task_actions -> fetch_task_project_context(activity.content.task_id)
       activity.action == "comment_added" -> fetch_comment_added_context(activity)
@@ -149,6 +151,9 @@ defmodule Operately.Activities.ContextAutoAssigner do
     |> Repo.one()
   end
 
+
+  defp fetch_goal_context(%{new_parent_goal_id: goal_id}), do: fetch_goal_context(goal_id)
+  defp fetch_goal_context(%{goal_id: goal_id}), do: fetch_goal_context(goal_id)
   defp fetch_goal_context(goal_id) do
     from(c in Context,
       join: g in assoc(c, :goal),

--- a/lib/operately/data/change_013_create_activities_access_context.ex
+++ b/lib/operately/data/change_013_create_activities_access_context.ex
@@ -48,7 +48,6 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
 
     # exceptions
     "group_edited",
-    "goal_reparent",
   ]
 
   @goal_actions [
@@ -105,6 +104,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
       activity.action in @project_actions -> assign_project_context(activity, activity.content.project_id)
       activity.action in @task_actions -> assign_task_project_context(activity)
       activity.action == "comment_added" -> assign_context_to_comment_added(activity)
+      activity.action == "goal_reparent" -> assign_goal_context(activity, activity.content.new_parent_goal_id)
       true ->
         Logger.error("Unhandled activity: #{inspect(activity)}")
         raise "Activity not handled in the data migration #{activity.action}"
@@ -124,8 +124,6 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContext do
     space_id = case activity.action do
       "group_edited" ->
         activity.content.group_id
-      "goal_reparent" ->
-        activity.content.new_parent_goal_id
       _ ->
         activity.content.space_id
     end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -214,20 +214,20 @@ defmodule Operately.AccessActivityContextAssignerTest do
       create_activity(attrs)
       |> assert_context_assigned(ctx.group.access_context.id)
     end
+  end
 
+  describe "assigns access_context to goal activities" do
     test "goal_reparent action", ctx do
       attrs = %{
         action: "goal_reparent",
         author_id: ctx.author.id,
-        content: %{ new_parent_goal_id: ctx.group.id, company_id: "-", old_parent_goal_id: "-" }
+        content: %{ new_parent_goal_id: ctx.goal.id, company_id: "-", old_parent_goal_id: "-" }
       }
 
       create_activity(attrs)
-      |> assert_context_assigned(ctx.group.access_context.id)
+      |> assert_context_assigned(ctx.goal.access_context.id)
     end
-  end
 
-  describe "assigns access_context to goal activities" do
     test "goal_check_in action", ctx do
       attrs = %{
         action: "goal_check_in",

--- a/test/operately/data/change_013_create_activities_access_context_test.exs
+++ b/test/operately/data/change_013_create_activities_access_context_test.exs
@@ -270,21 +270,6 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContextTest do
       |> assign_activity_context
       |> assert_context_assigned(ctx.group.access_context.id)
     end
-
-    test "goal_reparent action", ctx do
-      attrs = %{
-        action: "goal_reparent",
-        author_id: ctx.author.id,
-        content: %{
-          new_parent_goal_id: ctx.group.id,
-        }
-      }
-
-      create_activities(attrs)
-      |> assert_no_context
-      |> assign_activity_context
-      |> assert_context_assigned(ctx.group.access_context.id)
-    end
   end
 
   describe "assigns access_context to goal activities" do
@@ -295,6 +280,22 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContextTest do
       goal = Repo.preload(goal, :access_context)
 
       Map.merge(ctx, %{goal: goal})
+    end
+
+    test "goal_reparent action", ctx do
+      attrs = %{
+        action: "goal_reparent",
+        author_id: ctx.author.id,
+        content: %{
+          company_id: ctx.company.id,
+          new_parent_goal_id: ctx.goal.id,
+        }
+      }
+
+      create_activities(attrs)
+      |> assert_no_context
+      |> assign_activity_context
+      |> assert_context_assigned(ctx.goal.access_context.id)
     end
 
     test "goal_check_in action", ctx do


### PR DESCRIPTION
The `goal_reparent` activity was being treated as a `space` activity by both the migration 13 and the activity context auto assigner. Now it's treated as as a `goal` activity.