### PR TITLE
feat: Add subscriptions list to goal update

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1931,6 +1931,8 @@ export interface PostGoalProgressUpdateInput {
   content?: string | null;
   goalId?: string | null;
   newTargetValues?: string | null;
+  sendNotificationsToEveryone?: boolean | null;
+  subscriberIds?: string[] | null;
 }
 
 export interface PostGoalProgressUpdateResult {

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1199,6 +1199,7 @@ export interface GetGoalInput {
   includeProjects?: boolean | null;
   includeReviewer?: boolean | null;
   includeSpace?: boolean | null;
+  includeSpaceMembers?: boolean | null;
   includeTargets?: boolean | null;
   includeAccessLevels?: boolean | null;
 }

--- a/assets/js/features/Subscriptions/SubscribersSelector.tsx
+++ b/assets/js/features/Subscriptions/SubscribersSelector.tsx
@@ -9,14 +9,15 @@ import { SubscribersSelectorProvider } from "./SubscribersSelectorContext";
 interface Props {
   state: SubscriptionsState;
   projectName?: string;
+  spaceName?: string;
 }
 
-export function SubscribersSelector({ state, projectName }: Props) {
+export function SubscribersSelector({ state, projectName, spaceName }: Props) {
   const [showSelector, setShowSelector] = useState(false);
   const { people, selectedPeople, subscriptionType, setSubscriptionType, alwaysNotify } = state;
 
   const selectedPeopleLabel = useMemo(() => buildSelectedPeopleLabel(selectedPeople), [selectedPeople]);
-  const allPeopleLabel = useMemo(() => buildAllPeopleLabel(people, { projectName }), []);
+  const allPeopleLabel = useMemo(() => buildAllPeopleLabel(people, { projectName, spaceName }), []);
 
   // If all notifiable people must be notified,
   // the widget is not displayed.
@@ -48,6 +49,7 @@ export function SubscribersSelector({ state, projectName }: Props) {
 
 interface BuildAllPeopleLabelOpts {
   projectName?: string;
+  spaceName?: string;
 }
 
 function buildAllPeopleLabel(people: NotifiablePerson[], opts: BuildAllPeopleLabelOpts) {
@@ -56,6 +58,8 @@ function buildAllPeopleLabel(people: NotifiablePerson[], opts: BuildAllPeopleLab
 
   if (opts.projectName) {
     part2 = ` contributing to ${opts.projectName}`;
+  } else if (opts.spaceName) {
+    part2 = ` who are members of the ${opts.spaceName} space`;
   }
 
   return part1 + part2;

--- a/assets/js/features/Subscriptions/utils.tsx
+++ b/assets/js/features/Subscriptions/utils.tsx
@@ -1,5 +1,6 @@
 import { Person } from "@/models/people";
 import { Project } from "@/models/projects";
+import { Goal } from "@/models/goals";
 import { Subscription } from "@/models/notifications";
 import { NotifiablePerson } from "@/features/Subscriptions";
 import { compareIds, includesId } from "@/routes/paths";
@@ -8,6 +9,10 @@ export function getSelectedPeopleFromSubscriptions(people: NotifiablePerson[], s
   const ids = subscriptions.map((s) => s.person!.id!);
 
   return people.filter((p) => includesId(ids, p.id));
+}
+
+export function getReviewerAndChampion(people: NotifiablePerson[]) {
+  return people.filter((p) => p.title === "Reviewer" || p.title === "Champion");
 }
 
 export function findNotifiableProjectContributors(project: Project, me?: Person): NotifiablePerson[] {
@@ -30,6 +35,30 @@ export function findNotifiableProjectContributors(project: Project, me?: Person)
           break;
         default:
           person.title = contrib.responsibility!;
+      }
+
+      return person;
+    });
+
+  return people;
+}
+
+export function findGoalNotifiablePeople(goal: Goal, me?: Person): NotifiablePerson[] {
+  const people = goal
+    .space!.members!.filter((member) => !compareIds(me?.id, member.id))
+    .map((member) => {
+      const person = {
+        id: member.id!,
+        fullName: member.fullName!,
+        avatarUrl: member.avatarUrl!,
+        title: member.title!,
+      };
+
+      if (compareIds(member.id, goal.reviewer?.id)) {
+        person.title = "Reviewer";
+      }
+      if (compareIds(member.id, goal.champion?.id)) {
+        person.title = "Champion";
       }
 
       return person;

--- a/assets/js/features/goals/GoalCheckInForm/Form.tsx
+++ b/assets/js/features/goals/GoalCheckInForm/Form.tsx
@@ -5,6 +5,8 @@ import * as Forms from "@/components/Form";
 
 import { FormState } from "./useForm";
 import { createTestId } from "@/utils/testid";
+import { Spacer } from "@/components/Spacer";
+import { SubscribersSelector } from "@/features/Subscriptions";
 
 export function Form({ form }: { form: FormState }) {
   return (
@@ -12,6 +14,12 @@ export function Form({ form }: { form: FormState }) {
       <Header />
       <TargetInputs form={form} />
       <Editor form={form} />
+
+      <Spacer size={4} />
+
+      {form.mode === "create" && (
+        <SubscribersSelector state={form.subscriptionsState} spaceName={form.goal.space!.name!} />
+      )}
     </>
   );
 }

--- a/assets/js/features/projectCheckIns/Form/useForm.tsx
+++ b/assets/js/features/projectCheckIns/Form/useForm.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from "react-router-dom";
 import { Paths } from "@/routes/paths";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { useSubscriptions, SubscriptionsState, Options, NotifiablePerson } from "@/features/Subscriptions";
+import { getReviewerAndChampion } from "@/features/Subscriptions/utils";
 
 interface UseFormOptions {
   mode: "create" | "edit";
@@ -50,7 +51,7 @@ export interface FormState {
 export function useForm({ mode, project, checkIn, author, notifiablePeople = [] }: UseFormOptions): FormState {
   const navigate = useNavigate();
   const subscriptionsState = useSubscriptions(notifiablePeople, {
-    alwaysNotify: getAlwaysNotifiablePeople(notifiablePeople),
+    alwaysNotify: getReviewerAndChampion(notifiablePeople),
   });
 
   const [status, setStatus] = React.useState<string | null>(mode === "edit" ? checkIn!.status! : null);
@@ -159,8 +160,4 @@ function validate(status: string | null, description: string): Error[] {
   }
 
   return errors;
-}
-
-function getAlwaysNotifiablePeople(people: NotifiablePerson[]) {
-  return people.filter((p) => p.title === "Reviewer" || p.title === "Champion");
 }

--- a/lib/operately/demo/goals.ex
+++ b/lib/operately/demo/goals.ex
@@ -5,7 +5,7 @@ defmodule Operately.Demo.Goals do
 
   import Ecto.Query
 
-  def create_goals_and_projects(context) do 
+  def create_goals_and_projects(context) do
     context
     |> add_goal(%{
       space: context.company_space,
@@ -104,7 +104,7 @@ defmodule Operately.Demo.Goals do
       parent: find_goal(context, "Recruit Key Talent"),
       check_in: %{
         status: "on_track",
-        description: rich_text("We have several good candidates in the final step of the selection process. If everything goes well, we will have a hired engineer by the end of this week."),
+        content: rich_text("We have several good candidates in the final step of the selection process. If everything goes well, we will have a hired engineer by the end of this week."),
       },
       milestones: [
         "Candidates are selected for the second round",
@@ -183,7 +183,7 @@ defmodule Operately.Demo.Goals do
         },
       ],
       parent_goal_id: attrs[:parent] && attrs.parent.id,
-      anonymous_access_level: 0, 
+      anonymous_access_level: 0,
       company_access_level: 100,
       space_access_level: 100,
     })
@@ -198,12 +198,12 @@ defmodule Operately.Demo.Goals do
         }
       end)
 
-      {:ok, _} = Operately.Operations.GoalCheckIn.run(
-        goal.champion, 
-        goal, 
-        rich_text("Everything is going as planned! Last week we had a new batch of beta testers and they loved the product! We are now fully focusing on eliminating the leftover bugs"),
-        targets
-      )
+      {:ok, _} = Operately.Operations.GoalCheckIn.run(goal.champion, goal, %{
+        content: rich_text("Everything is going as planned! Last week we had a new batch of beta testers and they loved the product! We are now fully focusing on eliminating the leftover bugs"),
+        target_values: targets,
+        subscription_parent_type: :goal_update,
+        subscriber_ids: [],
+      } )
     end
 
     context
@@ -221,7 +221,7 @@ defmodule Operately.Demo.Goals do
       visibility: "everyone",
       group_id: attrs.space.id,
       goal_id: attrs[:parent] && attrs.parent.id,
-      anonymous_access_level: 0, 
+      anonymous_access_level: 0,
       company_access_level: 100,
       space_access_level: 100,
     })
@@ -261,13 +261,13 @@ defmodule Operately.Demo.Goals do
   def create_project_check_in(champion, project, :default) do
     create_project_check_in(champion, project, %{
       status: "on_track",
-      description: rich_text("Everything is going as planned! Last week we had a new batch of beta testers and they loved the product! We are now fully focusing on eliminating the leftover bugs"),
+      content: rich_text("Everything is going as planned! Last week we had a new batch of beta testers and they loved the product! We are now fully focusing on eliminating the leftover bugs"),
     })
   end
 
   def create_project_check_in(champion, project, attrs) do
     Operately.Operations.ProjectCheckIn.run(champion, project, Map.merge(attrs, %{
-      send_notifications_to_everyone: true,
+      subscription_parent_type: :project_check_in,
       subscriber_ids: []
     }))
   end
@@ -302,7 +302,7 @@ defmodule Operately.Demo.Goals do
   end
 
   def complete_project_milestones(project) do
-    milestones = Operately.Repo.preload(project, :milestones).milestones 
+    milestones = Operately.Repo.preload(project, :milestones).milestones
     completed = Enum.take(milestones, :rand.uniform(length(milestones)))
 
     completed
@@ -322,7 +322,7 @@ defmodule Operately.Demo.Goals do
       find_person(context, "Frank Miller"),
       find_person(context, "Olivia Hall"),
       find_person(context, "Mia Clark"),
-    ] 
+    ]
     |> Enum.filter(fn p -> p.id != attrs.champion.id end)
     |> Enum.filter(fn p -> p.id != attrs.reviewer.id end)
     |> Enum.each(fn p ->
@@ -361,7 +361,7 @@ defmodule Operately.Demo.Goals do
         }
       ]
     }
