### PR TITLE
chore: Remove default props as they will not be supported in React 19

### DIFF
--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -181,7 +181,3 @@ export default function Avatar(props: AvatarProps): JSX.Element {
     return UnassingedAvatar(props);
   }
 }
-
-Avatar.defaultProps = {
-  size: AvatarSize.Normal,
-};

--- a/assets/js/components/PaperContainer/index.tsx
+++ b/assets/js/components/PaperContainer/index.tsx
@@ -98,7 +98,13 @@ const bodyPaddings = {
   xxlarge: "px-16 py-12",
 };
 
-export function Body({ children, minHeight, className = "", noPadding = false, backgroundColor = "bg-surface" }) {
+export function Body({
+  children,
+  minHeight = "none",
+  className = "",
+  noPadding = false,
+  backgroundColor = "bg-surface",
+}) {
   const { size } = React.useContext(Context);
   const padding = noPadding ? "" : bodyPaddings[size];
 
@@ -113,10 +119,6 @@ export function Body({ children, minHeight, className = "", noPadding = false, b
     </div>
   );
 }
-
-Body.defaultProps = {
-  minHeight: "none",
-};
 
 export function Title({ children }) {
   return (

--- a/assets/js/components/RichContent/index.tsx
+++ b/assets/js/components/RichContent/index.tsx
@@ -36,9 +36,5 @@ export default function RichContent({ jsonContent, className, skipParse }: RichC
   return <TipTapEditor.EditorContent editor={editor} className={"ProseMirror " + className} />;
 }
 
-RichContent.defaultProps = {
-  className: "",
-};
-
 export * from "./Summary";
 export * from "./contentOps";


### PR DESCRIPTION
As we have upgraded to React 18.3, we are getting warnings for things that will no longer work in React 19 once it comes out. Support for default props is one of them.

![Screenshot 2024-09-14 at 02 30 03](https://github.com/user-attachments/assets/ac1405e4-0cf2-47c7-8cc5-607f2da85a27)
