### PR TITLE
fix: Create access context and bindings for company space

### DIFF
--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -137,7 +137,7 @@ defmodule Operately.Access do
     end)
   end
 
-  defp maybe_insert_anonymous_binding(multi, company_id, access_level) do
+  def maybe_insert_anonymous_binding(multi, company_id, access_level) do
     if access_level == Binding.view_access() do
       anonymous = get_group!(company_id: company_id, tag: :anonymous)
       insert_binding(multi, :anonymous_binding, anonymous, Binding.view_access())

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -118,23 +118,6 @@ defmodule Operately.Access do
     end)
   end
 
-  def maybe_insert_anonymous_binding(multi, company_id, access_level) do
-    if access_level == Binding.view_access() do
-      anonymous = get_group!(company_id: company_id, tag: :anonymous)
-      insert_binding(multi, :anonymous_binding, anonymous, Binding.view_access())
-    else
-      multi
-    end
-  end
-
-  def update_bindings_to_company(multi, company_id, members_access_level, anonymous_access_level) do
-    standard = get_group!(company_id: company_id, tag: :standard)
-
-    multi
-    |> update_or_insert_binding(:company_members_binding, standard, members_access_level)
-    |> maybe_update_anonymous_binding(company_id, anonymous_access_level)
-  end
-
   def update_or_insert_binding(multi, name, access_group, access_level, tag \\ nil) do
     multi
     |> Multi.run(name, fn _, %{context: context} ->
@@ -158,6 +141,15 @@ defmodule Operately.Access do
           }}
       end
     end)
+  end
+
+  def maybe_insert_anonymous_binding(multi, company_id, access_level) do
+    if access_level == Binding.view_access() do
+      anonymous = get_group!(company_id: company_id, tag: :anonymous)
+      insert_binding(multi, :anonymous_binding, anonymous, Binding.view_access())
+    else
+      multi
+    end
   end
 
   def maybe_update_anonymous_binding(multi, company_id, access_level) do

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -107,25 +107,6 @@ defmodule Operately.Access do
     Binding.changeset(binding, attrs)
   end
 
