### PR TITLE
fix: ProjectCheckIn operation creates 1 subscription per user

### DIFF
--- a/lib/operately/operations/project_check_in/subscription.ex
+++ b/lib/operately/operations/project_check_in/subscription.ex
@@ -1,0 +1,49 @@
+defmodule Operately.Operations.ProjectCheckIn.Subscription do
+  alias Ecto.Multi
+  alias Operately.Notifications.Subscription
+
+  def insert(multi, author, attrs) do
+    mentioned = find_mentioned_people(attrs.description)
+    invited = [author.id | attrs.subscriber_ids]
+
+    ids = categorize_ids(invited, mentioned)
+
+    Enum.reduce(ids, multi, fn {id, type}, multi ->
+      name = "subscription_" <> id
+
+      Multi.insert(multi, name, fn changes ->
+        Subscription.changeset(%{
+          subscription_list_id: changes.subscription_list.id,
+          person_id: id,
+          type: type,
+        })
+      end)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp find_mentioned_people(description) do
+    {:ok, ids} =
+      description
+      |> Operately.RichContent.find_mentioned_ids()
+      |> Enum.uniq()
+      |> OperatelyWeb.Api.Helpers.decode_id()
+
+    ids
+  end
+
+  defp categorize_ids(invited, mentioned) do
+    mentioned ++ invited
+    |> Enum.uniq()
+    |> Enum.map(fn id ->
+      if Enum.member?(invited, id) do
+        {id, :invited}
+      else
+        {id, :mentioned}
+      end
+    end)
+  end
+end

--- a/lib/operately/operations/project_check_in/subscription_list.ex
+++ b/lib/operately/operations/project_check_in/subscription_list.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Operations.ProjectCheckIn.SubscriptionList do
+  alias Ecto.Multi
+  alias Operately.Notifications.SubscriptionList
+
+  def insert(multi, attrs) do
+    multi
+    |> Multi.insert(:subscription_list, SubscriptionList.changeset(%{
+      send_to_everyone: attrs.send_notifications_to_everyone,
+    }))
+  end
+
+  def update(multi) do
+    multi
+    |> Multi.update(:updated_subscription_list, fn changes ->
+      SubscriptionList.changeset(changes.subscription_list, %{
+        parent_type: :project_check_in,
+        parent_id: changes.check_in.id,
+      })
+    end)
+  end
+end

--- a/lib/operately_web/api/mutations/post_project_check_in.ex
+++ b/lib/operately_web/api/mutations/post_project_check_in.ex
@@ -49,7 +49,7 @@ defmodule OperatelyWeb.Api.Mutations.PostProjectCheckIn do
       status: inputs.status,
       description: Jason.decode!(inputs.description),
       send_notifications_to_everyone: inputs[:send_notifications_to_everyone] || false,
-      subscriber_ids: subscriber_ids
+      subscriber_ids: subscriber_ids || []
     }}
   end
 end


### PR DESCRIPTION
I've updated `Operately.Operations.ProjectCheckIn` so that it doesn't create more than one notifications subscription per user.