### PR TITLE
fix: Notifications Widget and useForm updated

### DIFF
--- a/assets/js/components/Forms/useForm.tsx
+++ b/assets/js/components/Forms/useForm.tsx
@@ -69,7 +69,10 @@ export function useForm<FieldTypes extends MapOfFields>(props: UseFormProps<Fiel
 
         for (const key in props.fields) {
           const field = props.fields[key]!;
-          field.setValue(field.initial);
+
+          if (field.initial) {
+            field.setValue(field.initial);
+          }
         }
       },
     },

--- a/assets/js/features/Subscriptions/current-subscriptions/EditSubscriptionsModal.tsx
+++ b/assets/js/features/Subscriptions/current-subscriptions/EditSubscriptionsModal.tsx
@@ -14,7 +14,7 @@ interface Props {
 
 export function EditSubscriptionsModal({ isModalOpen, hideModal }: Props) {
   const { people, subscriptionList, callback, type } = useCurrentSubscriptionsContext();
-  const [edit, { loading }] = useEditSubscriptionsList();
+  const [edit] = useEditSubscriptionsList();
 
   const alreadySelected = getSelectedPeopleFromSubscriptions(people, subscriptionList.subscriptions!);
   const subscriptionsState = useSubscriptions(people, { alreadySelected });
@@ -35,7 +35,7 @@ export function EditSubscriptionsModal({ isModalOpen, hideModal }: Props) {
   return (
     <SubscribersSelectorProvider state={subscriptionsState}>
       <Modal title="Edit subscribers" isOpen={isModalOpen} hideModal={hideModal} minHeight="200px">
-        <SubscribersSelectorForm callback={submitForm} closeForm={hideModal} loading={loading} />
+        <SubscribersSelectorForm callback={submitForm} closeForm={hideModal} />
       </Modal>
     </SubscribersSelectorProvider>
   );

--- a/assets/js/features/Subscriptions/selector/SubscribersSelectorForm.tsx
+++ b/assets/js/features/Subscriptions/selector/SubscribersSelectorForm.tsx
@@ -2,11 +2,10 @@ import React from "react";
 
 import Forms from "@/components/Forms";
 import { includesId } from "@/routes/paths";
-import { PrimaryButton, SecondaryButton } from "@/components/Buttons";
 import { ActionLink } from "@/components/Link";
 import { useSubscribersSelectorContext } from "../SubscribersSelectorContext";
 
-export function SubscribersSelectorForm({ closeForm, loading = false, callback }) {
+export function SubscribersSelectorForm({ closeForm, callback }) {
   const { people, alwaysNotify, setSelectedPeople, selectedPeople } = useSubscribersSelectorContext();
 
   const form = Forms.useForm({
@@ -25,6 +24,7 @@ export function SubscribersSelectorForm({ closeForm, loading = false, callback }
         callback(form);
       }
     },
+    cancel: closeForm,
   });
 
   const { options, setValue } = form.fields.people;
@@ -39,21 +39,17 @@ export function SubscribersSelectorForm({ closeForm, loading = false, callback }
 
   return (
     <Forms.Form form={form}>
-      <div className="flex flex-col gap-6 max-h-[400px] overflow-y-auto">
+      <div className="flex flex-col gap-6">
         <div className="flex items-center gap-3">
           <ActionLink onClick={handleSelectEveryone}>Select everyone</ActionLink>
           <span className="text-content-dimmed">&middot;</span>
           <ActionLink onClick={handleSelectNoone}>Select no one</ActionLink>
         </div>
 
-        <Forms.MultiPeopleSelectField field="people" />
-      </div>
-
-      <div className="flex justify-center gap-2">
-        <PrimaryButton loading={loading} type="submit">
-          Save selection
-        </PrimaryButton>
-        <SecondaryButton onClick={closeForm}>Never mind</SecondaryButton>
+        <div className="max-h-[380px] overflow-y-auto">
+          <Forms.MultiPeopleSelectField field="people" />
+        </div>
+        <Forms.Submit saveText="Save selection" cancelText="Never mind" />
       </div>
     </Forms.Form>
   );


### PR DESCRIPTION
After the latest update in our Forms, I noticed that closing the people's selection form in the notifications widget was raising a 500 error.

The problem was that the `reset` action in the `useForm` hook was resetting the value to the initial value, but the multi-people-select field doesn't have an initial value. So, the value would be set to undefined and everything would break. 

To fix the problem, I've added a condition to check if an initial value exists before setting the value to it.