### PR TITLE
fix: Hide subscription widget when there are no contributors

### DIFF
--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -10,7 +10,7 @@ export const SubscriptionsContext = createContext<SubscriptionsState | undefined
 
 export function SubscribersSelector({ state, project }: { state: SubscriptionsState; project: Project }) {
   const [showSelector, setShowSelector] = useState(false);
-  const { people, selectedPeople, subscriptionType, setSubscriptionType } = state;
+  const { people, selectedPeople, subscriptionType, setSubscriptionType, alwaysNotify } = state;
 
   const selectedPeopleLabel = useMemo(() => {
     switch (selectedPeople.length) {
@@ -22,6 +22,10 @@ export function SubscribersSelector({ state, project }: { state: SubscriptionsSt
         return `Only the following ${selectedPeople.length} people I selected`;
     }
   }, [selectedPeople]);
+
+  // If all notifiable people must be notified,
+  // the widget is not displayed.
+  if (alwaysNotify.length >= people.length) return <></>;
 
   return (
     <SubscriptionsContext.Provider value={state}>

--- a/assets/js/features/projectCheckIns/Form/useForm.tsx
+++ b/assets/js/features/projectCheckIns/Form/useForm.tsx
@@ -50,7 +50,7 @@ export interface FormState {
 export function useForm({ mode, project, checkIn, author, notifiablePeople = [] }: UseFormOptions): FormState {
   const navigate = useNavigate();
   const subscriptionsState = useSubscriptions(notifiablePeople, {
-    alwaysNotify: getReviewerAndChampion(notifiablePeople),
+    alwaysNotify: getAlwaysNotifiablePeople(notifiablePeople),
   });
 
   const [status, setStatus] = React.useState<string | null>(mode === "edit" ? checkIn!.status! : null);
@@ -161,6 +161,6 @@ function validate(status: string | null, description: string): Error[] {
   return errors;
 }
 
-function getReviewerAndChampion(people: NotifiablePerson[]) {
+function getAlwaysNotifiablePeople(people: NotifiablePerson[]) {
   return people.filter((p) => p.title === "Reviewer" || p.title === "Champion");
 }

--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -16,6 +16,7 @@ defmodule Operately.Operations.ProjectCheckIn do
     |> Multi.insert(:subscription_list, SubscriptionList.changeset(%{
       send_to_everyone: attrs.send_notifications_to_everyone,
     }))
+    |> insert_author_subscription(author.id)
     |> insert_subscriptions(attrs.subscriber_ids)
     |> insert_mentioned_subscriptions(attrs.description)
     |> Multi.insert(:check_in, fn changes ->
@@ -56,6 +57,16 @@ defmodule Operately.Operations.ProjectCheckIn do
 
       error -> error
     end
+  end
+
+  defp insert_author_subscription(multi, author_id) do
+    Multi.insert(multi, :author_subscription, fn changes ->
+      Subscription.changeset(%{
+        subscription_list_id: changes.subscription_list.id,
+        person_id: author_id,
+        type: :invited,
+      })
+    end)
   end
 
   defp insert_subscriptions(multi, nil), do: multi


### PR DESCRIPTION
I'm addressing the issue described in https://github.com/operately/operately/issues/1039 and also making sure that the author is always included in the subscriptions list.

I recorded a few videos showing the different behaviors of the widget.

1) Champion checks in and there aren't contributors:
(The widget is hidden, but the Champion and Reviewer are added to the list)

https://github.com/user-attachments/assets/fabe6d96-2390-4549-bb86-b73503b4dc96

2) Champion checks in and there are contributors:

https://github.com/user-attachments/assets/8ae9dd34-f0e8-44ca-854e-d6a6df23fdea

3) A contributor checks in and there aren't other contributors:
(The widget is hidden, but the Champion, Reviewer and contributor/author are added to the list)

https://github.com/user-attachments/assets/c0d2430f-b690-43f4-8be9-80910751272a

4) A contributor checks in and there are other contributors:

https://github.com/user-attachments/assets/3d027247-4997-49ae-832b-180d4e2b3374