-    |> Jason.encode!() 
+    |> Jason.encode!()
     |> Jason.decode!()
   end
 end

--- a/lib/operately/goals/update.ex
+++ b/lib/operately/goals/update.ex
@@ -5,6 +5,7 @@ defmodule Operately.Goals.Update do
   schema "goal_updates" do
     belongs_to :goal, Operately.Goals.Goal, foreign_key: :goal_id
     belongs_to :author, Operately.People.Person, foreign_key: :author_id
+    belongs_to :subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id
 
     has_one :access_context, through: [:goal, :access_context]
     has_many :reactions, Operately.Updates.Reaction, foreign_key: :entity_id, where: [entity_type: :goal_update]
@@ -26,8 +27,8 @@ defmodule Operately.Goals.Update do
 
   def changeset(check_in, attrs) do
     check_in
-    |> cast(attrs, [:goal_id, :author_id, :message, :acknowledged_at, :acknowledged_by_id])
+    |> cast(attrs, [:goal_id, :author_id, :message, :acknowledged_at, :acknowledged_by_id, :subscription_list_id])
     |> cast_embed(:targets)
-    |> validate_required([:goal_id, :author_id, :message])
+    |> validate_required([:goal_id, :author_id, :message, :subscription_list_id])
   end
 end

--- a/lib/operately/notifications/subscription_list.ex
+++ b/lib/operately/notifications/subscription_list.ex
@@ -4,7 +4,7 @@ defmodule Operately.Notifications.SubscriptionList do
 
   schema "subscription_lists" do
     field :parent_id, Ecto.UUID
