### PR TITLE
feat: Security for CreateComment mutation 

### DIFF
--- a/assets/js/features/CommentSection/useForDiscussion.tsx
+++ b/assets/js/features/CommentSection/useForDiscussion.tsx
@@ -19,7 +19,7 @@ export function useForDiscussion(discussion: Discussions.Discussion): FormState 
   const postComment = async (content: string) => {
     await post({
       entityId: discussion.id,
-      entityType: "update",
+      entityType: "discussion",
       content: JSON.stringify(content),
     });
   };

--- a/assets/js/features/CommentSection/useForGoalCheckIn.tsx
+++ b/assets/js/features/CommentSection/useForGoalCheckIn.tsx
@@ -45,7 +45,7 @@ export function useForGoalCheckIn(update: GoalCheckIns.Update) {
 
   const postComment = async (content: string) => {
     await post({
-      entityType: "update",
+      entityType: "goal_update",
       entityId: update.id,
       content: JSON.stringify(content),
     });

--- a/lib/operately/activities/activity.ex
+++ b/lib/operately/activities/activity.ex
@@ -26,6 +26,7 @@ defmodule Operately.Activities.Activity do
     field :resource_type, :string
 
     timestamps()
+    requester_access_level()
   end
 
   def changeset(attrs) do

--- a/lib/operately/activities/permissions.ex
+++ b/lib/operately/activities/permissions.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Activities.Permissions do
+  alias Operately.Access.Binding
+
+  defstruct [
+    :can_comment_on_thread,
+  ]
+
+  def calculate_permissions(access_level) do
+    %__MODULE__{
+      can_comment_on_thread: access_level >= Binding.comment_access(),
+    }
+  end
+
+  def check(access_level, permission) do
+    permissions = calculate_permissions(access_level)
+
+    if Map.get(permissions, permission) == true do
+      {:ok, :allowed}
+    else
+      {:error, :forbidden}
+    end
+  end
+end

--- a/lib/operately/goals/permissions.ex
+++ b/lib/operately/goals/permissions.ex
@@ -8,6 +8,7 @@ defmodule Operately.Goals.Permissions do
     :can_close,
     :can_archive,
     :can_reopen,
+    :can_comment_on_update,
   ]
 
   def calculate(goal, user) do
@@ -25,6 +26,7 @@ defmodule Operately.Goals.Permissions do
       can_check_in: can_check_in(access_level),
       can_edit: can_edit(access_level),
       can_reopen: can_edit(access_level),
+      can_comment_on_update: can_comment_on_update(access_level)
     }
   end
 
@@ -41,6 +43,7 @@ defmodule Operately.Goals.Permissions do
   def can_check_in(access_level), do: access_level >= Binding.full_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
   def can_reopen(access_level), do: access_level >= Binding.edit_access()
