### PR TITLE
feat: Add permissions filter to CloseGoal mutation

### DIFF
--- a/lib/operately/operations/goal_closing.ex
+++ b/lib/operately/operations/goal_closing.ex
@@ -5,9 +5,7 @@ defmodule Operately.Operations.GoalClosing do
   alias Operately.Activities
   alias Operately.Comments.CommentThread
 
-  def run(author, goal_id, success, retrospective) do
-    goal = Goals.get_goal!(goal_id)
-
+  def run(author, goal, success, retrospective) do
     changeset = Goals.Goal.changeset(goal, %{
       closed_at: DateTime.utc_now(),
       closed_by_id: author.id,
@@ -20,7 +18,7 @@ defmodule Operately.Operations.GoalClosing do
       %{
         company_id: author.company_id,
         space_id: goal.group_id,
-        goal_id: goal_id,
+        goal_id: goal.id,
         success: success
       }
     end, include_notification: false)

--- a/lib/operately_web/api/mutations/close_goal.ex
+++ b/lib/operately_web/api/mutations/close_goal.ex
@@ -2,6 +2,10 @@ defmodule OperatelyWeb.Api.Mutations.CloseGoal do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_full_access: 2, forbidden_or_not_found: 2]
+
+  alias Operately.Repo
+
   inputs do
     field :goal_id, :string
     field :success, :string
@@ -15,8 +19,25 @@ defmodule OperatelyWeb.Api.Mutations.CloseGoal do
   def call(conn, inputs) do
     author = me(conn)
     {:ok, goal_id} = decode_id(inputs.goal_id)
-    {:ok, goal} = Operately.Operations.GoalClosing.run(author, goal_id, inputs.success, inputs.retrospective)
 
-    {:ok, %{goal: OperatelyWeb.Api.Serializer.serialize(goal)}}
+    case load_goal(author, goal_id) do
+      nil ->
+        query(goal_id)
+        |> forbidden_or_not_found(author.id)
+
+      goal ->
+        {:ok, goal} = Operately.Operations.GoalClosing.run(author, goal, inputs.success, inputs.retrospective)
+        {:ok, %{goal: OperatelyWeb.Api.Serializer.serialize(goal)}}
+    end
+  end
+
+  defp load_goal(author, goal_id) do
+    query(goal_id)
+    |> filter_by_full_access(author.id)
+    |> Repo.one()
+  end
+
+  defp query(goal_id) do
+    from(g in Operately.Goals.Goal, where: g.id == ^goal_id)
   end
 end

--- a/test/operately/operations/goal_closing_test.exs
+++ b/test/operately/operations/goal_closing_test.exs
@@ -33,7 +33,7 @@ defmodule Operately.Operations.GoalClosingTest do
     assert ctx.goal.closed_by_id == nil
 
     Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal, "success", "{}")
     end)
 
     goal = Repo.reload(ctx.goal)
@@ -44,7 +44,7 @@ defmodule Operately.Operations.GoalClosingTest do
 
   test "GoalClosing operation creates activity, thread and notification", ctx do
     Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal.id, "success", "{}")
