### PR TITLE
feat: Add permissions filter to AddCompanyMember mutation

### DIFF
--- a/test/features/invite_member_test.exs
+++ b/test/features/invite_member_test.exs
@@ -5,15 +5,18 @@ defmodule Operately.Features.InviteMemberTest do
   import Operately.PeopleFixtures
   import Operately.InvitationsFixtures
 
+  alias Operately.Companies
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.InviteMemberSteps, as: Steps
 
   setup ctx do
     company = company_fixture()
-    admin = person_fixture_with_account(%{company_id: company.id, full_name: "John Admin", company_role: :admin})
-    ctx = Map.merge(ctx, %{company: company, admin: admin})
+    creator = hd(Companies.list_admins(company.id))
 
-    {:ok, ctx}
+    admin = person_fixture_with_account(%{company_id: company.id, full_name: "John Admin"})
+    Companies.add_admin(creator, admin.id)
+
+    Map.merge(ctx, %{company: company, admin: admin})
   end
 
   @new_member %{

--- a/test/operately/data/change_025_populate_account_full_name_test.exs
+++ b/test/operately/data/change_025_populate_account_full_name_test.exs
@@ -1,4 +1,4 @@
-defmodule Operately.Data.Change024RemovePrivateProjectsBindingsTest do
+defmodule Operately.Data.Change025PopulateAccountFullNameTest do
   use Operately.DataCase
 
   import Operately.CompaniesFixtures

--- a/test/operately_web/api/mutations/add_company_member_test.exs
+++ b/test/operately_web/api/mutations/add_company_member_test.exs
@@ -12,12 +12,12 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyMemberTest do
       assert {401, _} = mutation(ctx.conn, :add_company_member, %{})
     end
 
-    test "member account can't invite other members", ctx do
+    test "member account without full access can't invite other members", ctx do
       ctx = register_and_log_in_account(ctx)
 
-      assert {400, res} = mutation(ctx.conn, :add_company_member, @add_company_member_input)
+      assert {403, res} = mutation(ctx.conn, :add_company_member, @add_company_member_input)
 
-      assert res == %{:error => "Bad request", :message => "Only admins can add members"}
+      assert res == %{:error => "Forbidden", :message => "You don't have permission to perform this action"}
     end
   end
 
@@ -54,7 +54,7 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyMemberTest do
   end
 
   defp promote_to_admin(ctx) do
-    {:ok, person} = Operately.People.update_person(ctx.person, %{company_role: :admin})
-    %{ctx | person: person}
+    {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+    ctx
   end
-end 
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.AddCompanyMember` mutation.