### PR TITLE
chore: Don't attempt docker push in pull-requests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -77,7 +77,7 @@ blocks:
           commands:
             - docker pull operately/operately:latest
             - make docker.build
-            - if [ "$SEMAPHORE_GIT_BRANCH" = "main" ]; then make docker.push; fi
+            - if [ "$SEMAPHORE_GIT_BRANCH" = "main" && "$SEMAPHORE_GIT_REF_TYPE" = "branch" ]; then make docker.push; else echo "Skipping Docker push"; fi
 
   - name: Release Tests
     dependencies: ["Pre-Flight-Check"]


### PR DESCRIPTION
Based on this doc https://docs.semaphoreci.com/ci-cd-environment/environment-variables/#semaphore_git_branch, when the workflow is started on a pull-request it will point to `main`.

To fix this, I'm also testing for the ref type.