### PR TITLE
chore: Replace text-red-500 with a semantic color name

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -32,6 +32,7 @@ body[data-theme="light"] {
   --color-content-accent: rgba(0, 0, 0, 1);
   --color-content-dimmed: rgba(0, 0, 0, 0.6);
   --color-content-subtle: rgba(0, 0, 0, 0.3);
+  --color-content-error: var(--color-red-500);
 
   --color-stroke-base: rgba(0, 0, 0, 0.1);
   --color-stroke-dimmed: rgba(0, 0, 0, 0.05);
@@ -76,6 +77,7 @@ body[data-theme="dark"] {
   --color-content-accent: rgba(255, 255, 255, 1);
   --color-content-dimmed: rgba(255, 255, 255, 0.6);
   --color-content-subtle: rgba(255, 255, 255, 0.3);
+  --color-content-error: var(--color-red-500);
 
   --color-stroke-base: rgba(255, 255, 255, 0.1);
   --color-stroke-dimmed: rgba(255, 255, 255, 0.05);

--- a/assets/js/components/Forms/ErrorMessage.tsx
+++ b/assets/js/components/Forms/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
 
 export function ErrorMessage({ error }: { error: string }) {
-  return <div className="text-sm block text-red-500">{error}</div>;
+  return <div className="text-sm block text-content-error">{error}</div>;
 }

--- a/assets/js/components/Menu/index.tsx
+++ b/assets/js/components/Menu/index.tsx
@@ -59,7 +59,7 @@ export function MenuItem(props: MenuItemProps) {
 function MenuItemContent(props: MenuItemProps) {
   const className = classNames(menuItemClass, {
     "hover:text-content-base": !props.danger,
-    "hover:text-red-500": props.danger,
+    "hover:text-content-error": props.danger,
   });
 
   if (props.linkTo) {

--- a/assets/js/components/MilestoneIcon/index.tsx
+++ b/assets/js/components/MilestoneIcon/index.tsx
@@ -19,7 +19,7 @@ export function MilestoneIcon({ milestone, className, size = 16 }: MilestoneIcon
       color = "text-green-700";
     } else {
       if (isOverdue) {
-        color = "text-red-500";
+        color = "text-content-error";
       } else {
         color = "text-content-base";
       }

--- a/assets/js/features/PerfBar/index.tsx
+++ b/assets/js/features/PerfBar/index.tsx
@@ -11,7 +11,7 @@ export function PerfBar() {
   if (meData?.error) return null;
   if (meData?.data?.me?.companyRole !== "admin") return null;
 
-  const pageLoadColor = data.pageLoad < 500 ? "text-green-500" : "text-red-500";
+  const pageLoadColor = data.pageLoad < 500 ? "text-green-500" : "text-content-error";
 
   return (
     <div className="bg-black text-white-1 p-1 text-sm font-mono z-50">

--- a/assets/js/features/activities/GoalCheckIn/ConditionChanges.tsx
+++ b/assets/js/features/activities/GoalCheckIn/ConditionChanges.tsx
@@ -47,7 +47,7 @@ function TargetChange({ target }) {
   if (newProgress > oldProgress) {
     return <div className="text-green-600 font-bold shrink-0 text-sm">+ {Math.abs(diff)}</div>;
   } else if (newProgress < oldProgress) {
-    return <div className="text-red-500 font-bold shrink-0 test-sm">- {Math.abs(diff)}</div>;
+    return <div className="text-content-error font-bold shrink-0 test-sm">- {Math.abs(diff)}</div>;
   } else {
     return <div className="flex items-center gap-1 text-content-dimmed font-medium shrink-0 text-xs">No Change</div>;
   }

--- a/assets/js/features/goals/GoalCheckInForm/Form.tsx
+++ b/assets/js/features/goals/GoalCheckInForm/Form.tsx
@@ -26,7 +26,7 @@ function Editor({ form }: { form: FormState }) {
   return (
     <div className="mt-8">
       <div className="font-bold mb-2">Describe your progress and any learnings</div>
-      {contentError && <div className="text-red-500 text-sm font-medium mt-1">Required</div>}
+      {contentError && <div className="text-content-error text-sm font-medium mt-1">Required</div>}
       <div className="border border-surface-outline rounded overflow-hidden">
         <TipTapEditor.StandardEditorForm editor={form.editor.editor} />
       </div>

--- a/assets/js/features/goals/GoalForm/Form.tsx
+++ b/assets/js/features/goals/GoalForm/Form.tsx
@@ -49,7 +49,7 @@ function TargetSection({ form }: { form: FormState }) {
       <SectionHeader form={form} title="Success Conditions" subtitle="How will you know that you succeded?" />
 
       {form.errors.find((e) => e.field === "targets") && (
-        <div className="text-red-500 text-sm">At least one success condition is required</div>
+        <div className="text-content-error text-sm">At least one success condition is required</div>
       )}
 
       <div className="mt-4">

--- a/assets/js/features/goals/GoalPageHeader/index.tsx
+++ b/assets/js/features/goals/GoalPageHeader/index.tsx
@@ -55,7 +55,7 @@ function GoalTitle({ goal }: { goal: Goals.Goal }) {
 function GoalIcon() {
   return (
     <div className="bg-red-500/10 p-1.5 rounded-lg">
-      <Icons.IconTarget size={24} className="text-red-500" />
+      <Icons.IconTarget size={24} className="text-content-error" />
     </div>
   );
 }
@@ -213,7 +213,9 @@ function TimeframeState({ goal }) {
     return (
       <span>
         &middot;{" "}
-        <span className="text-red-500">Overdue by {plurarize(Timeframes.overdueDays(timeframe), "day", "days")}</span>
+        <span className="text-content-error">
+          Overdue by {plurarize(Timeframes.overdueDays(timeframe), "day", "days")}
+        </span>
       </span>
     );
   } else {

--- a/assets/js/features/goals/GoalTree/components/NodeIcon.tsx
+++ b/assets/js/features/goals/GoalTree/components/NodeIcon.tsx
@@ -6,7 +6,7 @@ import { Node } from "../tree";
 export function NodeIcon({ node }: { node: Pick<Node, "type"> }) {
   switch (node.type) {
     case "goal":
-      return <Icons.IconTarget size={15} className="text-red-500 shrink-0" />;
+      return <Icons.IconTarget size={15} className="text-content-error shrink-0" />;
     case "project":
       return <Icons.IconHexagons size={15} className="text-indigo-500 shrink-0" />;
     default:

--- a/assets/js/features/projectCheckIns/Form/Form.tsx
+++ b/assets/js/features/projectCheckIns/Form/Form.tsx
@@ -39,7 +39,7 @@ export function StatusSection({ form }: { form: FormState }) {
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">1. How's the project going?</div>
-      {error && <div className="text-xs text-red-500 mt-1 font-medium">Status is required</div>}
+      {error && <div className="text-xs text-content-error mt-1 font-medium">Status is required</div>}
 
       <div className="flex flex-col gap-2 mt-2">
         <StatusDropdown
@@ -63,7 +63,7 @@ function DescriptionSection({ form }: { form: FormState }) {
   return (
     <>
       <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
-      {error && <div className="text-xs text-red-500 mt-1 font-medium">Description is required</div>}
+      {error && <div className="text-xs text-content-error mt-1 font-medium">Description is required</div>}
       <div className={className}>
         <TipTapEditor.StandardEditorForm editor={form.editor.editor} />
       </div>

--- a/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
+++ b/assets/js/pages/CompanyAdminAddPeoplePage/page.tsx
@@ -123,7 +123,7 @@ function PersonForm({ fields, errors, submit, submitting }: ReturnType<typeof us
       </div>
 
       {errors.map((e, idx) => (
-        <div key={idx} className="text-red-500 text-sm">
+        <div key={idx} className="text-content-error text-sm">
           {e.message}
         </div>
       ))}

--- a/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
+++ b/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
@@ -61,7 +61,7 @@ function TrustedEmailDomainItem({ domain, form }: { domain: string; form: FormSt
     <div className="flex items-center gap-2 bg-surface-dimmed border border-stroke-base px-3 py-2 rounded">
       <div className="flex-1 font-medium">{domain}</div>
       <Icons.IconTrash
-        className="text-content-dimmed cursor-pointer hover:text-red-500 shrink-0"
+        className="text-content-dimmed cursor-pointer hover:text-content-error shrink-0"
         size={16}
         onClick={() => form.removeDomain(domain)}
         data-test-id={removeTestId}

--- a/assets/js/pages/DesignPage/Colors.tsx
+++ b/assets/js/pages/DesignPage/Colors.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import * as Icons from "@tabler/icons-react";
 import { Section, SectionTitle } from "./Section";
 
 export function Colors() {
@@ -12,41 +13,90 @@ export function Colors() {
         maintain a consistent look and feel, and easily make changes in the future.
       </div>
 
+      <h3 className="font-bold mt-4 text-lg">Background Colors</h3>
+      <p className="text-sm mb-6">Colors used for the background and surface.</p>
+
       <div className="grid grid-cols-2 gap-8">
-        <Color color="bg-base" usage="Background color of the application" />
-        <Color color="bg-surface" usage="Color of the UI surface" />
-        <Color color="bg-surface-dimmed" usage="Dimmed version of the UI surface, used for page footers" />
-        <Color color="bg-surface-accent" usage="Accent color of the UI surface, used for subtle highlights" />
-        <Color color="bg-surface-outline" usage="Outline color of the UI surface, used for borders" />
-        <Color color="bg-surface-highlight" usage="Highlight color of the UI surface, used for hover effects" />
-        <Color color="bg-content-base" usage="Default color of all text content" />
-        <Color color="bg-content-accent" usage="Accent color for text content" />
-        <Color color="bg-content-dimmed" usage="Dimmed color for text content" />
-        <Color color="bg-content-subtle" usage="Barely visible color for text content" />
-        <Color color="bg-stroke-base" usage="Color for dividers and subtle borders on a page" />
-        <Color color="bg-link-base" usage="Default color for links" />
-        <Color color="bg-link-hover" usage="Hover color for links" />
-        <Color color="bg-accent-1" usage="Primary accent color in the application" />
-        <Color color="bg-accent-1-light" usage="A lighter shade of the primary accent color for hover effects" />
-        <Color color="bg-red-500" usage="Error color for alerts and notifications" />
-        <Color color="bg-callout-info" usage="Information callout background color" />
-        <Color color="bg-callout-info-icon" usage="Information callout icon color" />
-        <Color color="bg-callout-info-message" usage="Information callout message text" />
-        <Color color="bg-callout-warning" usage="Warning callout background color" />
-        <Color color="bg-callout-warning-icon" usage="Warning callout icon color" />
-        <Color color="bg-callout-warning-message" usage="Warning callout message text" />
-        <Color color="bg-callout-error" usage="Error callout background color" />
-        <Color color="bg-callout-error-icon" usage="Error callout icon color" />
-        <Color color="bg-callout-error-message" usage="Error callout message text" />
-        <Color color="bg-callout-success" usage="Success callout background color" />
-        <Color color="bg-callout-success-icon" usage="Success callout icon color" />
-        <Color color="bg-callout-success-message" usage="Success callout message text" />
+        <ColorBox color="bg-base" usage="Background color of the application" />
+        <ColorBox color="bg-surface" usage="Color of the UI surface" />
+        <ColorBox color="bg-surface-dimmed" usage="Dimmed version of the UI surface, used for page footers" />
+        <ColorBox color="bg-surface-accent" usage="Accent color of the UI surface, used for subtle highlights" />
+        <ColorBox color="bg-surface-outline" usage="Outline color of the UI surface, used for borders" />
+        <ColorBox color="bg-surface-highlight" usage="Highlight color of the UI surface, used for hover effects" />
+      </div>
+
+      <h3 className="font-bold mt-12 text-lg">Interactive Components</h3>
+      <p className="text-sm mb-6">Form background, callouts, etc...</p>
+
+      <div className="grid grid-cols-2 gap-8">
+        <ColorBox color="bg-callout-info" usage="Information callout background color" />
+        <ColorBox color="bg-callout-info-icon" usage="Information callout icon color" />
+        <ColorBox color="bg-callout-info-message" usage="Information callout message text" />
+        <ColorBox color="bg-callout-warning" usage="Warning callout background color" />
+        <ColorBox color="bg-callout-warning-icon" usage="Warning callout icon color" />
+        <ColorBox color="bg-callout-warning-message" usage="Warning callout message text" />
+        <ColorBox color="bg-callout-error" usage="Error callout background color" />
+        <ColorBox color="bg-callout-error-icon" usage="Error callout icon color" />
+        <ColorBox color="bg-callout-error-message" usage="Error callout message text" />
+        <ColorBox color="bg-callout-success" usage="Success callout background color" />
+        <ColorBox color="bg-callout-success-icon" usage="Success callout icon color" />
+        <ColorBox color="bg-callout-success-message" usage="Success callout message text" />
+      </div>
+
+      <h3 className="font-bold mt-12 text-lg">Borders And Separators</h3>
+      <p className="text-sm mb-6">Colors used for dividers, borders, and other separators</p>
+
+      <div className="grid grid-cols-2 gap-8">
+        <ColorBox color="bg-stroke-base" usage="Color for dividers and subtle borders on a page" />
+        <ColorBox color="bg-stroke-dimmed" usage="Separator for condensed content, like lists" />
+      </div>
+
+      <h3 className="font-bold mt-12 text-lg">Solid Colors</h3>
+      <p className="text-sm mb-6">CTA, Buttons, Avatar background, etc...</p>
+
+      <div className="grid grid-cols-2 gap-8">
+        <ColorBox color="bg-accent-1" usage="Color that stands out, used for primary buttons and CTAs" />
+        <ColorBox color="bg-accent-1-light" usage="A lighter shade of the primary accent color for hover effects" />
+      </div>
+
+      <h3 className="font-bold mt-12 text-lg">Text Colors</h3>
+      <p className="text-sm mb-6">Colors used for text content, icons, warnings, and other content</p>
+
+      <div className="flex flex-col gap-4">
+        <ColorText color="text-content-base" usage="Default color of all text content" />
+        <ColorText color="text-content-dimmed" usage="Text content with less emphasis" />
+        <ColorText color="text-content-subtle" usage="Barely visible color for text content" />
+        <ColorText color="text-content-error" usage="Form errors, validation messages, etc..." />
+        <ColorText color="text-link-base" usage="Default color of all text links" />
+        <ColorText color="text-link-hover" usage="Color of text links on hover" />
       </div>
     </Section>
   );
 }
 
-function Color({ color, usage }: { color: string; usage: string }) {
+function ColorText({ color, usage }: { color: string; usage: string }) {
+  return (
+    <div className="flex items-center gap-16">
+      <div className="w-64">
+        <div className="text-content-accent font-bold">{color}</div>
+        <div className="text-xs">{usage}</div>
+      </div>
+
+      <span className={`font-medium ${color}`}>The quick brown fox jumps over the lazy dog</span>
+
+      <div className="flex items-center gap-4">
+        <Icons.IconTrash className={color} size={14} />
+        <Icons.IconUsers className={color} size={14} />
+        <Icons.IconRefresh className={color} size={14} />
+        <Icons.IconSettings className={color} size={14} />
+        <Icons.IconSearch className={color} size={14} />
+        <Icons.IconX className={color} size={14} />
+      </div>
+    </div>
+  );
+}
+
+function ColorBox({ color, usage }: { color: string; usage: string }) {
   return (
     <div className="flex items-start gap-4">
       <ColorShowcase color={color} />
@@ -63,7 +113,7 @@ function ColorDetails({ color, usage }: { color: string; usage: string }) {
   return (
     <div>
       <div className="text-content-accent font-bold">{color.slice(3)}</div>
-      <div className="text-sm">{usage}</div>
+      <div className="text-xs">{usage}</div>
     </div>
   );
 }

--- a/assets/js/pages/GoalAddPage/page.tsx
+++ b/assets/js/pages/GoalAddPage/page.tsx
@@ -90,7 +90,7 @@ function SubmitButton({ form }: { form: FormState }) {
   return (
     <div className="mt-8">
       {form.errors.length > 0 && (
-        <div className="text-red-500 text-sm font-medium text-center mb-4">Please fill out all fields</div>
+        <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>
       )}
 
       <div className="flex items-center justify-center gap-4">

--- a/assets/js/pages/GoalEditPage/page.tsx
+++ b/assets/js/pages/GoalEditPage/page.tsx
@@ -72,5 +72,5 @@ function Header({ form }: { form: FormState }) {
 function ErrorMessage({ form }: { form: FormState }) {
   if (form.errors.length === 0) return null;
 
-  return <div className="text-red-500 text-sm font-medium text-center mb-4">Please fill out all fields</div>;
+  return <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>;
 }

--- a/assets/js/pages/GoalEditTimeframePage/index.tsx
+++ b/assets/js/pages/GoalEditTimeframePage/index.tsx
@@ -212,7 +212,7 @@ function Submit({ goal, form }: { goal: Goals.Goal; form: Form }) {
 function Error({ form }: { form: Form }) {
   if (!form.error) return null;
 
-  return <div className="mb-2 text-red-500 font-medium">{form.error.message}</div>;
+  return <div className="mb-2 text-content-error font-medium">{form.error.message}</div>;
 }
 
 function WhoWillBeNotified({ goal, me }: { goal: Goals.Goal; me: People.Person }) {

--- a/assets/js/pages/GoalProgressUpdatePage/page.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/page.tsx
@@ -165,7 +165,7 @@ function TargetChange({ target }) {
   if (newProgress > oldProgress) {
     return <div className="text-green-600 font-bold shrink-0 text-sm">+ {Math.abs(diff)}</div>;
   } else if (newProgress < oldProgress) {
-    return <div className="text-red-500 font-bold shrink-0 test-sm">- {Math.abs(diff)}</div>;
+    return <div className="text-content-error font-bold shrink-0 test-sm">- {Math.abs(diff)}</div>;
   } else {
     return <div className="flex items-center gap-1 text-content-dimmed font-medium shrink-0 text-xs">No Change</div>;
   }

--- a/assets/js/pages/JoinPage/page.tsx
+++ b/assets/js/pages/JoinPage/page.tsx
@@ -63,7 +63,7 @@ function Form() {
       />
 
       {errors.map((e, idx) => (
-        <div key={idx} className="text-red-500 text-sm">
+        <div key={idx} className="text-content-error text-sm">
           {e.message}
         </div>
       ))}

--- a/assets/js/pages/NewCompanyPage/index.tsx
+++ b/assets/js/pages/NewCompanyPage/index.tsx
@@ -49,7 +49,7 @@ export function Page() {
               />
 
               {form.errors.some((e) => e.field === "companyName") && (
-                <div className="text-red-500 text-sm mt-1">
+                <div className="text-content-error text-sm mt-1">
                   {form.errors.find((e) => e.field === "companyName")?.message}
                 </div>
               )}
@@ -66,7 +66,9 @@ export function Page() {
               />
 
               {form.errors.some((e) => e.field === "title") && (
-                <div className="text-red-500 text-sm mt-1">{form.errors.find((e) => e.field === "title")?.message}</div>
+                <div className="text-content-error text-sm mt-1">
+                  {form.errors.find((e) => e.field === "title")?.message}
+                </div>
               )}
             </div>
           </div>

--- a/assets/js/pages/ProjectAddPage/page.tsx
+++ b/assets/js/pages/ProjectAddPage/page.tsx
@@ -78,7 +78,7 @@ function SubmitButton({ form }: { form: FormState }) {
   return (
     <div className="mt-8">
       {form.errors.length > 0 && (
-        <div className="text-red-500 text-sm font-medium text-center mb-4">Please fill out all fields</div>
+        <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>
       )}
 
       <div className="flex items-center justify-center gap-4">

--- a/assets/js/pages/ProjectClosePage/page.tsx
+++ b/assets/js/pages/ProjectClosePage/page.tsx
@@ -50,7 +50,7 @@ function Question({ title, editor, error }) {
   return (
     <div className="" data-test-id={testId}>
       <h2 className="text-content-accent text font-bold mb-1">{title}</h2>
-      {error && <div className="text-sm text-red-500 mb-2 font-medium">Please fill in this field</div>}
+      {error && <div className="text-sm text-content-error mb-2 font-medium">Please fill in this field</div>}
 
       <div className="border-x border-stroke-base">
         <TipTapEditor.Root editor={editor}>

--- a/assets/js/pages/ProjectEditTimelinePage/MilestoneList.tsx
+++ b/assets/js/pages/ProjectEditTimelinePage/MilestoneList.tsx
@@ -142,7 +142,7 @@ function MilestoneDisplay({ milestone, form, edit }) {
 
             {milestone.deletable && (
               <div
-                className="rounded-full bg-surface-dimmed hover:bg-surface-accent p-1 cursor-pointer hover:text-red-500 transition-colors"
+                className="rounded-full bg-surface-dimmed hover:bg-surface-accent p-1 cursor-pointer hover:text-content-error transition-colors"
                 onClick={() => form.milestoneList.remove(milestone.id)}
                 data-test-id={"remove-" + milestoneTestID(milestone)}
               >

--- a/assets/js/pages/ProjectEditTimelinePage/page.tsx
+++ b/assets/js/pages/ProjectEditTimelinePage/page.tsx
@@ -62,7 +62,7 @@ function Header({ form }: { form: FormState }) {
       </Paper.Header>
 
       {form.errors.length > 0 && (
-        <div className="text-red-500 text-sm font-medium text-center mb-4">Please fill out all fields</div>
+        <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>
       )}
     </div>
   );

--- a/assets/js/pages/ReviewPage/page.tsx
+++ b/assets/js/pages/ReviewPage/page.tsx
@@ -76,7 +76,7 @@ function DueDate({ date }: { date: string }) {
       <b>
         <FormattedTime time={date} format="short-date" />
       </b>
-      <span className={`text-sm ${isRed ? "text-red-500" : "text-content-dimmed"}`}>{daysAgo}</span>
+      <span className={`text-sm ${isRed ? "text-content-error" : "text-content-dimmed"}`}>{daysAgo}</span>
     </div>
   );
 }

--- a/assets/js/pages/SetupPage/page.tsx
+++ b/assets/js/pages/SetupPage/page.tsx
@@ -84,7 +84,7 @@ function Form() {
       />
 
       {errors.map((e, idx) => (
-        <div key={idx} className="text-red-500 text-sm">
+        <div key={idx} className="text-content-error text-sm">
           {e.message}
         </div>
       ))}

--- a/assets/js/pages/SpaceEditPage/page.tsx
+++ b/assets/js/pages/SpaceEditPage/page.tsx
@@ -54,7 +54,7 @@ function SubmitButton({ form }: { form: FormState }) {
   return (
     <div className="mt-8">
       {form.errors.length > 0 && (
-        <div className="text-red-500 text-sm font-medium text-center mb-4">Please fill out all fields</div>
+        <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>
       )}
       <div className="flex items-center justify-center">
         <FilledButton onClick={form.submit} testId="save" bzzzOnClickFailure>

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -21,6 +21,7 @@ module.exports = {
         "content-accent": "var(--color-content-accent)",
         "content-dimmed": "var(--color-content-dimmed)",
         "content-subtle": "var(--color-content-subtle)",
+        "content-error": "var(--color-content-error)",
 
         "stroke-base": "var(--color-stroke-base)",
         "stroke-dimmed": "var(--color-stroke-dimmed)",


### PR DESCRIPTION
fixes: https://github.com/operately/operately/issues/969

I've also separated the colors in three categories. To have a good judgment about text colors I need to see actual text on the page.

The currently nicknamed "Miscellaneous" will most likely become UI elements, or Form colors.

![Screenshot 2024-08-27 at 18 31 18](https://github.com/user-attachments/assets/0af753d5-a153-4cce-99f3-3835c2995460)