+  def can_comment_on_update(access_level), do: access_level >= Binding.comment_access()
 
   def check(access_level, permission) do
     permissions = calculate_permissions(access_level)

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -4,6 +4,7 @@ defmodule Operately.Groups.Permissions do
   defstruct [
     :can_create_goal,
     :can_create_project,
+    :can_comment_on_discussions,
     :can_edit,
     :can_edit_discussions,
     :can_edit_members_permissions,
@@ -18,6 +19,7 @@ defmodule Operately.Groups.Permissions do
     %__MODULE__{
       can_create_goal: can_create_goal(access_level),
       can_create_project: can_create_project(access_level),
+      can_comment_on_discussions: can_comment_on_discussions(access_level),
       can_edit: can_edit(access_level),
       can_edit_discussions: can_edit_discussions(access_level),
       can_edit_members_permissions: can_edit_members_permissions(access_level),
@@ -31,6 +33,7 @@ defmodule Operately.Groups.Permissions do
 
   def can_create_goal(access_level), do: access_level >= Binding.edit_access()
   def can_create_project(access_level), do: access_level >= Binding.edit_access()
+  def can_comment_on_discussions(access_level), do: access_level >= Binding.comment_access()
   def can_edit(access_level), do: access_level >= Binding.edit_access()
   def can_edit_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_edit_members_permissions(access_level), do: access_level >= Binding.full_access()

--- a/lib/operately/operations/comment_adding.ex
+++ b/lib/operately/operations/comment_adding.ex
@@ -4,15 +4,13 @@ defmodule Operately.Operations.CommentAdding do
   alias Operately.Activities
   alias Ecto.Multi
 
-  def run(creator, entity_id, entity_type, content) do
+  def run(creator, entity, entity_type, content) do
     changeset = Comment.changeset(%{
       author_id: creator.id,
-      entity_id: entity_id,
+      entity_id: entity.id,
       entity_type: String.to_existing_atom(entity_type),
       content: %{"message" => content}
     })
-
-    entity = find_entity(entity_id, entity_type)
     action = find_action(entity)
 
     Multi.new()
@@ -93,15 +91,6 @@ defmodule Operately.Operations.CommentAdding do
 
       fields
     end)
-  end
-
-  def find_entity(entity_id, entity_type) do
-    case entity_type do
-      "update" -> Operately.Updates.get_update!(entity_id)
-      "project_check_in" -> Operately.Projects.get_check_in!(entity_id)
-      "comment_thread" -> Operately.Comments.get_thread!(entity_id)
-      _ -> raise "Unknown entity type: #{entity_type}"
-    end
   end
 
   def find_action(%Operately.Updates.Update{type: :project_discussion}), do: :discussion_comment_submitted

--- a/lib/operately/projects/permissions.ex
+++ b/lib/operately/projects/permissions.ex
@@ -10,6 +10,7 @@ defmodule Operately.Projects.Permissions do
     :can_reopen_milestone,
     :can_create_milestone,
     :can_delete_milestone,
+    :can_comment_on_check_in,
     :can_edit_check_in,
     :can_edit_contributors,
     :can_edit_description,
@@ -34,10 +35,11 @@ defmodule Operately.Projects.Permissions do
       can_comment_on_milestone: is_public_or_contributor?(project, user),
       can_complete_milestone: is_contributor?(project, user),
       can_reopen_milestone: is_contributor?(project, user),
-
       can_create_milestone: is_contributor?(project, user),
       can_delete_milestone: is_contributor?(project, user),
       can_edit_milestone: is_contributor?(project, user),
+
+      can_comment_on_check_in: is_contributor?(project, user),
       can_edit_check_in: is_contributor?(project, user),
       can_edit_description: is_contributor?(project, user),
       can_edit_timeline: is_contributor?(project, user),
@@ -62,6 +64,7 @@ defmodule Operately.Projects.Permissions do
       can_complete_milestone: can_complete_milestone(access_level),
       can_reopen_milestone: can_reopen_milestone(access_level),
 
+      can_comment_on_check_in: can_comment_on_check_in(access_level),
       can_edit_check_in: can_edit_check_in(access_level),
       can_edit_contributors: can_edit_contributors(access_level),
       can_edit_description: can_edit_description(access_level),
@@ -94,13 +97,16 @@ defmodule Operately.Projects.Permissions do
     is_public?(project) || is_contributor?(project, user)
   end
 
+
   def can_comment_on_milestone(access_level), do: access_level >= Binding.comment_access()
   def can_complete_milestone(access_level), do: access_level >= Binding.edit_access()
+  def can_edit_milestone(access_level), do: access_level >= Binding.edit_access()
   def can_reopen_milestone(access_level), do: access_level >= Binding.edit_access()
+
+  def can_comment_on_check_in(access_level), do: access_level >= Binding.comment_access()
   def can_edit_check_in(access_level), do: access_level >= Binding.full_access()
   def can_edit_contributors(access_level), do: access_level >= Binding.full_access()
   def can_edit_description(access_level), do: access_level >= Binding.edit_access()
-  def can_edit_milestone(access_level), do: access_level >= Binding.edit_access()
   def can_edit_name(access_level), do: access_level >= Binding.edit_access()
   def can_edit_permissions(access_level), do: access_level >= Binding.full_access()
   def can_edit_resources(access_level), do: access_level >= Binding.edit_access()

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -7,7 +7,6 @@ defmodule Operately.Updates do
 
   alias Operately.Activities
   alias Operately.Updates.Update
-  alias Operately.Goals.Goal
   alias Operately.Projects.Project
   alias Operately.Projects.ReviewRequest
   alias Operately.Access.{Binding, Fetch}
@@ -54,7 +53,7 @@ defmodule Operately.Updates do
 
   def get_update_with_goal_and_access_level(id, person_id) do
     query = from(u in Update, as: :update,
-        join: g in Goal, on: g.id == u.updatable_id, as: :resource,
+        join: g in Operately.Goals.Goal, on: g.id == u.updatable_id, as: :resource,
         where: u.id == ^id
       )
       |> Fetch.join_access_level(person_id)
@@ -71,6 +70,28 @@ defmodule Operately.Updates do
       {update, goal, level} ->
         goal = apply(goal.__struct__, :set_requester_access_level, [goal, level])
         {:ok, Map.put(update, :goal, goal)}
+    end
+  end
+
+  def get_update_with_space_and_access_level(id, person_id) do
+    query = from(u in Update, as: :update,
+        join: s in Operately.Groups.Group, on: s.id == u.updatable_id, as: :resource,
+        where: u.id == ^id
+      )
+      |> Fetch.join_access_level(person_id)
+
+
+    from([update: u, resource: s, binding: b] in query,
+      where: b.access_level >= ^Binding.view_access(),
+      group_by: [u.id, s.id],
+      select: {u, s, max(b.access_level)}
+    )
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      {update, space, level} ->
+        space = apply(space.__struct__, :set_requester_access_level, [space, level])
+        {:ok, Map.put(update, :space, space)}
     end
   end
 

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -7,8 +7,10 @@ defmodule Operately.Updates do
 
   alias Operately.Activities
   alias Operately.Updates.Update
+  alias Operately.Goals.Goal
   alias Operately.Projects.Project
   alias Operately.Projects.ReviewRequest
+  alias Operately.Access.{Binding, Fetch}
 
   alias Operately.Repo
   alias Ecto.Multi
@@ -49,6 +51,28 @@ defmodule Operately.Updates do
   end
 
   def get_update!(id), do: Repo.get!(Update, id)
+
+  def get_update_with_goal_and_access_level(id, person_id) do
+    query = from(u in Update, as: :update,
+        join: g in Goal, on: g.id == u.updatable_id, as: :resource,
+        where: u.id == ^id
+      )
+      |> Fetch.join_access_level(person_id)
+
+
+    from([update: u, resource: g, binding: b] in query,
+      where: b.access_level >= ^Binding.view_access(),
+      group_by: [u.id, g.id],
+      select: {u, g, max(b.access_level)}
+    )
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      {update, goal, level} ->
+        goal = apply(goal.__struct__, :set_requester_access_level, [goal, level])
+        {:ok, Map.put(update, :goal, goal)}
+    end
+  end
 
   def create_update(attrs \\ %{}) do
     %Update{} |> Update.changeset(attrs) |> Repo.insert()

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -68,9 +68,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
 
   defp execute(ctx, inputs, type) do
     case type do
-      :goal_update -> CommentAdding.run(ctx.me, ctx.id, "update", ctx.content)
-      :discussion -> CommentAdding.run(ctx.me, ctx.id, "update", ctx.content)
-      _ -> CommentAdding.run(ctx.me, ctx.id, inputs.entity_type, ctx.content)
+      :goal_update -> CommentAdding.run(ctx.me, ctx.parent, "update", ctx.content)
+      :discussion -> CommentAdding.run(ctx.me, ctx.parent, "update", ctx.content)
+      _ -> CommentAdding.run(ctx.me, ctx.parent, inputs.entity_type, ctx.content)
     end
   end
 end

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -2,6 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Projects
+  alias Operately.Operations.CommentAdding
+
   inputs do
     field :entity_id, :string
     field :entity_type, :string
@@ -13,12 +16,38 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
   end
 
   def call(conn, inputs) do
-    author = me(conn)
-    {:ok, entity_id} = decode_id(inputs.entity_id)
-    entity_type = inputs.entity_type
-    {:ok, content} = Jason.decode(inputs.content)
+    type = String.to_existing_atom(inputs.entity_type)
 
-    {:ok, comment} = Operately.Operations.CommentAdding.run(author, entity_id, entity_type, content)
-    {:ok, %{comment: Serializer.serialize(comment, level: :essential)}}
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.entity_id) end)
+    |> run(:content, fn -> Jason.decode(inputs.content) end)
+    |> run(:parent, fn ctx -> fetch_parent(ctx.me.id, ctx.id, type) end)
+    |> run(:check_permissions, fn ctx -> check_permissions(ctx.parent, type) end)
+    |> run(:operation, fn ctx -> CommentAdding.run(ctx.me, ctx.id, inputs.entity_type, ctx.content) end)
+    |> run(:serialized, fn ctx -> {:ok, %{comment: Serializer.serialize(ctx.operation, level: :essential)}} end)
+    |> respond()
+  end
+
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :content, _} -> {:error, :bad_request}
+      {:error, :parent, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp check_permissions(parent, type) do
+    case type do
+      :project_check_in -> Projects.Permissions.check(parent.requester_access_level, :can_comment_on_check_in)
+    end
+  end
+
+  defp fetch_parent(person_id, id, :project_check_in) do
+    Projects.get_check_in_with_access_level(id, person_id)
   end
 end

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -2,7 +2,11 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  alias Operately.Projects
+  alias Operately.{
+    Activities,
+    Comments,
+    Projects
+  }
   alias Operately.Operations.CommentAdding
 
   inputs do
@@ -44,10 +48,14 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
   defp check_permissions(parent, type) do
     case type do
       :project_check_in -> Projects.Permissions.check(parent.requester_access_level, :can_comment_on_check_in)
+      :comment_thread -> Activities.Permissions.check(parent.activity.requester_access_level, :can_comment_on_thread)
     end
   end
 
-  defp fetch_parent(person_id, id, :project_check_in) do
-    Projects.get_check_in_with_access_level(id, person_id)
+  defp fetch_parent(person_id, id, type) do
+    case type do
+      :project_check_in -> Projects.get_check_in_with_access_level(id, person_id)
+      :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person_id)
+    end
   end
 end

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -8,6 +8,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
     Projects,
     Updates,
     Goals,
