### PR TITLE
feat: Security for PostMilestoneComment mutation

### DIFF
--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -5,6 +5,9 @@ defmodule Operately.Projects.Permissions do
     :can_acknowledge_check_in,
     :can_check_in,
     :can_close,
+    :can_comment_on_milestone,
+    :can_complete_milestone,
+    :can_reopen_milestone,
     :can_create_milestone,
     :can_delete_milestone,
     :can_edit_check_in,
@@ -27,6 +30,10 @@ defmodule Operately.Projects.Permissions do
 
     %__MODULE__{
       can_view: is_public_or_contributor?(project, user),
+
+      can_comment_on_milestone: is_public_or_contributor?(project, user),
+      can_complete_milestone: is_contributor?(project, user),
+      can_reopen_milestone: is_contributor?(project, user),
 
       can_create_milestone: is_contributor?(project, user),
       can_delete_milestone: is_contributor?(project, user),
@@ -51,6 +58,10 @@ defmodule Operately.Projects.Permissions do
 
   defp calculate_permissions(access_level) do
     %__MODULE__{
+      can_comment_on_milestone: can_comment_on_milestone(access_level),
+      can_complete_milestone: can_complete_milestone(access_level),
+      can_reopen_milestone: can_reopen_milestone(access_level),
+
       can_edit_check_in: can_edit_check_in(access_level),
       can_edit_description: can_edit_description(access_level),
       can_edit_milestone: can_edit_milestone(access_level),
@@ -82,6 +93,9 @@ defmodule Operately.Projects.Permissions do
     is_public?(project) || is_contributor?(project, user)
   end
 
+  def can_comment_on_milestone(access_level), do: access_level >= Binding.comment_access()
+  def can_complete_milestone(access_level), do: access_level >= Binding.edit_access()
+  def can_reopen_milestone(access_level), do: access_level >= Binding.edit_access()
   def can_edit_check_in(access_level), do: access_level >= Binding.full_access()
   def can_edit_description(access_level), do: access_level >= Binding.edit_access()
   def can_edit_milestone(access_level), do: access_level >= Binding.edit_access()

--- a/lib/operately_web/api/mutations/post_milestone_comment.ex
+++ b/lib/operately_web/api/mutations/post_milestone_comment.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.PostMilestoneComment do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Projects
+  alias Operately.Projects.Permissions
+
   inputs do
     field :milestone_id, :string
     field :content, :string
@@ -13,23 +16,46 @@ defmodule OperatelyWeb.Api.Mutations.PostMilestoneComment do
   end
 
   def call(conn, inputs) do
-    {:ok, milestone_id} = decode_id(inputs.milestone_id)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.milestone_id) end)
+    |> run(:milestone, fn ctx -> Projects.get_milestone_with_access_level(ctx.id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> check_permissions(ctx.milestone, inputs.action) end)
+    |> run(:operation, fn ctx -> execute(ctx.me, ctx.milestone, inputs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{comment: Serializer.serialize(ctx.operation)}} end)
+    |> respond()
+  end
 
-    action = inputs.action
-    person = me(conn)
-    milestone = Operately.Projects.get_milestone!(milestone_id)
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :milestone, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp execute(person, milestone, inputs) do
     message = inputs.content && Jason.decode!(inputs.content)
 
-    {:ok, comment} = Operately.Comments.create_milestone_comment(
+    Operately.Comments.create_milestone_comment(
       person,
-      milestone, 
-      action,
+      milestone,
+      inputs.action,
       %{
         content: %{"message" => message},
         author_id: person.id,
       }
     )
+  end
 
-    {:ok, %{comment: Serializer.serialize(comment)}}
+  defp check_permissions(milestone, action) do
+    case action do
+      "none" -> Permissions.check(milestone.requester_access_level, :can_comment_on_milestone)
+      "reopen" -> Permissions.check(milestone.requester_access_level, :can_reopen_milestone)
+      "complete" -> Permissions.check(milestone.requester_access_level, :can_complete_milestone)
+    end
   end
 end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -408,6 +408,9 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Permissions do
   def serialize(permissions, level: :essential) do
     %{
       can_view: permissions.can_view,
+      can_comment_on_milestone: permissions.can_comment_on_milestone,
+      can_complete_milestone: permissions.can_complete_milestone,
+      can_reopen_milestone: permissions.can_reopen_milestone,
       can_create_milestone: permissions.can_create_milestone,
       can_delete_milestone: permissions.can_delete_milestone,
       can_edit_milestone: permissions.can_edit_milestone,

--- a/test/operately_web/api/mutations/post_milestone_comment_test.exs
+++ b/test/operately_web/api/mutations/post_milestone_comment_test.exs
@@ -1,3 +1,166 @@
 defmodule OperatelyWeb.Api.Mutations.PostMilestoneCommentTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.ProjectsFixtures
+  import Operately.GroupsFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Comments
+  alias Operately.Access.Binding
+  alias Operately.Support.RichText
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :post_milestone_comment, %{})
+    end
+  end
+
+  describe "permissions" do
+    @table [
+      %{action: "none",    company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{action: "none",    company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{action: "none",    company: :no_access,      space: :no_access,      project: :comment_access, expected: 200},
+      %{action: "none",    company: :no_access,      space: :no_access,      project: :edit_access,    expected: 200},
+      %{action: "none",    company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{action: "none",    company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{action: "none",    company: :no_access,      space: :comment_access, project: :no_access,      expected: 200},
+      %{action: "none",    company: :no_access,      space: :edit_access,    project: :no_access,      expected: 200},
+      %{action: "none",    company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{action: "none",    company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{action: "none",    company: :comment_access, space: :no_access,      project: :no_access,      expected: 200},
+      %{action: "none",    company: :edit_access,    space: :no_access,      project: :no_access,      expected: 200},
+      %{action: "none",    company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+
+      %{action: "complete",    company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{action: "complete",    company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{action: "complete",    company: :no_access,      space: :no_access,      project: :comment_access, expected: 403},
+      %{action: "complete",    company: :no_access,      space: :no_access,      project: :edit_access,    expected: 200},
+      %{action: "complete",    company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{action: "complete",    company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{action: "complete",    company: :no_access,      space: :comment_access, project: :no_access,      expected: 403},
+      %{action: "complete",    company: :no_access,      space: :edit_access,    project: :no_access,      expected: 200},
+      %{action: "complete",    company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{action: "complete",    company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{action: "complete",    company: :comment_access, space: :no_access,      project: :no_access,      expected: 403},
+      %{action: "complete",    company: :edit_access,    space: :no_access,      project: :no_access,      expected: 200},
+      %{action: "complete",    company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+
+      %{action: "reopen",    company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{action: "reopen",    company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{action: "reopen",    company: :no_access,      space: :no_access,      project: :comment_access, expected: 403},
+      %{action: "reopen",    company: :no_access,      space: :no_access,      project: :edit_access,    expected: 200},
+      %{action: "reopen",    company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{action: "reopen",    company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{action: "reopen",    company: :no_access,      space: :comment_access, project: :no_access,      expected: 403},
+      %{action: "reopen",    company: :no_access,      space: :edit_access,    project: :no_access,      expected: 200},
+      %{action: "reopen",    company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{action: "reopen",    company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{action: "reopen",    company: :comment_access, space: :no_access,      project: :no_access,      expected: 403},
+      %{action: "reopen",    company: :edit_access,    space: :no_access,      project: :no_access,      expected: 200},
+      %{action: "reopen",    company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+    ]
+
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    tabletest @table do
+      test "if action=#{@test.action} and caller has levels company=#{@test.company}, space=#{@test.space}, project=#{@test.project} on the project, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx)
+        project = create_project(ctx, space, @test.company, @test.space, @test.project)
+        milestone = milestone_fixture(ctx.creator, %{project_id: project.id})
+
+        assert {code, res} = mutation(ctx.conn, :post_milestone_comment, %{
+          milestone_id: Paths.milestone_id(milestone),
+          content: RichText.rich_text("Content", :as_string),
+          action: @test.action,
+        })
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 -> assert length(Comments.list_milestone_comments(milestone.id)) == 1
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+  end
+
+  describe "post_milestone_comment functionality" do
+    @table [
+      %{action: :complete, content: nil, result: nil},
+      %{action: :reopen, content: nil, result: nil},
+      %{action: :none, content: RichText.rich_text("Content", :as_string), result: RichText.rich_text("Content")},
+    ]
+
+    setup :register_and_log_in_account
+
+    tabletest @table do
+      test "post comment with action: #{@test.action}", ctx do
+        project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+        milestone = milestone_fixture(ctx.person, %{project_id: project.id})
+
+        assert Comments.list_milestone_comments(milestone.id) == []
+
+        assert {200, _} = mutation(ctx.conn, :post_milestone_comment, %{
+          milestone_id: Paths.milestone_id(milestone),
+          content: @test.content,
+          action: Atom.to_string(@test.action),
+        })
+
+        comments = Comments.list_milestone_comments(milestone.id)
+        assert length(comments) == 1
+
+        comment = hd(comments)
+        assert comment.action == @test.action
+        assert comment.comment.content["message"] == @test.result
+      end
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  def create_space(ctx) do
+    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+  end
+
+  def create_project(ctx, space, company_members_level, space_members_level, project_member_level) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      name: "Name",
+      creator_id: ctx.creator.id,
+      group_id: space.id,
+      company_access_level: Binding.from_atom(company_members_level),
+      space_access_level: Binding.from_atom(space_members_level),
+    })
+
+    if space_members_level != :no_access do
+      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
+        id: ctx.person.id,
+        permissions: Binding.from_atom(space_members_level)
+      }])
+    end
+
+    if project_member_level != :no_access do
+      {:ok, _} = Operately.Projects.create_contributor(ctx.creator, %{
+        project_id: project.id,
+        person_id: ctx.person.id,
+        permissions: Binding.from_atom(project_member_level),
+        responsibility: "some responsibility"
+      })
+    end
+
+    project
+  end
+end


### PR DESCRIPTION
I've added a permissions check to the `OperatelyWeb.Api.Mutations.PostMilestoneComment` mutation.