### PR TITLE
feat: Creating check-in sends notifications using subscriptions list

### DIFF
--- a/lib/operately/activities/notifications/project_check_in_submitted.ex
+++ b/lib/operately/activities/notifications/project_check_in_submitted.ex
@@ -1,23 +1,15 @@
 defmodule Operately.Activities.Notifications.ProjectCheckInSubmitted do
-  alias Operately.Projects
+  alias Operately.{Notifications, Projects}
 
   def dispatch(activity) do
-    author_id = activity.author_id
-    project_id = activity.content["project_id"]
-    check_in = Operately.Projects.get_check_in!(activity.content["check_in_id"])
-
-    people = Projects.list_notification_subscribers(project_id, exclude: author_id)
-    mentioned = Operately.RichContent.lookup_mentioned_people(check_in.description)
-    people = Enum.uniq_by(people ++ mentioned, & &1.id)
-
-    notifications = Enum.map(people, fn person ->
+    Projects.Notifications.get_check_in_subscribers(activity.content["check_in_id"])
+    |> Enum.map(fn person_id ->
       %{
-        person_id: person.id,
+        person_id: person_id,
         activity_id: activity.id,
         should_send_email: true,
       }
     end)
-
-    Operately.Notifications.bulk_create(notifications)
+    |> Notifications.bulk_create()
   end
 end

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -1,0 +1,27 @@
+defmodule Operately.Projects.Notifications do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Projects.CheckIn
+
+  def get_check_in_subscribers(check_in_id) do
+    %{subscription_list: list, project: p} = from(c in CheckIn,
+        where: c.id == ^check_in_id,
+        preload: [project: :contributors, subscription_list: :subscriptions]
+      )
+      |> Repo.one()
+
+    if list.send_to_everyone do
+      Enum.filter(p.contributors, fn c ->
+        case Enum.find(list.subscriptions, &(&1.person_id == c.person_id)) do
+          nil -> true
+          %{canceled: false} -> true
+          _ -> false
+        end
+      end)
+      |> Enum.map(&(&1.person_id))
+    else
+      Enum.map(list.subscriptions, &(&1.person_id))
+    end
+  end
+end

--- a/test/operately/operations/project_check_in_test.exs
+++ b/test/operately/operations/project_check_in_test.exs
@@ -1,0 +1,122 @@
+defmodule Operately.Operations.ProjectCheckInTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Support.RichText
+  alias Operately.Operations.ProjectCheckIn
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
+    reviewer = person_fixture_with_account(%{company_id: company.id})
+
+    project = project_fixture(%{
+      company_id: company.id,
+      creator_id: creator.id,
+      creator_is_contributor: "no",
+      champion_id: champion.id,
+      reviewer_id: reviewer.id,
+      group_id: company.company_space_id,
+    })
+
+    Enum.each(1..3, fn _ ->
+      person = person_fixture_with_account(%{company_id: company.id})
+      contributor_fixture(creator, %{
+        project_id: project.id,
+        person_id: person.id,
+      })
+    end)
+
+    {:ok, %{creator: creator, champion: champion, reviewer: reviewer, project: project}}
+  end
+
+  test "Creating project check-in notifies only reviewer and champion", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      {:ok, _} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
+        status: "on_track",
+        description: RichText.rich_text("Some description"),
+        send_notifications_to_everyone: false,
+        subscriber_ids: [ctx.reviewer.id, ctx.champion.id]
+      })
+    end)
+    activity = get_activity(ctx.project)
+
+    assert 0 == notifications_count(action: "project_check_in_submitted")
+
+    perform_job(activity.id)
+
+    assert 2 == notifications_count(action: "project_check_in_submitted")
+
+    notifications = fetch_notifications(activity.id, action: "project_check_in_submitted")
+
+    assert Enum.find(notifications, &(&1.person_id == ctx.reviewer.id))
+    assert Enum.find(notifications, &(&1.person_id == ctx.champion.id))
+  end
+
+  test "Creating project check-in notifies all contributors", ctx do
+    contributors = Operately.Projects.list_project_contributors(ctx.project)
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      {:ok, _} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
+        status: "on_track",
+        description: RichText.rich_text("Some description"),
+        send_notifications_to_everyone: false,
+        subscriber_ids: Enum.map(contributors, &(&1.person_id))
+      })
+    end)
+    activity = get_activity(ctx.project)
+
+    assert 0 == notifications_count(action: "project_check_in_submitted")
+
+    perform_job(activity.id)
+
+    assert 5 == notifications_count(action: "project_check_in_submitted")
+
+    notifications = fetch_notifications(activity.id, action: "project_check_in_submitted")
+
+    Enum.each(contributors, fn c ->
+      assert Enum.find(notifications, &(&1.person_id == c.person_id))
+    end)
+  end
+
+  test "Creating project check-in notifies all contributors if send_to_everyone is true", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      {:ok, _} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
+        status: "on_track",
+        description: RichText.rich_text("Some description"),
+        send_notifications_to_everyone: true,
+        subscriber_ids: []
+      })
+    end)
+    activity = get_activity(ctx.project)
+
+    assert 0 == notifications_count(action: "project_check_in_submitted")
+
+    perform_job(activity.id)
+
+    assert 5 == notifications_count(action: "project_check_in_submitted")
+
+    notifications = fetch_notifications(activity.id, action: "project_check_in_submitted")
+    contributors = Operately.Projects.list_project_contributors(ctx.project)
+
+    Enum.each(contributors, fn c ->
+      assert Enum.find(notifications, &(&1.person_id == c.person_id))
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp get_activity(project) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == "project_check_in_submitted" and a.content["project_id"] == ^project.id
+    )
+    |> Repo.one()
+  end
+end

--- a/test/support/notifications.ex
+++ b/test/support/notifications.ex
@@ -15,6 +15,14 @@ defmodule Operately.Support.Notifications do
     Repo.aggregate(Notification, :count, :id)
   end
 
+  def notifications_count(action: action) do
+    from(n in Notification,
+      join: a in assoc(n, :activity),
+      where: a.action == ^action
+    )
+    |> Repo.aggregate(:count)
+  end
+
   def perform_job(activity_id) do
     Oban.Testing.perform_job(Operately.Activities.NotificationDispatcher, %{activity_id: activity_id}, [])
   end
@@ -25,6 +33,14 @@ defmodule Operately.Support.Notifications do
 
   def fetch_notifications(activity_id) do
     from(n in Notification, where: n.activity_id == ^activity_id) |> Repo.all()
+  end
+
+  def fetch_notifications(activity_id, action: action) do
+    from(n in Notification,
+      join: a in assoc(n, :activity),
+      where: n.activity_id == ^activity_id and a.action == ^action
+    )
+    |> Repo.all()
   end
 
   def notification_message(%Person{id: id, full_name: full_name}) do


### PR DESCRIPTION
I've updated `Operately.Activities.Notifications.ProjectCheckInSubmitted` so that it uses the check-in's subscriptions_list to send notifications. The new behavior is:

- If the notifications_list has `send_to_everyone = false`, it sends a notification to everyone who has a subscription (not canceled).

- If the notifications_list has `send_to_everyone = true`, it sends a notification to every contributor, unless the contributor's subscription was canceled.

I haven't handled permissions yet.

I've also added the module `Operately.Projects.Notifications`. My plan is to add to this module all the functions that will be used to get a resource's subscribers. So far, I've added a function to get a check-in's subscribers.

@shiroyasha, What do you think about the new notifications behavior? And how about the `Operately.Projects.Notifications` module?