### PR TITLE
feat: Prevent people from assigning themselves as both champion and reviewer

### DIFF
--- a/assets/js/components/Forms/useSelectPersonField.tsx
+++ b/assets/js/components/Forms/useSelectPersonField.tsx
@@ -17,7 +17,7 @@ export function useSelectPersonField(initial?: Person | null, config?: Config): 
   const [value, setValue] = React.useState(initial);
 
   const validate = (): string | null => {
-    if (!value) return !config?.optional ? "is required" : null;
+    if (!value) return !config?.optional ? "Can't be empty" : null;
 
     return null;
   };

--- a/assets/js/components/PeopleSearch/index.tsx
+++ b/assets/js/components/PeopleSearch/index.tsx
@@ -5,6 +5,7 @@ import Avatar, { AvatarSize } from "@/components/Avatar";
 import classnames from "classnames";
 
 import { Person } from "@/models/people";
+import { createTestId } from "@/utils/testid";
 
 export interface Option {
   value: string;
@@ -84,7 +85,7 @@ function personAsOption(person: Person, showTitle = false): Option {
 
 function PersonLabel({ person, showTitle }: { person: Person; showTitle: boolean }) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2" data-test-id={createTestId("person-option", person.fullName!)}>
       <Avatar person={person} size={AvatarSize.Tiny} />
       {person.fullName}
       {showTitle && <>&middot; {person.title}</>}

--- a/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
+++ b/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
@@ -124,6 +124,7 @@ export function MultiPeopleSearch(props: MultiPeopleSearchProps) {
                     "cursor-pointer": true,
                     "bg-sky-300": selectedPersonIndex === index,
                   })}
+                  data-test-id={createTestId("person-option", person.fullName!)}
                   onClick={() => {
                     props.setAddedPeople((people) => [...people, person]);
                     setSearchTerm("");

--- a/assets/js/pages/ProjectAddPage/page.tsx
+++ b/assets/js/pages/ProjectAddPage/page.tsx
@@ -81,6 +81,11 @@ function Form() {
       creatorRole: Forms.useTextField(null, { optional: true }),
       isContrib: Forms.useSelectField("no", WillYouContributeOptions),
     },
+    validate: (fields, addError) => {
+      if (compareIds(fields.champion.value?.id, fields.reviewer.value?.id)) {
+        addError("reviewer", "Can't be the same as the champion");
+      }
+    },
     submit: async (form) => {
       const res = await add({
         name: form.fields.name.value,

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -81,4 +81,14 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.submit_project_form(params)
     |> Steps.assert_reviewer_is_champions_manager(params)
   end
+
+  @tag login_as: :champion
+  feature "champion == reviewer is not allowed", ctx do
+    params = %{name: "Website Redesign", creator: ctx.champion, champion: ctx.champion, reviewer: ctx.champion}
+
+    ctx
+    |> Steps.start_adding_project()
+    |> Steps.submit_project_form(params)
+    |> Steps.assert_validation_error("Can't be the same as the champion")
+  end
 end

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -90,7 +90,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       |> UI.fill(testid: "creatorRole", with: "Responsible for managing the project")
     end)
     |> UI.click(testid: "submit")
-    |> UI.assert_text(fields.name)
+    |> UI.sleep(300)
   end
 
   step :assert_project_created, ctx, fields do
@@ -154,6 +154,10 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     project = Operately.Repo.preload(project, [:reviewer])
 
     assert project.reviewer.id == ctx.manager.id
+  end
+
+  step :assert_validation_error, ctx, error do
+    UI.assert_text(ctx, error)
   end
 
   defp who_should_be_notified(fields) do

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -182,10 +182,16 @@ defmodule Operately.Support.Features.UI do
 
   def select_person_in(state, id: id, name: name) do
     execute(state, fn session ->
-      session
-      |> Browser.fill_in(Query.css("#" <> id), with: name)
-      |> Browser.assert_text(name)
-      |> Browser.send_keys([:enter])
+      Browser.fill_in(session, Query.css("#" <> id), with: name)
+    end)
+    |> assert_has(testid: testid(["person-option", name]))
+    |> sleep(500)
+    |> press_enter()
+  end
+
+  def press_enter(state) do
+    execute(state, fn session ->
+      session |> Browser.send_keys([:enter])
     end)
   end
 


### PR DESCRIPTION
My initial thought was to filter out the list and remove the champion from the review dropdown box. However, while testing this behavior, it felt wrong as it is giving me the impression that  Operately is not working when I'm searching for a person.

So I've done it with a validation. It is better to be explicit. If you select champion === reviewer, the message is very explicit:

![Screenshot 2024-09-05 at 18 42 03](https://github.com/user-attachments/assets/bc6b0f03-9390-4645-8742-9d8fc983ab58)
