### PR TITLE
feat: Add permissions filter to PostDiscussion mutation

### DIFF
--- a/lib/operately_web/api/mutations/post_discussion.ex
+++ b/lib/operately_web/api/mutations/post_discussion.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussion do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters
+
   inputs do
     field :space_id, :string
     field :title, :string
@@ -14,13 +16,40 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussion do
 
   def call(conn, inputs) do
     person = me(conn)
-    title = inputs.title
-    body = inputs.body
 
     {:ok, space_id} = decode_id(inputs.space_id)
-    space = Operately.Groups.get_group!(space_id)
 
-    {:ok, discussion} = Operately.Operations.DiscussionPosting.run(person, space, title, body)
-    {:ok, %{discussion: Serializer.serialize(discussion, level: :essential)}}
+    case load_space(person, space_id, is_company_space?(conn, space_id)) do
+      nil ->
+        query(space_id)
+        |> return_error(person, is_company_space?(conn, space_id))
+
+      space ->
+        {:ok, discussion} = Operately.Operations.DiscussionPosting.run(person, space, inputs.title, inputs.body)
+        {:ok, %{discussion: Serializer.serialize(discussion, level: :essential)}}
+    end
+  end
+
+  defp load_space(person, space_id, false) do
+    query(space_id)
+    |> filter_by_edit_access(person.id)
+    |> Repo.one()
+  end
+
+  defp load_space(person, space_id, true) do
+    query(space_id)
+    |> filter_by_edit_access(person.id, join_parent: :company)
+    |> Repo.one()
+  end
+
+  defp return_error(q, person, false), do: forbidden_or_not_found(q, person.id)
+  defp return_error(q, person, true), do: forbidden_or_not_found(q, person.id, join_parent: :company)
+
+  defp query(space_id) do
+    from(s in Operately.Groups.Group, where: s.id == ^space_id)
+  end
+
+  defp is_company_space?(conn, space_id) do
+    company(conn).company_space_id == space_id
   end
 end

--- a/test/operately_web/api/mutations/post_discussion_test.exs
+++ b/test/operately_web/api/mutations/post_discussion_test.exs
@@ -1,3 +1,152 @@
 defmodule OperatelyWeb.Api.Mutations.PostDiscussionTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.Support.RichText
+  import Operately.GroupsFixtures
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :post_discussion, %{})
+    end
+  end
+
+  describe "company permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      space = Operately.Groups.get_group!(ctx.company.company_space_id)
+
+      Map.merge(ctx, %{space: space})
+    end
+
+    test "company member can see only their company", ctx do
+      other_ctx = register_and_log_in_account(ctx)
+
+      assert {404, res} = request(other_ctx.conn, ctx.space)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without edit access can't create discussion", ctx do
+      assert {403, res} = request(ctx.conn, ctx.space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with edit access can create discussion", ctx do
+      give_person_edit_access(ctx)
+
+      assert {200, res} = request(ctx.conn, ctx.space)
+      assert_discussion_created(res)
+    end
+
+    test "company admins can create discussion", ctx do
+      # Not admin
+      assert {403, _} = request(ctx.conn, ctx.space)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, ctx.space)
+      assert_discussion_created(res)
+    end
+  end
+
+  describe "space permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      space = group_fixture(ctx.company_creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{space: space})
+    end
+
+    test "company member without view access can't see space", ctx do
+      assert {404, res} = request(ctx.conn, ctx.space)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space member without edit access can't create discussion", ctx do
+      add_person_to_space(ctx, Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, ctx.space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members with edit access can create discussion", ctx do
+      add_person_to_space(ctx, Binding.edit_access())
+
+      assert {200, res} = request(ctx.conn, ctx.space)
+      assert_discussion_created(res)
+    end
+
+    test "company admins can create discussion", ctx do
+      # Not admin
+      assert {404, _} = request(ctx.conn, ctx.space)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, ctx.space)
+      assert_discussion_created(res)
+    end
+  end
+
+  describe "post_discussion functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      ctx
+    end
+
+    test "creates discussion within space", ctx do
+      space = group_fixture(ctx.company_creator, %{company_id: ctx.company.id})
+
+      assert {200, res} = request(ctx.conn, space)
+      assert_discussion_created(res)
+    end
+
+    test "creates discussion within company", ctx do
+      space = Operately.Groups.get_group!(ctx.company.company_space_id)
+
+      assert {200, res} = request(ctx.conn, space)
+      assert_discussion_created(res)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, space) do
+    mutation(conn, :post_discussion, %{
+      space_id: Paths.space_id(space),
+      title: "Discussion",
+      body: rich_text("Content") |> Jason.encode!(),
+    })
+  end
+
+  defp assert_discussion_created(res) do
+    {:ok, id} = OperatelyWeb.Api.Helpers.decode_id(res.discussion.id)
+    assert Operately.Updates.get_update!(id)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp give_person_edit_access(ctx) do
+    group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    context = Access.get_context!(company_id: ctx.company.id)
+
+    Access.get_binding!(group_id: group.id, context_id: context.id)
+    |> Access.update_binding(%{access_level: Binding.edit_access()})
+  end
+
+  defp add_person_to_space(ctx, access_level) do
+    Operately.Groups.add_members(ctx.person, ctx.space.id, [%{
+      id: ctx.person.id,
+      permissions: access_level,
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.PostDiscussion` mutation.