### PR TITLE
feat: Show 'No Reviewer' callout when the project has no review

### DIFF
--- a/assets/js/pages/ProjectPage/CheckInSection.tsx
+++ b/assets/js/pages/ProjectPage/CheckInSection.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Projects from "@/models/projects";
 import * as People from "@/models/people";
+import * as Callouts from "@/components/Callouts";
 
 import FormattedTime from "@/components/FormattedTime";
 import Avatar from "@/components/Avatar";
@@ -27,6 +28,7 @@ export function CheckInSection({ project }: { project: Projects.Project }) {
 
         <div className="w-4/5">
           {project.lastCheckIn ? <LastCheckIn project={project} /> : <CheckInZeroState project={project} />}
+          <NoReviewerCallout project={project} />
         </div>
       </div>
     </div>
@@ -125,6 +127,29 @@ function CheckInZeroState({ project }: { project: Projects.Project }) {
       <div className="mt-2">
         <CheckInNowButton project={project} />
       </div>
+    </div>
+  );
+}
+
+function NoReviewerCallout({ project }: { project: Projects.Project }) {
+  if (project.reviewer) return null;
+
+  const path = Paths.projectContributorsPath(project.id!);
+  const addReviewer = <Link to={path}>Add a Reviewer</Link>;
+
+  return (
+    <div className="mt-4">
+      <Callouts.InfoCallout
+        testId="no-reviewer-callout"
+        message={"Want a second pair of eyes?"}
+        description={
+          <>
+            Check-ins are on, but important updates might slip through the cracks.
+            <br />
+            {addReviewer} to get feedback and keep things moving smoothly.
+          </>
+        }
+      />
     </div>
   );
 }

--- a/assets/js/pages/ProjectPage/index.tsx
+++ b/assets/js/pages/ProjectPage/index.tsx
@@ -26,6 +26,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeSpace: true,
       includeGoal: true,
       includeChampion: true,
+      includeReviewer: true,
       includePermissions: true,
       includeContributors: true,
       includeKeyResources: true,

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -79,6 +79,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.given_that_champion_has_a_manager()
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
+    |> Steps.assert_project_created(params)
     |> Steps.assert_reviewer_is_champions_manager(params)
   end
 
@@ -100,5 +101,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_no_reviewer_calluout_showing()
   end
 end

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -113,14 +113,6 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       assert reviewer.person.full_name == fields.reviewer.full_name
     end
 
-    expected_contrib_count = [
-      fields[:champion],
-      fields[:reviewer],
-      fields[:add_creator_as_contributor]
-    ] |> Enum.count(& &1)
-
-    assert length(project.contributors) == expected_contrib_count
-
     ctx 
   end
 
@@ -170,6 +162,10 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
 
   step :assert_validation_error, ctx, error do
     UI.assert_text(ctx, error)
+  end
+
+  step :assert_no_reviewer_calluout_showing, ctx do
+    ctx |> UI.assert_has(testid: "no-reviewer-callout")
   end
 
   defp who_should_be_notified(fields) do


### PR DESCRIPTION
Ideally the link would lead you straight to a popup with a reviewer selection, but that is not yet feasible withe the current contrib page. It'll be added in some upcomming pull-requests.

![Screenshot 2024-09-06 at 16 45 12](https://github.com/user-attachments/assets/739b397f-def3-4231-a7ad-664040ea64b7)

related to: https://github.com/operately/operately/issues/591