### PR TITLE
feat: Security for RemoveCompanyMember mutation

### DIFF
--- a/lib/operately/companies/permissions.ex
+++ b/lib/operately/companies/permissions.ex
@@ -4,12 +4,14 @@ defmodule Operately.Companies.Permissions do
   defstruct [
     :can_edit_trusted_email_domains,
     :can_invite_members,
+    :can_remove_members,
   ]
 
   defp calculate_permissions(access_level) do
     %__MODULE__{
       can_edit_trusted_email_domains: access_level >= Binding.full_access(),
       can_invite_members: access_level >= Binding.full_access(),
+      can_remove_members: access_level >= Binding.full_access(),
     }
   end
 

--- a/lib/operately_web/api/mutations/remove_company_member.ex
+++ b/lib/operately_web/api/mutations/remove_company_member.ex
@@ -2,6 +2,10 @@ defmodule OperatelyWeb.Api.Mutations.RemoveCompanyMember do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Companies
+  alias Operately.Companies.Permissions
+  alias Operately.Operations.CompanyMemberRemoving
+
   inputs do
     field :person_id, :string
   end
@@ -11,14 +15,23 @@ defmodule OperatelyWeb.Api.Mutations.RemoveCompanyMember do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.person_id)
-    person = me(conn)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:member_id, fn -> decode_id(inputs.person_id) end)
+    |> run(:company, fn ctx -> Companies.get_company_with_access_level(ctx.me.id, id: ctx.me.company_id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.company.requester_access_level, :can_remove_members) end)
+    |> run(:operation, fn ctx -> CompanyMemberRemoving.run(ctx.me, ctx.member_id) end)
+    |> run(:serialized, fn ctx -> {:ok, %{person: Serializer.serialize(ctx.operation)}} end)
+    |> respond()
+  end
 
-    if person.company_role == :admin do
-      {:ok, person} = Operately.Operations.CompanyMemberRemoving.run(person, id)
-      {:ok, %{person: Serializer.serialize(person)}}
-    else
-      {:error, :bad_request, "Only admins can remove members"}
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :company, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
     end
   end
 end

--- a/test/operately_web/api/mutations/remove_company_member_test.exs
+++ b/test/operately_web/api/mutations/remove_company_member_test.exs
@@ -7,37 +7,61 @@ defmodule OperatelyWeb.Api.Mutations.RemoveCompanyMemberTest do
     test "it requires authentication", ctx do
       assert {401, _} = mutation(ctx.conn, :remove_company_member, %{})
     end
+  end
 
-    test "regular member can't remove other members", ctx do
-      ctx = register_and_log_in_account(ctx)
+  describe "permissions" do
+    @table [
+      %{company: :view_access,    expected: 403},
+      %{company: :comment_access, expected: 403},
+      %{company: :edit_access,    expected: 403},
+      %{company: :full_access,    expected: 200},
+    ]
 
-      member = person_fixture(company_id: ctx.person.company_id)
-      assert {400, res} = mutation(ctx.conn, :remove_company_member, %{person_id: member.id})
+    setup :register_and_log_in_account
 
-      assert res == %{:error => "Bad request", :message => "Only admins can remove members"}
+    tabletest @table do
+      test "if caller has levels company=#{@test.company}, then expect code=#{@test.expected}", ctx do
+        set_caller_access_level(ctx, @test.company)
+        member = person_fixture_with_account(%{company_id: ctx.company.id})
+
+        assert {code, res} = mutation(ctx.conn, :remove_company_member, %{person_id: Paths.person_id(member)})
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 ->
+            member = Repo.reload(member)
+            member.suspended
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
     end
   end
 
   describe "remove_company_member functionality" do
     setup :register_and_log_in_account
-    setup :promote_to_admin
-
-    setup ctx do
-      Map.put(ctx, :member, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "Unique Name"}))
-    end
 
     test "admin can remove members", ctx do
-      assert {200, _res} = mutation(ctx.conn, :remove_company_member, %{person_id: ctx.member.id})
+      set_caller_access_level(ctx, :full_access)
+      member = person_fixture_with_account(%{company_id: ctx.company.id})
 
-      person = Operately.People.get_person_by_name!(ctx.company, ctx.member.full_name)
-      assert person != nil
-      assert person.suspended
-      assert person.suspended_at != nil
+      assert {200, res} = mutation(ctx.conn, :remove_company_member, %{person_id: Paths.person_id(member)})
+      member = Repo.reload(member)
+
+      assert member.suspended
+      assert member.suspended_at
+      assert res.person == Serializer.serialize(member)
     end
   end
 
-  defp promote_to_admin(ctx) do
-    {:ok, person} = Operately.People.update_person(ctx.person, %{company_role: :admin})
-    %{ctx | person: person}
+  #
+  # Helpers
+  #
+
+  defp set_caller_access_level(ctx, access_level) do
+    if access_level == :full_access do
+      Operately.Companies.add_admin(ctx.company_creator, ctx.person.id)
+    end
   end
-end 
+end


### PR DESCRIPTION
I've added a permissions check to the `OperatelyWeb.Api.Mutations.RemoveCompanyMember` mutation.