### PR TITLE
feat: Show privacy level indicators next to project names

### DIFF
--- a/assets/js/components/Tooltip/index.tsx
+++ b/assets/js/components/Tooltip/index.tsx
@@ -3,14 +3,15 @@ import React from "react";
 import * as ReactTooltip from "@radix-ui/react-tooltip";
 import classNames from "classnames";
 import { useColorMode } from "@/contexts/ThemeContext";
+import { TestableElement } from "@/utils/testid";
 
-interface TextTooltipProps {
+interface TextTooltipProps extends TestableElement {
   content: React.ReactNode | string;
   children: React.ReactNode;
   delayDuration?: number;
 }
 
-export function Tooltip({ content, delayDuration, children }: TextTooltipProps): JSX.Element {
+export function Tooltip({ content, delayDuration, children, testId }: TextTooltipProps): JSX.Element {
   const mode = useColorMode();
 
   const className = classNames(
@@ -21,6 +22,7 @@ export function Tooltip({ content, delayDuration, children }: TextTooltipProps):
     "break-normal",
     "select-none",
     "shadow-xl",
+    "whitespace-normal",
     {
       "border border-stroke-dimmed": mode === "dark",
     },
@@ -33,7 +35,9 @@ export function Tooltip({ content, delayDuration, children }: TextTooltipProps):
   return (
     <ReactTooltip.Provider>
       <ReactTooltip.Root delayDuration={delayDuration || 200}>
-        <ReactTooltip.Trigger asChild>{children}</ReactTooltip.Trigger>
+        <ReactTooltip.Trigger asChild data-test-id={testId}>
+          {children}
+        </ReactTooltip.Trigger>
         <ReactTooltip.Content sideOffset={10} className={className}>
           {content}
           <ReactTooltip.Arrow style={arrowStyle} />

--- a/assets/js/features/projects/PrivacyIndicator.tsx
+++ b/assets/js/features/projects/PrivacyIndicator.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import * as Icons from "@tabler/icons-react";
+import * as Projects from "@/models/projects";
+
+import { Tooltip } from "@/components/Tooltip";
+import { match } from "ts-pattern";
+
+export function PrivacyIndicator({ project }: { project: Projects.Project }) {
+  return match(project.privacy)
+    .with(Projects.PRIVACY_PUBLIC, () => <PrivacyPublic />)
+    .with(Projects.PRIVACY_INTERNAL, () => null)
+    .with(Projects.PRIVACY_CONFIDENTIAL, () => <PrivacyConfidential project={project} />)
+    .with(Projects.PRIVACY_SECRET, () => <PrivacySecret />)
+    .otherwise(() => {
+      throw new Error("Invalid privacy value");
+    });
+}
+
+function PrivacyPublic() {
+  const content = (
+    <div>
+      <div className="text-content-accent font-bold">Anyone on the internet</div>
+      <div className="text-content-dimmed mt-1 w-64">
+        This project is visible to anyone on the internet who has the link.
+      </div>
+    </div>
+  );
+
+  return (
+    <Tooltip content={content} testId="public-project-tooltip" delayDuration={100}>
+      <Icons.IconWorld size={24} />
+    </Tooltip>
+  );
+}
+
+function PrivacyConfidential({ project }: { project: Projects.Project }) {
+  const content = (
+    <div>
+      <div className="text-content-accent font-bold">Only {project.space!.name} members</div>
+      <div className="text-content-dimmed mt-1 w-64">
+        This project is visible only to members of the {project.space!.name} space.
+      </div>
+    </div>
+  );
+
+  return (
+    <Tooltip content={content} testId="confidential-project-tooltip" delayDuration={100}>
+      <Icons.IconLockFilled size={24} />
+    </Tooltip>
+  );
+}
+
+function PrivacySecret() {
+  const content = (
+    <div>
+      <div className="text-content-accent font-bold">Invite-Only</div>
+      <div className="text-content-dimmed mt-1 w-64">Only people explicitly invited to this project can view it.</div>
+    </div>
+  );
+
+  return (
+    <Tooltip content={content} testId="secret-project-tooltip" delayDuration={100}>
+      <Icons.IconLockFilled size={24} className="text-content-error" />
+    </Tooltip>
+  );
+}

--- a/assets/js/models/projects/index.tsx
+++ b/assets/js/models/projects/index.tsx
@@ -22,6 +22,11 @@ export {
   useRemoveProjectContributor,
 } from "@/api";
 
+export const PRIVACY_PUBLIC = "public";
+export const PRIVACY_INTERNAL = "internal";
+export const PRIVACY_CONFIDENTIAL = "confidential";
+export const PRIVACY_SECRET = "secret";
+
 export { groupBySpace } from "./groupBySpace";
 
 export function useProjectContributorCandidates(id: string): (query: string) => Promise<api.Person[]> {

--- a/assets/js/pages/ProjectPage/Header.tsx
+++ b/assets/js/pages/ProjectPage/Header.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import * as Icons from "@tabler/icons-react";
 import * as Projects from "@/models/projects";
 
-import classnames from "classnames";
 import ContributorAvatar from "@/components/ContributorAvatar";
 
 import { Link } from "react-router-dom";
@@ -12,6 +11,7 @@ import { Project } from "@/models/projects";
 import { Tooltip } from "@/components/Tooltip";
 import { Paths } from "@/routes/paths";
 import { GhostButton } from "@/components/Button";
+import { match } from "ts-pattern";
 
 interface HeaderProps {
   project: Project;
@@ -20,29 +20,29 @@ interface HeaderProps {
 export default function Header({ project }: HeaderProps): JSX.Element {
   return (
     <div>
-      <ProjectName project={project} />
-      <div className="mt-2"></div>
+      <div className="flex-1 truncate mb-2">
+        <ParentGoal project={project} />
+
+        <div className="flex items-center text-content-accent truncate mr-12">
+          <ProjectIcon />
+          <ProjectName project={project} />
+          <PrivacyIndicator project={project} />
+        </div>
+      </div>
+
       <ContributorList project={project} />
     </div>
   );
 }
 
 function ProjectName({ project }) {
+  return <div className="font-bold text-2xl text-content-accent truncate ml-3 mr-2">{project.name}</div>;
+}
+
+function ProjectIcon() {
   return (
-    <div className="flex-1 truncate">
-      <ParentGoal project={project} />
-
-      <div className={classnames("flex gap-3 items-center", "text-content-accent", "truncate mr-12")}>
-        <div className="bg-indigo-500/10 p-1.5 rounded-lg">
-          <Icons.IconHexagons size={24} className="text-indigo-500" />
-        </div>
-
-        <div className="inline-flex items-center gap-2 truncate">
-          <div className="font-bold text-2xl text-content-accent truncate flex-1">{project.name}</div>
-        </div>
-
-        <PrivateIndicator project={project} />
-      </div>
+    <div className="bg-indigo-500/10 p-1.5 rounded-lg">
+      <Icons.IconHexagons size={24} className="text-indigo-500" />
     </div>
   );
 }
@@ -83,13 +83,42 @@ function ParentGoal({ project }: { project: Projects.Project }) {
   );
 }
 
-function PrivateIndicator({ project }) {
-  if (!project.private) return null;
+function PrivacyIndicator({ project }: { project: Projects.Project }) {
+  return match(project.privacy)
+    .with(Projects.PRIVACY_PUBLIC, () => <PrivacyPublic />)
+    .with(Projects.PRIVACY_INTERNAL, () => null)
+    .with(Projects.PRIVACY_CONFIDENTIAL, () => <PrivacyConfidential />)
+    .with(Projects.PRIVACY_SECRET, () => <PrivacySecret />)
+    .otherwise(() => {
+      throw new Error("Invalid privacy value");
+    });
+}
 
+function PrivacyPublic() {
   return (
     <Tooltip content="Private project. Visible only to contributors.">
       <div className="mt-1" data-test-id="private-project-indicator">
         <Icons.IconLock size={20} />
+      </div>
+    </Tooltip>
+  );
+}
+
+function PrivacyConfidential() {
+  return (
+    <Tooltip content="TODO">
+      <div data-test-id="confidential-indicator">
+        <Icons.IconLockFilled size={20} />
+      </div>
+    </Tooltip>
+  );
+}
+
+function PrivacySecret() {
+  return (
+    <Tooltip content="TODO">
+      <div data-test-id="secret-indicator">
+        <Icons.IconLockFilled size={20} className="text-content-error" />
       </div>
     </Tooltip>
   );

--- a/assets/js/pages/ProjectPage/Header.tsx
+++ b/assets/js/pages/ProjectPage/Header.tsx
@@ -2,25 +2,17 @@ import * as React from "react";
 import * as Icons from "@tabler/icons-react";
 import * as Projects from "@/models/projects";
 
-import ContributorAvatar from "@/components/ContributorAvatar";
-
-import { Link } from "react-router-dom";
-import { DivLink } from "@/components/Link";
-import { Project } from "@/models/projects";
-
-import { Tooltip } from "@/components/Tooltip";
+import { DimmedLink, DivLink } from "@/components/Link";
 import { Paths } from "@/routes/paths";
 import { GhostButton } from "@/components/Button";
-import { match } from "ts-pattern";
+import { PrivacyIndicator } from "@/features/projects/PrivacyIndicator";
 
-interface HeaderProps {
-  project: Project;
-}
+import ContributorAvatar from "@/components/ContributorAvatar";
 
-export default function Header({ project }: HeaderProps): JSX.Element {
+export default function Header({ project }: { project: Projects.Project }) {
   return (
     <div>
-      <div className="flex-1 truncate mb-2">
+      <div className="flex-1 mb-2">
         <ParentGoal project={project} />
 
         <div className="flex items-center text-content-accent truncate mr-12">
@@ -67,10 +59,8 @@ function ParentGoal({ project }: { project: Projects.Project }) {
   } else {
     content = (
       <div className="text-sm text-content-dimmed mx-1 font-medium">
-        <Link to={Paths.editProjectGoalPath(project.id!)} className="underline hover:text-link-hover">
-          Link this project to a goal
-        </Link>{" "}
-        for context and purpose
+        <DimmedLink to={Paths.editProjectGoalPath(project.id!)}>Link this project to a goal</DimmedLink> for context and
+        purpose
       </div>
     );
   }
@@ -83,54 +73,13 @@ function ParentGoal({ project }: { project: Projects.Project }) {
   );
 }
 
-function PrivacyIndicator({ project }: { project: Projects.Project }) {
-  return match(project.privacy)
-    .with(Projects.PRIVACY_PUBLIC, () => <PrivacyPublic />)
-    .with(Projects.PRIVACY_INTERNAL, () => null)
-    .with(Projects.PRIVACY_CONFIDENTIAL, () => <PrivacyConfidential />)
-    .with(Projects.PRIVACY_SECRET, () => <PrivacySecret />)
-    .otherwise(() => {
-      throw new Error("Invalid privacy value");
-    });
-}
-
-function PrivacyPublic() {
-  return (
-    <Tooltip content="Private project. Visible only to contributors.">
-      <div className="mt-1" data-test-id="private-project-indicator">
-        <Icons.IconLock size={20} />
-      </div>
-    </Tooltip>
-  );
-}
-
-function PrivacyConfidential() {
-  return (
-    <Tooltip content="TODO">
-      <div data-test-id="confidential-indicator">
-        <Icons.IconLockFilled size={20} />
-      </div>
-    </Tooltip>
-  );
-}
-
-function PrivacySecret() {
-  return (
-    <Tooltip content="TODO">
-      <div data-test-id="secret-indicator">
-        <Icons.IconLockFilled size={20} className="text-content-error" />
-      </div>
-    </Tooltip>
-  );
-}
-
 function ContributorList({ project }: { project: Projects.Project }) {
   const contributorsPath = Paths.projectContributorsPath(project.id!);
   const sortedContributors = Projects.sortContributorsByRole(project.contributors as Projects.ProjectContributor[]);
 
   return (
     <div className="flex items-center">
-      <Link to={contributorsPath} data-test-id="project-contributors">
+      <DivLink to={contributorsPath} testId="project-contributors">
         <div className="flex items-center justify-center gap-1 cursor-pointer">
           {sortedContributors!.map((c) => c && <ContributorAvatar key={c.id} contributor={c} />)}
 
@@ -142,7 +91,7 @@ function ContributorList({ project }: { project: Projects.Project }) {
             </div>
           )}
         </div>
-      </Link>
+      </DivLink>
     </div>
   );
 }


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/966

---

Public:

![Screenshot 2024-09-04 at 11 25 26](https://github.com/user-attachments/assets/aeb8225d-1316-4c2d-a81d-600422fe2b61)

Company-wide (no-indicator):

![Screenshot 2024-09-04 at 11 27 33](https://github.com/user-attachments/assets/9dae83fb-aa0e-4988-a7eb-03e39bd23a60)

Only space members:

![Screenshot 2024-09-04 at 11 25 41](https://github.com/user-attachments/assets/9eb76e5a-f3bb-4b9a-83b6-e394894242c6)

Restricted project:

![Screenshot 2024-09-04 at 11 25 57](https://github.com/user-attachments/assets/0440b694-4612-4e9b-afbb-0e70b5a06972)