-    field :parent_type, Ecto.Enum, values: [:project_check_in]
+    field :parent_type, Ecto.Enum, values: [:project_check_in, :goal_update]
     field :send_to_everyone, :boolean, default: false
 
     has_many :subscriptions, Operately.Notifications.Subscription, foreign_key: :subscription_list_id

--- a/lib/operately/operations/notifications/subscription.ex
+++ b/lib/operately/operations/notifications/subscription.ex
@@ -4,7 +4,7 @@ defmodule Operately.Operations.Notifications.Subscription do
   alias Operately.Notifications.Subscription
 
   def insert(multi, author, attrs) do
-    mentioned = RichContent.find_mentioned_ids(attrs.description, :decode_ids)
+    mentioned = RichContent.find_mentioned_ids(attrs.content, :decode_ids)
     invited = [author.id | attrs.subscriber_ids]
 
     ids = categorize_ids(invited, mentioned)

--- a/lib/operately/operations/notifications/subscription.ex
+++ b/lib/operately/operations/notifications/subscription.ex
@@ -1,4 +1,4 @@
-defmodule Operately.Operations.ProjectCheckIn.Subscription do
+defmodule Operately.Operations.Notifications.Subscription do
   alias Ecto.Multi
   alias Operately.RichContent
   alias Operately.Notifications.Subscription

--- a/lib/operately/operations/notifications/subscription_list.ex
+++ b/lib/operately/operations/notifications/subscription_list.ex
@@ -1,4 +1,4 @@
-defmodule Operately.Operations.ProjectCheckIn.SubscriptionList do
+defmodule Operately.Operations.Notifications.SubscriptionList do
   alias Ecto.Multi
   alias Operately.Notifications.SubscriptionList
 

