### PR TITLE
feat: Add permissions filter to DisconnectGoalFromProject mutation

### DIFF
--- a/lib/operately/operations/project_goal_disconnection.ex
+++ b/lib/operately/operations/project_goal_disconnection.ex
@@ -3,7 +3,7 @@ defmodule Operately.Operations.ProjectGoalDisconnection do
   alias Operately.Activities
   alias Operately.Repo
 
-  def run(person, project, goal) do
+  def run(person, project) do
     project_changeset = Operately.Projects.change_project(project, %{
       goal_id: nil
     })
@@ -13,7 +13,7 @@ defmodule Operately.Operations.ProjectGoalDisconnection do
     |> Activities.insert_sync(person.id, :project_goal_disconnection, fn _ -> %{
       company_id: person.company_id,
       project_id: project.id,
-      goal_id: goal.id
+      goal_id: project.goal_id
     } end)
     |> Repo.transaction()
     |> Repo.extract_result(:project)

--- a/lib/operately_web/api/mutations/disconnect_goal_from_project.ex
+++ b/lib/operately_web/api/mutations/disconnect_goal_from_project.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.DisconnectGoalFromProject do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_edit_access: 2, forbidden_or_not_found: 2]
+
   inputs do
     field :project_id, :string
     field :goal_id, :string
@@ -14,12 +16,25 @@ defmodule OperatelyWeb.Api.Mutations.DisconnectGoalFromProject do
   def call(conn, inputs) do
     person = me(conn)
     {:ok, project_id} = decode_id(inputs.project_id)
-    {:ok, goal_id} = decode_id(inputs.goal_id)
 
-    project = Operately.Projects.get_project!(project_id)
-    goal = Operately.Goals.get_goal!(goal_id)
+    case load_project(person, project_id) do
+      nil ->
+        query(project_id)
+        |> forbidden_or_not_found(person.id)
 
-    {:ok, project} = Operately.Operations.ProjectGoalDisconnection.run(person, project, goal)
-    {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(project)}}
+      project ->
+        {:ok, project} = Operately.Operations.ProjectGoalDisconnection.run(person, project)
+        {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(project)}}
+    end
+  end
+
+  defp load_project(person, project_id) do
+    query(project_id)
+    |> filter_by_edit_access(person.id)
+    |> Repo.one()
+  end
+
+  defp query(project_id) do
+    from(p in Operately.Projects.Project, where: p.id == ^project_id)
   end
 end

--- a/test/operately/operations/project_goal_disconnection_test.exs
+++ b/test/operately/operations/project_goal_disconnection_test.exs
@@ -31,7 +31,7 @@ defmodule Operately.Operations.ProjectGoalDisconnectionTest do
   test "ProjectGoalDisconnection operation updates project.goal_id to nil", ctx do
     assert ctx.project.goal_id == ctx.goal.id
 
-    Operately.Operations.ProjectGoalDisconnection.run(ctx.creator, ctx.project, ctx.goal)
+    Operately.Operations.ProjectGoalDisconnection.run(ctx.creator, ctx.project)
 
     project = Repo.reload(ctx.project)
 
@@ -40,7 +40,7 @@ defmodule Operately.Operations.ProjectGoalDisconnectionTest do
 
   test "ProjectGoalDisconnection operation creates activity and notification", ctx do
     Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.ProjectGoalDisconnection.run(ctx.creator, ctx.project, ctx.goal)
+      Operately.Operations.ProjectGoalDisconnection.run(ctx.creator, ctx.project)
     end)
 
     activity = from(a in Activity, where: a.action == "project_goal_disconnection" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()

--- a/test/operately_web/api/mutations/disconnect_goal_from_project_test.exs
+++ b/test/operately_web/api/mutations/disconnect_goal_from_project_test.exs
@@ -1,3 +1,250 @@
 defmodule OperatelyWeb.Api.Mutations.DisconnectGoalFromProjectTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.GoalsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :disconnect_goal_from_project, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator, creator_id: creator.id, space_id: space.id})