+    Groups,
   }
   alias Operately.Operations.CommentAdding
 
@@ -52,6 +53,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
       :project_check_in -> Projects.get_check_in_with_access_level(id, person_id)
       :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person_id)
       :goal_update -> Updates.get_update_with_goal_and_access_level(id, person_id)
+      :discussion -> Updates.get_update_with_space_and_access_level(id, person_id)
     end
   end
 
@@ -60,12 +62,14 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
       :project_check_in -> Projects.Permissions.check(parent.requester_access_level, :can_comment_on_check_in)
       :comment_thread -> Activities.Permissions.check(parent.activity.requester_access_level, :can_comment_on_thread)
       :goal_update -> Goals.Permissions.check(parent.goal.requester_access_level, :can_comment_on_update)
+      :discussion -> Groups.Permissions.check(parent.space.requester_access_level, :can_comment_on_discussions)
     end
   end
 
   defp execute(ctx, inputs, type) do
     case type do
       :goal_update -> CommentAdding.run(ctx.me, ctx.id, "update", ctx.content)
+      :discussion -> CommentAdding.run(ctx.me, ctx.id, "update", ctx.content)
       _ -> CommentAdding.run(ctx.me, ctx.id, inputs.entity_type, ctx.content)
     end
   end

--- a/lib/operately_web/api/serializer.ex
+++ b/lib/operately_web/api/serializer.ex
@@ -414,6 +414,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Permissions do
       can_create_milestone: permissions.can_create_milestone,
       can_delete_milestone: permissions.can_delete_milestone,
       can_edit_milestone: permissions.can_edit_milestone,
