### PR TITLE
fix: SearchProjectContributorCandidates returns only people from the same company

### DIFF
--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -245,7 +245,7 @@ defmodule Operately.Projects do
     |> Repo.all()
   end
 
-  def list_project_contributor_candidates(project_id, query, exclude_ids, limit) do
+  def list_project_contributor_candidates(company_id, project_id, query, exclude_ids, limit) do
     ilike_pattern = "%#{query}%"
 
     query = (
@@ -254,7 +254,7 @@ defmodule Operately.Projects do
       where: is_nil(contrib.project_id),
       where: person.id not in ^exclude_ids,
       where: ilike(person.full_name, ^ilike_pattern) or ilike(person.title, ^ilike_pattern),
-      where: not person.suspended,
+      where: not person.suspended and person.company_id == ^company_id,
       limit: ^limit
     )
 

--- a/lib/operately_web/api/queries/search_project_contributor_candidates.ex
+++ b/lib/operately_web/api/queries/search_project_contributor_candidates.ex
@@ -17,10 +17,11 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidates do
   end
 
   def call(conn, inputs) do
+    person = me(conn)
     {:ok, project_id} = decode_id(inputs.project_id)
 
     if has_permissions?(me(conn), project_id) do
-      people = Projects.list_project_contributor_candidates(project_id, inputs.query, [], 10)
+      people = Projects.list_project_contributor_candidates(person.company_id, project_id, inputs.query, [], 10)
       {:ok, %{people: Serializer.serialize(people)}}
     else
       {:ok, %{people: []}}


### PR DESCRIPTION
The `SearchProjectContributorCandidates` query was returning people from different companies.