### PR TITLE
feat: Edit project check-in security

### DIFF
--- a/lib/operately/operations/project_check_in_edit.ex
+++ b/lib/operately/operations/project_check_in_edit.ex
@@ -6,14 +6,13 @@ defmodule Operately.Operations.ProjectCheckInEdit do
   alias Operately.Projects.CheckIn
   alias Operately.Repo
 
-  def run(author, check_in_id, status, description) do
-    check_in = Operately.Projects.get_check_in!(check_in_id)
+  def run(author, check_in, status, description) do
     project = Operately.Projects.get_project!(check_in.project_id)
 
     Multi.new()
     |> Multi.update(:check_in, fn _ ->
       CheckIn.changeset(check_in, %{
-        status: status, 
+        status: status,
         description: description
       })
     end)

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -39,6 +39,11 @@ defmodule Operately.Projects do
     Repo.all(from c in CheckIn, where: c.project_id == ^project_id, order_by: [desc: c.inserted_at])
   end
 
+  def get_check_in_with_access_level(check_in_id, person_id) do
+    from(c in CheckIn, as: :resource, where: c.id == ^check_in_id)
+    |> Fetch.get_resource_with_access_level(person_id)
+  end
+
   defdelegate create_project(params), to: Operately.Operations.ProjectCreation, as: :run
   defdelegate list_projects(person, filters), to: Operately.Projects.ListOperation, as: :run
 

--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -11,10 +11,12 @@ defmodule Operately.Projects.CheckIn do
     belongs_to :acknowledged_by, Operately.People.Person, foreign_key: :acknowledged_by_id
     field :acknowledged_at, :utc_datetime
 
+    has_one :access_context, through: [:project, :access_context]
     has_many :reactions, Operately.Updates.Reaction, foreign_key: :entity_id, where: [entity_type: :project_check_in]
     has_many :comments, Operately.Updates.Comment, foreign_key: :entity_id, where: [entity_type: :project_check_in]
 
     timestamps()
+    requester_access_level()
   end
 
   def changeset(attrs) do

--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -7,6 +7,7 @@ defmodule Operately.Projects.Permissions do
     :can_close,
     :can_create_milestone,
     :can_delete_milestone,
+    :can_edit_check_in,
     :can_edit_contributors,
     :can_edit_description,
     :can_edit_goal,
@@ -30,6 +31,7 @@ defmodule Operately.Projects.Permissions do
       can_create_milestone: is_contributor?(project, user),
       can_delete_milestone: is_contributor?(project, user),
       can_edit_milestone: is_contributor?(project, user),
+      can_edit_check_in: is_contributor?(project, user),
       can_edit_description: is_contributor?(project, user),
       can_edit_timeline: is_contributor?(project, user),
       can_edit_resources: is_contributor?(project, user),