--- a/lib/operately/operations/notifications/subscription_list.ex
+++ b/lib/operately/operations/notifications/subscription_list.ex
@@ -5,16 +5,16 @@ defmodule Operately.Operations.Notifications.SubscriptionList do
   def insert(multi, attrs) do
     multi
     |> Multi.insert(:subscription_list, SubscriptionList.changeset(%{
-      send_to_everyone: attrs.send_notifications_to_everyone,
+      send_to_everyone: attrs[:send_to_everyone] || false,
+      parent_type: attrs.subscription_parent_type,
     }))
   end
 
-  def update(multi) do
+  def update(multi, key) do
     multi
     |> Multi.update(:updated_subscription_list, fn changes ->
       SubscriptionList.changeset(changes.subscription_list, %{
-        parent_type: :project_check_in,
-        parent_id: changes.check_in.id,
+        parent_id: changes[key].id,
       })
     end)
   end

--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -20,11 +20,11 @@ defmodule Operately.Operations.ProjectCheckIn do
         author_id: author.id,
         project_id: project.id,
         status: attrs.status,
-        description: attrs.description,
+        description: attrs.content,
         subscription_list_id: changes.subscription_list.id,
       })
     end)
-    |> SubscriptionList.update()
+    |> SubscriptionList.update(:check_in)
     |> Multi.update(:project, fn changes ->
       Project.changeset(project, %{
         last_check_in_id: changes.check_in.id,

--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -4,7 +4,7 @@ defmodule Operately.Operations.ProjectCheckIn do
   alias Operately.Repo
   alias Operately.Activities
   alias Operately.Projects.{CheckIn, Project}
-  alias Operately.Operations.ProjectCheckIn.{Subscription, SubscriptionList}
+  alias Operately.Operations.Notifications.{Subscription, SubscriptionList}
 
   def run(author, project, attrs) do
     next_check_in = Operately.Time.calculate_next_weekly_check_in(

--- a/lib/operately_web/api/mutations/post_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/post_goal_progress_update.ex
@@ -24,7 +24,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
     |> run(:attrs, fn -> parse_inputs(inputs) end)
     |> run(:goal, fn ctx -> Goals.get_goal_with_access_level(ctx.attrs.goal_id, ctx.me.id) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.goal.requester_access_level, :can_check_in) end)
-    |> run(:operation, fn ctx -> GoalCheckIn.run(ctx.me, ctx.goal, ctx.attrs.content, ctx.attrs.target_values) end)
+    |> run(:operation, fn ctx -> GoalCheckIn.run(ctx.me, ctx.goal, ctx.attrs) end)
     |> run(:serialized, fn ctx -> {:ok, %{update: Serializer.serialize(ctx.operation, level: :full)}} end)
     |> respond()
   end
@@ -42,10 +42,15 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
 
   defp parse_inputs(inputs) do
     {:ok, goal_id} = decode_id(inputs.goal_id)
+    {:ok, subscriber_ids} = decode_id(inputs[:subscriber_ids], :allow_nil)
+
     {:ok, %{
       goal_id: goal_id,
       target_values: Jason.decode!(inputs.new_target_values),
       content: Jason.decode!(inputs.content),
+      send_to_everyone: inputs[:send_notifications_to_everyone] || false,
+      subscription_parent_type: :goal_update,
+      subscriber_ids: subscriber_ids || []
     }}
   end
 end

--- a/lib/operately_web/api/mutations/post_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/post_goal_progress_update.ex
@@ -10,6 +10,8 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
     field :content, :string
     field :goal_id, :string
     field :new_target_values, :string
+    field :send_notifications_to_everyone, :boolean
+    field :subscriber_ids, list_of(:string)
   end
 
   outputs do

--- a/lib/operately_web/api/mutations/post_project_check_in.ex
+++ b/lib/operately_web/api/mutations/post_project_check_in.ex
@@ -47,8 +47,9 @@ defmodule OperatelyWeb.Api.Mutations.PostProjectCheckIn do
     {:ok, %{
       project_id: project_id,
       status: inputs.status,
-      description: Jason.decode!(inputs.description),
-      send_notifications_to_everyone: inputs[:send_notifications_to_everyone] || false,
+      content: Jason.decode!(inputs.description),
+      send_to_everyone: inputs[:send_notifications_to_everyone] || false,
+      subscription_parent_type: :project_check_in,
       subscriber_ids: subscriber_ids || []
     }}
   end

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -17,6 +17,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
     field :include_projects, :boolean
     field :include_reviewer, :boolean
     field :include_space, :boolean
+    field :include_space_members, :boolean
     field :include_targets, :boolean
     field :include_access_levels, :boolean
   end
@@ -65,6 +66,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
         :include_projects -> from p in q, preload: [projects: [:champion, :reviewer]]
         :include_reviewer -> from p in q, preload: [:reviewer]
         :include_space -> from p in q, preload: [:group]
+        :include_space_members -> from p in q, preload: [group: [:members, :company]]
         :include_targets -> from p in q, preload: [:targets]
         :include_access_levels -> q # this is done after the load
         _ -> raise "Unknown include filter: #{inspect(include)}"

--- a/lib/operately_web/api/serializers/goal.ex
+++ b/lib/operately_web/api/serializers/goal.ex
@@ -27,7 +27,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Goal do
       progress_percentage: Operately.Goals.progress_percentage(goal),
 
       timeframe: OperatelyWeb.Api.Serializer.serialize(goal.timeframe),
-      space: OperatelyWeb.Api.Serializer.serialize(goal.group),
+      space: serialize_space(goal.group),
       champion: OperatelyWeb.Api.Serializer.serialize(goal.champion),
       reviewer: OperatelyWeb.Api.Serializer.serialize(goal.reviewer),
       projects: OperatelyWeb.Api.Serializer.serialize(goal.projects, level: :full),
@@ -36,5 +36,13 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Goal do
       permissions: OperatelyWeb.Api.Serializer.serialize(goal.permissions, level: :full),
       access_levels: OperatelyWeb.Api.Serializer.serialize(goal.access_levels, level: :full),
     }
+  end
+
+  defp serialize_space(space) do
+    if Ecto.assoc_loaded?(space.members) and Ecto.assoc_loaded?(space.company) do
+      OperatelyWeb.Api.Serializer.serialize(space, level: :full)
+    else
+      OperatelyWeb.Api.Serializer.serialize(space)
+    end
   end
 end

--- a/lib/operately_web/api/serializers/goal.ex
+++ b/lib/operately_web/api/serializers/goal.ex
@@ -39,10 +39,13 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Goal do
   end
 
   defp serialize_space(space) do
-    if Ecto.assoc_loaded?(space.members) and Ecto.assoc_loaded?(space.company) do
-      OperatelyWeb.Api.Serializer.serialize(space, level: :full)
-    else
-      OperatelyWeb.Api.Serializer.serialize(space)
+    cond do
+      not Ecto.assoc_loaded?(space) ->
+        OperatelyWeb.Api.Serializer.serialize(space)
+      Ecto.assoc_loaded?(space.members) and Ecto.assoc_loaded?(space.company) ->
+        OperatelyWeb.Api.Serializer.serialize(space, level: :full)
+      true ->
+        OperatelyWeb.Api.Serializer.serialize(space)
     end
   end
 end

--- a/priv/repo/migrations/20240914202720_add_subscription_list_relationship_with_goal_update_table.exs
+++ b/priv/repo/migrations/20240914202720_add_subscription_list_relationship_with_goal_update_table.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSubscriptionListRelationshipWithGoalUpdateTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:goal_updates) do
+      add :subscription_list_id, references(:subscription_lists, on_delete: :nothing, type: :binary_id)
+    end
+
+    create index(:goal_updates, [:subscription_list_id])
+  end
+end

--- a/test/operately/operations/comment_adding_test.exs
+++ b/test/operately/operations/comment_adding_test.exs
@@ -50,9 +50,10 @@ defmodule Operately.Operations.CommentAddingTest do
     test "Commenting on check-in notifies everyone", ctx do
       {:ok, check_in} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: false,
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: false,
         subscriber_ids: Enum.map(ctx.contribs, &(&1.person_id)),
+        subscription_parent_type: :project_check_in
       })
 
       {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
@@ -78,9 +79,10 @@ defmodule Operately.Operations.CommentAddingTest do
     test "Mentioned person is notified", ctx do
       {:ok, check_in} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: false,
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: false,
         subscriber_ids: [ctx.champion.id],
+        subscription_parent_type: :project_check_in
       })
 
       # Without permissions

