### PR TITLE
chore: Use system theme on design page

### DIFF
--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -4,7 +4,7 @@ import DefaultLayout from "@/layouts/DefaultLayout";
 
 import pages from "@/pages";
 
-import { createBrowserRouter } from "react-router-dom";
+import { Outlet, createBrowserRouter } from "react-router-dom";
 import { companyLoader } from "./companyLoader";
 import { pageRoute } from "./pageRoute";
 
@@ -24,13 +24,26 @@ function ProtectedRoutes() {
   );
 }
 
+function PublicRoutes() {
+  return (
+    <ThemeProvider>
+      <Outlet />
+    </ThemeProvider>
+  );
+}
+
 export function createAppRoutes() {
   return createBrowserRouter([
     pageRoute("/", pages.LobbyPage),
     pageRoute("/new", pages.NewCompanyPage),
     pageRoute("/setup", pages.SetupPage),
     pageRoute("/join", pages.JoinPage),
-    pageRoute("/__design__", pages.DesignPage),
+    {
+      path: "/",
+      element: <PublicRoutes />,
+      errorElement: <ErrorPage />,
+      children: [pageRoute("/__design__", pages.DesignPage)],
+    },
     {
       path: "/:companyId",
       loader: companyLoader,


### PR DESCRIPTION
Without this, it was impossible to test dark/light mode on the design page.
As the design page is "public" it will follow the system preferences.

Protip: If you are touching design you will have to switch between light/dark mode often.
Set up a mac script and easily switch with `cmd-space` `toggle-dark...`. https://medium.com/@geert.cuppens/macos-keyboard-shortcut-to-toggle-dark-mode-2724c9f7fbfe.


https://github.com/user-attachments/assets/58e6a940-f101-4fab-997d-03e528951821

