### PR TITLE
chore: Always use white background for secondary buttons

### DIFF
--- a/assets/js/components/Buttons/index.tsx
+++ b/assets/js/components/Buttons/index.tsx
@@ -38,7 +38,7 @@ export function GhostButton(props: BaseButtonProps) {
 
 export function SecondaryButton(props: BaseButtonProps) {
   const className = calcClassName(props, {
-    always: "border border-surface-outline",
+    always: "border border-surface-outline bg-surface",
     normal: "text-content-dimmed hover:text-content-base hover:bg-surface-accent",
     loading: "text-content-subtle",
   });


### PR DESCRIPTION
I wanted to use a secondary button on the dimmed section of the page, and it looked ugly because it was transparent.