### PR TITLE
feat: Add permissions filter to RemoveCompanyAdmin mutation

### DIFF
--- a/lib/operately/companies.ex
+++ b/lib/operately/companies.ex
@@ -64,26 +64,7 @@ defmodule Operately.Companies do
     Repo.all(from p in Person, where: p.company_role == :admin and p.company_id == ^company_id and not p.suspended)
   end
 
-  def remove_admin(admin, person_id) do
-    person = Operately.People.get_person!(person_id)
-
-    cond do
-      person == nil ->
-        {:error, "Person not found"}
-
-      admin.id == person.id ->
-        {:error, "Admins cannot remove themselves"}
-
-      admin.company_role != :admin ->
-        {:error, "Only admins can remove other admins"}
-
-      admin.company_id != person.company_id ->
-        {:error, "Person is not in the same company"}
-
-      true ->
-        Operately.People.update_person(person, %{company_role: :member})
-    end
-  end
+  defdelegate remove_admin(admin, person), to: Operately.Operations.CompanyAdminRemoving, as: :run
 
   def add_admin(admin, person_id), do: add_admins(admin, [person_id])
   defdelegate add_admins(admin, people_ids), to: Operately.Operations.CompanyAdminAdding, as: :run

--- a/lib/operately/operations/company_admin_removing.ex
+++ b/lib/operately/operations/company_admin_removing.ex
@@ -1,11 +1,11 @@
 defmodule Operately.Operations.CompanyAdminRemoving do
   alias Ecto.Multi
-  alias Operately.{Repo, Access, Activities, People}
+  alias Operately.{Repo, Access, Activities}
   alias Operately.People.Person
 
-  def run(%Person{company_role: :admin} = admin, person_id) do
+  def run(%Person{company_role: :admin} = admin, person) do
     Multi.new()
-    |> update_person(person_id)
+    |> update_person(person)
     |> remove_admin_permissions(admin)
     |> insert_member_permissions(admin)
     |> insert_activity(admin)
@@ -13,12 +13,9 @@ defmodule Operately.Operations.CompanyAdminRemoving do
     |> Repo.extract_result(:person)
   end
 
-  defp update_person(multi, person_id) do
+  defp update_person(multi, person) do
     multi
-    |> Multi.run(:person, fn _, _ ->
-      {:ok, People.get_person!(person_id)}
-    end)
-    |> Multi.update(:updated_person, fn %{person: person} ->
+    |> Multi.update(:person, fn _ ->
       Person.changeset(person, %{company_role: :member})
     end)
   end

--- a/lib/operately_web/api/mutations/remove_company_admin.ex
+++ b/lib/operately_web/api/mutations/remove_company_admin.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.RemoveCompanyAdmin do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_full_access: 3, forbidden_or_not_found: 3]
+
   inputs do
     field :person_id, :string
   end
@@ -11,8 +13,34 @@ defmodule OperatelyWeb.Api.Mutations.RemoveCompanyAdmin do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.person_id)
-    {:ok, person} = Operately.Companies.remove_admin(me(conn), id)
-    {:ok, %{person: Serializer.serialize(person)}}
+    author = me(conn)
+    {:ok, person_id} = decode_id(inputs.person_id)
+
+    case load_person(author, person_id) do
+      {:error, reason, message} ->
+        {:error, reason, message}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      person ->
+        {:ok, person} = Operately.Operations.CompanyAdminRemoving.run(me(conn), person)
+        {:ok, %{person: Serializer.serialize(person)}}
+    end
+  end
+
+  defp load_person(author, person_id) when author.id == person_id do
+    {:error, :bad_request, "Admins cannot remove themselves"}
+  end
+
+  defp load_person(author, person_id) do
+    query = from(p in Operately.People.Person, where: p.id == ^person_id)
+
+    person = filter_by_full_access(query, author.id, join_parent: :company) |> Repo.one()
+
+    case person do
+      nil -> forbidden_or_not_found(query, author.id, join_parent: :company)
+      person -> person
+    end
   end
 end

--- a/test/operately/operations/company_admin_removing_test.exs
+++ b/test/operately/operations/company_admin_removing_test.exs
@@ -19,7 +19,7 @@ defmodule Operately.Operations.CompanyAdminRemovingTest do
   test "CompanyAdminRemoving operation updates admin to member", ctx do
     assert ctx.member.company_role == :admin
 