+      can_comment_on_check_in: permissions.can_comment_on_check_in,
       can_edit_check_in: permissions.can_edit_check_in,
       can_edit_description: permissions.can_edit_description,
       can_edit_timeline: permissions.can_edit_timeline,

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -21,7 +21,7 @@ defmodule Operately.Features.DiscussionsTest do
     Operately.Groups.add_members(author, space.id, [
       %{
         id: reader.id,
-        permissions: Binding.view_access(),
+        permissions: Binding.comment_access(),
       },
     ])
 

--- a/test/operately_web/api/mutations/create_comment_test.exs
+++ b/test/operately_web/api/mutations/create_comment_test.exs
@@ -1,3 +1,127 @@
 defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
-  use OperatelyWeb.ConnCase
-end 
+  use OperatelyWeb.TurboCase
+
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Updates
+  alias Operately.Access.Binding
+  alias Operately.Support.RichText
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :create_comment, %{})
+    end
+  end
+
+  describe "permissions" do
+    @table [
+      %{company: :no_access,      space: :no_access,      project: :no_access,      expected: 404},
+      %{company: :no_access,      space: :no_access,      project: :view_access,    expected: 403},
+      %{company: :no_access,      space: :no_access,      project: :comment_access, expected: 200},
+      %{company: :no_access,      space: :no_access,      project: :edit_access,    expected: 200},
+      %{company: :no_access,      space: :no_access,      project: :full_access,    expected: 200},
+
+      %{company: :no_access,      space: :view_access,    project: :no_access,      expected: 403},
+      %{company: :no_access,      space: :comment_access, project: :no_access,      expected: 200},
+      %{company: :no_access,      space: :edit_access,    project: :no_access,      expected: 200},
+      %{company: :no_access,      space: :full_access,    project: :no_access,      expected: 200},
+
+      %{company: :view_access,    space: :no_access,      project: :no_access,      expected: 403},
+      %{company: :comment_access, space: :no_access,      project: :no_access,      expected: 200},
+      %{company: :edit_access,    space: :no_access,      project: :no_access,      expected: 200},
+      %{company: :full_access,    space: :no_access,      project: :no_access,      expected: 200},
+    ]
+
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      Map.merge(ctx, %{creator: creator})
+    end
+
+    tabletest @table do
+      test "if caller has levels company=#{@test.company}, space=#{@test.space}, project=#{@test.project} on the project, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx)
+        project = create_project(ctx, space, @test.company, @test.space, @test.project)
+        check_in = create_check_in(ctx.creator, project)
+
+        assert {code, res} = mutation(ctx.conn, :create_comment, %{
+          entity_id: Paths.project_check_in_id(check_in),
+          entity_type: "project_check_in",
+          content: RichText.rich_text("Content", :as_string)
+        })
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 -> assert Updates.count_comments(check_in.id, :project_check_in) == 1
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+  end
+
+  describe "create_comment functionality" do
+    setup :register_and_log_in_account
+
+    test "creates comment", ctx do
+      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+      check_in = create_check_in(ctx.person, project)
+
+      assert Updates.count_comments(check_in.id, :project_check_in) == 0
+
+      assert {200, res} = mutation(ctx.conn, :create_comment, %{
+        entity_id: Paths.project_check_in_id(check_in),
+        entity_type: "project_check_in",
+        content: RichText.rich_text("Content", :as_string)
+      })
+
+      assert Updates.count_comments(check_in.id, :project_check_in) == 1
+      comment = hd(Updates.list_comments(check_in.id, :project_check_in))
+      assert res.comment == Serializer.serialize(comment, level: :essential)
+    end
+
+  end
+
+  #
+  # Helpers
+  #
+
+  def create_space(ctx) do
+    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+  end
+
+  def create_project(ctx, space, company_members_level, space_members_level, project_member_level) do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: space.id,
+      company_access_level: Binding.from_atom(company_members_level),
+      space_access_level: Binding.from_atom(space_members_level),
+    })
+
+    if space_members_level != :no_access do
+      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
+        id: ctx.person.id,
+        permissions: Binding.from_atom(space_members_level)
+      }])
+    end
+
+    if project_member_level != :no_access do
+      {:ok, _} = Operately.Projects.create_contributor(ctx.creator, %{
+        project_id: project.id,
+        person_id: ctx.person.id,
+        permissions: Binding.from_atom(project_member_level),
+        responsibility: "some responsibility"
+      })
+    end
+
+    project
+  end
+
+  def create_check_in(author, project) do
+    check_in_fixture(%{author_id: author.id, project_id: project.id})
+  end
+end

