### PR TITLE
feat: Add permissions check to notifications

### DIFF
--- a/lib/operately/activities/notifications/project_check_in_commented.ex
+++ b/lib/operately/activities/notifications/project_check_in_commented.ex
@@ -1,9 +1,8 @@
 defmodule Operately.Activities.Notifications.ProjectCheckInCommented do
-  alias Operately.{Notifications, Projects}
+  alias Operately.Projects.Notifications
 
   def dispatch(activity) do
-    Projects.Notifications.get_check_in_subscribers(activity.content["check_in_id"])
-    |> Enum.filter(&(&1 != activity.author_id))
+    Notifications.get_check_in_subscribers(activity.content["check_in_id"], ignore: [activity.author_id])
     |> Enum.map(fn person_id ->
       %{
         person_id: person_id,
@@ -11,6 +10,6 @@ defmodule Operately.Activities.Notifications.ProjectCheckInCommented do
         should_send_email: true,
       }
     end)
-    |> Notifications.bulk_create()
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/activities/notifications/project_check_in_submitted.ex
+++ b/lib/operately/activities/notifications/project_check_in_submitted.ex
@@ -1,9 +1,8 @@
 defmodule Operately.Activities.Notifications.ProjectCheckInSubmitted do
-  alias Operately.{Notifications, Projects}
+  alias Operately.Projects.Notifications
 
   def dispatch(activity) do
-    Projects.Notifications.get_check_in_subscribers(activity.content["check_in_id"])
-    |> Enum.filter(&(&1 != activity.author_id))
+    Notifications.get_check_in_subscribers(activity.content["check_in_id"], ignore: [activity.author_id])
     |> Enum.map(fn person_id ->
       %{
         person_id: person_id,
@@ -11,6 +10,6 @@ defmodule Operately.Activities.Notifications.ProjectCheckInSubmitted do
         should_send_email: true,
       }
     end)
-    |> Notifications.bulk_create()
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -11,6 +11,7 @@ defmodule Operately.People.Person do
 
     has_one :access_group, Operately.Access.Group, foreign_key: :person_id
     has_one :access_context, through: [:company, :access_context]
+    has_many :access_group_memberships, Operately.Access.GroupMembership, foreign_key: :person_id
 
     has_one :invitation, Operately.Invitations.Invitation, foreign_key: :member_id
 

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -2,26 +2,57 @@ defmodule Operately.Projects.Notifications do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
-  alias Operately.Projects.CheckIn
+  alias Operately.Access.Binding
 
-  def get_check_in_subscribers(check_in_id) do
-    %{subscription_list: list, project: p} = from(c in CheckIn,
-        where: c.id == ^check_in_id,
-        preload: [project: :contributors, subscription_list: :subscriptions]
-      )
-      |> Repo.one()
+  def get_check_in_subscribers(check_in_id, opts \\ []) do
+    ignore = Keyword.get(opts, :ignore, [])
 
-    if list.send_to_everyone do
-      Enum.filter(p.contributors, fn c ->
-        case Enum.find(list.subscriptions, &(&1.person_id == c.person_id)) do
-          nil -> true
-          %{canceled: false} -> true
-          _ -> false
-        end
-      end)
-      |> Enum.map(&(&1.person_id))
-    else
-      Enum.map(list.subscriptions, &(&1.person_id))
-    end
+    check_in_id
+    |> fetch_check_in()
+    |> filter_subscribers()
+    |> Enum.map(&(&1.person_id))
+    |> Enum.filter(&(not Enum.member?(ignore, &1)))
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_check_in(check_in_id) do
+    from(c in Operately.Projects.CheckIn,
+      where: c.id == ^check_in_id,
+
+      # subscriptions
+      join: list in assoc(c, :subscription_list),
+      join: subs in assoc(list, :subscriptions),
+      preload: [subscription_list: {list, [subscriptions: subs]}],
+
+      # permissions
+      join: project in assoc(c, :project),
+      join: context in assoc(project, :access_context),
+      join: contribs in assoc(project, :contributors),
+      join: person in assoc(contribs, :person),
+      join: m in assoc(person, :access_group_memberships),
+      join: g in assoc(m, :group),
+      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
+      preload: [project: {project, [contributors: contribs]}]
+    )
+    |> Repo.one()
+  end
+
+  defp filter_subscribers(%{project: p, subscription_list: l = %{send_to_everyone: true}}) do
+    Enum.filter(p.contributors, fn c ->
+      case Enum.find(l.subscriptions, &(&1.person_id == c.person_id)) do
+        nil -> true
+        %{canceled: false} -> true
+        _ -> false
+      end
+    end)
+  end
+
+  defp filter_subscribers(%{project: p, subscription_list: l = %{send_to_everyone: false}}) do
+    Enum.filter(l.subscriptions, fn s ->
+      Enum.any?(p.contributors, &(&1.person_id == s.person_id))
+    end)
   end
 end


### PR DESCRIPTION
I've updated `Operately.Projects.Notifications.get_check_in_subscribers\2` so that it only returns subscribers who have permissions to view the check-in.