### PR TITLE
fix: Fix check-in scheduler when checking in earlier

### DIFF
--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -8,7 +8,10 @@ defmodule Operately.Operations.ProjectCheckIn do
   alias Operately.Notifications.{SubscriptionList, Subscriptions}
 
   def run(author, project, attrs) do
-    next_check_in = Operately.Time.calculate_next_check_in(project.next_check_in_scheduled_at, DateTime.utc_now())
+    next_check_in = Operately.Time.calculate_next_weekly_check_in(
+      project.next_check_in_scheduled_at, 
+      DateTime.utc_now()
+    )
 
     Multi.new()
     |> Multi.insert(:subscription_list, SubscriptionList.changeset(%{

--- a/test/operately/time_test.exs
+++ b/test/operately/time_test.exs
@@ -3,45 +3,57 @@ defmodule Operately.TimeTest do
 
   alias Operately.Time
 
-  describe "calculate_next_check_in" do
+  describe "calculate_next_weekly_check_in" do
     @due ~D[2020-01-03] # this is a Friday
 
-    test "check in on time" do
-      assert Time.calculate_next_check_in(@due, ~D[2020-01-03]) == Time.as_datetime(~D[2020-01-10])
+    test "had no previous due date -> schedule next check-in for next Friday" do
+      assert Time.calculate_next_weekly_check_in(nil, ~D[2020-01-03]) == Time.as_datetime(~D[2020-01-10])
     end
 
-    test "check in on before due date" do
-      assert Time.calculate_next_check_in(@due, ~D[2020-01-01]) == Time.as_datetime(~D[2020-01-10])
+    test "check in on time -> schedule next check-in for next Friday" do
+      assert Time.calculate_next_weekly_check_in(@due, ~D[2020-01-03]) == Time.as_datetime(~D[2020-01-10])
     end
 
-    test "check in on significantly before due date" do
-      assert Time.calculate_next_check_in(@due, ~D[2020-01-01]) == Time.as_datetime(~D[2020-01-10])
+    test "check in on before due date -> schedule next check-in for next Friday" do
+      assert Time.calculate_next_weekly_check_in(@due, ~D[2020-01-02]) == Time.as_datetime(~D[2020-01-10])
     end
 
-    test "check in late" do
-      assert Time.calculate_next_check_in(@due, ~D[2020-01-04]) == Time.as_datetime(~D[2020-01-10])
+    test "check in on significantly before due date, more than a week -> don't change the next check-in" do
+      assert Time.calculate_next_weekly_check_in(@due, ~D[2019-12-22]) == Time.as_datetime(@due)
     end
 
-    test "check in significantly late" do
-      assert Time.calculate_next_check_in(@due, ~D[2020-01-20]) == Time.as_datetime(~D[2020-01-24])
+    test "check in late -> schedule next check-in for next Friday" do
+      assert Time.calculate_next_weekly_check_in(@due, ~D[2020-01-04]) == Time.as_datetime(~D[2020-01-10])
+    end
+
+    test "check in significantly late -> schedule next check-in for next Friday" do
+      assert Time.calculate_next_weekly_check_in(@due, ~D[2020-01-20]) == Time.as_datetime(~D[2020-01-24])
     end
   end
 
   describe "calculate_next_montly_check_in" do
-    test "if you check-in after the due date, it will set the next check-in to the next month" do
-      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-02-10]) == Time.as_datetime(~D[2020-03-01])
+    test "had no previous due date -> schedule next check-in for next month" do
+      assert Time.calculate_next_monthly_check_in(nil, ~D[2020-02-01]) == Time.as_datetime(~D[2020-03-01])
     end
 
-    test "if you check-in more than a week before the due date, it will keep the next check-in to the same month" do
+    test "check in on time -> schedule first of next month" do
+      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-02-01]) == Time.as_datetime(~D[2020-03-01])
+    end
+
+    test "check in on before due date -> schedule next check-in for first of next month" do
+      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-01-31]) == Time.as_datetime(~D[2020-03-01])
+    end
+
+    test "check in on significantly before due date, more than a week -> don't change the next check-in" do
       assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-01-15]) == Time.as_datetime(~D[2020-02-01])
     end
 
-    test "if you check-in in the one week window before the due date, it will move the next check-in to the next month" do
-      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-01-27]) == Time.as_datetime(~D[2020-03-01])
+    test "check in late -> schedule next check-in for first of next month" do
+      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-02-02]) == Time.as_datetime(~D[2020-03-01])
     end
 
-    test "if you check-in after several months after the due date, it will set the next check-in to the next month" do
-      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-03-17]) == Time.as_datetime(~D[2020-04-01])
+    test "check in significantly late -> schedule next check-in for first of next month" do
+      assert Time.calculate_next_monthly_check_in(~D[2020-02-01], ~D[2020-03-20]) == Time.as_datetime(~D[2020-04-01])
     end
   end
 end


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/994

The problem with the previous implementation was that it over scheduled the next check in if you have checked in very early. 

Example:

Given that you have this week that starts with a Saturday and the check-in due date is presented:

```
S  S  M  T  W  T  F  S  S  M  T  W  T  
^                 ^ 
today             check-in due
```

The old implementation would move the check-in due for a week, making it almost 14 days dalay between two check-ins.

```
S  S  M  T  W  T  F  S  S  M  T  W  T  F
^                                      ^ 
today                                  check-in due
```

The new implementation ignores this super early check-in and keeps the due date the same:

```
S  S  M  T  W  T  F  S  S  M  T  W  T  F
^                 ^ 
today             check-in due
```

The only time when the algorithm accepts an early check-in as "on time" is 1 day earlier for weekly check-ins or one week earlier for monthly check-ins. This factor might need to be adjusted based on real life usage.