--- a/test/operately/operations/project_check_in_test.exs
+++ b/test/operately/operations/project_check_in_test.exs
@@ -42,9 +42,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
     {:ok, check_in} = Oban.Testing.with_testing_mode(:manual, fn ->
       ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: false,
-        subscriber_ids: [ctx.reviewer.id, ctx.champion.id]
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: false,
+        subscriber_ids: [ctx.reviewer.id, ctx.champion.id],
+        subscription_parent_type: :project_check_in
       })
     end)
     activity = get_activity(check_in)
@@ -66,9 +67,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
     {:ok, check_in} = Oban.Testing.with_testing_mode(:manual, fn ->
       ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: false,
-        subscriber_ids: Enum.map(contributors, &(&1.person_id))
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: false,
+        subscriber_ids: Enum.map(contributors, &(&1.person_id)),
+        subscription_parent_type: :project_check_in
       })
     end)
     activity = get_activity(check_in)
@@ -92,9 +94,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
     {:ok, check_in} = Oban.Testing.with_testing_mode(:manual, fn ->
       ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: true,
-        subscriber_ids: []
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: true,
+        subscriber_ids: [],
+        subscription_parent_type: :project_check_in
       })
     end)
     activity = get_activity(check_in)
@@ -118,9 +121,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
     {:ok, check_in} = Oban.Testing.with_testing_mode(:manual, fn ->
       ProjectCheckIn.run(ctx.champion, ctx.project, %{
         status: "on_track",
-        description: RichText.rich_text("Some description"),
-        send_notifications_to_everyone: false,
-        subscriber_ids: [ctx.champion.id]
+        content: RichText.rich_text("Some description"),
+        send_to_everyone: false,
+        subscriber_ids: [ctx.champion.id],
+        subscription_parent_type: :project_check_in
       })
     end)
 
