### PR TITLE
feat: Add permissions filter to EditGoalDiscussion mutation

### DIFF
--- a/lib/operately/operations/goal_discussion_editing.ex
+++ b/lib/operately/operations/goal_discussion_editing.ex
@@ -5,14 +5,11 @@ defmodule Operately.Operations.GoalDiscussionEditing do
 
   @action :goal_discussion_editing
 
-  def run(author, activity_id, title, message) do
-    activity = Operately.Activities.get_activity!(activity_id)
+  def run(author, activity, attrs) do
     goal = Operately.Goals.get_goal!(activity.content["goal_id"])
-    comment_thread = Operately.Comments.get_thread!(activity.comment_thread_id)
-
-    change = Operately.Comments.CommentThread.changeset(comment_thread, %{
-      title: title,
-      message: Jason.decode!(message),
+    change = Operately.Comments.CommentThread.changeset(activity.comment_thread, %{
+      title: attrs.title,
+      message: Jason.decode!(attrs.message),
     })
 
     Multi.new()
@@ -22,7 +19,7 @@ defmodule Operately.Operations.GoalDiscussionEditing do
         company_id: goal.company_id,
         space_id: goal.group_id,
         goal_id: goal.id,
-        activity_id: activity_id,
+        activity_id: activity.id,
       }
     end)
     |> Repo.transaction()

--- a/lib/operately_web/api/mutations/edit_goal_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_goal_discussion.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalDiscussion do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  import Ecto.Query, only: [from: 2, preload: 2]
+  import Operately.Access.Filters, only: [filter_by_edit_access: 2, forbidden_or_not_found: 2]
+
   inputs do
     field :activity_id, :string
     field :title, :string
@@ -11,11 +14,26 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalDiscussion do
   def call(conn, inputs) do
     author = me(conn)
     {:ok, activity_id} = decode_id(inputs.activity_id)
-    title = inputs.title
-    message = inputs.message
 
-    {:ok, _} = Operately.Operations.GoalDiscussionEditing.run(author, activity_id, title, message)
+    case load_activity(author, activity_id) do
+      nil ->
+        query(activity_id)
+        |> forbidden_or_not_found(author.id)
 
-    {:ok, %{}}
+      activity ->
+        {:ok, _} = Operately.Operations.GoalDiscussionEditing.run(author, activity, inputs)
+        {:ok, %{}}
+    end
+  end
+
+  defp load_activity(author, activity_id) do
+    query(activity_id)
+    |> preload(:comment_thread)
+    |> filter_by_edit_access(author.id)
+    |> Repo.one()
+  end
+
+  defp query(activity_id) do
+    from(a in Operately.Activities.Activity, where: a.id == ^activity_id)
   end
 end

--- a/test/operately_web/api/mutations/edit_goal_discussion_test.exs
+++ b/test/operately_web/api/mutations/edit_goal_discussion_test.exs
@@ -1,3 +1,203 @@
 defmodule OperatelyWeb.Api.Mutations.EditGoalDiscussionTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.Support.RichText
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.GoalsFixtures
+
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_goal_discussion, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+      goal = goal_fixture(ctx.person, %{space_id: space.id})
+
+      Map.merge(ctx, %{creator: creator, goal: goal, space_id: space.id})
+    end
+
+    test "company members without view access can't see a goal discussion", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.no_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {404, res} = request(ctx.conn, discussion)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without edit access can't edit a goal discussion", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.comment_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {403, res} = request(ctx.conn, discussion)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with edit access can edit a goal discussion", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.edit_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+
+    test "company admins can edit a goal discussion", ctx do
+      goal = create_goal(ctx, company_access_level: Binding.view_access())
+      discussion = create_discussion(ctx, goal)
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, discussion)
+
+      # Admin
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+
+    test "space members without view access can't see a goal discussion", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.no_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {404, res} = request(ctx.conn, discussion)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space members without edit access can't edit a goal discussion", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.comment_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {403, res} = request(ctx.conn, discussion)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members with edit access can edit a goal discussion", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.edit_access())
+      discussion = create_discussion(ctx, goal)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+
+    test "space managers can edit a goal discussion", ctx do
+      add_person_to_space(ctx)
+      goal = create_goal(ctx, space_access_level: Binding.no_access())
+      discussion = create_discussion(ctx, goal)
+
+      # Not manager
+      assert {404, _} = request(ctx.conn, discussion)
+
+      # Manager
+      add_manager_to_space(ctx)
+      assert {200, _} = request(ctx.conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+
+    test "champions can edit a goal discussion", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx, champion_id: champion.id, company_access_level: Binding.view_access())
+      discussion = create_discussion(ctx, goal)
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, discussion)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+
+    test "reviewers can edit a goal discussion", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      goal = create_goal(ctx, reviewer_id: reviewer.id, company_access_level: Binding.view_access())
+      discussion = create_discussion(ctx, goal)
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, discussion)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, _} = request(conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+  end
+
+  describe "edit_goal_discussion functionality" do
+    setup :register_and_log_in_account
+
+    test "edits a goal discussion", ctx do
+      goal = create_goal(ctx)
+      discussion = create_discussion(ctx, goal)
+
+      assert {200, _} = request(ctx.conn, discussion)
+      asset_discussion_edited(discussion)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, discussion) do
+    discussion = Repo.preload(discussion, :comment_thread)
+
+    mutation(conn, :edit_goal_discussion, %{
+      activity_id: Paths.activity_id(discussion),
+      title: "Edited title",
+      message: rich_text("Edited content") |> Jason.encode!(),
+    })
+  end
+
+  defp asset_discussion_edited(discussion) do
+    discussion = Repo.reload(discussion) |> Repo.preload(:comment_thread)
+
+    assert discussion.comment_thread.title == "Edited title"
+    assert discussion.comment_thread.message == rich_text("Edited content")
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_goal(ctx, attrs \\ []) do
+    goal_fixture(ctx[:creator] || ctx.person, Enum.into(attrs, %{
+      space_id: ctx[:space_id] || ctx.company.company_space_id,
+      company_access_level: Binding.no_access(),
+      space_access_level: Binding.no_access(),
+    }))
+  end
+
+  defp create_discussion(ctx, goal) do
+    content = rich_text("Content") |> Jason.encode!()
+    {:ok, discussion} = Operately.Operations.GoalDiscussionCreation.run(ctx[:creator] || ctx.person, goal, "Title", content)
+    discussion
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp add_manager_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.full_access(),
+    }])
+  end
+end

--- a/test/support/turbo_case.ex
+++ b/test/support/turbo_case.ex
@@ -13,14 +13,15 @@ defmodule OperatelyWeb.TurboCase do
 
       alias OperatelyWeb.Api.Serializer
       alias OperatelyWeb.Paths
+      alias Operately.Repo
     end
   end
 
   setup tags do
     Operately.DataCase.setup_sandbox(tags)
 
-    conn = 
-      Phoenix.ConnTest.build_conn() 
+    conn =
+      Phoenix.ConnTest.build_conn()
       |> Plug.Conn.put_req_header("content-type", "application/json")
 
     {:ok, conn: conn}
@@ -75,5 +76,5 @@ defmodule OperatelyWeb.TurboCase do
   def not_found_response do
     {404, %{error: "Not found", message: "The requested resource was not found"}}
   end
-  
+
 end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.EditGoalDiscussion` mutation.