### PR TITLE
feat: Security for editing contributor mutations

### DIFF
--- a/lib/operately/access/fetch.ex
+++ b/lib/operately/access/fetch.ex
@@ -5,7 +5,7 @@ defmodule Operately.Access.Fetch do
   alias Operately.Access.Binding
 
   def get_resource_with_access_level(query, person_id) do
-    query = join_resources(query, person_id)
+    query = join_access_level(query, person_id)
 
     from([resource: r, binding: b] in query,
       where: b.access_level >= ^Binding.view_access(),
@@ -20,7 +20,7 @@ defmodule Operately.Access.Fetch do
   end
 
   def get_access_level(query, person_id) do
-    query = join_resources(query, person_id)
+    query = join_access_level(query, person_id)
 
     from([binding: b] in query,
       where: b.access_level >= ^Binding.view_access(),
@@ -33,7 +33,7 @@ defmodule Operately.Access.Fetch do
     end
   end
 
-  defp join_resources(query, person_id) do
+  def join_access_level(query, person_id) do
     from([resource: r] in query,
       join: c in assoc(r, :access_context),
       join: b in assoc(c, :bindings), as: :binding,

--- a/lib/operately/operations/project_contributor_removing.ex
+++ b/lib/operately/operations/project_contributor_removing.ex
@@ -2,27 +2,15 @@ defmodule Operately.Operations.ProjectContributorRemoving do
   alias Ecto.Multi
   alias Operately.Repo
   alias Operately.Access
-  alias Operately.Projects
   alias Operately.Activities
 
-  def run(author, contrib_id) do
+  def run(author, contrib) do
     Multi.new()
-    |> delete_contributor(contrib_id)
+    |> Multi.delete(:contributor, fn _ -> contrib end)
     |> delete_binding()
     |> insert_activity(author)
     |> Repo.transaction()
     |> Repo.extract_result(:contributor)
-  end
-
-  defp delete_contributor(multi, contrib_id) do
-    multi
-    |> Multi.run(:contributor, fn _, _ ->
-      contributor = Projects.get_contributor!(contrib_id)
-      {:ok, contributor}
-    end)
-    |> Multi.delete(:contributor_deleted, fn %{contributor: contributor} ->
-      contributor
-    end)
   end
 
   defp delete_binding(multi) do

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -7,7 +7,7 @@ defmodule Operately.Projects do
   alias Operately.People.Person
   alias Operately.Updates
   alias Operately.Activities
-  alias Operately.Access.Fetch
+  alias Operately.Access.{Binding, Fetch}
 
   alias Operately.Projects.{
     Project,
@@ -186,6 +186,29 @@ defmodule Operately.Projects do
 
   def get_contributor!(id) do
     Repo.get!(Contributor, id)
+  end
+
+  def get_contributor_with_project_and_access_level(id, person_id) do
+    query = from(c in Contributor, as: :contributor,
+        join: assoc(c, :project), as: :resource,
+        where: c.id == ^id
+      )
+      |> Fetch.join_access_level(person_id)
+
+
+    from([contributor: c, resource: p, binding: b] in query,
+      where: b.access_level >= ^Binding.view_access(),
+      group_by: [c.id, p.id],
+      preload: [project: p],
+      select: {c, max(b.access_level)}
+    )
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      {c, level} ->
+        project = apply(c.project.__struct__, :set_requester_access_level, [c.project, level])
+        {:ok, %{c | project: project}}
+    end
   end
 
   def get_contributor_role!(project, person_id) do

--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -52,6 +52,7 @@ defmodule Operately.Projects.Permissions do
   defp calculate_permissions(access_level) do
     %__MODULE__{
       can_edit_check_in: can_edit_check_in(access_level),
+      can_edit_contributors: can_edit_contributors(access_level),
       can_edit_description: can_edit_description(access_level),
       can_edit_milestone: can_edit_milestone(access_level),
       can_edit_name: can_edit_name(access_level),
@@ -83,6 +84,7 @@ defmodule Operately.Projects.Permissions do
   end
 
   def can_edit_check_in(access_level), do: access_level >= Binding.full_access()
+  def can_edit_contributors(access_level), do: access_level >= Binding.full_access()
   def can_edit_description(access_level), do: access_level >= Binding.edit_access()
   def can_edit_milestone(access_level), do: access_level >= Binding.edit_access()
   def can_edit_name(access_level), do: access_level >= Binding.edit_access()

--- a/lib/operately_web/api/mutations/remove_project_contributor.ex
+++ b/lib/operately_web/api/mutations/remove_project_contributor.ex
@@ -2,8 +2,8 @@ defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributor do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  alias Operately.Access.{Binding, Fetch}
-  alias Operately.Projects.{Contributor, Permissions}
+  alias Operately.Projects
+  alias Operately.Projects.Permissions
   alias Operately.Operations.ProjectContributorRemoving
 
   inputs do
@@ -17,9 +17,9 @@ defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributor do
   def call(conn, inputs) do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
-    |> run(:data, fn ctx -> load(ctx.me.id, inputs.contrib_id) end)
-    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.data.access_level, :can_edit_contributors) end)
-    |> run(:operation, fn ctx -> ProjectContributorRemoving.run(ctx.me, ctx.data.contributor) end)
+    |> run(:contrib, fn ctx -> Projects.get_contributor_with_project_and_access_level(inputs.contrib_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.contrib.project.requester_access_level, :can_edit_contributors) end)
+    |> run(:operation, fn ctx -> ProjectContributorRemoving.run(ctx.me, ctx.contrib) end)
     |> run(:serialized, fn ctx -> {:ok, %{contributor: Serializer.serialize(ctx.operation, level: :essential)}} end)
     |> respond()
   end
@@ -27,33 +27,10 @@ defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributor do
   defp respond(result) do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
-      {:error, :data, _} -> {:error, :not_found}
+      {:error, :contrib, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}
     end
-  end
-
-  defp load(admin_id, contrib_id) do
-    no_access = Binding.no_access()
-
-    from([contributor: c, binding: b] in contributor_query(admin_id, contrib_id),
-      group_by: c.id,
-      select: {c, max(b.access_level)}
-    )
-    |> Repo.one()
-    |> case do
-      nil -> {:error, :not_found}
-      {_, ^no_access} -> {:error, :not_found}
-      {c, access} -> {:ok, %{contributor: c, access_level: access}}
-    end
-  end
-
-  defp contributor_query(admin_id, contrib_id) do
-    from(c in Contributor, as: :contributor,
-      join: assoc(c, :project), as: :resource,
-      where: c.id == ^contrib_id
-    )
-    |> Fetch.join_access_level(admin_id)
   end
 end

--- a/lib/operately_web/api/mutations/remove_project_contributor.ex
+++ b/lib/operately_web/api/mutations/remove_project_contributor.ex
@@ -2,6 +2,10 @@ defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributor do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Access.{Binding, Fetch}
+  alias Operately.Projects.{Contributor, Permissions}
+  alias Operately.Operations.ProjectContributorRemoving
+
   inputs do
     field :contrib_id, :string
   end
@@ -11,10 +15,45 @@ defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributor do
   end
 
   def call(conn, inputs) do
-    person = me(conn)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:data, fn ctx -> load(ctx.me.id, inputs.contrib_id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.data.access_level, :can_edit_contributors) end)
+    |> run(:operation, fn ctx -> ProjectContributorRemoving.run(ctx.me, ctx.data.contributor) end)
+    |> run(:serialized, fn ctx -> {:ok, %{contributor: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
 
-    {:ok, contributor} = Operately.Operations.ProjectContributorRemoving.run(person, inputs.contrib_id)
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :data, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
 
-    {:ok, %{contributor: Serializer.serialize(contributor, level: :essential)}}
+  defp load(admin_id, contrib_id) do
+    no_access = Binding.no_access()
+
+    from([contributor: c, binding: b] in contributor_query(admin_id, contrib_id),
+      group_by: c.id,
+      select: {c, max(b.access_level)}
+    )
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      {_, ^no_access} -> {:error, :not_found}
+      {c, access} -> {:ok, %{contributor: c, access_level: access}}
+    end
+  end
+
+  defp contributor_query(admin_id, contrib_id) do
+    from(c in Contributor, as: :contributor,
+      join: assoc(c, :project), as: :resource,
+      where: c.id == ^contrib_id
+    )
+    |> Fetch.join_access_level(admin_id)
   end
 end

--- a/lib/operately_web/api/mutations/update_project_contributor.ex
+++ b/lib/operately_web/api/mutations/update_project_contributor.ex
@@ -2,6 +2,10 @@ defmodule OperatelyWeb.Api.Mutations.UpdateProjectContributor do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Projects
+  alias Operately.Projects.Permissions
+  alias Operately.Operations.ProjectContributorEditing
+
   inputs do
     field :contrib_id, :string
     field :person_id, :string
@@ -14,14 +18,29 @@ defmodule OperatelyWeb.Api.Mutations.UpdateProjectContributor do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.contrib_id)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:attrs, fn -> parse_inputs(inputs) end)
+    |> run(:contrib, fn ctx -> Projects.get_contributor_with_project_and_access_level(ctx.attrs.contrib_id, ctx.me.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.contrib.project.requester_access_level, :can_edit_contributors) end)
+    |> run(:operation, fn ctx -> ProjectContributorEditing.run(ctx.me, ctx.contrib, ctx.attrs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{contributor: Serializer.serialize(ctx.operation)}} end)
+    |> respond()
+  end
+
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :attrs, _} -> {:error, :bad_request}
+      {:error, :contrib, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp parse_inputs(inputs) do
     {:ok, person_id} = decode_id(inputs.person_id)
-    contrib = Operately.Projects.get_contributor!(id)
-
-    attrs = Map.merge(inputs, %{person_id: person_id})
-
-    {:ok, contrib} = Operately.Operations.ProjectContributorEditing.run(me(conn), contrib, attrs)
-
-    {:ok, %{contributor: OperatelyWeb.Api.Serializer.serialize(contrib)}}
+    {:ok, %{inputs | person_id: person_id}}
   end
 end

--- a/test/operately/operations/project_contributor_removing_test.exs
+++ b/test/operately/operations/project_contributor_removing_test.exs
@@ -32,7 +32,7 @@ defmodule Operately.Operations.ProjectContributorRemovingTest do
     assert 3 == length(contributors)
     assert Enum.member?(contributors, {ctx.person.id, :contributor})
 
-    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor.id)
+    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor)
 
     contributors = get_contributors(ctx.project)
 
@@ -46,7 +46,7 @@ defmodule Operately.Operations.ProjectContributorRemovingTest do
 
     assert Access.get_binding(context_id: context.id, group_id: group.id)
 
-    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor.id)
+    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor)
 
     refute Access.get_binding(context_id: context.id, group_id: group.id)
   end
