### PR TITLE
feat: Add permissions filter to EditProjectName mutation

### DIFF
--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -45,6 +45,13 @@ defmodule Operately.Projects.Permissions do
     }
   end
 
+  defp calculate_permissions(access_level) do
+    %__MODULE__{
+      can_edit_name: can_edit_name(access_level),
+      can_edit_permissions: can_edit_permissions(access_level),
+    }
+  end
+
   # ---
 
   defp is_contributor?(project, user) do
@@ -63,5 +70,16 @@ defmodule Operately.Projects.Permissions do
     is_public?(project) || is_contributor?(project, user)
   end
 
+  def can_edit_name(access_level), do: access_level >= Binding.edit_access()
   def can_edit_permissions(access_level), do: access_level >= Binding.full_access()
+
+  def check(access_level, permission) do
+    permissions = calculate_permissions(access_level)
+
+    if Map.get(permissions, permission) == true do
+      {:ok, :allowed}
+    else
+      {:error, :forbidden}
+    end
+  end
 end

--- a/lib/operately_web/api/mutations/edit_project_name.ex
+++ b/lib/operately_web/api/mutations/edit_project_name.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectName do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Projects
+  alias Operately.Projects.Permissions
+
   inputs do
     field :project_id, :string
     field :name, :string
@@ -12,10 +15,24 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectName do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.project_id)
-    project = Operately.Projects.get_project!(id)
-    {:ok, project} = Operately.Projects.rename_project(me(conn), project, inputs.name)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:project_id, fn -> decode_id(inputs.project_id) end)
+    |> run(:project, fn ctx -> Projects.get_project_with_access_level(ctx.project_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.project.requester_access_level, :can_edit_name) end)
+    |> run(:operation, fn ctx -> Projects.rename_project(ctx.me, ctx.project, inputs.name) end)
+    |> run(:serialized, fn ctx -> {:ok, %{project: Serializer.serialize(ctx.operation)}} end)
+    |> respond()
+  end
 
-    {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(project)}}
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :project_id, _} -> {:error, :bad_request}
+      {:error, :project, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
   end
 end

--- a/lib/operately_web/api/mutations/edit_project_permissions.ex
+++ b/lib/operately_web/api/mutations/edit_project_permissions.ex
@@ -20,7 +20,7 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectPermissions do
     |> run(:me, fn -> find_me(conn) end)
     |> run(:id, fn -> decode_id(inputs.project_id) end)
     |> run(:project, fn ctx -> Projects.get_project_with_access_level(ctx.id, ctx.me.id) end)
-    |> run(:check_permissions, fn ctx -> check_permissions(ctx.project) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.project.requester_access_level, :can_edit_permissions) end)
     |> run(:operation, fn ctx -> ProjectPermissionsEditing.run(ctx.me, ctx.project, inputs.access_levels) end)
     |> respond()
   end
@@ -33,14 +33,6 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectPermissions do
       {:error, :project, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
       _ -> {:error, :internal_server_error}
-    end
-  end
-
-  defp check_permissions(project) do
-    if Permissions.can_edit_permissions(project.requester_access_level) do
-      {:ok, :allowed}
-    else
-      {:error, :forbidden}
     end
   end
 end

--- a/test/operately_web/api/mutations/edit_project_name_test.exs
+++ b/test/operately_web/api/mutations/edit_project_name_test.exs
@@ -1,3 +1,219 @@
 defmodule OperatelyWeb.Api.Mutations.EditProjectNameTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_project_name, %{})
