### PR TITLE
feat: Add permissions filter to EditDiscussion mutation

### DIFF
--- a/lib/operately/operations/discussion_editing.ex
+++ b/lib/operately/operations/discussion_editing.ex
@@ -3,12 +3,11 @@ defmodule Operately.Operations.DiscussionEditing do
   alias Operately.Repo
   alias Operately.Activities
 
-  def run(creator, discussion, title, message) do
-    space = Operately.Groups.get_group!(discussion.updatable_id)
+  def run(creator, discussion, space, attrs) do
     update = Operately.Updates.Update.changeset(discussion, %{
       content: %{
-        title: title,
-        body: Jason.decode!(message)
+        title: attrs.title,
+        body: Jason.decode!(attrs.body)
       }
     })
 

--- a/lib/operately_web/api/mutations/edit_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_discussion.ex
@@ -2,6 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Operately.Access.Filters
+
   inputs do
     field :discussion_id, :string
     field :title, :string
@@ -15,11 +17,39 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
   def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.discussion_id)
     person = me(conn)
-    title = inputs.title
-    body = inputs.body
-    discussion = Operately.Updates.get_update!(id)
+    discussion = %{updatable_id: space_id} = Operately.Updates.get_update!(id)
 
-    {:ok, discussion} = Operately.Operations.DiscussionEditing.run(person, discussion, title, body)
-    {:ok, %{discussion: Serializer.serialize(discussion, level: :essential)}}
+    case load_space(person, space_id, is_company_space?(conn, space_id)) do
+      nil ->
+        query(space_id)
+        |> return_error(person, is_company_space?(conn, space_id))
+
+      space ->
+        {:ok, discussion} = Operately.Operations.DiscussionEditing.run(person, discussion, space, inputs)
+        {:ok, %{discussion: Serializer.serialize(discussion, level: :essential)}}
+    end
+  end
+
+  defp load_space(person, space_id, false) do
+    query(space_id)
+    |> filter_by_edit_access(person.id)
+    |> Repo.one()
+  end
+
+  defp load_space(person, space_id, true) do
+    query(space_id)
+    |> filter_by_edit_access(person.id, join_parent: :company)
+    |> Repo.one()
+  end
+
+  defp return_error(q, person, false), do: forbidden_or_not_found(q, person.id)
+  defp return_error(q, person, true), do: forbidden_or_not_found(q, person.id, join_parent: :company)
+
+  defp query(space_id) do
+    from(s in Operately.Groups.Group, where: s.id == ^space_id)
+  end
+
+  defp is_company_space?(conn, space_id) do
+    company(conn).company_space_id == space_id
   end
 end

--- a/test/operately_web/api/mutations/edit_discussion_test.exs
+++ b/test/operately_web/api/mutations/edit_discussion_test.exs
@@ -1,3 +1,175 @@
 defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.Support.RichText
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.UpdatesFixtures
+
+  alias Operately.{Repo, Access}
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_discussion, %{})
+    end
+  end
+
+  describe "company permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator_id: creator.id})
+    end
+
+    test "company member can see only their company", ctx do
+      other_ctx = register_and_log_in_account(ctx)
+      discussion = create_discussion(ctx)
+
+      assert {404, res} = request(other_ctx.conn, discussion)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without edit access can't edit discussion", ctx do
+      discussion = create_discussion(ctx)
+
+      assert {403, res} = request(ctx.conn, discussion)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with edit access can edit discussion", ctx do
+      give_person_edit_access(ctx)
+      discussion = create_discussion(ctx)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      assert_discussion_edited(discussion)
+    end
+
+    test "company admins can edit discussion", ctx do
+      discussion = create_discussion(ctx)
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, discussion)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      assert_discussion_edited(discussion)
+    end
+  end
+
+  describe "space permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator_id: creator.id, space_id: space.id})
+    end
+
+    test "company member without view access can't see space", ctx do
+      discussion = create_discussion(ctx)
+
+      assert {404, res} = request(ctx.conn, discussion)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space member without edit access can't edit discussion", ctx do
+      discussion = create_discussion(ctx)
+      add_person_to_space(ctx, Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, discussion)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members with edit access can edit discussion", ctx do
+      discussion = create_discussion(ctx)
+      add_person_to_space(ctx, Binding.edit_access())
+
+      assert {200, _} = request(ctx.conn, discussion)
+      assert_discussion_edited(discussion)
+    end
+
+    test "company admins can edit discussion", ctx do
+      discussion = create_discussion(ctx)
+
+      # Not admin
+      assert {404, _} = request(ctx.conn, discussion)
+
+      # Admin
+      {:ok, _} = Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      assert_discussion_edited(discussion)
+    end
+  end
+
+  describe "edit_discussion functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      ctx
+    end
+
+    test "edits discussion", ctx do
+      discussion = create_discussion(ctx)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      assert_discussion_edited(discussion)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, discussion) do
+    mutation(conn, :edit_discussion, %{
+      discussion_id: Paths.discussion_id(discussion),
+      title: "New title",
+      body: rich_text("New body") |> Jason.encode!(),
+    })
+  end
+
+  defp assert_discussion_edited(discussion) do
+    discussion = Repo.reload(discussion)
+
+    assert discussion.content["title"] == "New title"
+    assert discussion.content["body"] == rich_text("New body")
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_discussion(ctx) do
+    update_fixture(%{
+      author_id: ctx[:creator_id] || ctx.person.id,
+      updatable_id: ctx[:space_id] || ctx.company.company_space_id,
+      updatable_type: :space,
+      type: :project_discussion,
+      content: %{
+        title: "Title",
+        body: rich_text("Body")
+      }
+    })
+  end
+
+  defp give_person_edit_access(ctx) do
+    group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    context = Access.get_context!(company_id: ctx.company.id)
+
+    Access.get_binding!(group_id: group.id, context_id: context.id)
+    |> Access.update_binding(%{access_level: Binding.edit_access()})
+  end
+
+  defp add_person_to_space(ctx, access_level) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: access_level,
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.EditDiscussion` mutation.