### PR TITLE
chore: Fix warning on react-select for React 19 compatibility

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -33,7 +33,7 @@
         "react-i18next": "^12.2.0",
         "react-modal": "^3.16.1",
         "react-router-dom": "^6.10.0",
-        "react-select": "^5.7.1",
+        "react-select": "^5.8.0",
         "react-spinners": "^0.13.8",
         "tippy.js": "^6.3.7",
         "ts-pattern": "^5.0.8"
@@ -8334,9 +8334,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
-      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -14887,9 +14887,9 @@
       }
     },
     "react-select": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.7.1.tgz",
-      "integrity": "sha512-u/brzm3B6vgI+PtxNyE4/18kXgaf6bn5sOAjKhaQ54EItBfW41SRLH1AJC5fefPnGM4JmMcM51t/HAVCi5GrpQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.8.0.tgz",
+      "integrity": "sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -28,7 +28,7 @@
     "react-i18next": "^12.2.0",
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.10.0",
-    "react-select": "^5.7.1",
+    "react-select": "^5.8.0",
     "react-spinners": "^0.13.8",
     "tippy.js": "^6.3.7",
     "ts-pattern": "^5.0.8"


### PR DESCRIPTION
In `v5.7.1` the loading spinner had a default value prop that will no longer be supported in React 19.