@@ -56,7 +56,7 @@ defmodule Operately.Operations.ProjectContributorRemovingTest do
 
     refute Repo.one(query)
 
-    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor.id)
+    Operately.Operations.ProjectContributorRemoving.run(ctx.creator, ctx.contributor)
 
     assert Repo.one(query)
   end

--- a/test/operately_web/api/mutations/remove_project_contributor_test.exs
+++ b/test/operately_web/api/mutations/remove_project_contributor_test.exs
@@ -1,3 +1,123 @@
 defmodule OperatelyWeb.Api.Mutations.RemoveProjectContributorTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Projects
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :remove_project_contributor, %{})
+    end
+  end
+
+  describe "permissions" do
+    @table [
+      %{company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :comment_access, expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :edit_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :comment_access, project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :edit_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :comment_access, space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :edit_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+    ]
+
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    tabletest @table do
+      test "if caller has levels company=#{@test.company}, space=#{@test.space}, project=#{@test.project} on the project, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx)
+        project = create_project(ctx, space, @test.company, @test.space, @test.project)
+        contributor = create_contributor(ctx, project)
+
+        assert {code, res} = mutation(ctx.conn, :remove_project_contributor, %{contrib_id: contributor.id})
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 -> refute from(c in Projects.Contributor, where: c.id == ^contributor.id) |> Repo.one()
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+  end
+
+  describe "remove_project_contributor functionality" do
+    setup :register_and_log_in_account
+
+    test "removes project contributor", ctx do
+      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+      contributor = create_contributor(ctx, project)
+
+      assert {200, res} = mutation(ctx.conn, :remove_project_contributor, %{contrib_id: contributor.id})
+
+      assert res.contributor == Serializer.serialize(contributor, level: :essential)
+      refute from(c in Projects.Contributor, where: c.id == ^contributor.id) |> Repo.one()
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_contributor(ctx, project) do
+    person = person_fixture_with_account(%{company_id: ctx.company.id})
+    {:ok, contributor} = Projects.create_contributor(ctx[:creator] || ctx.person, %{
+      project_id: project.id,
+      person_id: person.id,
+      responsibility: "some responsibility",
+      permissions: Binding.edit_access(),
+    })
+
+    contributor
+  end
+
+  def create_space(ctx) do
+    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+  end
+
+  def create_project(ctx, space, company_members_level, space_members_level, project_member_level) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: space.id,
+      company_access_level: Binding.from_atom(company_members_level),
+      space_access_level: Binding.from_atom(space_members_level),
+    })
+
+    if space_members_level != :no_access do
+      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
+        id: ctx.person.id,
+        permissions: Binding.from_atom(space_members_level)
+      }])
+    end
+
+    if project_member_level != :no_access do
+      {:ok, _} = Projects.create_contributor(ctx.creator, %{
+        project_id: project.id,
+        person_id: ctx.person.id,
+        permissions: Binding.from_atom(project_member_level),
+        responsibility: "some responsibility"
+      })
+    end
+
+    project
+  end
+end

