### PR TITLE
fix: Creating check-in doesn't notify creator

### DIFF
--- a/lib/operately/activities/notifications/project_check_in_submitted.ex
+++ b/lib/operately/activities/notifications/project_check_in_submitted.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Notifications.ProjectCheckInSubmitted do
 
   def dispatch(activity) do
     Projects.Notifications.get_check_in_subscribers(activity.content["check_in_id"])
+    |> Enum.filter(&(&1 != activity.author_id))
     |> Enum.map(fn person_id ->
       %{
         person_id: person_id,


### PR DESCRIPTION
I've updated `Operately.Activities.Notifications.ProjectCheckInSubmitted` so that it doesn't notify that check-in creator.