### PR TITLE
chore: Improve proportions and colors of buttons, add to design system

### DIFF
--- a/assets/js/components/Button/FilledButton.tsx
+++ b/assets/js/components/Button/FilledButton.tsx
@@ -93,27 +93,27 @@ function className(
   }
 
   if (size === "xxs") {
-    result += " px-2 py-[1px] text-sm rounded-2xl";
+    result += " px-2.5 py-1 text-xs rounded-2xl";
   }
 
   if (size === "xs") {
-    result += " px-2.5 py-0.5 text-sm rounded-2xl";
+    result += " px-2.5 py-1 text-sm rounded-full";
   }
 
   if (size === "sm") {
-    result += " px-3 py-1 text-sm rounded-2xl";
+    result += " px-3 py-1.5 text-sm rounded-full";
   }
 
   if (size === "base") {
-    result += " px-4 py-1 rounded-3xl";
+    result += " px-3.5 py-2 rounded-full";
   }
 
   if (size === "lg") {
-    result += " px-6 py-2 text-lg rounded-3xl";
+    result += " px-4 py-2.5 rounded-full";
   }
 
   if (type === "primary") {
-    result += " border-2 border-accent-1 bg-accent-1";
+    result += " bg-accent-1 hover:bg-accent-1-light";
     if (loading) {
       result += " text-content-subtle";
     } else {

--- a/assets/js/components/Button/GhostButton.tsx
+++ b/assets/js/components/Button/GhostButton.tsx
@@ -52,7 +52,7 @@ function className(size?: "xxs" | "xs" | "sm" | "base" | "lg", type?: "primary" 
   size = size || "base";
   type = type || "primary";
 
-  let result = "relative font-medium transition-all duration-100 text-center";
+  let result = "relative font-semibold hover:bg-surface-highlight transition-all duration-100 text-center flex-grow-0 flex-shrink-0";
 
   if (loading) {
     result += " cursor-default";
@@ -61,27 +61,27 @@ function className(size?: "xxs" | "xs" | "sm" | "base" | "lg", type?: "primary" 
   }
 
   if (size === "xxs") {
-    result += " px-2 py-[1px] text-sm rounded-2xl";
+    result += " px-2 py-[1px] text-xs rounded-2xl";
   }
 
   if (size === "xs") {
-    result += " px-2.5 py-0.5 text-sm rounded-2xl";
+    result += " px-2.5 py-1 text-sm rounded-2xl";
   }
 
   if (size === "sm") {
-    result += " px-3 py-1 text-sm rounded-2xl";
+    result += " px-3 py-1.5 text-sm rounded-2xl";
   }
 
   if (size === "base") {
-    result += " px-4 py-1 rounded-3xl";
+    result += " px-3.5 py-2 rounded-3xl";
   }
 
   if (size === "lg") {
-    result += " px-6 py-2 text-lg rounded-3xl";
+    result += " px-4 py-2.5 rounded-3xl";
   }
 
   if (type === "primary") {
-    result += " border-2 border-accent-1";
+    result += " border border-accent-1";
     if (loading) {
       result += " text-content-subtle";
     } else {
@@ -94,7 +94,7 @@ function className(size?: "xxs" | "xs" | "sm" | "base" | "lg", type?: "primary" 
     if (loading) {
       result += " text-content-subtle";
     } else {
-      result += " text-content-dimmed hover:text-content-accent";
+      result += " text-content-base hover:text-content-accent";
     }
   }
 

--- a/assets/js/pages/DesignPage/Buttons.tsx
+++ b/assets/js/pages/DesignPage/Buttons.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { Section, SectionTitle } from "./Section";
+import { FilledButton, GhostButton } from "@/components/Button";
 
 export function Buttons() {
   return (
@@ -10,79 +11,38 @@ export function Buttons() {
       <div className="max-w-2xl mb-8">
         <p className="mt-2">
           Operately uses rounded primary and secondary buttons. The primary button is used for the main action on a
-          page, while the secondary button is used for secondary actions or as a subtle call to action. UI copy is
-          written like a sentence, not capitalized.
+          page, while the secondary button is used for secondary actions or as a subtle call to action. We write UI copy in active voice, not capitalized.
         </p>
       </div>
 
       <h3 className="font-bold mb-4">Primary buttons</h3>
 
       <div className="flex items-center space-x-4">
-        <a
-          className="rounded-full bg-accent-1 px-2.5 py-1 text-xs font-semibold text-slate-50 shadow-sm hover:bg-accent-1-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bg-accent-1"
-          href=""
-        >
-          Button text
-        </a>
-        <a
-          className="rounded-full bg-accent-1 px-2.5 py-1 text-sm font-semibold text-slate-50 shadow-sm hover:bg-accent-1-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bg-accent-1"
-          href=""
-        >
-          Button text
-        </a>
-        <a
-          className="rounded-full bg-accent-1 px-3 py-1.5 text-sm font-semibold text-slate-50 shadow-sm hover:bg-accent-1-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bg-accent-1"
-          href=""
-        >
-          Button text
-        </a>
-        <a
-          className="rounded-full bg-accent-1 px-3.5 py-2 text-sm font-semibold text-slate-50 shadow-sm hover:bg-accent-1-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bg-accent-1"
-          href=""
-        >
-          Button text
-        </a>
-        <a
-          className="rounded-full bg-accent-1 px-4 py-2.5 text-sm font-semibold text-slate-50 shadow-sm hover:bg-accent-1-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-bg-accent-1"
-          href=""
-        >
-          Button text
-        </a>
+        <FilledButton size="xxs">Button text</FilledButton>
+        <FilledButton size="xs">Button text</FilledButton>
+        <FilledButton size="sm">Button text</FilledButton>
+        <FilledButton size="base">Button text</FilledButton>
+        <FilledButton size="lg">Button text</FilledButton>
       </div>
 
-      <h3 className="font-bold mt-8 mb-4">Secondary buttons</h3>
+      <h3 className="font-bold mt-8 mb-4">Ghost buttons - primary</h3>
 
-      <div className="flex items-center space-x-4">
-        <button
-          type="button"
-          className="rounded-full bg-white px-2.5 py-1 text-xs font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
-          Button text
-        </button>
-        <button
-          type="button"
-          className="rounded-full bg-white px-2.5 py-1 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
-          Button text
-        </button>
-        <button
-          type="button"
-          className="rounded-full bg-white px-3 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
-          Button text
-        </button>
-        <button
-          type="button"
-          className="rounded-full bg-white px-3.5 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
-          Button text
-        </button>
-        <button
-          type="button"
-          className="rounded-full bg-white px-4 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-        >
-          Button text
-        </button>
+      <div className="flex items-center space-x-4 w-auto">
+        <GhostButton type="primary" size="xxs">Button text</GhostButton>
+        <GhostButton type="primary" size="xs">Button text</GhostButton>
+        <GhostButton type="primary" size="sm">Button text</GhostButton>
+        <GhostButton type="primary" size="base">Button text</GhostButton>
+        <GhostButton type="primary" size="lg">Button text</GhostButton>
+      </div>
+
+      <h3 className="font-bold mt-8 mb-4">Ghost buttons - secondary</h3>
+
+      <div className="flex items-center space-x-4 w-auto">
+        <GhostButton type="secondary" size="xxs">Button text</GhostButton>
+        <GhostButton type="secondary" size="xs">Button text</GhostButton>
+        <GhostButton type="secondary" size="sm">Button text</GhostButton>
+        <GhostButton type="secondary" size="base">Button text</GhostButton>
+        <GhostButton type="secondary" size="lg">Button text</GhostButton>
       </div>
     </Section>
   );


### PR DESCRIPTION
In a previous PR #956 I added buttons to the design system that were actually not properly componentized nor used anywhere apart from my mockup #882.

While designing further I decided to adapt the existing `FilledButton` and `GhostButton` components.

The video shows before and after. In both cases these are the Filled and Ghostbuttons. The switch to new happens at ~00:23:

https://github.com/user-attachments/assets/bdac09ec-a80b-4538-90a4-cc849965bd5d

