### PR TITLE
chore: Introduce custom validators for forms

### DIFF
--- a/assets/js/components/Forms/useForm.tsx
+++ b/assets/js/components/Forms/useForm.tsx
@@ -4,6 +4,7 @@ import { FormState, MapOfFields, ErrorMap } from "./FormState";
 
 interface UseFormProps<FieldTypes extends MapOfFields> {
   fields: FieldTypes;
+  validate: (fields: FieldTypes, addError: (field: keyof FieldTypes, message: string) => void) => void;
   submit: (form: FormState<FieldTypes>) => Promise<void>;
 }
 
@@ -15,6 +16,10 @@ export function useForm<FieldTypes extends MapOfFields>(props: UseFormProps<Fiel
 
   const validate = (): boolean => {
     const newErrors: ErrorMap<FieldTypes> = {};
+
+    props.validate(props.fields, (field, message) => {
+      newErrors[field] = message;
+    });
 
     for (const key in props.fields) {
       const field = props.fields[key]!;


### PR DESCRIPTION
Example usage:

``` typescript
const form = Forms.useForm({
  fields: {
    password: Forms.useTextField(""),
    passwordConfirmation: Forms.useTextField(""),
  },
  validate: (fields, addError) => {
    if (fields.password.value !== fields.passwordConfirmation.value) {
      addError("passwordConfirmation", "Passwords do not match");
    }
  },
  submit: async (form) => {
      ...
  },
});
```