### PR TITLE
feat: Add canceled field to subscriptions schema

### DIFF
--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -147,6 +147,9 @@ defmodule Operately.Notifications do
 
   alias Operately.Notifications.Subscription
 
+  def get_subscription(id) when is_binary(id) , do: Repo.get(Subscription, id)
+  def get_subscription(attrs) when is_list(attrs), do: Repo.get_by(Subscription, attrs)
+
   def list_subscriptions(%SubscriptionList{} = subscription_list), do: list_subscriptions(subscription_list.id)
   def list_subscriptions(subscription_list_id) do
     from(s in Subscription, where: s.subscription_list_id == ^subscription_list_id)
@@ -157,6 +160,12 @@ defmodule Operately.Notifications do
     %Subscription{}
     |> Subscription.changeset(attrs)
     |> Repo.insert()
+  end
+
+  def update_subscription(%Subscription{} = subscription, attrs) do
+    subscription
+    |> Subscription.changeset(attrs)
+    |> Repo.update()
   end
 
   def is_subscriber?(person_id, subscription_list_id) do

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -161,7 +161,8 @@ defmodule Operately.Notifications do
 
   def is_subscriber?(person_id, subscription_list_id) do
     from(s in Subscription,
-      where: s.person_id == ^person_id and s.subscription_list_id == ^subscription_list_id
+      where: s.person_id == ^person_id and s.subscription_list_id == ^subscription_list_id,
+      where: not s.canceled
     )
     |> Repo.exists?()
   end

--- a/lib/operately/notifications/subscription.ex
+++ b/lib/operately/notifications/subscription.ex
@@ -20,4 +20,12 @@ defmodule Operately.Notifications.Subscription do
     |> cast(attrs, [:type, :subscription_list_id, :person_id, :canceled])
     |> validate_required([:type, :subscription_list_id, :person_id])
   end
+
+  # Queries
+  import Ecto.Query, only: [from: 2]
+
+  def preload_subscriptions(query) do
+    subquery = from(s in Operately.Notifications.Subscription, where: s.canceled == false, preload: :person)
+    from(p in query, preload: [subscription_list: [subscriptions: ^subquery]])
+  end
 end

--- a/lib/operately/notifications/subscription.ex
+++ b/lib/operately/notifications/subscription.ex
@@ -6,6 +6,7 @@ defmodule Operately.Notifications.Subscription do
     belongs_to :person, Operately.People.Person, foreign_key: :person_id
 
     field :type, Ecto.Enum, values: [:invited, :joined, :mentioned]
+    field :canceled, :boolean, default: false
 
     timestamps()
   end
@@ -16,7 +17,7 @@ defmodule Operately.Notifications.Subscription do
 
   def changeset(subscriptions, attrs) do
     subscriptions
-    |> cast(attrs, [:type, :subscription_list_id, :person_id])
+    |> cast(attrs, [:type, :subscription_list_id, :person_id, :canceled])
     |> validate_required([:type, :subscription_list_id, :person_id])
   end
 end

--- a/lib/operately/operations/notifications_subscribing.ex
+++ b/lib/operately/operations/notifications_subscribing.ex
@@ -1,15 +1,27 @@
 defmodule Operately.Operations.NotificationsSubscribing do
   alias Ecto.Multi
-  alias Operately.Repo
-  alias Operately.Notifications.Subscription
+  alias Operately.{Repo, Notifications}
 
   def run(person_id, subscription_list_id) do
     Multi.new()
-    |> Multi.insert(:subscription, Subscription.changeset(%{
-      person_id: person_id,
-      subscription_list_id: subscription_list_id,
-      type: :joined,
-    }))
+    |> Multi.run(:existing_subscription, fn _, _ ->
+      {:ok, Notifications.get_subscription(person_id: person_id, subscription_list_id: subscription_list_id)}
+    end)
+    |> Multi.run(:subscription, fn _, changes ->
+      case changes.existing_subscription do
+        nil ->
+          Notifications.create_subscription(%{
+            person_id: person_id,
+            subscription_list_id: subscription_list_id,
+            type: :joined
+          })
+        subscription ->
+          Notifications.update_subscription(subscription, %{
+            canceled: false,
+            type: :joined
+          })
+      end
+    end)
     |> Repo.transaction()
   end
 end

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -5,6 +5,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   import Operately.Access.Filters
 
   alias Operately.Projects.CheckIn
+  alias Operately.Notifications.Subscription
 
   inputs do
     field :id, :string
@@ -52,7 +53,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
         :include_author -> from p in q, preload: [:author]
         :include_project -> from p in q, preload: [project: [:reviewer, [contributors: :person]]]
         :include_reactions -> from p in q, preload: [reactions: :person]
-        :include_subscriptions -> from p in q, preload: [subscription_list: [subscriptions: :person]]
+        :include_subscriptions -> Subscription.preload_subscriptions(q)
         _ -> raise ArgumentError, "Unknown include filter: #{inspect(include)}"
       end
     end)

--- a/priv/repo/migrations/20240909112047_add_canceled_field_to_subscriptions_schema.exs
+++ b/priv/repo/migrations/20240909112047_add_canceled_field_to_subscriptions_schema.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddCanceledFieldToSubscriptionsSchema do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      add :canceled, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
I've added the field `canceled` to the subscriptions schema.

When someone unsubscribes from a resource, subscriptions are no longer deleted. They are marked as "canceled" instead.