@@ -138,9 +142,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
     # Without permissions
     {:ok, check_in} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
       status: "on_track",
-      description: content,
-      send_notifications_to_everyone: false,
-      subscriber_ids: []
+      content: content,
+      send_to_everyone: false,
+      subscriber_ids: [],
+      subscription_parent_type: :project_check_in
     })
     activity = get_activity(check_in)
 
@@ -152,9 +157,10 @@ defmodule Operately.Operations.ProjectCheckInTest do
 
     {:ok, check_in} = ProjectCheckIn.run(ctx.champion, ctx.project, %{
       status: "on_track",
-      description: content,
-      send_notifications_to_everyone: false,
-      subscriber_ids: []
+      content: content,
+      send_to_everyone: false,
+      subscriber_ids: [],
+      subscription_parent_type: :project_check_in
     })
     activity = get_activity(check_in)
     notifications = fetch_notifications(activity.id, action: action)

--- a/test/operately_web/api/mutations/acknowledge_goal_progress_update_test.exs
+++ b/test/operately_web/api/mutations/acknowledge_goal_progress_update_test.exs
@@ -8,7 +8,6 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdateTest do
   alias OperatelyWeb.Paths
   alias Operately.Repo
   alias Operately.Access.Binding
-  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -108,8 +107,7 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdateTest do
       company_access_level: Keyword.get(opts, :company_access_level, Binding.no_access()),
       space_access_level: Keyword.get(opts, :space_access_level, Binding.no_access()),
     }))
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(ctx.creator, goal)
   end
 
   defp add_person_to_space(ctx) do

--- a/test/operately_web/api/mutations/add_reaction_test.exs
+++ b/test/operately_web/api/mutations/add_reaction_test.exs
@@ -414,8 +414,7 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
   end
 
   defp create_goal_update(ctx, goal) do
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(ctx.creator, goal)
   end
 
   defp create_check_in(author, project) do

--- a/test/operately_web/api/mutations/create_comment_test.exs
+++ b/test/operately_web/api/mutations/create_comment_test.exs
@@ -327,8 +327,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
   end
 
   defp create_goal_update(ctx, goal) do
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(ctx.creator, goal)
   end
 
   defp create_discussion(ctx, space) do

--- a/test/operately_web/api/mutations/edit_comment_test.exs
+++ b/test/operately_web/api/mutations/edit_comment_test.exs
@@ -346,8 +346,7 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
   end
 
   defp create_goal_update(ctx, goal) do
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(ctx.creator, goal)
   end
 
   defp create_discussion(ctx, space) do

--- a/test/operately_web/api/mutations/edit_goal_progress_update_test.exs
+++ b/test/operately_web/api/mutations/edit_goal_progress_update_test.exs
@@ -121,13 +121,12 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdateTest do
       space_access_level: Binding.no_access(),
     }))
 
-    content = RichText.rich_text("Content")
-    targets = Enum.map(Goals.list_targets(goal.id), fn t ->
+    target_values = Enum.map(Goals.list_targets(goal.id), fn t ->
       %{"id" => t.id, "value" => 50}
     end)
+    content = RichText.rich_text("Content")
 
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx[:creator] || ctx.person, goal, content, targets)
-    update
+    goal_update_fixture(ctx[:creator] || ctx.person, goal, target_values: target_values, content: content)
   end
 
   defp add_person_to_space(ctx) do

