### PR TITLE
feat: Add permissions filter to EditGroup and EditSpacePermissions

### DIFF
--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -14,9 +14,13 @@ defmodule Operately.Access.Filters do
       where: m.person_id == ^person_id and b.access_level >= ^Binding.view_access(),
       where: is_nil(p.suspended_at),
       group_by: r.id,
-      select: {:ok, r, max(b.access_level)}
+      select: {r, max(b.access_level)}
     )
     |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      {r, level} -> {:ok, r, level}
+    end
   end
 
   def filter_by_view_access(query, person_id, opts \\ []) do

--- a/lib/operately/access/filters.ex
+++ b/lib/operately/access/filters.ex
@@ -4,6 +4,21 @@ defmodule Operately.Access.Filters do
   alias Operately.Repo
   alias Operately.Access.Binding
 
+  def get_resource_and_access_level(query, person_id) do
+    from([resource: r] in query,
+      join: c in assoc(r, :access_context),
+      join: b in assoc(c, :bindings),
+      join: g in assoc(b, :group),
+      join: m in assoc(g, :memberships),
+      join: p in assoc(m, :person),
+      where: m.person_id == ^person_id and b.access_level >= ^Binding.view_access(),
+      where: is_nil(p.suspended_at),
+      group_by: r.id,
+      select: {:ok, r, max(b.access_level)}
+    )
+    |> Repo.one()
+  end
+
   def filter_by_view_access(query, person_id, opts \\ []) do
     query
     |> join_context(opts)

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -1,14 +1,11 @@
 defmodule Operately.Groups do
   import Ecto.Query, warn: false
+
   alias Operately.Repo
-
-  alias Operately.Groups.Group
-  alias Operately.Groups.Member
-  alias Operately.Groups.Contact
-  alias Operately.Access.Context
-
-  alias Operately.People.Person
   alias Ecto.Multi
+  alias Operately.Groups.{Group, Member, Contact}
+  alias Operately.Access.{Context, Filters}
+  alias Operately.People.Person
   alias Operately.Activities
 
   def archive(group) do
@@ -50,6 +47,11 @@ defmodule Operately.Groups do
   def get_group(nil), do: nil
   def get_group(id), do: Repo.get(Group, id)
   def get_group!(id), do: Repo.get!(Group, id)
+
+  def get_group_and_access_level(group_id, person_id) do
+    from(g in Group, as: :resource, where: g.id == ^group_id)
+    |> Filters.get_resource_and_access_level(person_id)
+  end
 
   def get_group_by_name(name) do
     Repo.one(from g in Group, where: g.name == ^name)

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -1,0 +1,18 @@
+defmodule Operately.Groups.Permissions do
+  alias Operately.Access.Binding
+
+  defstruct [
+    :can_view,
+    :can_edit,
+  ]
+
+  def calculate_permissions(access_level) do
+    %__MODULE__{
+      can_view: can_view(access_level),
+      can_edit: can_edit(access_level),
+    }
+  end
+
+  def can_view(access_level), do: access_level >= Binding.view_access()
+  def can_edit(access_level), do: access_level >= Binding.edit_access()
+end

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -4,15 +4,18 @@ defmodule Operately.Groups.Permissions do
   defstruct [
     :can_view,
     :can_edit,
+    :can_edit_permissions,
   ]
 
   def calculate_permissions(access_level) do
     %__MODULE__{
       can_view: can_view(access_level),
       can_edit: can_edit(access_level),
+      can_edit_permissions: can_edit_permissions(access_level),
     }
   end
 
   def can_view(access_level), do: access_level >= Binding.view_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
+  def can_edit_permissions(access_level), do: access_level >= Binding.full_access()
 end

--- a/lib/operately_web/api/mutations/edit_group.ex
+++ b/lib/operately_web/api/mutations/edit_group.ex
@@ -17,16 +17,16 @@ defmodule OperatelyWeb.Api.Mutations.EditGroup do
 
   def call(conn, inputs) do
     person = me(conn)
