### PR TITLE
feat: Add action link

### DIFF
--- a/assets/js/components/Link/index.tsx
+++ b/assets/js/components/Link/index.tsx
@@ -20,6 +20,11 @@ interface ButtonLinkProps extends Props {
   onClick: () => void;
 }
 
+interface ActionLinkProps extends Props {
+  onClick: () => void;
+  underline?: "always" | "hover" | "never";
+}
+
 interface DivLinkProps extends Props {
   to: string;
   className?: string;
@@ -64,6 +69,17 @@ export function ButtonLink({ onClick, children, testId }: ButtonLinkProps) {
       {children}
     </span>
   );
+}
+
+export function ActionLink(props: ActionLinkProps) {
+  const className = classNames(
+    baseLinkClass,
+    underlineClass(props.underline),
+    "text-link-base hover:text-link-hover",
+    props.className,
+  );
+
+  return <span {...props} className={className} />;
 }
 
 export function DimmedLink(props: LinkProps) {


### PR DESCRIPTION
I've added an ActionLink component. It has the same styles as the Link component, but it takes the `onClick` prop instead of `to`.