### PR TITLE
feat: GetGoalProgressUpdate query can include subscriptions

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1210,7 +1210,12 @@ export interface GetGoalResult {
 
 export interface GetGoalProgressUpdateInput {
   id?: string | null;
+  includeAuthor?: boolean | null;
+  includeAcknowledgedBy?: boolean | null;
+  includeReactions?: boolean | null;
   includeGoal?: boolean | null;
+  includeGoalTargets?: boolean | null;
+  includeSubscriptions?: boolean | null;
 }
 
 export interface GetGoalProgressUpdateResult {

--- a/assets/js/pages/GoalProgressUpdateEditPage/index.tsx
+++ b/assets/js/pages/GoalProgressUpdateEditPage/index.tsx
@@ -15,7 +15,7 @@ interface LoaderResult {
 export async function loader({ params }): Promise<LoaderResult> {
   const checkInPromise = GoalCheckIns.getGoalProgressUpdate({
     id: params.id,
-    includeGoal: true,
+    includeGoalTargets: true,
   }).then((data) => data.update!);
 
   return {

--- a/assets/js/pages/GoalProgressUpdatePage/loader.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/loader.tsx
@@ -8,7 +8,10 @@ interface LoaderResult {
 export async function loader({ params }): Promise<LoaderResult> {
   const updatePromise = GoalCheckIns.getGoalProgressUpdate({
     id: params.id,
-    includeGoal: true,
+    includeGoalTargets: true,
+    includeAcknowledgedBy: true,
+    includeReactions: true,
+    includeAuthor: true,
   }).then((data) => data.update!);
 
   return {

--- a/lib/operately/notifications/subscription.ex
+++ b/lib/operately/notifications/subscription.ex
@@ -26,8 +26,12 @@ defmodule Operately.Notifications.Subscription do
   # Queries
   import Ecto.Query, only: [from: 2]
 
-  def preload_subscriptions(query) do
+  def preload_subscriptions() do
     subquery = from(s in Operately.Notifications.Subscription, where: s.canceled == false, preload: :person)
-    from(p in query, preload: [subscription_list: [subscriptions: ^subquery]])
+    [subscription_list: [subscriptions: subquery]]
+  end
+
+  def preload_subscriptions(query) do
+    from(p in query, preload: ^preload_subscriptions())
   end
 end

--- a/lib/operately_web/api/serializers/goal_update.ex
+++ b/lib/operately_web/api/serializers/goal_update.ex
@@ -12,6 +12,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update  do
       reactions: OperatelyWeb.Api.Serializer.serialize(update.reactions),
       comments_count: Operately.Updates.count_comments(update.id, :goal_update),
       goal_target_updates: parse_targets(update.targets),
+      subscription_list: OperatelyWeb.Api.Serializer.serialize(update.subscription_list),
     }
   end
 

--- a/test/operately_web/api/queries/get_goal_progress_update_test.exs
+++ b/test/operately_web/api/queries/get_goal_progress_update_test.exs
@@ -85,7 +85,11 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdateTest do
   #
 
   defp allowed_request(conn, update_id) do
-    assert {200, %{update: update} = _res} = query(conn, :get_goal_progress_update, %{id: update_id})
+    assert {200, %{update: update} = _res} = query(conn, :get_goal_progress_update, %{
+      id: update_id,
+      include_goal_targets: true,
+      include_author: true,
+    })
 
     assert update.id == update_id
     assert update.author


### PR DESCRIPTION
`OperatelyWeb.Api.Queries.GetGoalProgressUpdate` was preloading all resources in every request. 

Now, specific resources can be requested, including `subscriptions`.