### PR TITLE
feat: Reviewer and Champion always selected in notifications widget

### DIFF
--- a/assets/js/components/Forms/MultiPeopleSelectField.tsx
+++ b/assets/js/components/Forms/MultiPeopleSelectField.tsx
@@ -6,26 +6,44 @@ import { getFormContext } from "./FormContext";
 
 export function MultiPeopleSelectField({ field }: { field: string }) {
   const form = getFormContext();
-  const f = form.fields[field];
+  const { alwaysSelected, options } = form.fields[field];
+
+  const alwaysSelectedIds = alwaysSelected.map((p) => p.id!);
 
   return (
     <div>
-      {f.options.map((person: Person) => (
-        <PersonOption person={person} field={field} key={person.id} />
+      {alwaysSelected.map((person) => (
+        <PersonAlwaysSelected person={person} key={person.id} />
       ))}
+
+      {options
+        .filter((person) => !alwaysSelectedIds.includes(person.id))
+        .map((person) => (
+          <PersonOption person={person} field={field} key={person.id} />
+        ))}
+    </div>
+  );
+}
+
+function PersonAlwaysSelected({ person }: { person: Person }) {
+  return (
+    <div className="flex gap-4 border-b border-bg-stroke-subtle px-2 pb-4 mb-4 last:border-0 last:mb-0">
+      <Avatar person={person} size="large" />
+      <div className="flex w-full items-center justify-between">
+        <div className="text-content-dimmed">
+          <p className="font-bold">{person.fullName}</p>
+          <p className="text-sm">{person.title} - will always be notified</p>
+        </div>
+      </div>
     </div>
   );
 }
 
 function PersonOption({ person, field }: { person: Person; field: string }) {
   const form = getFormContext();
-  const { value, setValue, alwaysSelected } = form.fields[field];
+  const { value, setValue } = form.fields[field];
 
   const handleChange = () => {
-    // if alwaysSelected includes the person,
-    // handleChange doesn't do anything
-    if (alwaysSelected.find((p) => p.id === person.id)) return;
-
     const ids = value.map((p) => p.id);
 
     if (ids.includes(person.id)) {

--- a/assets/js/components/Forms/MultiPeopleSelectField.tsx
+++ b/assets/js/components/Forms/MultiPeopleSelectField.tsx
@@ -19,11 +19,17 @@ export function MultiPeopleSelectField({ field }: { field: string }) {
 
 function PersonOption({ person, field }: { person: Person; field: string }) {
   const form = getFormContext();
-  const { value, setValue } = form.fields[field];
+  const { value, setValue, alwaysSelected } = form.fields[field];
 
   const handleChange = () => {
-    if (value.includes(person)) {
-      setValue((prev: Person[]) => prev.filter((item) => item !== person));
+    // if alwaysSelected includes the person,
+    // handleChange doesn't do anything
+    if (alwaysSelected.find((p) => p.id === person.id)) return;
+
+    const ids = value.map((p) => p.id);
+
+    if (ids.includes(person.id)) {
+      setValue((prev: Person[]) => prev.filter((item) => item.id !== person.id));
     } else {
       setValue((prev: Person[]) => [...prev, person]);
     }

--- a/assets/js/components/Forms/MultiPeopleSelectField.tsx
+++ b/assets/js/components/Forms/MultiPeopleSelectField.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Avatar from "@/components/Avatar";
 import { Person } from "@/models/people";
 import { getFormContext } from "./FormContext";
+import { compareIds, includesId } from "@/routes/paths";
 
 export function MultiPeopleSelectField({ field }: { field: string }) {
   const form = getFormContext();
@@ -17,7 +18,7 @@ export function MultiPeopleSelectField({ field }: { field: string }) {
       ))}
 
       {options
-        .filter((person) => !alwaysSelectedIds.includes(person.id))
+        .filter((person) => !includesId(alwaysSelectedIds, person.id))
         .map((person) => (
           <PersonOption person={person} field={field} key={person.id} />
         ))}
@@ -46,8 +47,8 @@ function PersonOption({ person, field }: { person: Person; field: string }) {
   const handleChange = () => {
     const ids = value.map((p) => p.id);
 
-    if (ids.includes(person.id)) {
-      setValue((prev: Person[]) => prev.filter((item) => item.id !== person.id));
+    if (includesId(ids, person.id)) {
+      setValue((prev: Person[]) => prev.filter((item) => !compareIds(item.id, person.id)));
     } else {
       setValue((prev: Person[]) => [...prev, person]);
     }
@@ -62,7 +63,10 @@ function PersonOption({ person, field }: { person: Person; field: string }) {
           <p className="text-sm">{person.title}</p>
         </div>
         <input
-          checked={value.map((p) => p.id).includes(person.id)}
+          checked={includesId(
+            value.map((p) => p.id),
+            person.id,
+          )}
           onChange={handleChange}
           type="checkbox"
           className="form-checkbox h-5 w-5 text-blue-600 rounded focus:ring-blue-500"

--- a/assets/js/components/Forms/useMultiPeopleSelectField.tsx
+++ b/assets/js/components/Forms/useMultiPeopleSelectField.tsx
@@ -7,14 +7,17 @@ export type SelectMultiPeopleField = Field<Person[]> & {
   type: "select-multi-people";
   setValue: React.Dispatch<React.SetStateAction<Person[]>>;
   options: Person[];
+  alwaysSelected: Person[];
 };
 
 interface Config {
   optional?: boolean;
+  alwaysSelected?: Person[];
 }
 
 export function useMultiPeopleSelectField(options: Person[], config?: Config): SelectMultiPeopleField {
-  const [value, setValue] = React.useState<Person[]>([]);
+  const alwaysSelected = config?.alwaysSelected ? [...config.alwaysSelected] : [];
+  const [value, setValue] = React.useState<Person[]>(alwaysSelected);
 
   const validate = (): string | null => {
     if (value.length < 1) return !config?.optional ? "Can't be empty" : null;
@@ -29,5 +32,6 @@ export function useMultiPeopleSelectField(options: Person[], config?: Config): S
     validate,
     options,
     optional: config?.optional,
+    alwaysSelected,
   };
 }

--- a/assets/js/features/Subscriptions/SubscribersSelectorModal.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelectorModal.tsx
@@ -5,6 +5,7 @@ import Modal from "@/components/Modal";
 import { FilledButton } from "@/components/Button";
 import { ActionLink } from "@/components/Link";
 import { SubscriptionsContext } from "./SubscribersSelector";
+import { includesId } from "@/routes/paths";
 
 interface SelectorModalProps {
   showSelector: boolean;
@@ -20,7 +21,7 @@ export function SubscribersSelectorModal({ showSelector, setShowSelector }: Sele
     },
     submit: async (form) => {
       const selectedPeopleIds = form.fields.people.value!.map((p) => p.id);
-      setSelectedPeople(people.filter((person) => selectedPeopleIds.includes(person.id)));
+      setSelectedPeople(people.filter((person) => includesId(selectedPeopleIds, person.id)));
       setShowSelector(false);
     },
   });

--- a/assets/js/features/Subscriptions/SubscribersSelectorModal.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelectorModal.tsx
@@ -12,11 +12,11 @@ interface SelectorModalProps {
 }
 
 export function SubscribersSelectorModal({ showSelector, setShowSelector }: SelectorModalProps) {
-  const { people, setSelectedPeople } = useContext(SubscriptionsContext)!;
+  const { people, alwaysNotify, setSelectedPeople } = useContext(SubscriptionsContext)!;
 
   const form = Forms.useForm({
     fields: {
-      people: Forms.useMultiPeopleSelectField(people, { optional: true }),
+      people: Forms.useMultiPeopleSelectField(people, { optional: true, alwaysSelected: alwaysNotify }),
     },
     submit: async (form) => {
       const selectedPeopleIds = form.fields.people.value!.map((p) => p.id);
@@ -27,7 +27,7 @@ export function SubscribersSelectorModal({ showSelector, setShowSelector }: Sele
   const { options, setValue } = form.fields.people;
 
   const handleSelectNoone = () => {
-    setValue([]);
+    setValue([...alwaysNotify]);
   };
 
   const handleSelectEveryone = () => {

--- a/assets/js/features/Subscriptions/index.tsx
+++ b/assets/js/features/Subscriptions/index.tsx
@@ -7,3 +7,10 @@ export enum Options {
   SELECTED = "selected",
   NONE = "none",
 }
+
+export interface NotifiablePerson {
+  id: string;
+  avatarUrl: string;
+  fullName: string;
+  title: string;
+}

--- a/assets/js/features/Subscriptions/useSubscriptions.tsx
+++ b/assets/js/features/Subscriptions/useSubscriptions.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { Options } from ".";
 import { Person } from "@/models/people";
 
@@ -9,11 +9,25 @@ export interface SubscriptionsState {
   subscriptionType: Options;
   setSubscriptionType: Dispatch<SetStateAction<Options>>;
   alwaysNotify: Person[];
+  currentSubscribersList: string[];
 }
 
 export function useSubscriptions(people: Person[], opts?: { alwaysNotify?: Person[] }): SubscriptionsState {
-  const [selectedPeople, setSelectedPeople] = useState<Person[]>(opts?.alwaysNotify ? [...opts.alwaysNotify] : []);
+  const alwaysNotify = opts?.alwaysNotify ? [...opts.alwaysNotify] : [];
+
+  const [selectedPeople, setSelectedPeople] = useState<Person[]>(alwaysNotify);
   const [subscriptionType, setSubscriptionType] = useState(Options.ALL);
+
+  const currentSubscribersList = useMemo(() => {
+    switch (subscriptionType) {
+      case Options.ALL:
+        return people.map((p) => p.id!);
+      case Options.SELECTED:
+        return selectedPeople.map((p) => p.id!);
+      case Options.NONE:
+        return alwaysNotify.map((p) => p.id!);
+    }
+  }, [subscriptionType, selectedPeople, people, alwaysNotify]);
 
   return {
     people,
@@ -22,5 +36,6 @@ export function useSubscriptions(people: Person[], opts?: { alwaysNotify?: Perso
     subscriptionType,
     setSubscriptionType,
     alwaysNotify: opts?.alwaysNotify || [],
+    currentSubscribersList,
   };
 }

--- a/assets/js/features/Subscriptions/useSubscriptions.tsx
+++ b/assets/js/features/Subscriptions/useSubscriptions.tsx
@@ -1,9 +1,9 @@
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
-import { Options } from ".";
+import { NotifiablePerson, Options } from ".";
 import { Person } from "@/models/people";
 
 export interface SubscriptionsState {
-  people: Person[];
+  people: NotifiablePerson[];
   selectedPeople: Person[];
   setSelectedPeople: Dispatch<SetStateAction<Person[]>>;
   subscriptionType: Options;
@@ -12,7 +12,7 @@ export interface SubscriptionsState {
   currentSubscribersList: string[];
 }
 
-export function useSubscriptions(people: Person[], opts?: { alwaysNotify?: Person[] }): SubscriptionsState {
+export function useSubscriptions(people: NotifiablePerson[], opts?: { alwaysNotify?: Person[] }): SubscriptionsState {
   const alwaysNotify = opts?.alwaysNotify ? [...opts.alwaysNotify] : [];
 
   const [selectedPeople, setSelectedPeople] = useState<Person[]>(alwaysNotify);

--- a/assets/js/features/Subscriptions/useSubscriptions.tsx
+++ b/assets/js/features/Subscriptions/useSubscriptions.tsx
@@ -8,10 +8,11 @@ export interface SubscriptionsState {
   setSelectedPeople: Dispatch<SetStateAction<Person[]>>;
   subscriptionType: Options;
   setSubscriptionType: Dispatch<SetStateAction<Options>>;
+  alwaysNotify: Person[];
 }
 
-export function useSubscriptions(people: Person[]): SubscriptionsState {
-  const [selectedPeople, setSelectedPeople] = useState<Person[]>([]);
+export function useSubscriptions(people: Person[], opts?: { alwaysNotify?: Person[] }): SubscriptionsState {
+  const [selectedPeople, setSelectedPeople] = useState<Person[]>(opts?.alwaysNotify ? [...opts.alwaysNotify] : []);
   const [subscriptionType, setSubscriptionType] = useState(Options.ALL);
 
   return {
@@ -20,5 +21,6 @@ export function useSubscriptions(people: Person[]): SubscriptionsState {
     setSelectedPeople,
     subscriptionType,
     setSubscriptionType,
+    alwaysNotify: opts?.alwaysNotify || [],
   };
 }

--- a/assets/js/features/Subscriptions/utils.tsx
+++ b/assets/js/features/Subscriptions/utils.tsx
@@ -1,18 +1,30 @@
 import { Person } from "@/models/people";
 import { Project } from "@/models/projects";
+import { NotifiablePerson } from "@/features/Subscriptions";
 
-export function findNotifiableProjectContributors(project: Project, me: Person): Person[] {
+export function findNotifiableProjectContributors(project: Project, me: Person): NotifiablePerson[] {
   const people = project
     .contributors!.filter((contrib) => contrib.person!.id !== me.id)
     .map((contrib) => {
+      const person = {
+        id: contrib.person!.id!,
+        fullName: contrib.person!.fullName!,
+        avatarUrl: contrib.person!.avatarUrl!,
+        title: "",
+      };
+
       switch (contrib.role) {
         case "reviewer":
-          return { ...contrib.person, title: "Reviewer" };
+          person.title = "Reviewer";
+          break;
         case "champion":
-          return { ...contrib.person, title: "Champion" };
+          person.title = "Champion";
+          break;
         default:
-          return { ...contrib.person, title: contrib.responsibility };
+          person.title = contrib.responsibility!;
       }
+
+      return person;
     });
 
   return people;

--- a/assets/js/features/Subscriptions/utils.tsx
+++ b/assets/js/features/Subscriptions/utils.tsx
@@ -1,10 +1,11 @@
 import { Person } from "@/models/people";
 import { Project } from "@/models/projects";
 import { NotifiablePerson } from "@/features/Subscriptions";
+import { compareIds } from "@/routes/paths";
 
 export function findNotifiableProjectContributors(project: Project, me: Person): NotifiablePerson[] {
   const people = project
-    .contributors!.filter((contrib) => contrib.person!.id !== me.id)
+    .contributors!.filter((contrib) => !compareIds(contrib.person!.id, me.id))
     .map((contrib) => {
       const person = {
         id: contrib.person!.id!,

--- a/assets/js/features/projectCheckIns/Form/useForm.tsx
+++ b/assets/js/features/projectCheckIns/Form/useForm.tsx
@@ -84,7 +84,7 @@ export function useForm({ mode, project, checkIn, author, notifiablePeople = [] 
         status,
         description: JSON.stringify(editor.editor.getJSON()),
         sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
-        subscriberIds: subscriptionsState.selectedPeople.map((person) => person.id!),
+        subscriberIds: subscriptionsState.currentSubscribersList,
       });
 
       navigate(Paths.projectCheckInPath(res.checkIn.id));

--- a/assets/js/features/projectCheckIns/Form/useForm.tsx
+++ b/assets/js/features/projectCheckIns/Form/useForm.tsx
@@ -47,9 +47,11 @@ export interface FormState {
   cancelPath: string;
 }
 
-export function useForm({ mode, project, checkIn, author, notifiablePeople }: UseFormOptions): FormState {
+export function useForm({ mode, project, checkIn, author, notifiablePeople = [] }: UseFormOptions): FormState {
   const navigate = useNavigate();
-  const subscriptionsState = useSubscriptions(notifiablePeople || []);
+  const subscriptionsState = useSubscriptions(notifiablePeople, {
+    alwaysNotify: getReviewerAndChampion(notifiablePeople),
+  });
 
   const [status, setStatus] = React.useState<string | null>(mode === "edit" ? checkIn!.status! : null);
   const [errors, setErrors] = React.useState<Error[]>([]);
@@ -157,4 +159,8 @@ function validate(status: string | null, description: string): Error[] {
   }
 
   return errors;
+}
+
+function getReviewerAndChampion(people: People.Person[]) {
+  return people.filter((p) => p.title === "Reviewer" || p.title === "Champion");
 }

--- a/assets/js/features/projectCheckIns/Form/useForm.tsx
+++ b/assets/js/features/projectCheckIns/Form/useForm.tsx
@@ -8,12 +8,12 @@ import * as TipTapEditor from "@/components/Editor";
 import { useNavigate } from "react-router-dom";
 import { Paths } from "@/routes/paths";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
-import { useSubscriptions, SubscriptionsState, Options } from "@/features/Subscriptions";
+import { useSubscriptions, SubscriptionsState, Options, NotifiablePerson } from "@/features/Subscriptions";
 
 interface UseFormOptions {
   mode: "create" | "edit";
   author: People.Person;
-  notifiablePeople?: People.Person[];
+  notifiablePeople?: NotifiablePerson[];
 
   project?: Projects.Project;
   checkIn?: ProjectCheckIns.ProjectCheckIn;
@@ -161,6 +161,6 @@ function validate(status: string | null, description: string): Error[] {
   return errors;
 }
 
-function getReviewerAndChampion(people: People.Person[]) {
+function getReviewerAndChampion(people: NotifiablePerson[]) {
   return people.filter((p) => p.title === "Reviewer" || p.title === "Champion");
 }

--- a/assets/js/routes/paths.tsx
+++ b/assets/js/routes/paths.tsx
@@ -360,7 +360,9 @@ function validatePathElements(elements: string[]) {
   });
 }
 
-export function compareIds(a: string | null | undefined, b: string | null | undefined) {
+type ID = string | null | undefined;
+
+export function compareIds(a: ID, b: ID) {
   if (!a || !b) return false;
 
   if (isUUID(a) && isUUID(b)) {
@@ -368,6 +370,20 @@ export function compareIds(a: string | null | undefined, b: string | null | unde
   }
 
   return idWithoutComments(a) === idWithoutComments(b);
+}
+
+export function includesId(idsList: ID[], id: ID) {
+  if (!id) return false;
+
+  const ids = idsList
+    .filter((id) => id)
+    .map((id: string) => {
+      if (isUUID(id)) return id;
+      return idWithoutComments(id);
+    });
+
+  if (isUUID(id)) return ids.includes(id);
+  return ids.includes(idWithoutComments(id));
 }
 
 function isUUID(id: string) {


### PR DESCRIPTION
In https://github.com/operately/operately/pull/1019, it was mentioned that some people should be always notified and that this problem could be solved in different ways.

In this PR, I solved it by updating the notifications widget so that some people can be never unselected. This is how it looks:

https://github.com/user-attachments/assets/5000c627-8552-4646-b45e-9c757945bfbd

I noticed that it might not be so clear to the user why they can't unselect some people. Do you think it is necessary to add a custom message explaining why the champion and reviewer can't be unselected? And are there any other necessary adjustments?

@shiroyasha @markoa