@@ -49,6 +51,7 @@ defmodule Operately.Projects.Permissions do
 
   defp calculate_permissions(access_level) do
     %__MODULE__{
+      can_edit_check_in: can_edit_check_in(access_level),
       can_edit_resources: can_edit_resources(access_level),
       can_edit_name: can_edit_name(access_level),
       can_edit_permissions: can_edit_permissions(access_level),
@@ -77,6 +80,7 @@ defmodule Operately.Projects.Permissions do
     is_public?(project) || is_contributor?(project, user)
   end
 
+  def can_edit_check_in(access_level), do: access_level >= Binding.full_access()
   def can_edit_resources(access_level), do: access_level >= Binding.edit_access()
   def can_edit_name(access_level), do: access_level >= Binding.edit_access()
   def can_edit_permissions(access_level), do: access_level >= Binding.full_access()

--- a/lib/operately_web/api/mutations/edit_project_check_in.ex
+++ b/lib/operately_web/api/mutations/edit_project_check_in.ex
@@ -2,6 +2,10 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectCheckIn do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Projects
+  alias Operately.Projects.Permissions
+  alias Operately.Operations.ProjectCheckInEdit
+
   inputs do
     field :check_in_id, :string
     field :status, :string
@@ -13,13 +17,26 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectCheckIn do
   end
 
   def call(conn, inputs) do
-    {:ok, check_in_id} = decode_id(inputs.check_in_id)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.check_in_id) end)
+    |> run(:description, fn -> {:ok, Jason.decode!(inputs.description)} end)
+    |> run(:check_in, fn ctx -> Projects.get_check_in_with_access_level(ctx.id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.check_in.requester_access_level, :can_edit_check_in) end)
+    |> run(:operation, fn ctx -> ProjectCheckInEdit.run(ctx.me, ctx.check_in, inputs.status, ctx.description) end)
+    |> run(:serialized, fn ctx -> {:ok, %{check_in: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
 
-    author = me(conn)
-    status = inputs.status
-    description = Jason.decode!(inputs.description)
-
-    {:ok, check_in} = Operately.Operations.ProjectCheckInEdit.run(author, check_in_id, status, description)
-    {:ok, %{check_in: Serializer.serialize(check_in, level: :essential)}}
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :description, _} -> {:error, :bad_request}
+      {:error, :check_in, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
   end
 end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -411,6 +411,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Permissions do
       can_create_milestone: permissions.can_create_milestone,
       can_delete_milestone: permissions.can_delete_milestone,
       can_edit_milestone: permissions.can_edit_milestone,
+      can_edit_check_in: permissions.can_edit_check_in,
       can_edit_description: permissions.can_edit_description,
       can_edit_timeline: permissions.can_edit_timeline,
       can_edit_resources: permissions.can_edit_resources,

--- a/test/operately_web/api/mutations/edit_project_check_in_test.exs
+++ b/test/operately_web/api/mutations/edit_project_check_in_test.exs
@@ -1,0 +1,125 @@
+defmodule OperatelyWeb.Api.Mutations.EditProjectCheckInTest do
+  use OperatelyWeb.TurboCase
+
+  alias Operately.Support.RichText
+  alias Operately.Access.Binding
+
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :edit_project_check_in, %{})
+    end
+  end
+
+  describe "permissions" do
+    @table [
+      %{company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{company: :no_access,      space: :no_access,      project: :comment_access, expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :edit_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{company: :no_access,      space: :comment_access, project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :edit_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{company: :comment_access, space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :edit_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+    ]
+
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    tabletest @table do
+      test "if caller has levels company=#{@test.company}, space=#{@test.space}, project=#{@test.project} on the project, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx)
+        project = create_project(ctx, space, @test.company, @test.space, @test.project)
+        check_in = create_check_in(ctx.creator, project)
+
+        assert {code, res} = mutation(ctx.conn, :edit_project_check_in, %{
+          check_in_id: Paths.project_check_in_id(check_in),
+          status: "on_track",
+          description: RichText.rich_text("New description", :as_string),
+        })
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 ->
+            check_in = Repo.reload(check_in)
+            assert res == %{check_in: Serializer.serialize(check_in, level: :essential)}
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+  end
+
+  describe "edit_project_check_in functionality" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+
+      Map.merge(ctx, %{project: project})
+    end
+
+    test "edits project check-in", ctx do
+      check_in = create_check_in(ctx.person, ctx.project)
+
+      assert {200, res} = mutation(ctx.conn, :edit_project_check_in, %{
+        check_in_id: Paths.project_check_in_id(check_in),
+        status: "on_track",
+        description: RichText.rich_text("New description", :as_string),
+      })
+      check_in = Repo.reload(check_in)
+
+      assert res.check_in == Serializer.serialize(check_in)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  def create_space(ctx) do
+    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+  end
+
+  def create_project(ctx, space, company_members_level, space_members_level, project_member_level) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: space.id,
+      company_access_level: Binding.from_atom(company_members_level),
+      space_access_level: Binding.from_atom(space_members_level),
+    })
+
+    if space_members_level != :no_access do
+      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
+        id: ctx.person.id,
+        permissions: Binding.from_atom(space_members_level)
+      }])
+    end
+
+    if project_member_level != :no_access do
+      {:ok, _} = Operately.Projects.create_contributor(ctx.creator, %{
+        project_id: project.id,
+        person_id: ctx.person.id,
+        permissions: Binding.from_atom(project_member_level),
+        responsibility: "some responsibility"
+      })
+    end
+
+    project
+  end
+
+  def create_check_in(author, project) do
+    check_in_fixture(%{author_id: author.id, project_id: project.id})
+  end
+end


### PR DESCRIPTION
I've added a permissions check to the `OperatelyWeb.Api.Mutations.EditProjectCheckIn` mutation.