### PR TITLE
feat: Add permissions filter to CreateGroup mutation

### DIFF
--- a/lib/operately_web/api/mutations/create_group.ex
+++ b/lib/operately_web/api/mutations/create_group.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateGroup do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters, only: [filter_by_full_access: 2]
+
   inputs do
     field :name, :string
     field :mission, :string
@@ -17,7 +19,19 @@ defmodule OperatelyWeb.Api.Mutations.CreateGroup do
   end
 
   def call(conn, inputs) do
-    {:ok, group} = Operately.Groups.create_group(me(conn), inputs)
-    {:ok, %{group: Serializer.serialize(group, level: :essential)}}
+    author = me(conn)
+
+    if has_permissions?(author) do
+      {:ok, group} = Operately.Groups.create_group(author, inputs)
+      {:ok, %{group: Serializer.serialize(group, level: :essential)}}
+    else
+      {:error, :forbidden}
+    end
+  end
+
+  defp has_permissions?(person) do
+    from(c in Operately.Companies.Company, where: c.id == ^person.company_id)
+    |> filter_by_full_access(person.id)
+    |> Repo.exists?()
   end
 end

--- a/test/operately_web/api/mutations/create_group_test.exs
+++ b/test/operately_web/api/mutations/create_group_test.exs
@@ -1,3 +1,82 @@
 defmodule OperatelyWeb.Api.Mutations.CreateGroupTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :create_group, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup :register_and_log_in_account
+
+    test "company members without full access can't create space", ctx do
+      assert {403, res} = request(ctx.conn)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with full access can create space", ctx do
+      give_person_full_access(ctx)
+
+      assert {200, res} = request(ctx.conn)
+      assert_space_created(res)
+    end
+
+    test "company admins can create space", ctx do
+      # Not admin
+      assert {403, _} = request(ctx.conn)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn)
+      assert_space_created(res)
+    end
+  end
+
+  describe "create_group functionality" do
+    setup :register_and_log_in_account
+
+    test "creates space", ctx do
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn)
+      assert_space_created(res)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn) do
+    mutation(conn, :create_group, %{
+      name: "some name",
+      mission: "some mission",
+      icon: "IconBuildingEstate",
+      color: "text-cyan-500",
+      company_permissions: Binding.view_access(),
+      public_permissions: Binding.no_access(),
+    })
+  end
+
+  defp assert_space_created(res) do
+    {:ok, id} = OperatelyWeb.Api.Helpers.decode_id(res.group.id)
+    assert Operately.Groups.get_group(id)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp give_person_full_access(ctx) do
+    group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    context = Access.get_context!(company_id: ctx.company.id)
+
+    Access.get_binding!(group_id: group.id, context_id: context.id)
+    |> Access.update_binding(%{access_level: Binding.full_access()})
+  end
+end

--- a/test/support/features/space_steps.ex
+++ b/test/support/features/space_steps.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Support.Features.SpaceSteps do
   use Operately.FeatureCase
 
+  alias Operately.Companies
   alias Operately.Support.Features.UI
   alias Operately.Support.Features.NotificationsSteps
   alias Operately.Support.Features.EmailSteps
@@ -11,7 +12,10 @@ defmodule Operately.Support.Features.SpaceSteps do
 
   step :setup, ctx do
     company = company_fixture(%{name: "Test Org"})
+    admin = hd(Companies.list_admins(company.id))
+
     person = person_fixture_with_account(%{full_name: "Kevin Kernel", company_id: company.id})
+    Companies.add_admin(admin, person.id)
 
     ctx = Map.merge(ctx, %{company: company, person: person})
     ctx = UI.login_as(ctx, ctx.person)


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.CreateGroup` mutation.