### PR TITLE
feat: Add SubscribersSelector component

### DIFF
--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -72,7 +72,7 @@ function SelectedPeople({ people, hide }) {
   if (people.length === 0 || hide) return <></>;
 
   return (
-    <div className="flex gap-2 ml-6">
+    <div className="flex flex-wrap gap-2 ml-6">
       {people.map((person) => (
         <Avatar person={person} size="tiny" key={person.id} />
       ))}

--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -115,7 +115,7 @@ function SelectorModal({ showSelector, setShowSelector }: SelectorModalProps) {
       minHeight="200px"
     >
       <Forms.Form form={form}>
-        <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-6 max-h-[400px] overflow-y-auto">
           <div className="flex items-center gap-3">
             <ActionLink onClick={handleSelectEveryone}>Select everyone</ActionLink>
             <span className="text-content-dimmed">&middot;</span>

--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -42,11 +42,7 @@ export function SubscribersSelector() {
           onClick={() => setShowSelector(true)}
         />
 
-        <SubscriptionOption
-          label="No one"
-          value={Options.NONE}
-          people={[]}
-        />
+        <SubscriptionOption label="No one" value={Options.NONE} people={[]} />
       </RadioGroup>
 
       <SelectorModal showSelector={showSelector} setShowSelector={setShowSelector} />

--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useMemo } from "react";
+
+import { useSubscriptionsContext, Options } from "./SubscriptionsContext";
+import Forms from "@/components/Forms";
+import Modal from "@/components/Modal";
+import Avatar from "@/components/Avatar";
+import { Radio, RadioGroup } from "@/components/Form";
+import { FilledButton } from "@/components/Button";
+import { ActionLink } from "@/components/Link";
+import { Person } from "@/models/people";
+
+export function SubscribersSelector() {
+  const [showSelector, setShowSelector] = useState(false);
+  const { people, selectedPeople, subscriptionType, setSubscriptionType } = useSubscriptionsContext();
+
+  const selectedPeopleLabel = useMemo(() => {
+    switch (selectedPeople.length) {
+      case 0:
+        return "Only the people I select";
+      case 1:
+        return "Only the following person I selected";
+      default:
+        return `Only the following ${selectedPeople.length} people I selected`;
+    }
+  }, [selectedPeople]);
+
+  return (
+    <div>
+      <p className="text-lg font-bold mb-2">When I post this, notify:</p>
+
+      <RadioGroup name="subscriptions-options" onChange={setSubscriptionType} defaultValue={subscriptionType}>
+        <SubscriptionOption
+          label={`All ${people.length} people who are members of the space`}
+          value={Options.ALL}
+          people={people}
+        />
+
+        <SubscriptionOption
+          label={selectedPeopleLabel}
+          value={Options.SELECTED}
+          people={selectedPeople}
+          onClick={() => setShowSelector(true)}
+        />
+
+        <SubscriptionOption
+          label="No one"
+          value={Options.NONE}
+          people={[]}
+        />
+      </RadioGroup>
+
+      <SelectorModal showSelector={showSelector} setShowSelector={setShowSelector} />
+    </div>
+  );
+}
+
+interface SubscriptionOptionProps {
+  label: string;
+  value: Options;
+  people: Person[];
+  onClick?: () => void;
+}
+
+function SubscriptionOption({ label, value, people, onClick }: SubscriptionOptionProps) {
+  const { subscriptionType } = useSubscriptionsContext();
+
+  return (
+    <div className="my-1" onClick={onClick}>
+      <Radio label={label} value={value} />
+      <SelectedPeople people={people} hide={subscriptionType !== value} />
+    </div>
+  );
+}
+
+function SelectedPeople({ people, hide }) {
+  if (people.length === 0 || hide) return <></>;
+
+  return (
+    <div className="flex gap-2 ml-6">
+      {people.map((person) => (
+        <Avatar person={person} size="tiny" key={person.id} />
+      ))}
+    </div>
+  );
+}
+
+interface SelectorModalProps {
+  showSelector: boolean;
+  setShowSelector: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+function SelectorModal({ showSelector, setShowSelector }: SelectorModalProps) {
+  const { people, setSelectedPeople } = useSubscriptionsContext();
+
+  const form = Forms.useForm({
+    fields: {
+      people: Forms.useMultiPeopleSelectField(people, { optional: true }),
+    },
+    submit: async (form) => {
+      setSelectedPeople(people.filter((person) => form.fields.people.value!.includes(person)));
+      setShowSelector(false);
+    },
+  });
+  const { options, setValue } = form.fields.people;
+
+  const handleSelectNoone = () => {
+    setValue([]);
+  };
+
+  const handleSelectEveryone = () => {
+    setValue(options.map((person) => person));
+  };
+
+  return (
+    <Modal
+      title="Select people to notify"
+      isOpen={showSelector}
+      hideModal={() => setShowSelector(false)}
+      minHeight="200px"
+    >
+      <Forms.Form form={form}>
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-3">
+            <ActionLink onClick={handleSelectEveryone}>Select everyone</ActionLink>
+            <span className="text-content-dimmed">&middot;</span>
+            <ActionLink onClick={handleSelectNoone}>Select no one</ActionLink>
+          </div>
+
+          <Forms.MultiPeopleSelectField field="people" />
+        </div>
+
+        <div className="flex justify-center gap-2">
+          <FilledButton type="primary" submit>
+            Save selection
+          </FilledButton>
+          <FilledButton onClick={() => setShowSelector(false)} type="secondary">
+            Never mind
+          </FilledButton>
+        </div>
+      </Forms.Form>
+    </Modal>
+  );
+}

--- a/assets/js/features/Subscriptions/SubscriptionsContext.tsx
+++ b/assets/js/features/Subscriptions/SubscriptionsContext.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+import { Person } from "@/models/people";
+
+enum Options {
+  ALL = "all",
+  SELECTED = "selected",
+  NONE = "none",
+}
+
+interface ContextType {
+  people: Person[];
+  selectedPeople: Person[];
+  setSelectedPeople: React.Dispatch<React.SetStateAction<Person[]>>;
+  subscriptionType: Options;
+  setSubscriptionType: React.Dispatch<React.SetStateAction<Options>>;
+}
+
+interface Props {
+  children: NonNullable<React.ReactNode>;
+  people: Person[];
+}
+
+function SubscriptionsProvider({ children, people }: Props) {
+  const [selectedPeople, setSelectedPeople] = React.useState<Person[]>([]);
+  const [subscriptionType, setSubscriptionType] = React.useState(Options.ALL);
+
+  const data = {
+    people,
+    selectedPeople,
+    setSelectedPeople,
+    subscriptionType,
+    setSubscriptionType,
+  };
+
+  return <SubscriptionsContext.Provider value={data}>{children}</SubscriptionsContext.Provider>;
+}
+
+const SubscriptionsContext = React.createContext<ContextType | undefined>(undefined);
+
+function useSubscriptionsContext() {
+  const context = React.useContext(SubscriptionsContext);
+
+  if (context === undefined) {
+    throw Error("useSubscriptionsContext must be used within a SubscriptionsProvider");
+  }
+
+  return context;
+}
+
+export { SubscriptionsProvider, useSubscriptionsContext, Options };

--- a/assets/js/features/Subscriptions/index.tsx
+++ b/assets/js/features/Subscriptions/index.tsx
@@ -1,0 +1,2 @@
+export { SubscribersSelector } from "./SubscribersSelector";
+export { SubscriptionsProvider, useSubscriptionsContext } from "./SubscriptionsContext";

--- a/assets/knip.json
+++ b/assets/knip.json
@@ -2,10 +2,10 @@
   "$schema": "https://unpkg.com/knip@2/schema.json",
   "entry": ["js/app.tsx", "build.js", "codegen.ts"],
   "project": ["js/**/*.ts", "js/**/*.tsx"],
-  "ignore": ["js/gql/generated.tsx", "js/api/index.tsx"],
+  "ignore": ["js/gql/generated.tsx", "js/api/index.tsx", "js/features/Subscriptions/"],
   "ignoreDependencies": ["@types/jest"],
 
   "rules": {
-    "nsTypes": "off",
+    "nsTypes": "off"
   }
 }


### PR DESCRIPTION
I've added the component `SubscribersSelector` and the context `SubscriptionsContext`.

I tried to follow the wireframe as strictly as possible, but most likely we still need some adjustments in the design.

Also, once I add and update the API endpoints, other adjustments in the functionality will be necessary as well, such as displaying the Space name or whether it's a Space, Goal, Project, etc.
But overall the component and context should be mostly ready.

https://github.com/user-attachments/assets/a275adb5-bbe9-4498-a059-1b787adae512