--- a/test/operately_web/api/mutations/update_project_contributor_test.exs
+++ b/test/operately_web/api/mutations/update_project_contributor_test.exs
@@ -1,3 +1,134 @@
 defmodule OperatelyWeb.Api.Mutations.UpdateProjectContributorTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Projects
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :update_project_contributor, %{})
+    end
+  end
+
+  describe "permissions" do
+    @table [
+      %{company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :comment_access, expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :edit_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :comment_access, project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :edit_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :comment_access, space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :edit_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+    ]
+
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    tabletest @table do
+      test "if caller has levels company=#{@test.company}, space=#{@test.space}, project=#{@test.project} on the project, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx)
+        project = create_project(ctx, space, @test.company, @test.space, @test.project)
+        {person, contributor} = create_contributor(ctx, project)
+
+        assert {code, res} = mutation(ctx.conn, :update_project_contributor, %{
+          contrib_id: contributor.id,
+          person_id: Paths.person_id(person),
+          responsibility: "New responsibility",
+          permissions: Binding.edit_access(),
+        })
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 ->
+            contributor = Repo.reload(contributor)
+            assert res.contributor == Serializer.serialize(contributor)
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+  end
+
+  describe "update_project_contributor functionality" do
+    setup :register_and_log_in_account
+
+    test "updates project contributor", ctx do
+      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+      {person, contributor} = create_contributor(ctx, project)
+
+      assert {200, res} = mutation(ctx.conn, :update_project_contributor, %{
+        contrib_id: contributor.id,
+        person_id: Paths.person_id(person),
+        responsibility: "New responsibility",
+        permissions: Binding.edit_access(),
+      })
+
+      contributor = Repo.reload(contributor)
+      assert res.contributor == Serializer.serialize(contributor)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_space(ctx) do
+    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+  end
+
+  defp create_contributor(ctx, project) do
+    person = person_fixture_with_account(%{company_id: ctx.company.id})
+    {:ok, contributor} = Projects.create_contributor(ctx[:creator] || ctx.person, %{
+      project_id: project.id,
+      person_id: person.id,
+      responsibility: "some responsibility",
+      permissions: Binding.edit_access(),
+    })
+
+    {person, contributor}
+  end
+
+  defp create_project(ctx, space, company_members_level, space_members_level, project_member_level) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: space.id,
+      company_access_level: Binding.from_atom(company_members_level),
+      space_access_level: Binding.from_atom(space_members_level),
+    })
+
+    if space_members_level != :no_access do
+      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
+        id: ctx.person.id,
+        permissions: Binding.from_atom(space_members_level)
+      }])
+    end
+
+    if project_member_level != :no_access do
+      {:ok, _} = Projects.create_contributor(ctx.creator, %{
+        project_id: project.id,
+        person_id: ctx.person.id,
+        permissions: Binding.from_atom(project_member_level),
+        responsibility: "some responsibility"
+      })
+    end
+
+    project
+  end
+end


### PR DESCRIPTION
I've added a permissions check to the following mutations: 

- `OperatelyWeb.Api.Mutations.RemoveProjectContributor` 
- `OperatelyWeb.Api.Mutations.UpdateProjectContributor`