### PR TITLE
chore: Centered layout for submit area

### DIFF
--- a/assets/js/components/Forms/Submit.tsx
+++ b/assets/js/components/Forms/Submit.tsx
@@ -2,12 +2,23 @@ import * as React from "react";
 
 import { getFormContext } from "./FormContext";
 import { FilledButton } from "@/components/Button";
+import classNames from "classnames";
 
-export function Submit({ saveText }: { saveText: string }) {
+interface SubmitProps {
+  saveText: string;
+  layout?: "left" | "centered";
+}
+
+export function Submit({ saveText, layout }: SubmitProps) {
   const form = getFormContext();
 
+  const className = classNames("flex items-center gap-2 mt-8", {
+    "justify-start": layout === "left",
+    "justify-center": layout === "centered",
+  });
+
   return (
-    <div className="flex items-center gap-2 mt-8">
+    <div className={className}>
       <FilledButton type="primary" submit loading={form.state === "submitting"} testId="submit">
         {saveText}
       </FilledButton>


### PR DESCRIPTION
On pages that have a single form, it looks better when the submit button is in the center. Example is the project add page:

![Screenshot 2024-09-05 at 13 46 17](https://github.com/user-attachments/assets/6b887756-fc07-424e-ac87-54cfa1e139e7)