+      Operately.Operations.GoalClosing.run(ctx.author, ctx.goal, "success", "{}")
     end)
 
     activity = from(a in Activity, where: a.action == "goal_closing" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()

--- a/test/operately_web/api/mutations/close_goal_test.exs
+++ b/test/operately_web/api/mutations/close_goal_test.exs
@@ -1,3 +1,206 @@
 defmodule OperatelyWeb.Api.Mutations.CloseGoalTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.Support.RichText
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.GoalsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+  alias OperatelyWeb.Paths
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :close_goal, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator, space_id: space.id})
+    end
+
+    test "company members without view access can't see a goal", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, goal)
+      assert res.message == "The requested resource was not found"
+      refute_goal_closed(goal)
+    end
+
+    test "company members without full access can't close a goal", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.edit_access())
+
+      assert {403, res} = request(ctx.conn, goal)
+      assert res.message == "You don't have permission to perform this action"
+      refute_goal_closed(goal)
+    end
+
+    test "company members with full access can close a goal", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.full_access())
+
+      assert {200, _} = request(ctx.conn, goal)
+      assert_goal_closed(goal, ctx.person)
+    end
+
+    test "company admins can close a goal", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.view_access())
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, goal)
+      refute_goal_closed(goal)
+
+      # Admin
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, _} = request(ctx.conn, goal)
+      assert_goal_closed(goal, ctx.person)
+    end
+
+    test "space members without view access can't see a goal", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, goal)
+      assert res.message == "The requested resource was not found"
+      refute_goal_closed(goal)
+    end
+
+    test "space members without full access can't close a goal", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, goal)
+      assert res.message == "You don't have permission to perform this action"
+      refute_goal_closed(goal)
+    end
+
+    test "space members with full access can close a goal", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.full_access())
+
+      assert {200, _} = request(ctx.conn, goal)
+      assert_goal_closed(goal, ctx.person)
+    end
+
+    test "space managers can close a goal", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.view_access())
+
+      # Not manager
+      assert {403, _} = request(ctx.conn, goal)
+      refute_goal_closed(goal)
+
+      # Manager
+      add_manager_to_space(ctx)
+      assert {200, _} = request(ctx.conn, goal)
+      assert_goal_closed(goal, ctx.person)
+    end
+
+    test "champions can close a goal", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx, champion_id: champion.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, goal)
+      refute_goal_closed(goal)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, goal)
+      assert_goal_closed(goal, champion)
+    end
+
+    test "reviewers can close a goal", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx, reviewer_id: reviewer.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, goal)
+      refute_goal_closed(goal)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, goal)
+      assert_goal_closed(goal, reviewer)
+    end
+  end
+
+  describe "close_goal functionality" do
+    setup :register_and_log_in_account
+
+    test "closes goal", ctx do
+      goal = create_goal(ctx)
+
+      refute_goal_closed(goal)
+
+      assert {200, res} = request(ctx.conn, goal)
+
+      assert_goal_closed(goal, ctx.person)
+      assert res.goal == Serializer.serialize(goal)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, goal) do
+    mutation(conn, :close_goal, %{
+      goal_id: Paths.goal_id(goal),
+      success: "yes",
+      retrospective: rich_text("result") |> Jason.encode!(),
+    })
+  end
+
+  defp refute_goal_closed(goal) do
+    goal = Repo.reload(goal)
+
+    refute goal.closed_at
+    refute goal.closed_by_id
+    refute goal.success
+  end
+
+  defp assert_goal_closed(goal, author) do
+    goal = Repo.reload(goal)
+
+    assert goal.closed_at
+    assert goal.success
+    assert goal.closed_by_id == author.id
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_goal(ctx, attrs \\ %{}) do
+    goal_fixture(ctx[:creator] || ctx.person, Enum.into(attrs, %{
+      space_id: ctx[:space_id] || ctx.company.company_space_id,
+      company_access_level: Binding.no_access(),
+      space_access_level: Binding.no_access(),
+    }))
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp add_manager_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.full_access(),
+    }])
+  end
+end

--- a/test/operately_web/api/queries/get_goal_test.exs
+++ b/test/operately_web/api/queries/get_goal_test.exs
@@ -158,7 +158,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalTest do
       assert res.goal.closed_by == nil
 
       retrospective = Jason.encode!(RichText.rich_text("Writing a retrospective"))
-      {:ok, goal} = Operately.Operations.GoalClosing.run(ctx.person, goal.id, "success", retrospective)
+      {:ok, goal} = Operately.Operations.GoalClosing.run(ctx.person, goal, "success", retrospective)
 
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal), include_closed_by: true})
       assert res.goal.closed_by == serialize(ctx.person, level: :essential)


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.CloseGoal` mutation.