--- a/test/operately_web/api/queries/get_assignments_count_test.exs
+++ b/test/operately_web/api/queries/get_assignments_count_test.exs
@@ -5,7 +5,6 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsCountTest do
   import Operately.GoalsFixtures
 
   alias Operately.Repo
-  alias Operately.Goals
   alias Operately.Goals.{Goal, Update}
   alias Operately.Projects.{Project, CheckIn}
 
@@ -111,15 +110,15 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsCountTest do
         reviewer_id: ctx.person.id,
         champion_id: another_ctx.person.id,
       })
-      create_update(goal)
-      create_update(goal)
+      goal_update_fixture(another_ctx.person, goal)
+      goal_update_fixture(another_ctx.person, goal)
 
       # Updates for another person
       another_goal = create_goal(another_ctx, upcoming_date(), %{
         reviewer_id: another_ctx.person.id,
         champion_id: ctx.person.id,
       })
-      create_update(another_goal)
+      goal_update_fixture(ctx.person, another_goal)
 
       assert Repo.aggregate(Update, :count, :id) == 3
 
@@ -198,14 +197,5 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsCountTest do
       author_id: project.champion.id,
       project_id: project.id,
     })
-  end
-
-  defp create_update(goal) do
-    {:ok, update} = Goals.create_update(%{
-      author_id: goal.champion_id,
-      goal_id: goal.id,
-      message: %{},
-    })
-    update
   end
 end

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -9,7 +9,6 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
   alias Operately.{Repo, Goals, Projects}
   alias Operately.Goals.{Goal, Update}
   alias Operately.Projects.{Project, CheckIn}
-  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -377,14 +376,6 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
   end
 
   defp create_update(creator, goal) do
-    # update_fixture(%{
-    #   updatable_type: :goal,
-    #   updatable_id: goal.id,
-    #   author_id: goal.champion_id,
-    #   type: :goal_check_in,
-    # })
-    # |> Repo.reload()
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(creator, goal)
   end
 end

--- a/test/operately_web/api/queries/get_comments_test.exs
+++ b/test/operately_web/api/queries/get_comments_test.exs
@@ -483,8 +483,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
       company_access_level: Keyword.get(opts, :company_access, Binding.no_access()),
       space_access_level: Keyword.get(opts, :space_access, Binding.no_access()),
     })
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-    update
+    goal_update_fixture(ctx.creator, goal)
   end
 
   defp create_discussion(ctx, attrs) do

--- a/test/operately_web/api/queries/get_goal_progress_update_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_update_test.exs
@@ -8,7 +8,6 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdateTest do
   alias Operately.Repo
   alias OperatelyWeb.Paths
   alias Operately.Access.Binding
-  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -113,7 +112,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdateTest do
       company_access_level: company_access,
       space_access_level: space_access,
     })
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
+    update = goal_update_fixture(ctx.creator, goal)
     update_id = Paths.goal_update_id(update)
 
     update_id

--- a/test/operately_web/api/queries/get_goal_progress_updates_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_updates_test.exs
@@ -8,7 +8,6 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdatesTest do
   alias Operately.Repo
   alias OperatelyWeb.Paths
   alias Operately.Access.Binding
-  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -116,8 +115,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdatesTest do
       space_access_level: space_access,
     })
     updates = Enum.map(1..3, fn _ ->
-      {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, goal, RichText.rich_text("content"), [])
-      update
+      goal_update_fixture(ctx.creator, goal)
     end)
 
     goal_id = Paths.goal_id(goal)

--- a/test/operately_web/api/queries/get_goal_test.exs
+++ b/test/operately_web/api/queries/get_goal_test.exs
@@ -1,5 +1,4 @@
 defmodule OperatelyWeb.Api.Queries.GetGoalTest do
-  alias Operately.Goals
   alias Operately.Support.RichText
   alias Operately.Access.Binding
   alias OperatelyWeb.Paths
@@ -175,7 +174,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalTest do
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal), include_last_check_in: true})
       assert res.goal.last_check_in == nil
 
-      {:ok, update} = Goals.create_update(%{goal_id: goal.id, author_id: goal.champion_id, message: RichText.rich_text("message")})
+      update = goal_update_fixture(ctx.person, goal)
       update = Operately.Repo.preload(update, [:author, [reactions: :author]])
 
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal), include_last_check_in: true})