+    {:ok, space_id} = decode_id(inputs.id)
 
-    with {:ok, space_id} <- decode_id(inputs.id),
-        {:ok, space, access_level} <- Groups.get_group_and_access_level(space_id, person.id),
-        true <- Permissions.can_edit(access_level)
-    do
-      execute(person, space, inputs)
-    else
+    case Groups.get_group_and_access_level(space_id, person.id) do
+      {:ok, space, access_level} ->
+        if Permissions.can_edit(access_level) do
+          execute(person, space, inputs)
+        else
+          {:error, :forbidden}
+        end
       nil -> {:error, :not_found}
-      false -> {:error, :forbidden}
-      _ -> {:error, :bad_request}
     end
   end
 

--- a/lib/operately_web/api/mutations/edit_group.ex
+++ b/lib/operately_web/api/mutations/edit_group.ex
@@ -26,7 +26,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGroup do
         else
           {:error, :forbidden}
         end
-      nil -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/operately_web/api/mutations/edit_group.ex
+++ b/lib/operately_web/api/mutations/edit_group.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditGroup do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Groups
+  alias Operately.Groups.Permissions
+
   inputs do
     field :id, :string
     field :name, :string
@@ -13,14 +16,22 @@ defmodule OperatelyWeb.Api.Mutations.EditGroup do
   end
 
   def call(conn, inputs) do
-    {:ok, space_id} = decode_id(inputs.id)
-    space = Operately.Groups.get_group!(space_id)
+    person = me(conn)
 
-    {:ok, space} = Operately.Groups.edit_group_name_and_purpose(me(conn), space, %{
-      name: inputs.name,
-      mission: inputs.mission
-    })
+    with {:ok, space_id} <- decode_id(inputs.id),
+        {:ok, space, access_level} <- Groups.get_group_and_access_level(space_id, person.id),
+        true <- Permissions.can_edit(access_level)
+    do
+      execute(person, space, inputs)
+    else
+      nil -> {:error, :not_found}
+      false -> {:error, :forbidden}
+      _ -> {:error, :bad_request}
+    end
+  end
 
+  defp execute(person, space, inputs) do
+    {:ok, space} = Groups.edit_group_name_and_purpose(person, space, inputs)
     {:ok, %{space: Serializer.serialize(space)}}
   end
 end

--- a/lib/operately_web/api/mutations/edit_space_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_space_permissions.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditSpacePermissions do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Groups
+  alias Operately.Groups.Permissions
+
   inputs do
     field :space_id, :string
     field :access_levels, :access_levels
@@ -12,12 +15,22 @@ defmodule OperatelyWeb.Api.Mutations.EditSpacePermissions do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.space_id)
+    person = me(conn)
 
-    space = Operately.Groups.get_group!(id)
+    with {:ok, space_id} <- decode_id(inputs.space_id),
+        {:ok, space, access_level} <- Groups.get_group_and_access_level(space_id, person.id),
+        true <- Permissions.can_edit_permissions(access_level)
+    do
+      execute(person, space, inputs)
+    else
+      nil -> {:error, :not_found}
+      false -> {:error, :forbidden}
+      _ -> {:error, :bad_request}
+    end
+  end
 
-    {:ok, _} = Operately.Operations.GroupPermissionsEditing.run(me(conn), space, inputs.access_levels)
-
-    {:ok, true}
+  defp execute(person, space, inputs) do
+    {:ok, _} = Operately.Operations.GroupPermissionsEditing.run(person, space, inputs.access_levels)
+    {:ok, %{success: true}}
   end
 end

--- a/lib/operately_web/api/mutations/edit_space_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_space_permissions.ex
@@ -17,20 +17,32 @@ defmodule OperatelyWeb.Api.Mutations.EditSpacePermissions do
   def call(conn, inputs) do
     person = me(conn)
 