--- a/test/operately_web/api/queries/get_comments_test.exs
+++ b/test/operately_web/api/queries/get_comments_test.exs
@@ -33,7 +33,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have no access", ctx do
       check_in = create_check_in(ctx, company_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -46,7 +46,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have access", ctx do
       check_in = create_check_in(ctx, company_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -60,7 +60,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       check_in = create_check_in(ctx, space_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -74,7 +74,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       check_in = create_check_in(ctx, space_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -88,7 +88,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       champion = person_fixture_with_account(%{company_id: ctx.company.id})
       check_in = create_check_in(ctx, champion_id: champion.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       account = Repo.preload(champion, :account).account
@@ -113,7 +113,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
       check_in = create_check_in(ctx, reviewer_id: reviewer.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, check_in.id, "project_check_in")
+        add_comment(ctx, check_in, "project_check_in")
       end)
 
       account = Repo.preload(reviewer, :account).account
@@ -147,7 +147,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have no access", ctx do
       update = create_goal_update(ctx, company_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -160,7 +160,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have access", ctx do
       update = create_goal_update(ctx, company_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -174,7 +174,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       update = create_goal_update(ctx, space_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -188,7 +188,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       update = create_goal_update(ctx, space_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -202,7 +202,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       champion = person_fixture_with_account(%{company_id: ctx.company.id})
       update = create_goal_update(ctx, champion_id: champion.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       account = Repo.preload(champion, :account).account
@@ -227,7 +227,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
       update = create_goal_update(ctx, reviewer_id: reviewer.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, update.id, "update")
+        add_comment(ctx, update, "update")
       end)
 
       account = Repo.preload(reviewer, :account).account
@@ -260,7 +260,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company space - company members have access", ctx do
       discussion = create_discussion(ctx, space_id: ctx.company.company_space_id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, discussion.id, "update")
+        add_comment(ctx, discussion, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -274,7 +274,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       space = create_space(ctx, company_permissions: Binding.no_access())
       discussion = create_discussion(ctx, space_id: space.id)
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, discussion.id, "update")
+        add_comment(ctx, discussion, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -288,7 +288,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       space = create_space(ctx, company_permissions: Binding.view_access())
       discussion = create_discussion(ctx, space_id: space.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, discussion.id, "update")
+        add_comment(ctx, discussion, "update")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -302,7 +302,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       space = create_space(ctx, company_permissions: Binding.no_access())
       discussion = create_discussion(ctx, space_id: space.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, discussion.id, "update")
+        add_comment(ctx, discussion, "update")
       end)
 
       # Outside of space
@@ -335,7 +335,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have no access", ctx do
       thread = create_comment_thread(ctx, company_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -348,7 +348,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     test "company members have access", ctx do
       thread = create_comment_thread(ctx, company_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -362,7 +362,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       thread = create_comment_thread(ctx, space_access: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -376,7 +376,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       add_person_to_space(ctx)
       thread = create_comment_thread(ctx, space_access: Binding.view_access())
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       assert {200, res} = query(ctx.conn, :get_comments, %{
@@ -390,7 +390,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       champion = person_fixture_with_account(%{company_id: ctx.company.id})
       thread = create_comment_thread(ctx, champion_id: champion.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       account = Repo.preload(champion, :account).account
@@ -415,7 +415,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
       thread = create_comment_thread(ctx, reviewer_id: reviewer.id)
       comments = Enum.map(1..3, fn _ ->
-        add_comment(ctx, thread.id, "comment_thread")
+        add_comment(ctx, thread, "comment_thread")
       end)
 
       account = Repo.preload(reviewer, :account).account
@@ -511,8 +511,8 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     comment_thread_fixture(%{parent_id: activity.id})
   end
 
-  defp add_comment(ctx, entity_id, entity_type, content \\ "Hello World") do
-    {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.person, entity_id, entity_type, RichText.rich_text(content))
+  defp add_comment(ctx, entity, entity_type, content \\ "Hello World") do
+    {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.person, entity, entity_type, RichText.rich_text(content))
     Repo.preload(comment, :author)
     |> serialize(level: :full)
   end

--- a/test/operately_web/api/queries/get_discussion_test.exs
+++ b/test/operately_web/api/queries/get_discussion_test.exs
@@ -152,6 +152,6 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
   end
 
   defp add_comment(ctx, discussion, content) do
-    Operately.Operations.CommentAdding.run(ctx.person, discussion.id, "update", RichText.rich_text(content))
+    Operately.Operations.CommentAdding.run(ctx.person, discussion, "update", RichText.rich_text(content))
   end
 end


### PR DESCRIPTION
I've added a permissions check to the `OperatelyWeb.Api.Mutations.CreateComment` mutation.