### PR TITLE
chore: Introduce forms.reset

### DIFF
--- a/assets/js/components/Forms/FormState.tsx
+++ b/assets/js/components/Forms/FormState.tsx
@@ -15,6 +15,7 @@ export interface FormState<FieldTypes extends MapOfFields> {
     validate: () => boolean;
     submit: (form: FormState<FieldTypes>) => Promise<void>;
     cancel: (form: FormState<FieldTypes>) => Promise<void>;
+    reset: () => void;
   };
 }
 

--- a/assets/js/components/Forms/useForm.tsx
+++ b/assets/js/components/Forms/useForm.tsx
@@ -55,9 +55,22 @@ export function useForm<FieldTypes extends MapOfFields>(props: UseFormProps<Fiel
         setState("submitting");
         await props.submit(form);
         setState("idle");
+
+        form.actions.reset();
       },
       cancel: async () => {
-        if (props.cancel) await props.cancel(form);
+        if (!props.cancel) return;
+
+        form.actions.reset();
+        await props.cancel(form);
+      },
+      reset: () => {
+        form.actions.clearErrors();
+
+        for (const key in props.fields) {
+          const field = props.fields[key]!;
+          field.setValue(field.initial);
+        }
       },
     },
   };

--- a/assets/js/pages/DesignPage/Forms.tsx
+++ b/assets/js/pages/DesignPage/Forms.tsx
@@ -106,6 +106,8 @@ function GridForm() {
           <Forms.PasswordInput field={"password"} label={"Password"} />
           <Forms.PasswordInput field={"confirmPassword"} label={"Confirm Password"} />
         </Forms.FieldGroup>
+
+        <Forms.Submit saveText="Submit" />
       </Forms.Form>
     </div>
   );


### PR DESCRIPTION
When we click submit or click, the form will reset to the initial state. Useful in places where we want to use the form multiple times.