### PR TITLE
chore: Migration for creating subscriptions list for existing check-ins

### DIFF
--- a/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
+++ b/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
@@ -1,0 +1,65 @@
+defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
+  import Ecto.Query, only: [from: 1, from: 2]
+
+  alias Operately.{Repo, Notifications}
+  alias Operately.Projects.{CheckIn, Contributor}
+
+  def run do
+    Repo.transaction(fn ->
+      from(c in CheckIn)
+      |> Repo.all()
+      |> create_subscriptions_list()
+      |> create_subscriptions()
+    end)
+  end
+
+  defp create_subscriptions_list(check_ins) when is_list(check_ins) do
+    Enum.map(check_ins, fn c ->
+      create_subscriptions_list(c)
+    end)
+  end
+
+  defp create_subscriptions_list(check_in) do
+    case Notifications.get_subscription_list(parent_id: check_in.id) do
+      nil ->
+        {:ok, subscriptions_list} = Notifications.create_subscription_list(%{
+          parent_id: check_in.id,
+          parent_type: :project_check_in,
+          send_to_everyone: true,
+        })
+        subscriptions_list
+
+      subscriptions_list -> subscriptions_list
+    end
+  end
+
+  defp create_subscriptions(subscriptions_list) when is_list(subscriptions_list) do
+    Enum.map(subscriptions_list, fn list ->
+      create_subscriptions(list)
+    end)
+  end
+
+  defp create_subscriptions(subscriptions_list) do
+    from(contrib in Contributor,
+      join: p in assoc(contrib, :project),
+      join: c in assoc(p, :check_ins),
+      where: c.id == ^subscriptions_list.parent_id
+    )
+    |> Repo.all()
+    |> Enum.map(fn contrib ->
+      find_or_create_subscription(subscriptions_list, contrib)
+    end)
+  end
+
+  defp find_or_create_subscription(subscriptions_list, contrib) do
+    case Notifications.get_subscription(subscription_list_id: subscriptions_list.id, person_id: contrib.person_id) do
+      nil ->
+        {:ok, _} = Notifications.create_subscription(%{
+          subscription_list_id: subscriptions_list.id,
+          person_id: contrib.person_id,
+          type: :invited,
+        })
+      _ -> :ok
+    end
+  end
+end

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -109,6 +109,9 @@ defmodule Operately.Notifications do
   def get_subscription_list!(id) when is_binary(id), do: Repo.get!(SubscriptionList, id)
   def get_subscription_list!(attrs) when is_list(attrs), do: Repo.get_by!(SubscriptionList, attrs)
 
+  def get_subscription_list(id) when is_binary(id), do: Repo.get(SubscriptionList, id)
+  def get_subscription_list(attrs) when is_list(attrs), do: Repo.get_by(SubscriptionList, attrs)
+
   def get_subscription_list_by_parent_id(parent_id) do
     from(list in SubscriptionList,
       preload: :subscriptions,

--- a/test/operately/data/chenge_027_create_subscriptions_list_for_check_ins_test.exs
+++ b/test/operately/data/chenge_027_create_subscriptions_list_for_check_ins_test.exs
@@ -1,0 +1,47 @@
+defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckInsTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.{Projects, Notifications}
+
+  setup ctx do
+    company = company_fixture(%{})
+    creator = person_fixture_with_account(%{company_id: company.id})
+    project = project_fixture(%{company_id: company.id, creator_id: creator.id, group_id: company.company_space_id})
+
+    Enum.each(1..3, fn _ ->
+      person = person_fixture_with_account(%{company_id: company.id})
+      contributor_fixture(creator, %{
+        project_id: project.id,
+        person_id: person.id
+      })
+    end)
+
+    Map.merge(ctx, %{creator: creator, project: project})
+  end
+
+  test "creates subscriptions list for existing check-ins", ctx do
+    check_ins = Enum.map(1..3, fn _ ->
+      check_in_fixture(%{author_id: ctx.creator.id, project_id: ctx.project.id})
+    end)
+
+    contribs = Projects.list_project_contributors(ctx.project)
+
+    Enum.each(check_ins, fn check_in ->
+      Enum.each(contribs, fn contrib ->
+        refute Notifications.get_subscription(subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
+      end)
+    end)
+
+    Operately.Data.Chenge027CreateSubscriptionsListForCheckIns.run()
+
+    Enum.each(check_ins, fn check_in ->
+      Enum.each(contribs, fn contrib ->
+        assert Notifications.get_subscription(subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
+      end)
+    end)
+  end
+end


### PR DESCRIPTION
I've added a data migration which creates a subscriptions list for existing project check-ins. A subscription is created for every contributor of the project.

If a check-in already has a subscriptions list or a contributor already has subscription, they are skipped.