+    end
+  end
+
+  describe "permissions" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator_id: creator.id, space_id: space.id})
+    end
+
+    test "company members without view access can't see a project", ctx do
+      project = create_project(ctx, company_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, project)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "company members without edit access can't edit project name", ctx do
+      project = create_project(ctx, company_access_level: Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, project)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "company members with edit access can edit project name", ctx do
+      project = create_project(ctx, company_access_level: Binding.edit_access())
+
+      assert {200, res} = request(ctx.conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "company admins can edit project name", ctx do
+      project = create_project(ctx, company_access_level: Binding.view_access())
+
+      # Not admin
+      assert {403, _} = request(ctx.conn, project)
+
+      # Admin
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+
+      assert {200, res} = request(ctx.conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "space members without view access can't see a project", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access_level: Binding.no_access())
+
+      assert {404, res} = request(ctx.conn, project)
+      assert res.message == "The requested resource was not found"
+    end
+
+    test "space members without edit access can't edit project name", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access_level: Binding.comment_access())
+
+      assert {403, res} = request(ctx.conn, project)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "space members with edit access can edit project name", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access_level: Binding.edit_access())
+
+      assert {200, res} = request(ctx.conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "space managers can edit project name", ctx do
+      add_person_to_space(ctx)
+      project = create_project(ctx, space_access_level: Binding.view_access())
+
+      # Not manager
+      assert {403, _} = request(ctx.conn, project)
+
+      # Manager
+      add_manager_to_space(ctx)
+      assert {200, res} = request(ctx.conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "contributors without edit access can't edit project name", ctx do
+      project = create_project(ctx)
+      contributor = create_contributor(ctx, project, Binding.comment_access())
+
+      account = Repo.preload(contributor, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {403, res} = request(conn, project)
+      assert res.message == "You don't have permission to perform this action"
+    end
+
+    test "contributors with edit access can edit project name", ctx do
+      project = create_project(ctx)
+      contributor = create_contributor(ctx, project, Binding.full_access())
+
+      account = Repo.preload(contributor, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = request(conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "champions can edit project name", ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      project = create_project(ctx, champion_id: champion.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, project)
+
+      # champion's request
+      account = Repo.preload(champion, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = request(conn, project)
+      assert_name_edited(res, project)
+    end
+
+    test "reviewers can edit project name", ctx do
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      project = create_project(ctx, reviewer_id: reviewer.id, company_access_level: Binding.view_access())
+
+      # another user's request
+      assert {403, _} = request(ctx.conn, project)
+
+      # reviewer's request
+      account = Repo.preload(reviewer, :account).account
+      conn = log_in_account(ctx.conn, account)
+
+      assert {200, res} = request(conn, project)
+      assert_name_edited(res, project)
+    end
+  end
+
+  describe "edit_project_name functionality" do
+    setup :register_and_log_in_account
+
+    test "edits project name", ctx do
+      project = create_project(ctx)
+
+      assert project.name == "Name"
+
+      assert {200, res} = request(ctx.conn, project)
+      assert_name_edited(res, project)
+    end
+  end
+
+  #
+  # Steps
+  #
+
+  defp request(conn, project) do
+    mutation(conn, :edit_project_name, %{
+      project_id: Paths.project_id(project),
+      name: "New name",
+    })
+  end
+
+  defp assert_name_edited(res, project) do
+    project = Repo.reload(project)
+
+    assert project.name == "New name"
+    assert res.project == Serializer.serialize(project)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_project(ctx, attrs \\ []) do
+    project_fixture(Enum.into(attrs, %{
+      company_id: ctx.company.id,
+      name: "Name",
+      creator_id: ctx[:creator_id] || ctx.person.id,
+      group_id: ctx[:space_id] || ctx.company.company_space_id,
+      company_access_level: Binding.no_access(),
+      space_access_level: Binding.no_access(),
+    }))
+  end
+
+  defp create_contributor(ctx, project, permissions) do
+    contributor = person_fixture_with_account(%{company_id: ctx.company.id})
+    {:ok, _} = Operately.Projects.create_contributor(ctx.person, %{
+      project_id: project.id,
+      person_id: contributor.id,
+      responsibility: "some responsibility",
+      permissions: permissions,
+    })
+    contributor
+  end
+
+  defp add_person_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.edit_access(),
+    }])
+  end
+
+  defp add_manager_to_space(ctx) do
+    Operately.Groups.add_members(ctx.person, ctx.space_id, [%{
+      id: ctx.person.id,
+      permissions: Binding.full_access(),
+    }])
+  end
+end


### PR DESCRIPTION
I've added a permissions filter to the `OperatelyWeb.Api.Mutations.EditProjectName` mutation.