-    with {:ok, space_id} <- decode_id(inputs.space_id),
-        {:ok, space, access_level} <- Groups.get_group_and_access_level(space_id, person.id),
-        true <- Permissions.can_edit_permissions(access_level)
-    do
-      execute(person, space, inputs)
-    else
+    load_group(inputs, person)
+    |> verify_permissions()
+    |> execute(person, inputs)
+  end
+
+  defp load_group(inputs, person) do
+    {:ok, space_id} = decode_id(inputs.space_id)
+
+    case Groups.get_group_and_access_level(space_id, person.id) do
       nil -> {:error, :not_found}
-      false -> {:error, :forbidden}
-      _ -> {:error, :bad_request}
+      result -> result
     end
   end
 
-  defp execute(person, space, inputs) do
+  defp verify_permissions({:ok, space, access_level}) do
+    if Permissions.can_edit_permissions(access_level) do
+      {:ok, space}
+    else
+      {:error, :forbidden}
+    end
+  end
+  defp verify_permissions(error), do: error
+
+  defp execute({:ok, space}, person, inputs) do
     {:ok, _} = Operately.Operations.GroupPermissionsEditing.run(person, space, inputs.access_levels)
     {:ok, %{success: true}}
   end
+  defp execute(error, _, _), do: error
 end

--- a/lib/operately_web/api/mutations/edit_space_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_space_permissions.ex
@@ -16,33 +16,21 @@ defmodule OperatelyWeb.Api.Mutations.EditSpacePermissions do
 
   def call(conn, inputs) do
     person = me(conn)
-
-    load_group(inputs, person)
-    |> verify_permissions()
-    |> execute(person, inputs)
-  end
-
-  defp load_group(inputs, person) do
     {:ok, space_id} = decode_id(inputs.space_id)
 
     case Groups.get_group_and_access_level(space_id, person.id) do
-      nil -> {:error, :not_found}
-      result -> result
+      {:ok, space, access_level} ->
+        if Permissions.can_edit_permissions(access_level) do
+          execute(person, space, inputs)
+        else
+          {:error, :forbidden}
+        end
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  defp verify_permissions({:ok, space, access_level}) do
-    if Permissions.can_edit_permissions(access_level) do
-      {:ok, space}
-    else
-      {:error, :forbidden}
-    end
-  end
-  defp verify_permissions(error), do: error
-
-  defp execute({:ok, space}, person, inputs) do
+  defp execute(person, space, inputs) do
     {:ok, _} = Operately.Operations.GroupPermissionsEditing.run(person, space, inputs.access_levels)
     {:ok, %{success: true}}
   end
-  defp execute(error, _, _), do: error
 end

--- a/test/operately_web/api/mutations/edit_group_test.exs
+++ b/test/operately_web/api/mutations/edit_group_test.exs
@@ -1,3 +1,128 @@
 defmodule OperatelyWeb.Api.Mutations.EditGroupTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_group, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    test "company members without view access can't see a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, space)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without edit access can't edit a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.view_access())