+    end
+
+    test "company members without view access can't see a project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, company_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, project, goal)
+      assert res.message == "The requested resource was not found"
+      refute_goal_disconnected(project, goal)
+    end
+
+    test "company members without edit access can't disconnect goal from project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, company_access_level: Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, project, goal)
+      assert res.message == "You don't have permission to perform this action"
+      refute_goal_disconnected(project, goal)
+    end
+
+    test "company members with edit access can disconnect goal from project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, company_access_level: Binding.edit_access())
+
+      assert {200, _} = request(ctx.conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "company admins can disconnect goal from project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, company_access_level: Binding.view_access())
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, project, goal)
+      refute_goal_disconnected(project, goal)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, _} = request(ctx.conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "space members without view access can't see a project", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, space_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, project, goal)
+      assert res.message == "The requested resource was not found"
+      refute_goal_disconnected(project, goal)
+    end
+
+    test "space members without edit access can't disconnect goal from project", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, space_access_level: Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, project, goal)
+      assert res.message == "You don't have permission to perform this action"
+      refute_goal_disconnected(project, goal)
+    end
+
+    test "space members with edit access can disconnect goal from project", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, space_access_level: Binding.edit_access())
+
+      assert {200, _} = request(ctx.conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "space managers can disconnect goal from project", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, space_access_level: Binding.view_access())
+
+      # Not manager
+      assert {403, _} = request(ctx.conn, project, goal)
+      refute_goal_disconnected(project, goal)
+
+      # Manager
+      add_manager_to_space(ctx)
+      assert {200, _} = request(ctx.conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "contributors without edit access can't disconnect goal from project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id)
+      contributor = create_contributor(ctx, project, Binding.comment_access())
+
+      account = Repo.preload(contributor, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {403, res} = request(conn, project, goal)
+      assert res.message == "You don't have permission to perform this action"
+      refute_goal_disconnected(project, goal)
+    end
+
+    test "contributors with edit access can disconnect goal from project", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id)
+      contributor = create_contributor(ctx, project, Binding.edit_access())
+
+      account = Repo.preload(contributor, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "champions can disconnect goal from project", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, champion_id: champion.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, project, goal)
+      refute_goal_disconnected(project, goal)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+
+    test "reviewers can disconnect goal from project", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id, reviewer_id: reviewer.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, project, goal)
+      refute_goal_disconnected(project, goal)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, project, goal)
+      assert_goal_disconnected(project)
+    end
+  end
+
+  describe "disconnect_goal_from_project functionality" do
+    setup :register_and_log_in_account
+
+    test "disconnects goal", ctx do
+      goal = create_goal(ctx)
+      project = create_project(ctx, goal_id: goal.id)
+
+      assert {200, res} = request(ctx.conn, project, goal)
+
+      assert res.project == Serializer.serialize(project)
+      assert_goal_disconnected(project)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, project, goal) do
+    mutation(conn, :disconnect_goal_from_project, %{
+      project_id: Paths.project_id(project),
+      goal_id: Paths.goal_id(goal),
+    })
+  end
+
+  defp assert_goal_disconnected(project) do
+    project = Repo.reload(project)
+    refute project.goal_id
+  end
+
+  defp refute_goal_disconnected(project, goal) do
+    project = Repo.reload(project)
+    assert project.goal_id == goal.id
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project(ctx, attrs) do
+    project_fixture(Enum.into(attrs, %{
+      company_id: ctx.company.id,
+      creator_id: ctx[:creator_id] || ctx.person.id,
+      group_id: ctx[:space_id] || ctx.company.company_space_id,
+      company_access_level: Binding.no_access(),
+      space_access_level: Binding.no_access(),
+    }))
+  end
+
+  defp create_goal(ctx) do
+    goal_fixture(ctx.person, %{space_id: ctx.company.company_space_id})
+  end
+
+  defp create_contributor(ctx, project, permissions) do
+    contributor = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    {:ok, _} = Operately.Projects.create_contributor(ctx.creator, %{
+      project_id: project.id,
+      person_id: contributor.id,
+      responsibility: "some responsibility",
+      permissions: permissions,
+    })
+    contributor
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp add_manager_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.full_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.DisconnectGoalFromProject` mutation.