-  def insert_bindings_to_company(multi, company_id, members_access_level, anonymous_access_level \\ 0) do
-    full_access = get_group!(company_id: company_id, tag: :full_access)
-    standard = get_group!(company_id: company_id, tag: :standard)
-
-    multi
-    |> insert_binding(:company_full_access_binding, full_access, Binding.full_access())
-    |> insert_binding(:company_members_binding, standard, members_access_level)
-    |> maybe_insert_anonymous_binding(company_id, anonymous_access_level)
-  end
-
-  def insert_bindings_to_space(multi, space_id, members_access_level) do
-    full_access = get_group!(group_id: space_id, tag: :full_access)
-    standard = get_group!(group_id: space_id, tag: :standard)
-
-    multi
-    |> insert_binding(:space_full_access_binding, full_access, Binding.full_access())
-    |> insert_binding(:space_members_binding, standard, members_access_level)
-  end
-
   def insert_binding(multi, name, access_group, access_level, tag \\ nil) do
     Multi.insert(multi, name, fn %{context: context} ->
       Binding.changeset(%{

--- a/lib/operately/access.ex
+++ b/lib/operately/access.ex
@@ -135,13 +135,6 @@ defmodule Operately.Access do
     |> maybe_update_anonymous_binding(company_id, anonymous_access_level)
   end
 
-  def update_bindings_to_space(multi, space_id, members_access_level) do
-    standard = get_group!(group_id: space_id, tag: :standard)
-
-    multi
-    |> update_or_insert_binding(:space_members_binding, standard, members_access_level)
-  end
-
   def update_or_insert_binding(multi, name, access_group, access_level, tag \\ nil) do
     multi
     |> Multi.run(name, fn _, %{context: context} ->

--- a/lib/operately/data/change_021_create_project_bindings_to_company_and_space.ex
+++ b/lib/operately/data/change_021_create_project_bindings_to_company_and_space.ex
@@ -1,11 +1,10 @@
 defmodule Operately.Data.Change021CreateProjectBindingsToCompanyAndSpace do
-  import Ecto.Query, only: [from: 1, from: 2]
+  import Ecto.Query, only: [from: 1]
 
   alias Operately.Repo
   alias Operately.Projects.Project
   alias Operately.Access
   alias Operately.Access.Binding
-  alias Operately.Companies.Company
 
   def run do
     Repo.transaction(fn ->
@@ -15,7 +14,7 @@ defmodule Operately.Data.Change021CreateProjectBindingsToCompanyAndSpace do
         context = Access.get_context!(project_id: project.id)
 
         create_bindings_to_company(context, project.company_id)
-        maybe_create_bindings_to_space(context, project)
+        create_bindings_to_space(context, project)
       end)
     end)
   end
@@ -28,18 +27,12 @@ defmodule Operately.Data.Change021CreateProjectBindingsToCompanyAndSpace do
     create_binding(context.id, standard.id, Binding.edit_access())
   end
 
-  defp maybe_create_bindings_to_space(context, project) do
-    company_space_id = from(c in Company, where: c.id == ^project.company_id, select: c.company_space_id) |> Repo.one!()
+  defp create_bindings_to_space(context, project) do
+    full_access = Access.get_group!(group_id: project.group_id, tag: :full_access)
+    standard = Access.get_group!(group_id: project.group_id, tag: :standard)
 
-    if project.group_id != company_space_id do
-      full_access = Access.get_group!(group_id: project.group_id, tag: :full_access)
-      standard = Access.get_group!(group_id: project.group_id, tag: :standard)
-
-      create_binding(context.id, full_access.id, Binding.full_access())
-      create_binding(context.id, standard.id, Binding.edit_access())
-    else
-      :ok
-    end
+    create_binding(context.id, full_access.id, Binding.full_access())
+    create_binding(context.id, standard.id, Binding.edit_access())
   end
 
   defp create_binding(context_id, group_id, access_level) do

--- a/lib/operately/goals.ex
+++ b/lib/operately/goals.ex
@@ -4,6 +4,7 @@ defmodule Operately.Goals do
   alias Operately.Repo
   alias Operately.Goals.Goal
   alias Operately.Goals.Target
+  alias Operately.Access.Fetch
 
   def list_goals do
     Repo.all(Goal)
@@ -11,11 +12,11 @@ defmodule Operately.Goals do
 
   def list_goals(filter) do
     from(goal in Goal)
-    |> apply_if(filter.space_id, fn query -> 
-      from(goal in query, where: goal.group_id == ^filter.space_id) 
+    |> apply_if(filter.space_id, fn query ->
+      from(goal in query, where: goal.group_id == ^filter.space_id)
     end)
-    |> apply_if(filter.company_id, fn query -> 
-      from(goal in query, where: goal.company_id == ^filter.company_id) 
+    |> apply_if(filter.company_id, fn query ->
+      from(goal in query, where: goal.company_id == ^filter.company_id)
     end)
     |> Repo.all()
   end
@@ -25,6 +26,11 @@ defmodule Operately.Goals do
   end
 
   def get_goal!(id), do: Repo.get_by_id(Goal, id, :with_deleted)
+
+  def get_goal_with_access_level(goal_id, person_id) do
+    from(g in Goal, as: :resource, where: g.id == ^goal_id)
+    |> Fetch.get_resource_with_access_level(person_id)
+  end
 
   defdelegate create_goal(creator, attrs), to: Operately.Operations.GoalCreation, as: :run
   defdelegate archive_goal(author, goal), to: Operately.Operations.GoalArchived, as: :run

--- a/lib/operately/goals/goal.ex
+++ b/lib/operately/goals/goal.ex
@@ -34,6 +34,7 @@ defmodule Operately.Goals.Goal do
 
     timestamps()
     soft_delete()
+    requester_access_level()
   end
 
   def changeset(attrs) do

--- a/lib/operately/goals/permissions.ex
+++ b/lib/operately/goals/permissions.ex
@@ -1,4 +1,6 @@
 defmodule Operately.Goals.Permissions do
+  alias Operately.Access.Binding
+
   defstruct [
     :can_edit,
     :can_check_in,
@@ -17,6 +19,12 @@ defmodule Operately.Goals.Permissions do
     }
   end
 
+  defp calculate_permissions(access_level) do
+    %__MODULE__{
+      can_edit: can_edit(access_level),
+    }
+  end
+
   # ---
 
   defp is_champion?(goal, user) do
@@ -25,5 +33,17 @@ defmodule Operately.Goals.Permissions do
 
   defp is_reviewer?(goal, user) do
     goal.reviewer_id == user.id
+  end
+
+  def can_edit(access_level), do: access_level >= Binding.edit_access()
+
+  def check(access_level, permission) do
+    permissions = calculate_permissions(access_level)
+
+    if Map.get(permissions, permission) == true do
+      {:ok, :allowed}
+    else
+      {:error, :forbidden}
+    end
   end
 end

--- a/lib/operately/groups.ex
+++ b/lib/operately/groups.ex
@@ -4,7 +4,7 @@ defmodule Operately.Groups do
   alias Operately.Repo
   alias Ecto.Multi
   alias Operately.Groups.{Group, Member, Contact}
-  alias Operately.Access.{Context, Fetch}
+  alias Operately.Access.Fetch
   alias Operately.People.Person
   alias Operately.Activities
 
@@ -91,33 +91,7 @@ defmodule Operately.Groups do
     Group.changeset(group, attrs)
   end
 
-  def insert_group(multi, attrs) do
-    cond do
-      Map.has_key?(attrs, :company_id) ->
-        multi
-        |> Multi.insert(:group, Group.changeset(attrs))
-        |> insert_group_context
-
-      MapSet.member?(multi.names, :company) ->
-        multi
-        |> Multi.insert(:group, fn changes ->
-          Group.changeset(Map.merge(attrs, %{ company_id: changes[:company].id }))
-        end)
-        |> insert_group_context
-
-      true ->
-        raise "Include company_id in attrs or company in multi's operations"
-    end
-  end
-
-  defp insert_group_context(multi) do
-    multi
-    |> Multi.insert(:context, fn changes ->
-      Context.changeset(%{
-        group_id: changes.group.id,
-      })
-    end)
-  end
+  defdelegate insert_group(multi, attrs), to: Operately.Groups.InsertGroup, as: :insert
 
   alias Operately.Groups.Member
 

--- a/lib/operately/groups/insert_group.ex
+++ b/lib/operately/groups/insert_group.ex
@@ -1,0 +1,69 @@
+defmodule Operately.Groups.InsertGroup do
+  alias Ecto.Multi
+  alias Operately.{Access, Groups}
+  alias Operately.Access.Binding
+
+  def insert(multi, attrs) do
+    multi
+    |> insert_group(attrs)
+    |> insert_group_context()
+    |> insert_members_access_group()
+    |> insert_managers_access_group()
+    |> insert_bindings(attrs)
+  end
+
+  defp insert_group(multi, attrs) do
+    multi
+    |> Multi.insert(:group, fn changes ->
+      Groups.Group.changeset(Map.merge(attrs, %{
+        company_id: attrs[:company_id] || changes[:company].id
+      }))
+    end)
+  end
+
+  defp insert_group_context(multi) do
+    multi
+    |> Multi.insert(:context, fn changes ->
+      Access.Context.changeset(%{
+        group_id: changes.group.id,
+      })
+    end)
+  end
+
+  defp insert_members_access_group(multi) do
+    multi
+    |> Multi.insert(:space_members_access_group, fn %{group: group} ->
+      Access.Group.changeset(%{group_id: group.id, tag: :standard})
+    end)
+  end
+
+  defp insert_managers_access_group(multi) do
+    multi
+    |> Multi.insert(:space_managers_access_group, fn %{group: group} ->
+      Access.Group.changeset(%{group_id: group.id, tag: :full_access})
+    end)
+  end
+
+  defp insert_bindings(multi, attrs) do
+    multi
+    |> Multi.insert(:space_full_access_binding, fn changes ->
+      group = Access.get_group!(company_id: changes.group.company_id, tag: :full_access)
+
+      Binding.changeset(%{group_id: group.id, context_id: changes.context.id, access_level: Binding.full_access()})
+    end)
+    |> Multi.insert(:space_members_binding, fn changes ->
+      access_level = Map.get(attrs, :company_permissions, Binding.no_access())
+      group = Access.get_group!(company_id: changes.group.company_id, tag: :standard)
+
+      Binding.changeset(%{group_id: group.id, context_id: changes.context.id, access_level: access_level})
+    end)
+    |> Multi.run(:anonymous_binding, fn _, changes ->
+      if attrs[:public_permissions] == Binding.view_access() do
+        group = Access.get_group!(company_id: changes.group.company_id, tag: :anonymous)
+        Access.create_binding(%{group_id: group.id, context_id: changes.context.id, access_level: Binding.view_access()})
+      else
+        {:ok, nil}
+      end
+    end)
+  end
+end

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -3,6 +3,7 @@ defmodule Operately.Groups.Permissions do
 
   defstruct [
     :can_create_goal,
+    :can_create_project,
     :can_edit,
     :can_edit_discussions,
     :can_edit_members_permissions,
@@ -16,6 +17,7 @@ defmodule Operately.Groups.Permissions do
   def calculate_permissions(access_level) do
     %__MODULE__{
       can_create_goal: can_create_goal(access_level),
+      can_create_project: can_create_project(access_level),
       can_edit: can_edit(access_level),
       can_edit_discussions: can_edit_discussions(access_level),
       can_edit_members_permissions: can_edit_members_permissions(access_level),
@@ -28,6 +30,7 @@ defmodule Operately.Groups.Permissions do
   end
 
   def can_create_goal(access_level), do: access_level >= Binding.edit_access()
+  def can_create_project(access_level), do: access_level >= Binding.edit_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
   def can_edit_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_edit_members_permissions(access_level), do: access_level >= Binding.full_access()

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -2,6 +2,7 @@ defmodule Operately.Groups.Permissions do
   alias Operately.Access.Binding
 
   defstruct [
+    :can_create_goal,
     :can_edit,
     :can_edit_discussions,
     :can_edit_members_permissions,
@@ -14,6 +15,7 @@ defmodule Operately.Groups.Permissions do
 
   def calculate_permissions(access_level) do
     %__MODULE__{
+      can_create_goal: can_create_goal(access_level),
       can_edit: can_edit(access_level),
       can_edit_discussions: can_edit_discussions(access_level),
       can_edit_members_permissions: can_edit_members_permissions(access_level),
@@ -25,6 +27,7 @@ defmodule Operately.Groups.Permissions do
     }
   end
 
+  def can_create_goal(access_level), do: access_level >= Binding.edit_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
   def can_edit_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_edit_members_permissions(access_level), do: access_level >= Binding.full_access()

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -7,29 +7,32 @@ defmodule Operately.Groups.Permissions do
     :can_edit_members_permissions,
     :can_edit_permissions,
     :can_join,
+    :can_post_discussions,
     :can_remove_member,
     :can_view,
   ]
 
   def calculate_permissions(access_level) do
     %__MODULE__{
-      can_view: can_view(access_level),
       can_edit: can_edit(access_level),
-      can_remove_member: can_remove_member(access_level),
       can_edit_discussions: can_edit_discussions(access_level),
       can_edit_members_permissions: can_edit_members_permissions(access_level),
       can_edit_permissions: can_edit_permissions(access_level),
       can_join: can_join(access_level),
+      can_post_discussions: can_post_discussions(access_level),
+      can_remove_member: can_remove_member(access_level),
+      can_view: can_view(access_level),
     }
   end
 
-  def can_view(access_level), do: access_level >= Binding.view_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
   def can_edit_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_edit_members_permissions(access_level), do: access_level >= Binding.full_access()
   def can_edit_permissions(access_level), do: access_level >= Binding.full_access()
   def can_join(access_level), do: access_level >= Binding.full_access()
+  def can_post_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_remove_member(access_level), do: access_level >= Binding.full_access()
+  def can_view(access_level), do: access_level >= Binding.view_access()
 
   def check(access_level, permission) do
     permissions = calculate_permissions(access_level)

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -3,6 +3,7 @@ defmodule Operately.Groups.Permissions do
 
   defstruct [
     :can_edit,
+    :can_edit_discussions,
     :can_edit_members_permissions,
     :can_edit_permissions,
     :can_join,
@@ -15,6 +16,7 @@ defmodule Operately.Groups.Permissions do
       can_view: can_view(access_level),
       can_edit: can_edit(access_level),
       can_remove_member: can_remove_member(access_level),
+      can_edit_discussions: can_edit_discussions(access_level),
       can_edit_members_permissions: can_edit_members_permissions(access_level),
       can_edit_permissions: can_edit_permissions(access_level),
       can_join: can_join(access_level),
@@ -23,6 +25,7 @@ defmodule Operately.Groups.Permissions do
 
   def can_view(access_level), do: access_level >= Binding.view_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
+  def can_edit_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_edit_members_permissions(access_level), do: access_level >= Binding.full_access()
   def can_edit_permissions(access_level), do: access_level >= Binding.full_access()
   def can_join(access_level), do: access_level >= Binding.full_access()
@@ -35,6 +38,6 @@ defmodule Operately.Groups.Permissions do
       {:ok, :allowed}
     else
       {:error, :forbidden}
-    end 
+    end
   end
 end

--- a/lib/operately/operations/group_creation.ex
+++ b/lib/operately/operations/group_creation.ex
@@ -5,7 +5,7 @@ defmodule Operately.Operations.GroupCreation do
   alias Operately.Groups
   alias Operately.Groups.Member
   alias Operately.Access
-  alias Operately.Access.{Group, Binding, GroupMembership}
+  alias Operately.Access.{Binding, GroupMembership}
 
   def run(creator, attrs) do
     attrs = Map.merge(attrs, %{
@@ -14,51 +14,25 @@ defmodule Operately.Operations.GroupCreation do
 
     Multi.new()
     |> Groups.insert_group(attrs)
-    |> Multi.insert(:creator, fn %{group: group} ->
-      Member.changeset(%{group_id: group.id, person_id: creator.id})
-    end)
-    |> insert_bindings(creator, attrs)
-    |> insert_members_access_group()
-    |> insert_managers_access_group(creator)
+    |> insert_creator(creator)
     |> insert_activity(creator)
     |> Repo.transaction()
     |> Repo.extract_result(:group)
   end
 
-  defp insert_members_access_group(multi) do
-    multi
-    |> Multi.insert(:members_access_group, fn changes ->
-      Group.changeset(%{
-        group_id: changes.group.id,
-        tag: :standard,
-      })
-    end)
-  end
-
-  defp insert_managers_access_group(multi, creator) do
-    multi
-    |> Multi.insert(:managers_access_group, fn changes ->
-      Group.changeset(%{
-        group_id: changes.group.id,
-        tag: :full_access,
-      })
-    end)
-    |> Multi.insert(:creator_in_managers, fn changes ->
-      GroupMembership.changeset(%{
-        group_id: changes.managers_access_group.id,
-        person_id: creator.id,
-      })
-    end)
-  end
-
-  defp insert_bindings(multi, creator, attrs) do
-    company_members = Map.get(attrs, :company_permissions, Binding.no_access())
-    anonymous_users = Map.get(attrs, :public_permissions, nil)
-
+  defp insert_creator(multi, creator) do
     creator_group = Access.get_group!(person_id: creator.id)
 
     multi
-    |> Access.insert_bindings_to_company(attrs.company_id, company_members, anonymous_users)
+    |> Multi.insert(:creator, fn %{group: group} ->
+      Member.changeset(%{group_id: group.id, person_id: creator.id})
+    end)
+    |> Multi.insert(:creator_in_managers, fn changes ->
+      GroupMembership.changeset(%{
+        group_id: changes.space_managers_access_group.id,
+        person_id: creator.id,
+      })
+    end)
     |> Access.insert_binding(:creator_group_binding, creator_group, Binding.full_access())
   end
 

--- a/lib/operately/operations/group_permissions_editing.ex
+++ b/lib/operately/operations/group_permissions_editing.ex
@@ -9,9 +9,17 @@ defmodule Operately.Operations.GroupPermissionsEditing do
     |> Multi.run(:context, fn _, _ ->
       {:ok, Access.get_context!(group_id: space.id)}
     end)
-    |> Access.update_bindings_to_company(space.company_id, attrs.company, attrs.public)
+    |> update_bindings(space.company_id, attrs)
     |> insert_activity(author, space)
     |> Repo.transaction()
+  end
+
+  defp update_bindings(multi, company_id, attrs) do
+    standard = Access.get_group!(company_id: company_id, tag: :standard)
+
+    multi
+    |> Access.update_or_insert_binding(:company_members_binding, standard, attrs.company)
+    |> Access.maybe_update_anonymous_binding(company_id, attrs.public)
   end
 
   defp insert_activity(multi, author, space) do

--- a/lib/operately_web/api/mutations/create_goal.ex
+++ b/lib/operately_web/api/mutations/create_goal.ex
@@ -35,7 +35,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
     |> respond()
   end
 
-  def respond(result) do
+  defp respond(result) do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
       {:error, :attrs, _} -> {:error, :bad_request}

--- a/lib/operately_web/api/mutations/create_goal.ex
+++ b/lib/operately_web/api/mutations/create_goal.ex
@@ -2,7 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_edit_access: 2, forbidden_or_not_found: 2]
+  alias Operately.Groups
+  alias Operately.Groups.Permissions
+  alias Operately.Operations.GoalCreation
 
   inputs do
     field :space_id, :string
@@ -23,40 +25,38 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoal do
   end
 
   def call(conn, inputs) do
-    person = me(conn)
-    company = company(conn)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:attrs, fn -> decode_inputs(inputs) end)
+    |> run(:space, fn ctx -> Groups.get_group_with_access_level(ctx.attrs.space_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.requester_access_level, :can_create_goal) end)
+    |> run(:operation, fn ctx -> GoalCreation.run(ctx.me, ctx.attrs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{goal: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
+
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :attrs, _} -> {:error, :bad_request}
+      {:error, :space, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp decode_inputs(inputs) do
     {:ok, space_id} = decode_id(inputs.space_id)
     {:ok, champion_id} = decode_id(inputs[:champion_id], :allow_nil)
     {:ok, reviewer_id} = decode_id(inputs[:reviewer_id], :allow_nil)
     {:ok, parent_goal_id} = decode_id(inputs[:parent_goal_id], :allow_nil)
 
-    attrs = Map.merge(inputs, %{
+    {:ok, Map.merge(inputs, %{
       space_id: space_id,
       champion_id: champion_id,
       reviewer_id: reviewer_id,
       parent_goal_id: parent_goal_id,
-    })
-
-    if has_permissions?(person, company, space_id) do
-      {:ok, goal} = Operately.Operations.GoalCreation.run(me(conn), attrs)
-      {:ok, %{goal: Serializer.serialize(goal, level: :essential)}}
-    else
-      query(company, space_id)
-      |> forbidden_or_not_found(person.id)
-    end
-  end
-
-  defp has_permissions?(person, company, space_id) do
-    query(company, space_id)
-    |> filter_by_edit_access(person.id)
-    |> Repo.exists?()
-  end
-
-  defp query(company, space_id) when company.company_space_id != space_id do
-    from(s in Operately.Groups.Group, where: s.id == ^space_id)
-  end
-
-  defp query(company, space_id) when company.company_space_id == space_id do
-    from(c in Operately.Companies.Company, where: c.id == ^company.id)
+    })}
   end
 end

--- a/lib/operately_web/api/mutations/create_project.ex
+++ b/lib/operately_web/api/mutations/create_project.ex
@@ -2,7 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_edit_access: 2, forbidden_or_not_found: 2]
+  alias Operately.Groups
+  alias Operately.Groups.Permissions
+  alias Operately.Operations.ProjectCreation
 
   inputs do
     field :space_id, :string
@@ -23,15 +25,34 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
   end
 
   def call(conn, inputs) do
-    person = me(conn)
-    company = company(conn)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:attrs, fn ctx -> decode_inputs(ctx.me, inputs) end)
+    |> run(:space, fn ctx -> Groups.get_group_with_access_level(ctx.attrs.group_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.requester_access_level, :can_create_project) end)
+    |> run(:operation, fn ctx -> ProjectCreation.run(ctx.attrs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{project: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
 
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :attrs, _} -> {:error, :bad_request}
+      {:error, :space, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp decode_inputs(person, inputs) do
     {:ok, goal_id} = decode_id(inputs[:goal_id], :allow_nil)
     {:ok, space_id} = decode_id(inputs[:space_id], :allow_nil)
     {:ok, champion_id} = decode_id(inputs[:champion_id], :allow_nil)
     {:ok, reviewer_id} = decode_id(inputs[:reviewer_id], :allow_nil)
 
-    args = %Operately.Operations.ProjectCreation{
+    {:ok, %ProjectCreation{
       name: inputs.name,
       champion_id: champion_id,
       reviewer_id: reviewer_id,
@@ -45,28 +66,6 @@ defmodule OperatelyWeb.Api.Mutations.CreateProject do
       anonymous_access_level: inputs.anonymous_access_level,
       company_access_level: inputs.company_access_level,
       space_access_level: inputs.space_access_level,
-    }
-
-    if has_permissions?(person, company, space_id) do
-      {:ok, project} = Operately.Projects.create_project(args)
-      {:ok, %{project: Serializer.serialize(project, level: :essential)}}
-    else
-      query(company, space_id)
-      |> forbidden_or_not_found(person.id)
-    end
-  end
-
-  defp has_permissions?(person, company, space_id) do
-    query(company, space_id)
-    |> filter_by_edit_access(person.id)
-    |> Repo.exists?()
-  end
-
-  defp query(company, space_id) when company.company_space_id != space_id do
-    from(s in Operately.Groups.Group, where: s.id == ^space_id)
-  end
-
-  defp query(company, space_id) when company.company_space_id == space_id do
-    from(c in Operately.Companies.Company, where: c.id == ^company.id)
+    }}
   end
 end

--- a/lib/operately_web/api/mutations/edit_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_discussion.ex
@@ -2,7 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters
+  alias Operately.Groups
+  alias Operately.Groups.Permissions
+  alias Operately.Operations.DiscussionEditing
 
   inputs do
     field :discussion_id, :string
@@ -15,41 +17,26 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.discussion_id)
-    person = me(conn)
-    discussion = %{updatable_id: space_id} = Operately.Updates.get_update!(id)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.discussion_id) end)
+    |> run(:discussion, fn ctx -> {:ok, Operately.Updates.get_update!(ctx.id)} end)
+    |> run(:space, fn ctx -> Groups.get_group_with_access_level(ctx.discussion.updatable_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.requester_access_level, :can_edit_discussions) end)
+    |> run(:operation, fn ctx -> DiscussionEditing.run(ctx.me, ctx.discussion, ctx.space, inputs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{discussion: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
 
-    case load_space(person, space_id, is_company_space?(conn, space_id)) do
-      nil ->
-        query(space_id)
-        |> return_error(person, is_company_space?(conn, space_id))
-
-      space ->
-        {:ok, discussion} = Operately.Operations.DiscussionEditing.run(person, discussion, space, inputs)
-        {:ok, %{discussion: Serializer.serialize(discussion, level: :essential)}}
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :discussion, _} -> {:error, :not_found}
+      {:error, :space, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
     end
-  end
-
-  defp load_space(person, space_id, false) do
-    query(space_id)
-    |> filter_by_edit_access(person.id)
-    |> Repo.one()
-  end
-
-  defp load_space(person, space_id, true) do
-    query(space_id)
-    |> filter_by_edit_access(person.id, join_parent: :company)
-    |> Repo.one()
-  end
-
-  defp return_error(q, person, false), do: forbidden_or_not_found(q, person.id)
-  defp return_error(q, person, true), do: forbidden_or_not_found(q, person.id, join_parent: :company)
-
-  defp query(space_id) do
-    from(s in Operately.Groups.Group, where: s.id == ^space_id)
-  end
-
-  defp is_company_space?(conn, space_id) do
-    company(conn).company_space_id == space_id
   end
 end

--- a/lib/operately_web/api/queries/get_discussions.ex
+++ b/lib/operately_web/api/queries/get_discussions.ex
@@ -2,11 +2,9 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters
-
-  alias Operately.Repo
   alias Operately.Groups.Group
   alias Operately.Updates.Update
+  alias Operately.Access.Filters
 
   inputs do
     field :space_id, :string
@@ -18,13 +16,12 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
 
   def call(conn, inputs) do
     {:ok, space_id} = decode_id(inputs.space_id)
-
-    updates = load(me(conn), company(conn), space_id)
+    updates = load(me(conn), space_id)
 
     {:ok, %{discussions: Serializer.serialize(updates, level: :essential)}}
   end
 
-  defp load(person, company, space_id) do
+  defp load(person, space_id) do
     from(u in Update,
       join: s in Group, on: s.id == u.updatable_id, as: :space,
       where: u.updatable_id == ^space_id,
@@ -33,17 +30,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
       preload: :author,
       order_by: [desc: u.inserted_at]
     )
-    |> view_access_filter(person, space_id, company.company_space_id)
+    |> Filters.filter_by_view_access(person.id, named_binding: :space)
     |> Repo.all()
-  end
-
-  defp view_access_filter(q, person, space_id, c_space_id) when space_id == c_space_id do
-    filter_by_view_access(q, person.id, [
-      join_parent: :company,
-      named_binding: :space,
-    ])
-  end
-  defp view_access_filter(q, person, _, _) do
-    filter_by_view_access(q, person.id, named_binding: :space)
   end
 end

--- a/lib/operately_web/api/queries/get_space.ex
+++ b/lib/operately_web/api/queries/get_space.ex
@@ -2,12 +2,8 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_view_access: 2, filter_by_view_access: 3]
-
-  alias Operately.Repo
+  alias Operately.Access.Filters
   alias Operately.Groups.Group
-
-  import Ecto.Query, only: [from: 2]
 
   inputs do
     field :id, :string
@@ -21,7 +17,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
   end
 
   def call(conn, inputs) do
-    space = load(me(conn), company(conn), inputs)
+    space = load(me(conn), inputs)
 
     if space do
       {:ok, %{space: Serializer.serialize(space, level: :full)}}
@@ -30,7 +26,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
     end
   end
 
-  defp load(person, company, inputs) do
+  defp load(person, inputs) do
     requested = extract_include_filters(inputs)
     {:ok, id} = decode_id(inputs[:id])
 
@@ -38,7 +34,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
     |> Group.scope_company(person.company_id)
     |> include_requested(requested)
     |> load_members_access_level(inputs[:include_members_access_levels], id)
-    |> view_access_filter(person, company_space: company.company_space_id == id)
+    |> Filters.filter_by_view_access(person.id)
     |> Repo.one()
     |> preload_is_member(person)
     |> sort_members()
@@ -70,11 +66,4 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
 
   defp load_members_access_level(query, true, space_id), do: Group.preload_members_access_level(query, space_id)
   defp load_members_access_level(query, _, _), do: query
-
-  defp view_access_filter(q, person, company_space: true) do
-    filter_by_view_access(q, person.id, join_parent: :company)
-  end
-  defp view_access_filter(q, person, company_space: false) do
-    filter_by_view_access(q, person.id)
-  end
 end

--- a/lib/operately_web/api/queries/get_spaces.ex
+++ b/lib/operately_web/api/queries/get_spaces.ex
@@ -2,44 +2,25 @@ defmodule OperatelyWeb.Api.Queries.GetSpaces do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_view_access: 2, filter_by_view_access: 3]
-
-  alias Operately.Groups.Group
+  import Operately.Access.Filters, only: [filter_by_view_access: 2]
 
   outputs do
     field :spaces, list_of(:space)
   end
 
   def call(conn, _inputs) do
-    spaces = load(me(conn), company(conn))
+    spaces = load_spaces(me(conn))
 
     {:ok, %{spaces: Serializer.serialize(spaces, level: :full)}}
   end
 
-  defp load(me, company) do
-    spaces = load_spaces(me)
-    company_space = load_company_space(me, company.company_space_id)
-
-    spaces ++ company_space
-    |> Enum.sort_by(&(&1.name))
-  end
-
   defp load_spaces(me) do
-    from(g in Group,
+    from(g in Operately.Groups.Group,
       where: g.company_id == ^me.company_id,
+      order_by: g.name,
       preload: [:company]
     )
     |> filter_by_view_access(me.id)
-    |> Operately.Repo.all()
-  end
-
-  defp load_company_space(me, id) do
-    from(g in Group,
-      join: c in assoc(g, :company), as: :company,
-      where: g.id == ^id,
-      preload: [company: c]
-    )
-    |> filter_by_view_access(me.id, named_binding: :company)
-    |> Operately.Repo.all()
+    |> Repo.all()
   end
 end

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -27,7 +27,7 @@ defmodule Operately.AccessBindingsTest do
 
       bindings_list = Access.list_bindings()
 
-      assert 3 == length(bindings_list)
+      assert 6 == length(bindings_list)
       assert Enum.member?(bindings_list, binding)
     end
 

--- a/test/operately/data/change_019_create_access_groups_for_spaces_test.exs
+++ b/test/operately/data/change_019_create_access_groups_for_spaces_test.exs
@@ -32,7 +32,9 @@ defmodule Operately.Data.Change019CreateAccessGroupsForSpacesTest do
     Enum.each(ctx.companies, fn company ->
       spaces = Groups.list_groups_for_company(company.id)
 
-      Enum.each(spaces, fn space ->
+      spaces
+      |> Enum.filter(&(&1.id != company.company_space_id))
+      |> Enum.each(fn space ->
         context = Access.get_context!(group_id: space.id)
         standard = Access.get_group!(company_id: company.id, tag: :standard)
         full_access = Access.get_group!(company_id: company.id, tag: :full_access)

--- a/test/operately/data/change_021_create_project_bindings_to_company_and_space_test.exs
+++ b/test/operately/data/change_021_create_project_bindings_to_company_and_space_test.exs
@@ -103,7 +103,7 @@ defmodule Operately.Data.Change021CreateProjectBindingsToCompanyAndSpaceTest do
     end)
   end
 
-  test "doesn't create access binding to spaces when it's the company space", ctx do
+  test "creates access binding to spaces when it's the company space", ctx do
     space_id = ctx.company.company_space_id
 
     projects_no_space = Enum.map(1..3, fn _ ->
@@ -117,10 +117,12 @@ defmodule Operately.Data.Change021CreateProjectBindingsToCompanyAndSpaceTest do
     Operately.Data.Change021CreateProjectBindingsToCompanyAndSpace.run()
 
     Enum.each(projects_no_space, fn project ->
-      refute Access.get_group(group_id: space_id, tag: :full_access)
-      refute Access.get_group(group_id: space_id, tag: :standard)
-
       context = Access.get_context!(project_id: project.id)
+      space_full_access = Access.get_group!(group_id: space_id, tag: :full_access)
+      space_standard = Access.get_group!(group_id: space_id, tag: :standard)
+
+      assert Access.get_binding(context_id: context.id, group_id: space_full_access.id)
+      assert Access.get_binding(context_id: context.id, group_id: space_standard.id)
 
       full_access = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
       standard = Access.get_group!(company_id: ctx.company.id, tag: :standard)

--- a/test/operately/operations/company_adding_test.exs
+++ b/test/operately/operations/company_adding_test.exs
@@ -74,12 +74,23 @@ defmodule Operately.Operations.CompanyAddingTest do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
 
     person = People.get_person_by_email(company, @email)
+
+    # Company
+    context = Access.get_context!(company_id: company.id)
     full_access = Access.get_group!(company_id: company.id, tag: :full_access)
     standard = Access.get_group!(company_id: company.id, tag: :standard)
 
     assert Access.get_group(company_id: company.id, tag: :anonymous)
-    assert Access.get_binding!(group_id: full_access.id, access_level: Binding.full_access())
-    assert Access.get_binding!(group_id: standard.id, access_level: Binding.view_access())
+    assert Access.get_binding!(context_id: context.id, group_id: full_access.id, access_level: Binding.full_access())
+    assert Access.get_binding!(context_id: context.id, group_id: standard.id, access_level: Binding.view_access())
+
+    assert Access.get_group_membership(group_id: full_access.id, person_id: person.id)
+    assert Access.get_group_membership(group_id: standard.id, person_id: person.id)
+
+    # Company Space
+    space = Groups.get_group!(company.company_space_id)
+    full_access = Access.get_group!(group_id: space.id, tag: :full_access)
+    standard = Access.get_group!(group_id: space.id, tag: :standard)
 
     assert Access.get_group_membership(group_id: full_access.id, person_id: person.id)
     assert Access.get_group_membership(group_id: standard.id, person_id: person.id)

--- a/test/operately/operations/goal_creation_test.exs
+++ b/test/operately/operations/goal_creation_test.exs
@@ -66,9 +66,11 @@ defmodule Operately.Operations.GoalCreationTest do
     context = Access.get_context!(goal_id: goal.id)
     full_access = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
     standard = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    anonymous = Access.get_group!(company_id: ctx.company.id, tag: :anonymous)
 
     assert Access.get_binding(context_id: context.id, group_id: full_access.id, access_level: Binding.full_access())
     assert Access.get_binding(context_id: context.id, group_id: standard.id, access_level: Binding.comment_access())
+    assert Access.get_binding(context_id: context.id, group_id: anonymous.id, access_level: Binding.view_access())
   end
 
   test "GoalCreation operation creates bindings to space", ctx do
@@ -82,20 +84,18 @@ defmodule Operately.Operations.GoalCreationTest do
     assert Access.get_binding(context_id: context.id, group_id: standard.id, access_level: Binding.edit_access())
   end
 
-  test "GoalCreation operation doesn't create bindings to space when it's company space", ctx do
+  test "GoalCreation operation creates bindings to space when it's company space", ctx do
     company_space_id = ctx.company.company_space_id
     attrs = Map.merge(ctx.attrs, %{space_id: company_space_id})
 
     {:ok, goal} = Operately.Operations.GoalCreation.run(ctx.creator, attrs)
 
     context = Access.get_context!(goal_id: goal.id)
-    full_access = Access.get_group!(group_id: ctx.space.id, tag: :full_access)
-    standard = Access.get_group!(group_id: ctx.space.id, tag: :standard)
+    full_access = Access.get_group!(group_id: company_space_id, tag: :full_access)
+    standard = Access.get_group!(group_id: company_space_id, tag: :standard)
 
-    refute Access.get_binding(context_id: context.id, group_id: full_access.id)
-    refute Access.get_binding(context_id: context.id, group_id: standard.id)
-
-    refute Access.get_group(group_id: company_space_id)
+    assert Access.get_binding(context_id: context.id, group_id: full_access.id, access_level: Binding.full_access())
+    assert Access.get_binding(context_id: context.id, group_id: standard.id, access_level: Binding.edit_access())
   end
 
   test "GoalCreation operation creates bindings to reviewer and champion", ctx do

--- a/test/operately/operations/group_creation_test.exs
+++ b/test/operately/operations/group_creation_test.exs
@@ -46,7 +46,7 @@ defmodule Operately.Operations.GroupCreationTest do
     context = Access.get_context!(group_id: group.id)
 
     assert context
-    assert length(access_groups) == 7 # 2 company's + 2 space's + 2 user's + 1 anonymous
+    assert length(access_groups) == 9 # 4 company and company space's + 2 space's + 2 user's + 1 anonymous
 
     assert Access.get_group(group_id: group.id, tag: :standard)
     assert Access.get_group(group_id: group.id, tag: :full_access)

--- a/test/operately_web/api/mutations/create_goal_test.exs
+++ b/test/operately_web/api/mutations/create_goal_test.exs
@@ -152,7 +152,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateGoalTest do
 
   defp give_person_edit_access(ctx) do
     group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
-    context = Access.get_context!(company_id: ctx.company.id)
+    context = Access.get_context!(group_id: ctx.company.company_space_id)
 
     Access.get_binding!(group_id: group.id, context_id: context.id)
     |> Access.update_binding(%{access_level: Binding.edit_access()})

--- a/test/operately_web/api/mutations/create_project_test.exs
+++ b/test/operately_web/api/mutations/create_project_test.exs
@@ -149,7 +149,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateProjectTest do
 
   defp give_person_edit_access(ctx) do
     group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
-    context = Access.get_context!(company_id: ctx.company.id)
+    context = Access.get_context!(group_id: ctx.company.company_space_id)
 
     Access.get_binding!(group_id: group.id, context_id: context.id)
     |> Access.update_binding(%{access_level: Binding.edit_access()})

--- a/test/operately_web/api/mutations/edit_discussion_test.exs
+++ b/test/operately_web/api/mutations/edit_discussion_test.exs
@@ -160,7 +160,7 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
 
   defp give_person_edit_access(ctx) do
     group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
-    context = Access.get_context!(company_id: ctx.company.id)
+    context = Access.get_context!(group_id: ctx.company.company_space_id)
 
     Access.get_binding!(group_id: group.id, context_id: context.id)
     |> Access.update_binding(%{access_level: Binding.edit_access()})

--- a/test/operately_web/api/mutations/post_discussion_test.exs
+++ b/test/operately_web/api/mutations/post_discussion_test.exs
@@ -137,7 +137,7 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussionTest do
 
   defp give_person_edit_access(ctx) do
     group = Access.get_group!(company_id: ctx.company.id, tag: :standard)
-    context = Access.get_context!(company_id: ctx.company.id)
+    context = Access.get_context!(group_id: ctx.company.company_space_id)
 
     Access.get_binding!(group_id: group.id, context_id: context.id)
     |> Access.update_binding(%{access_level: Binding.edit_access()})


### PR DESCRIPTION
Currently, we are not using the company space's own access context and bindings when we check someone's permissions. 
When a resource belongs to the company's space, we allow or deny access based on the company's access context. This PR aims to fix this issue.