### PR TITLE
chore: VS Code settings for JS/TS code formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}


### PR DESCRIPTION
if we want to use this plugin for all languages then we'd have to add:

```
{
  "editor.defaultFormatter": "esbenp.prettier-vscode"
}
```