+
+      assert {403, res} = request(ctx.conn, space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with edit access can edit a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.edit_access())
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.space == Serializer.serialize(space)
+    end
+
+    test "company admins can edit a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.view_access())
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, space)
+
+      # Admin
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.space == Serializer.serialize(space)
+    end
+
+    test "space members without edit access can't edit a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+      add_person_to_space(ctx, space.id, Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members with edit access can edit a space", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+      add_person_to_space(ctx, space.id, Binding.edit_access())
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.space == Serializer.serialize(space)
+    end
+  end
+
+  describe "edit_group functionality" do
+    setup :register_and_log_in_account
+
+    test "edits space name", ctx do
+      space = group_fixture(ctx.person, %{company_id: ctx.company.id, name: "Name"})
+      assert space.name == "Name"
+
+      assert {200, res} = request(ctx.conn, space, name: "New name")
+      space = Repo.reload(space)
+
+      assert space.name == "New name"
+      assert res.space == Serializer.serialize(space)
+    end
+
+    test "edits space mission", ctx do
+      space = group_fixture(ctx.person, %{company_id: ctx.company.id, mission: "Mission"})
+      assert space.mission == "Mission"
+
+      assert {200, _} = request(ctx.conn, space, mission: "Edited mission")
+      space = Repo.reload(space)
+
+      assert space.mission == "Edited mission"
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, space, attrs \\ []) do
+    mutation(conn, :edit_group, %{
+      id: Paths.space_id(space),
+      name: Keyword.get(attrs, :name, space.name),
+      mission: Keyword.get(attrs, :mission, space.mission),
+    })
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_space(ctx, attrs) do
+    group_fixture(ctx.creator, %{
+      company_id: ctx.company.id,
+      company_permissions: Keyword.get(attrs, :company_permissions, Binding.no_access()),
+    })
+  end
+
+  defp add_person_to_space(ctx, space_id, access_level) do
+    Operately.Groups.add_members(ctx.person, space_id, [%{
+      id: ctx.person.id,
+      permissions: access_level,
+    }])
+  end
+end

--- a/test/operately_web/api/mutations/edit_space_permissions_test.exs
+++ b/test/operately_web/api/mutations/edit_space_permissions_test.exs
@@ -1,0 +1,131 @@
+defmodule OperatelyWeb.Api.Mutations.EditSpacePermissionsTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_space_permissions, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    test "company members without view access can't see space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, space)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without full access can't edit space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.view_access())
+
+      assert {403, res} = request(ctx.conn, space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with full access can edit space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.full_access())
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.success
+    end
+
+    test "company admins can edit space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.view_access())
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, space)
+
+      # Admin
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.success
+    end
+
+    test "space members without full access can't edit space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+      add_person_to_space(ctx, space.id, Binding.edit_access())
+
+      assert {403, res} = request(ctx.conn, space)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space managers can edit space permissions", ctx do
+      space = create_space(ctx, company_permissions: Binding.no_access())
+      add_person_to_space(ctx, space.id, Binding.full_access())
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.success
+    end
+  end
+
+  describe "edit_space_permissions functionality" do
+    setup :register_and_log_in_account
+
+    test "edits space permissions", ctx do
+      space = group_fixture(ctx.person, %{
+        public_permissions: Binding.view_access(),
+        company_permissions: Binding.edit_access(),
+      })
+
+      assert {200, res} = request(ctx.conn, space)
+      assert res.success
+      assert_permissions_edited(ctx, space)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, space) do
+    mutation(conn, :edit_space_permissions, %{
+      space_id: Paths.space_id(space),
+      access_levels: %{
+        public: Binding.no_access(),
+        company: Binding.view_access(),
+      },
+    })
+  end
+
+  defp assert_permissions_edited(ctx, space) do
+    context = Access.get_context!(group_id: space.id)
+    anonymoys_group = Access.get_group!(company_id: ctx.company.id, tag: :anonymous)
+    members_group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+
+    assert Access.get_binding(context_id: context.id, group_id: anonymoys_group.id, access_level: Binding.no_access())
+    assert Access.get_binding(context_id: context.id, group_id: members_group.id, access_level: Binding.view_access())
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_space(ctx, attrs) do
+    group_fixture(ctx.creator, %{
+      company_id: ctx.company.id,
+      public_permissions: Keyword.get(attrs, :public_permissions, Binding.no_access()),
+      company_permissions: Keyword.get(attrs, :company_permissions, Binding.no_access()),
+    })
+  end
+
+  defp add_person_to_space(ctx, space_id, access_level) do
+    Operately.Groups.add_members(ctx.person, space_id, [%{
+      id: ctx.person.id,
+      permissions: access_level,
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.EditGroup` and `OperatelyWeb.Api.Mutations.EditSpacePermissions` mutations.