### PR TITLE
feat: GetProjectCheckIn can include subscriptions

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -752,6 +752,7 @@ export interface ProjectCheckIn {
   acknowledgedAt?: string | null;
   acknowledgedBy?: Person | null;
   reactions?: Reaction[] | null;
+  subscriptionList?: SubscriptionList | null;
 }
 
 export interface ProjectContributor {
@@ -839,6 +840,19 @@ export interface Space {
   color?: string | null;
   members?: Person[] | null;
   accessLevels?: AccessLevels | null;
+}
+
+export interface Subscription {
+  id?: string | null;
+  type?: string | null;
+  person?: Person | null;
+}
+
+export interface SubscriptionList {
+  id?: string | null;
+  parentType?: string | null;
+  sendToEveryone?: boolean | null;
+  subscriptions?: Subscription[] | null;
 }
 
 export interface Target {
@@ -1287,6 +1301,7 @@ export interface GetProjectCheckInInput {
   includeAuthor?: boolean | null;
   includeProject?: boolean | null;
   includeReactions?: boolean | null;
+  includeSubscriptions?: boolean | null;
 }
 
 export interface GetProjectCheckInResult {

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -113,11 +113,23 @@ defmodule Operately.Notifications do
     |> Repo.insert()
   end
 
-  alias Operately.Notifications.Subscriptions
+  def update_subscription_list(%SubscriptionList{} = subscription_list, attrs) do
+    subscription_list
+    |> SubscriptionList.changeset(attrs)
+    |> Repo.update()
+  end
+
+  alias Operately.Notifications.Subscription
 
   def list_subscriptions(%SubscriptionList{} = subscription_list), do: list_subscriptions(subscription_list.id)
   def list_subscriptions(subscription_list_id) do
-    from(s in Subscriptions, where: s.subscription_list_id == ^subscription_list_id)
+    from(s in Subscription, where: s.subscription_list_id == ^subscription_list_id)
     |> Repo.all()
+  end
+
+  def create_subscription(attrs \\ %{}) do
+    %Subscription{}
+    |> Subscription.changeset(attrs)
+    |> Repo.insert()
   end
 end

--- a/lib/operately/notifications/subscription.ex
+++ b/lib/operately/notifications/subscription.ex
@@ -1,4 +1,4 @@
-defmodule Operately.Notifications.Subscriptions do
+defmodule Operately.Notifications.Subscription do
   use Operately.Schema
 
   schema "subscriptions" do

--- a/lib/operately/notifications/subscription_list.ex
+++ b/lib/operately/notifications/subscription_list.ex
@@ -6,6 +6,8 @@ defmodule Operately.Notifications.SubscriptionList do
     field :parent_type, Ecto.Enum, values: [:project_check_in]
     field :send_to_everyone, :boolean, default: false
 
+    has_many :subscriptions, Operately.Notifications.Subscription, foreign_key: :subscription_list_id
+
     timestamps()
   end
 

--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -4,7 +4,7 @@ defmodule Operately.Operations.ProjectCheckIn do
   alias Operately.Repo
   alias Operately.Activities
   alias Operately.Projects.{CheckIn, Project}
-  alias Operately.Notifications.{SubscriptionList, Subscriptions}
+  alias Operately.Notifications.{SubscriptionList, Subscription}
 
   def run(author, project, attrs) do
     next_check_in = Operately.Time.calculate_next_weekly_check_in(
@@ -64,7 +64,7 @@ defmodule Operately.Operations.ProjectCheckIn do
       name = "subscription_" <> id
 
       Multi.insert(multi, name, fn changes ->
-        Subscriptions.changeset(%{
+        Subscription.changeset(%{
           subscription_list_id: changes.subscription_list.id,
           person_id: id,
           type: :invited,
@@ -84,7 +84,7 @@ defmodule Operately.Operations.ProjectCheckIn do
       name = "mentioned_subscription_" <> id
 
       Multi.insert(multi, name, fn changes ->
-        Subscriptions.changeset(%{
+        Subscription.changeset(%{
           subscription_list_id: changes.subscription_list.id,
           person_id: id,
           type: :mentioned,

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -11,6 +11,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
     field :include_author, :boolean
     field :include_project, :boolean
     field :include_reactions, :boolean
+    field :include_subscriptions, :boolean
   end
 
   outputs do
@@ -51,6 +52,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
         :include_author -> from p in q, preload: [:author]
         :include_project -> from p in q, preload: [project: [:reviewer, [contributors: :person]]]
         :include_reactions -> from p in q, preload: [reactions: :person]
+        :include_subscriptions -> from p in q, preload: [subscription_list: [subscriptions: :person]]
         _ -> raise ArgumentError, "Unknown include filter: #{inspect(include)}"
       end
     end)

--- a/lib/operately_web/api/serializers/project_check_in.ex
+++ b/lib/operately_web/api/serializers/project_check_in.ex
@@ -9,7 +9,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.CheckIn do
       acknowledged_by: OperatelyWeb.Api.Serializer.serialize(check_in.acknowledged_by),
       project: OperatelyWeb.Api.Serializer.serialize(check_in.project, level: :full),
       reactions: OperatelyWeb.Api.Serializer.serialize(check_in.reactions),
-      author: OperatelyWeb.Api.Serializer.serialize(check_in.author)
+      author: OperatelyWeb.Api.Serializer.serialize(check_in.author),
+      subscription_list: OperatelyWeb.Api.Serializer.serialize(check_in.subscription_list)
     }
   end
 

--- a/lib/operately_web/api/serializers/subscription_list.ex
+++ b/lib/operately_web/api/serializers/subscription_list.ex
@@ -1,0 +1,14 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Notifications.SubscriptionList do
+  def serialize(subscription_list, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.subscription_list_id(subscription_list),
+      parent_type: subscription_list.parent_type,
+      send_to_everyone: subscription_list.send_to_everyone,
+      subscriptions: OperatelyWeb.Api.Serializer.serialize(subscription_list.subscriptions),
+    }
+  end
+
+  def serialize(subscription_list, level: :full) do
+    serialize(subscription_list, level: :essential)
+  end
+end

--- a/lib/operately_web/api/serializers/subscriptions.ex
+++ b/lib/operately_web/api/serializers/subscriptions.ex
@@ -1,0 +1,13 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Notifications.Subscription do
+  def serialize(subscription, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.subscription_id(subscription),
+      type: subscription.type,
+      person: OperatelyWeb.Api.Serializer.serialize(subscription.person),
+    }
+  end
+
+  def serialize(subscription, level: :full) do
+    serialize(subscription, level: :essential)
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -883,6 +883,7 @@ defmodule OperatelyWeb.Api.Types do
     field :acknowledged_at, :datetime
     field :acknowledged_by, :person
     field :reactions, list_of(:reaction)
+    field :subscription_list, :subscription_list
   end
 
   object :activity_content_project_check_in_commented do
@@ -969,6 +970,19 @@ defmodule OperatelyWeb.Api.Types do
     field :unit, :string
     field :value, :float
     field :previous_value, :float
+  end
+
+  object :subscription_list do
+    field :id, :string
+    field :parent_type, :string
+    field :send_to_everyone, :boolean
+    field :subscriptions, list_of(:subscription)
+  end
+
+  object :subscription do
+    field :id, :string
+    field :type, :string
+    field :person, :person
   end
 
 end

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -192,6 +192,14 @@ defmodule OperatelyWeb.Paths do
     Operately.ShortUuid.encode!(comment.id)
   end
 
+  def subscription_list_id(comment) do
+    Operately.ShortUuid.encode!(comment.id)
+  end
+
+  def subscription_id(comment) do
+    Operately.ShortUuid.encode!(comment.id)
+  end
+
   #
   # Path Construction Helpers
   #

--- a/test/operately_web/api/queries/get_project_check_in_test.exs
+++ b/test/operately_web/api/queries/get_project_check_in_test.exs
@@ -6,7 +6,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
   import Operately.ProjectsFixtures
   import Operately.GroupsFixtures
 
-  alias Operately.Repo
+  alias Operately.{Repo, Notifications}
   alias Operately.Access.Binding
 
   describe "security" do
@@ -84,6 +84,35 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
       # another user's request
       assert {404, res} = query(ctx.conn, :get_project_check_in, %{id: check_in.id})
       assert res.message == "The requested resource was not found"
+    end
+  end
+
+  describe "get_project_check_in functionality" do
+    setup :register_and_log_in_account
+
+    test "include_subscriptions", ctx do
+      project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.company.company_space_id, creator_id: ctx.person.id})
+      check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
+      list = Notifications.get_subscription_list!(parent_id: check_in.id)
+
+      people = Enum.map(1..3, fn _ ->
+        person = person_fixture(%{company_id: ctx.company.id})
+        Notifications.create_subscription(%{
+          subscription_list_id: list.id,
+          person_id: person.id,
+          type: :invited,
+        })
+        person
+      end)
+
+      assert {200, res} = query(ctx.conn, :get_project_check_in, %{
+        id: check_in.id,
+        include_subscriptions: true,
+      })
+
+      Enum.each(res.project_check_in.subscription_list.subscriptions, fn s ->
+        assert Enum.find(people, &(serialize(&1) == s.person))
+      end)
     end
   end
 

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -117,6 +117,11 @@ defmodule Operately.ProjectsFixtures do
       |> Operately.Projects.CheckIn.changeset()
       |> Operately.Repo.insert()
 
+    {:ok, _} = Operately.Notifications.update_subscription_list(subscription_list, %{
+      parent_type: :project_check_in,
+      parent_id: check_in.id,
+    })
+
     check_in
   end
 end


### PR DESCRIPTION
I've added the `include_subscriptions` option to `OperatelyWeb.Api.Queries.GetProjectCheckIn`.