### PR TITLE
chore: Add Getter to Subscription and SubscriptionList

### DIFF
--- a/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
+++ b/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
@@ -2,7 +2,7 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
   import Ecto.Query, only: [from: 1, from: 2]
 
   alias Operately.{Repo, Notifications}
-  alias Operately.Notifications.Subscription
+  alias Operately.Notifications.{Subscription, SubscriptionList}
   alias Operately.Projects.{CheckIn, Contributor}
 
   def run do
@@ -21,8 +21,8 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
   end
 
   defp create_subscriptions_list(check_in) do
-    case Notifications.get_subscription_list(parent_id: check_in.id) do
-      nil ->
+    case SubscriptionList.get(:system, parent_id: check_in.id) do
+      {:error, :not_found} ->
         {:ok, subscriptions_list} = Notifications.create_subscription_list(%{
           parent_id: check_in.id,
           parent_type: :project_check_in,
@@ -30,7 +30,7 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
         })
         subscriptions_list
 
-      subscriptions_list -> subscriptions_list
+      {:ok, subscriptions_list} -> subscriptions_list
     end
   end
 

--- a/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
+++ b/lib/operately/data/chenge_027_create_subscriptions_list_for_check_ins.ex
@@ -2,6 +2,7 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
   import Ecto.Query, only: [from: 1, from: 2]
 
   alias Operately.{Repo, Notifications}
+  alias Operately.Notifications.Subscription
   alias Operately.Projects.{CheckIn, Contributor}
 
   def run do
@@ -52,8 +53,8 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
   end
 
   defp find_or_create_subscription(subscriptions_list, contrib) do
