### PR TITLE
chore: Alternative between feature files and steps

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,4 +1,14 @@
 {
+  "test/features/*_test.exs": {
+    "type": "test",
+    "alternate": "test/support/features/{}_steps.ex",
+    "template": ["# test/{}_test.exs", "defmodule XXX do", "end"]
+  },
+  "test/support/features/*_steps.ex": {
+    "type": "test",
+    "alternate": "test/features/{}_test.exs",
+    "template": ["# test/{}_test.exs", "defmodule XXX do", "end"]
+  },
   "lib/*.ex": {
     "type": "src",
     "alternate": "test/{}_test.exs",


### PR DESCRIPTION
Alternates between feature tests and the steps when you type `:A` in vim.
In VSCode, it works with https://marketplace.visualstudio.com/items?itemName=will-wow.vscode-alternate-file.