### PR TITLE
chore: Instead of creating a new browser session, clear the cookies to logout

### DIFF
--- a/test/support/features/invite_member_steps.ex
+++ b/test/support/features/invite_member_steps.ex
@@ -90,7 +90,7 @@ defmodule Operately.Support.Features.InviteMemberSteps do
 
   step :goto_invitation_page, ctx do
     ctx
-    |> UI.new_session()
+    |> UI.logout()
     |> UI.visit("/join?token=#{ctx.token}")
     |> UI.assert_text("Welcome to Operately")
     |> UI.assert_text("Choose a password")


### PR DESCRIPTION
My theory is that this tweak will eliminate, or drastically reduce the flakiness related to logins. Why is that?

After running a heavy log-in/log-out loop on my local computer (image down), I've noticed that not every chrome webdriver instance is killed off (I was running htop on the side). This accumulated memory and my machine started to swap which slowed down the execution and ultimately reproduced the same behaviour as we see in flaky tests.

In theory, this should also increase the performance of the test suite and reduce the total time for execution. This is left to be seen in practice.

Heavy log-in/log-out loop on my local computer:

![Screenshot 2024-08-29 at 20 20 49](https://github.com/user-attachments/assets/02c72eb1-53df-4635-b877-0d5335b4c863)