-    case Notifications.get_subscription(subscription_list_id: subscriptions_list.id, person_id: contrib.person_id) do
-      nil ->
+    case Subscription.get(:system, subscription_list_id: subscriptions_list.id, person_id: contrib.person_id) do
+      {:error, :not_found} ->
         {:ok, _} = Notifications.create_subscription(%{
           subscription_list_id: subscriptions_list.id,
           person_id: contrib.person_id,

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -106,12 +106,6 @@ defmodule Operately.Notifications do
 
   alias Operately.Notifications.SubscriptionList
 
-  def get_subscription_list!(id) when is_binary(id), do: Repo.get!(SubscriptionList, id)
-  def get_subscription_list!(attrs) when is_list(attrs), do: Repo.get_by!(SubscriptionList, attrs)
-
-  def get_subscription_list(id) when is_binary(id), do: Repo.get(SubscriptionList, id)
-  def get_subscription_list(attrs) when is_list(attrs), do: Repo.get_by(SubscriptionList, attrs)
-
   def get_subscription_list_with_access_level(id, type, person_id) do
     case type do
       :project_check_in ->

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -112,14 +112,6 @@ defmodule Operately.Notifications do
   def get_subscription_list(id) when is_binary(id), do: Repo.get(SubscriptionList, id)
   def get_subscription_list(attrs) when is_list(attrs), do: Repo.get_by(SubscriptionList, attrs)
 
-  def get_subscription_list_by_parent_id(parent_id) do
-    from(list in SubscriptionList,
-      preload: :subscriptions,
-      where: list.parent_id == ^parent_id
-    )
-    |> Repo.one()
-  end
-
   def get_subscription_list_with_access_level(id, type, person_id) do
     case type do
       :project_check_in ->

--- a/lib/operately/notifications.ex
+++ b/lib/operately/notifications.ex
@@ -150,9 +150,6 @@ defmodule Operately.Notifications do
 
   alias Operately.Notifications.Subscription
 
-  def get_subscription(id) when is_binary(id), do: Repo.get(Subscription, id)
-  def get_subscription(attrs) when is_list(attrs), do: Repo.get_by(Subscription, attrs)
-
   def list_subscriptions(%SubscriptionList{} = subscription_list), do: list_subscriptions(subscription_list.id)
   def list_subscriptions(subscription_list_id) do
     from(s in Subscription, where: s.subscription_list_id == ^subscription_list_id)

--- a/lib/operately/notifications/subscription.ex
+++ b/lib/operately/notifications/subscription.ex
@@ -1,5 +1,6 @@
 defmodule Operately.Notifications.Subscription do
   use Operately.Schema
+  use Operately.Repo.Getter
 
   schema "subscriptions" do
     belongs_to :subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id
@@ -9,6 +10,8 @@ defmodule Operately.Notifications.Subscription do
     field :canceled, :boolean, default: false
 
     timestamps()
+    # requester_info()
+    request_info()
   end
 
   def changeset(attrs) do

--- a/lib/operately/notifications/subscription_list.ex
+++ b/lib/operately/notifications/subscription_list.ex
@@ -1,5 +1,6 @@
 defmodule Operately.Notifications.SubscriptionList do
   use Operately.Schema
+  use Operately.Repo.Getter
 
   schema "subscription_lists" do
     field :parent_id, Ecto.UUID
@@ -9,6 +10,7 @@ defmodule Operately.Notifications.SubscriptionList do
     has_many :subscriptions, Operately.Notifications.Subscription, foreign_key: :subscription_list_id
 
     timestamps()
+    request_info()
     requester_access_level()
   end
 

--- a/lib/operately/operations/notifications_subscribing.ex
+++ b/lib/operately/operations/notifications_subscribing.ex
@@ -1,11 +1,15 @@
 defmodule Operately.Operations.NotificationsSubscribing do
   alias Ecto.Multi
   alias Operately.{Repo, Notifications}
+  alias Operately.Notifications.Subscription
 
   def run(person_id, subscription_list_id) do
     Multi.new()
     |> Multi.run(:existing_subscription, fn _, _ ->
-      {:ok, Notifications.get_subscription(person_id: person_id, subscription_list_id: subscription_list_id)}
+      case Subscription.get(:system, person_id: person_id, subscription_list_id: subscription_list_id) do
+        {:error, :not_found} -> {:ok, nil}
+        {:ok, subscription} -> {:ok, subscription}
+      end
     end)
     |> Multi.run(:subscription, fn _, changes ->
       case changes.existing_subscription do

--- a/lib/operately/operations/project_check_in/subscription.ex
+++ b/lib/operately/operations/project_check_in/subscription.ex
@@ -1,9 +1,10 @@
 defmodule Operately.Operations.ProjectCheckIn.Subscription do
   alias Ecto.Multi
+  alias Operately.RichContent
   alias Operately.Notifications.Subscription
 
   def insert(multi, author, attrs) do
-    mentioned = find_mentioned_people(attrs.description)
+    mentioned = RichContent.find_mentioned_ids(attrs.description, :decode_ids)
     invited = [author.id | attrs.subscriber_ids]
 
     ids = categorize_ids(invited, mentioned)
@@ -24,16 +25,6 @@ defmodule Operately.Operations.ProjectCheckIn.Subscription do
   #
   # Helpers
   #
-
-  defp find_mentioned_people(description) do
-    {:ok, ids} =
-      description
-      |> Operately.RichContent.find_mentioned_ids()
-      |> Enum.uniq()
-      |> OperatelyWeb.Api.Helpers.decode_id()
-
-    ids
-  end
 
   defp categorize_ids(invited, mentioned) do
     mentioned ++ invited

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -55,4 +55,6 @@ defmodule Operately.Projects.Notifications do
       Enum.any?(p.contributors, &(&1.person_id == s.person_id))
     end)
   end
+
+  defp filter_subscribers(nil), do: []
 end

--- a/lib/operately/rich_content.ex
+++ b/lib/operately/rich_content.ex
@@ -1,6 +1,6 @@
 defmodule Operately.RichContent do
   @moduledoc """
-  RichContent are the content of a messages, comments, etc, where the 
+  RichContent are the content of a messages, comments, etc, where the
   text is formatted as a ProseMirror JSON document.
   """
 
@@ -21,6 +21,16 @@ defmodule Operately.RichContent do
 
   def find_mentioned_ids(document) do
     extract_mentions_from_node(document) |> Enum.uniq()
+  end
+
+  def find_mentioned_ids(document, :decode_ids) do
+    {:ok, ids} =
+      document
+      |> find_mentioned_ids()
+      |> Enum.uniq()
+      |> OperatelyWeb.Api.Helpers.decode_id()
+
+    ids
   end
 
   def extract_mentions_from_node(%{"type" => "mention", "attrs" => %{"id" => id}}) do

--- a/test/operately/data/chenge_027_create_subscriptions_list_for_check_ins_test.exs
+++ b/test/operately/data/chenge_027_create_subscriptions_list_for_check_ins_test.exs
@@ -5,7 +5,8 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckInsTest do
   import Operately.PeopleFixtures
   import Operately.ProjectsFixtures
 
-  alias Operately.{Projects, Notifications}
+  alias Operately.Projects
+  alias Operately.Notifications.Subscription
 
   setup ctx do
     company = company_fixture(%{})
@@ -32,7 +33,7 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckInsTest do
 
     Enum.each(check_ins, fn check_in ->
       Enum.each(contribs, fn contrib ->
-        refute Notifications.get_subscription(subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
+        assert {:error, :not_found} = Subscription.get(:system, subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
       end)
     end)
 
@@ -40,7 +41,7 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckInsTest do
 
     Enum.each(check_ins, fn check_in ->
       Enum.each(contribs, fn contrib ->
-        assert Notifications.get_subscription(subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
+        assert {:ok, _} = Subscription.get(:system, subscription_list_id: check_in.subscription_list_id, person_id: contrib.person_id)
       end)
     end)
   end

--- a/test/operately_web/api/mutations/create_comment_test.exs
+++ b/test/operately_web/api/mutations/create_comment_test.exs
@@ -223,12 +223,10 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
         person_id: ctx.person.id,
         type: :joined,
       })
-      {:ok, list} = SubscriptionList.get(:system, parent_id: ctx.check_in.id, opts: [
-        preload: :subscriptions
-      ])
+      subscriptions = Notifications.list_subscriptions(list)
 
-      assert length(list.subscriptions) == 1
-      assert hd(list.subscriptions).person_id == ctx.person.id
+      assert length(subscriptions) == 1
+      assert hd(subscriptions).person_id == ctx.person.id
 
       assert {200, _} = mutation(ctx.conn, :create_comment, %{
         entity_id: Paths.project_check_in_id(ctx.check_in),
@@ -236,9 +234,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
         content: RichText.rich_text(mentioned_people: [ctx.person, another_person])
       })
 
-      {:ok, %{subscriptions: subscriptions}} = SubscriptionList.get(:system, parent_id: ctx.check_in.id, opts: [
-        preload: :subscriptions
-      ])
+      subscriptions = Notifications.list_subscriptions(list)
 
       assert length(subscriptions) == 2
       assert Enum.find(subscriptions, &(&1.person_id == another_person.id))

--- a/test/operately_web/api/mutations/edit_subscriptions_list_test.exs
+++ b/test/operately_web/api/mutations/edit_subscriptions_list_test.exs
@@ -7,6 +7,7 @@ defmodule OperatelyWeb.Api.Mutations.EditSubscriptionsListTest do
 
   alias Operately.Repo
   alias Operately.Notifications
+  alias Operately.Notifications.SubscriptionList
   alias Operately.Access.Binding
 
   describe "security" do
@@ -45,7 +46,7 @@ defmodule OperatelyWeb.Api.Mutations.EditSubscriptionsListTest do
         space = create_space(ctx)
         project = create_project(ctx, space, @test.company, @test.space, @test.project)
         check_in = check_in_fixture(%{author_id: ctx.creator.id, project_id: project.id})
-        subscription_list = Notifications.get_subscription_list!(parent_id: check_in.id)
+        {:ok, subscription_list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
         assert {code, res} = mutation(ctx.conn, :edit_subscriptions_list, %{
           id: Paths.subscription_list_id(subscription_list),
@@ -76,7 +77,7 @@ defmodule OperatelyWeb.Api.Mutations.EditSubscriptionsListTest do
       ctx = register_and_log_in_account(ctx)
       project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
       check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
-      subscriptions_list = Notifications.get_subscription_list!(parent_id: check_in.id)
+      {:ok, subscriptions_list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
       Map.merge(ctx, %{subscriptions_list: subscriptions_list})
     end

--- a/test/operately_web/api/mutations/subscribe_to_notifications_test.exs
+++ b/test/operately_web/api/mutations/subscribe_to_notifications_test.exs
@@ -2,6 +2,7 @@ defmodule OperatelyWeb.Api.Mutations.SubscribeToNotificationsTest do
   use OperatelyWeb.TurboCase
 
   alias Operately.Notifications
+  alias Operately.Notifications.SubscriptionList
   alias Operately.Access.Binding
 
   import Operately.GroupsFixtures
@@ -44,7 +45,8 @@ defmodule OperatelyWeb.Api.Mutations.SubscribeToNotificationsTest do
         space = create_space(ctx)
         project = create_project(ctx, space, @test.company, @test.space, @test.project)
         check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
-        subscription_list = Notifications.get_subscription_list!(parent_id: check_in.id)
+
+        {:ok, subscription_list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
         assert {code, res} = mutation(ctx.conn, :subscribe_to_notifications, %{
           id: Paths.subscription_list_id(subscription_list),
@@ -71,7 +73,8 @@ defmodule OperatelyWeb.Api.Mutations.SubscribeToNotificationsTest do
     setup ctx do
       project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
       check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
-      subscription_list = Notifications.get_subscription_list!(parent_id: check_in.id)
+
+      {:ok, subscription_list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
       Map.merge(ctx, %{subscription_list: subscription_list})
     end

--- a/test/operately_web/api/mutations/unsubscribe_from_notifications_test.exs
+++ b/test/operately_web/api/mutations/unsubscribe_from_notifications_test.exs
@@ -4,6 +4,7 @@ defmodule OperatelyWeb.Api.Mutations.UnsubscribeFromNotificationsTest do
   import Operately.ProjectsFixtures
 
   alias Operately.Notifications
+  alias Operately.Notifications.SubscriptionList
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -17,7 +18,7 @@ defmodule OperatelyWeb.Api.Mutations.UnsubscribeFromNotificationsTest do
 
       project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
       check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
-      subscription_list = Notifications.get_subscription_list!(parent_id: check_in.id)
+      {:ok, subscription_list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
       Map.merge(ctx, %{subscription_list: subscription_list})
     end

--- a/test/operately_web/api/queries/get_project_check_in_test.exs
+++ b/test/operately_web/api/queries/get_project_check_in_test.exs
@@ -6,8 +6,9 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
   import Operately.ProjectsFixtures
   import Operately.GroupsFixtures
 
-  alias Operately.{Repo, Notifications}
+  alias Operately.Repo
   alias Operately.Access.Binding
+  alias Operately.Notifications.SubscriptionList
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -93,11 +94,11 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
     test "include_subscriptions", ctx do
       project = project_fixture(%{company_id: ctx.company.id, group_id: ctx.company.company_space_id, creator_id: ctx.person.id})
       check_in = check_in_fixture(%{author_id: ctx.person.id, project_id: project.id})
-      list = Notifications.get_subscription_list!(parent_id: check_in.id)
+      {:ok, list} = SubscriptionList.get(:system, parent_id: check_in.id)
 
       people = Enum.map(1..3, fn _ ->
         person = person_fixture(%{company_id: ctx.company.id})
-        Notifications.create_subscription(%{
+        Operately.Notifications.create_subscription(%{
           subscription_list_id: list.id,
           person_id: person.id,
           type: :invited,


### PR DESCRIPTION
I've added the new `Operately.Repo.Getter` to: 
- Operately.Notifications.Subscription
- Operately.Notifications.SubscriptionList

I've also removed the following function from `Operately.Notifications` since they are no longer needed:
- get_subscription_list_by_parent_id
- get_subscription
- get_subscription_list