### PR TITLE
fix: Show current timezone in profile settings

### DIFF
--- a/lib/operately_web/api/serializers/person.ex
+++ b/lib/operately_web/api/serializers/person.ex
@@ -27,6 +27,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
       avatar_url: data.avatar_url,
       title: data.title,
       suspended: data.suspended,
+      timezone: data.timezone,
       manager: OperatelyWeb.Api.Serializer.serialize(data.manager),
       reports: OperatelyWeb.Api.Serializer.serialize(data.reports),
       peers: OperatelyWeb.Api.Serializer.serialize(data.peers),

--- a/test/features/account_settings_test.exs
+++ b/test/features/account_settings_test.exs
@@ -29,10 +29,15 @@ defmodule Operately.Features.AccountSettingsTest do
   end
 
   feature "changing the timezone in account settings", ctx do
+    props = %{
+      value: "Europe/Belgrade",
+      label: "(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague"
+    }
+
     ctx
     |> Steps.open_account_settings()
-    |> Steps.change_timezone("(UTC+01:00) Belgrade, Bratislava, Budapest, Ljubljana, Prague")
-    |> Steps.assert_person_timezone_changed("Europe/Belgrade")
+    |> Steps.change_timezone(props)
+    |> Steps.assert_person_timezone_changed(props)
   end
 
   feature "setting my manager in account settings", ctx do

--- a/test/support/features/account_settings_steps.ex
+++ b/test/support/features/account_settings_steps.ex
@@ -58,16 +58,20 @@ defmodule Operately.Support.Features.AccountSettingsSteps do
     ctx
   end
 
-  step :change_timezone, ctx, timezone do
+  step :change_timezone, ctx, props do
     ctx
-    |> UI.select(testid: "timezone", option: timezone)
+    |> UI.select(testid: "timezone", option: props[:label])
     |> UI.click(testid: "submit")
     |> UI.assert_has(testid: "my-account-page")
   end
 
-  step :assert_person_timezone_changed, ctx, timezone do
-    assert Operately.People.get_person!(ctx.person.id).timezone == timezone
+  step :assert_person_timezone_changed, ctx, props do
+    assert Operately.People.get_person!(ctx.person.id).timezone == props[:value]
+
     ctx
+    |> UI.visit(Paths.account_path(ctx.company))
+    |> UI.click(testid: "profile-link")
+    |> UI.assert_text(props[:label])
   end
 
   step :set_select_manager_from_list, ctx do


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/1074

When we introduced the possibility to edit other people's profile, we changed the API call from getMe to getPerson. The get person had no timezone exported, so it allowed setting the timezone, saving to the DB and also applying to the UI (via the getMe API call) but it would be set to null when you visit the profile edit page again.