### PR TITLE
chore: Allow fields to be hidden

### DIFF
--- a/assets/js/components/Forms/RadioButtons.tsx
+++ b/assets/js/components/Forms/RadioButtons.tsx
@@ -5,12 +5,18 @@ import { InputField } from "./FieldGroup";
 
 import classNames from "classnames";
 
-export function RadioButtons({ field, label }: { field: string; label?: string }) {
+interface RadioButtonsProps {
+  field: string;
+  label?: string;
+  hidden?: boolean;
+}
+
+export function RadioButtons({ field, label, hidden }: RadioButtonsProps) {
   const form = getFormContext();
   const f = form.fields[field];
 
   return (
-    <InputField field={field} label={label}>
+    <InputField field={field} label={label} hidden={hidden}>
       <div className="flex flex-col gap-2 mt-1">
         {f.options.map((option: { value: string; label: string }) => (
           <RadioButton key={option.value} field={field} value={option.value} label={option.label} />

--- a/assets/js/components/Forms/SelectBox.tsx
+++ b/assets/js/components/Forms/SelectBox.tsx
@@ -8,15 +8,16 @@ import { InputField } from "./FieldGroup";
 interface SelectBoxProps {
   field: string;
   label?: string;
+  hidden?: boolean;
   placeholder?: string;
 }
 
-export function SelectBox({ field, label, placeholder }: SelectBoxProps) {
+export function SelectBox({ field, label, placeholder, hidden }: SelectBoxProps) {
   const form = getFormContext();
   const error = form.errors[field];
 
   return (
-    <InputField field={field} label={label} error={error}>
+    <InputField field={field} label={label} error={error} hidden={hidden}>
       <SelectBoxInput field={field} placeholder={placeholder} error={!!error} />
     </InputField>
   );

--- a/assets/js/components/Forms/TextInput.tsx
+++ b/assets/js/components/Forms/TextInput.tsx
@@ -8,15 +8,16 @@ interface TextInputProps {
   field: string;
   label?: string;
   placeholder?: string;
+  hidden?: boolean;
 }
 
-export function TextInput({ field, label, placeholder }: TextInputProps) {
+export function TextInput({ field, label, placeholder, hidden }: TextInputProps) {
   const form = getFormContext();
   const error = form.errors[field];
   const f = form.fields[field];
 
   return (
-    <InputField field={field} label={label} error={error}>
+    <InputField field={field} label={label} error={error} hidden={hidden}>
       <input
         name={field}
         placeholder={placeholder}


### PR DESCRIPTION
Rationale: Previously we could use the `{shouldShowXX && <TextField ..>}` pattern, but I've found that quite hard to read. The hidden attribute streamlines this concern.

Before:

``` tsx
<Forms.Form form={form}>
  <Forms.FieldGroup>
    <Forms.TextInput label="Project Name" field={"name"} />
    {showSpaceSelector && (<Forms.SelectBox label="Space" field={"space"} />)}
    <Forms.SelectGoal field={"goal"} goals={goals} label={"Goal"} />

    <Forms.FieldGroup layout="grid" gridColumns={2}>
      <Forms.SelectPerson label="Champion" field={"champion"} />
      {showReviewer && (<Forms.SelectPerson label="Reviewer" field={"reviewer"} />)}
    </Forms.FieldGroup>
  </Forms.FieldGroup>
</Forms>
```

Now:

``` tsx
<Forms.Form form={form}>
  <Forms.FieldGroup>
    <Forms.TextInput label="Project Name" field={"name"} />
    <Forms.SelectBox label="Space" field={"space"} hidden={hideSpaceSelector} />
    <Forms.SelectGoal field={"goal"} goals={goals} label={"Goal"} />

    <Forms.FieldGroup layout="grid" gridColumns={2}>
      <Forms.SelectPerson label="Champion" field={"champion"} />
      <Forms.SelectPerson label="Reviewer" field={"reviewer"} hidden={hideReviewer} />
    </Forms.FieldGroup>
  </Forms.FieldGroup>
</Forms>
```