--- a/test/operately_web/api/queries/get_goals_test.exs
+++ b/test/operately_web/api/queries/get_goals_test.exs
@@ -7,9 +7,8 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
   import OperatelyWeb.Api.Serializer
 
   alias OperatelyWeb.Paths
-  alias Operately.Support.RichText
   alias Operately.Access.Binding
-  alias Operately.{Repo, Groups, Goals}
+  alias Operately.{Repo, Groups}
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -146,11 +145,11 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
       goal1 = goal_fixture(ctx.person, company_id: ctx.company.id, space_id: ctx.company.company_space_id)
       goal2 = goal_fixture(ctx.person, company_id: ctx.company.id, space_id: ctx.company.company_space_id)
 
-      update1 = create_update(goal1)
-      _update2 = create_update(goal1)
+      update1 = create_update(ctx.person, goal1)
+      _update2 = create_update(ctx.person, goal1)
 
-      update3 = create_update(goal2)
-      _update4 = create_update(goal2)
+      update3 = create_update(ctx.person, goal2)
+      _update4 = create_update(ctx.person, goal2)
 
       update1 = Operately.Repo.preload(update1, [:author, [reactions: :author]])
       update3 = Operately.Repo.preload(update3, [:author, [reactions: :author]])
@@ -182,8 +181,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
     }])
   end
 
-  defp create_update(goal) do
-    {:ok, update} = Goals.create_update(%{goal_id: goal.id, author_id: goal.champion_id, message: RichText.rich_text("message")})
-    update
+  defp create_update(person, goal) do
+    goal_update_fixture(person, goal)
   end
 end

--- a/test/support/features/review_steps.ex
+++ b/test/support/features/review_steps.ex
@@ -7,7 +7,6 @@ defmodule Operately.Support.Features.ReviewSteps do
   import Operately.ProjectsFixtures
   import Operately.GoalsFixtures
 
-  alias Operately.Support.RichText
   alias OperatelyWeb.Paths
   alias Operately.Goals.{Goal, Update}
   alias Operately.Projects.{Project, CheckIn}
@@ -53,11 +52,11 @@ defmodule Operately.Support.Features.ReviewSteps do
   end
 
   step :setup_updates, ctx, name do
-    create_goal(ctx.other_person, ctx.person, ctx.company, DateTime.utc_now(), name)
-    |> create_update()
+    goal = create_goal(ctx.other_person, ctx.person, ctx.company, DateTime.utc_now(), name)
+    goal_update_fixture(ctx.other_person, goal)
 
-    create_goal(ctx.other_person, ctx.person, ctx.company, past_date(), name)
-    |> create_update()
+    goal = create_goal(ctx.other_person, ctx.person, ctx.company, past_date(), name)
+    goal_update_fixture(ctx.other_person, goal)
 
     ctx
   end
@@ -237,14 +236,5 @@ defmodule Operately.Support.Features.ReviewSteps do
       author_id: project.champion.id,
       project_id: project.id,
     })
-  end
-
-  defp create_update(goal) do
-    {:ok, update} = Operately.Goals.create_update(%{
-      goal_id: goal.id,
-      author_id: goal.champion_id,
-      message: RichText.rich_text("Doing well")
-    })
-    update
   end
 end

--- a/test/support/fixtures/goals_fixtures.ex
+++ b/test/support/fixtures/goals_fixtures.ex
@@ -52,4 +52,18 @@ defmodule Operately.GoalsFixtures do
       type: "quarter"
     }
   end
+
+  def goal_update_fixture(author, goal, attrs \\ []) do
+    attrs = Enum.into(attrs, %{
+      goal_id: goal.id,
+      target_values: [],
+      content: Operately.Support.RichText.rich_text("content"),
+      send_to_everyone: false,
+      subscription_parent_type: :goal_update,
+      subscriber_ids: []
+    })
+
+    {:ok, update} = Operately.Operations.GoalCheckIn.run(author, goal, attrs)
+    update
+  end
 end


### PR DESCRIPTION
I've updated the create-goal-update form and `Operately.Operations.GoalCheckIn` so that creating a goal update also creates a subscriptions list.

I noticed that creating a subscriptions list for goal updates and project check-ins is very similar. And I'm pretty sure it's going to be as similar for other resources in the future. So, I did some small refactoring to use the same functions in both operations. 

Instead of: 
- `Operately.Operations.ProjectCheckIn.Subscription`
- `Operately.Operations.ProjectCheckIn.SubscriptionList`

Now we have:
- `Operately.Operations.Notifications.Subscription` 
- `Operately.Operations.Notifications.SubscriptionList`

Also, creating goal updates in tests was a bit cumbersome, so I've added `goal_update_fixture`.