-    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
 
     member = Repo.reload(ctx.member)
     assert member.company_role == :member
@@ -30,7 +30,7 @@ defmodule Operately.Operations.CompanyAdminRemovingTest do
 
     assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
 
-    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
 
     refute Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
   end
@@ -42,15 +42,15 @@ defmodule Operately.Operations.CompanyAdminRemovingTest do
 
     refute Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
 
-    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
     assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
 
-    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
     assert Access.get_group_membership(group_id: group.id, person_id: ctx.member.id)
   end
 
   test "CompanyAdminRemoving operation creates activity", ctx do
-    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+    {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
 
     activity = from(a in Activity, where: a.action == "company_admin_removed" and a.content["company_id"] == ^ctx.company.id) |> Repo.one()
 
@@ -60,7 +60,7 @@ defmodule Operately.Operations.CompanyAdminRemovingTest do
 
   test "CompanyAdminAdding operation creates notification", ctx do
     Oban.Testing.with_testing_mode(:manual, fn ->
-      {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member.id)
+      {:ok, _} = Operately.Operations.CompanyAdminRemoving.run(ctx.admin, ctx.member)
     end)
 
     activity = from(a in Activity, where: a.action == "company_admin_removed" and a.content["company_id"] == ^ctx.company.id) |> Repo.one()

--- a/test/operately_web/api/mutations/remove_company_admin_test.exs
+++ b/test/operately_web/api/mutations/remove_company_admin_test.exs
@@ -1,3 +1,94 @@
 defmodule OperatelyWeb.Api.Mutations.RemoveCompanyAdminTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias OperatelyWeb.Paths
+  alias Operately.Companies
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :remove_company_admin, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      admin = person_fixture_with_account(%{company_id: ctx.company.id})
+
+      Companies.add_admins(ctx.company_creator, [ctx.person.id, admin.id])
+
+      Map.merge(ctx, %{admin: admin})
+    end
+
+    test "company members without full access can't add admins", ctx do
+      Companies.remove_admin(ctx.company_creator, ctx.person)
+      assert {403, res} = request(ctx.conn, ctx.admin)
+
+      assert res.message == "You don't have permission to perform this action"
+      assert_is_admin(ctx.company, ctx.admin)
+    end
+
+    test "company admins can remove other admins", ctx do
+      assert {200, res} = request(ctx.conn, ctx.admin)
+
+      assert res.person == Serializer.serialize(ctx.admin)
+      refute_is_admin(ctx.company, ctx.admin)
+    end
+
+    test "admins from other companies are not found", ctx do
+      company = company_fixture()
+      admin = hd(Companies.list_admins(company.id))
+
+      assert {404, res} = request(ctx.conn, admin)
+      assert res.message == "The requested resource was not found"
+    end
+  end
+
+  describe "remove_company_admin functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      admin = person_fixture_with_account(%{company_id: ctx.company.id})
+
+      Companies.add_admins(ctx.company_creator, [ctx.person.id, admin.id])
+
+      Map.merge(ctx, %{admin: admin})
+    end
+
+    test "removes admin", ctx do
+      assert_is_admin(ctx.company, ctx.admin)
+
+      assert {200, res} = request(ctx.conn, ctx.admin)
+
+      assert res.person == Serializer.serialize(ctx.admin)
+      refute_is_admin(ctx.company, ctx.admin)
+    end
+
+    test "admins can't remove themselves", ctx do
+      assert {400, res} = request(ctx.conn, ctx.person)
+
+      assert res == %{error: "Bad request", message: "Admins cannot remove themselves"}
+      assert_is_admin(ctx.company, ctx.person)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, person) do
+    mutation(conn, :remove_company_admin, %{person_id: Paths.person_id(person)})
+  end
+
+  defp assert_is_admin(company, person) do
+    admins = Companies.list_admins(company.id)
+    assert Enum.find(admins, &(&1.id == person.id))
+  end
+
+  defp refute_is_admin(company, person) do
+    admins = Companies.list_admins(company.id)
+    refute Enum.find(admins, &(&1.id == person.id))
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.RemoveCompanyAdmin` mutation.