### PR TITLE
feat: comments on Goal Updates updated

### DIFF
--- a/lib/operately/activities/notifications/goal_check_in_commented.ex
+++ b/lib/operately/activities/notifications/goal_check_in_commented.ex
@@ -1,21 +1,15 @@
 defmodule Operately.Activities.Notifications.GoalCheckInCommented do
+  alias Operately.Goals.Notifications
+
   def dispatch(activity) do
-    goal_id = activity.content["goal_id"]
-    goal = Operately.Goals.get_goal!(goal_id)
-    comment = Operately.Updates.get_comment!(activity.content["comment_id"])
-
-    people = Enum.uniq([goal.champion_id, goal.reviewer_id] ++ [comment.author_id])
-
-    notifications = Enum.map(people, fn person ->
+    Notifications.get_goal_update_subscribers(activity.content["goal_check_in_id"], ignore: [activity.author_id])
+    |> Enum.map(fn person_id ->
       %{
-        person_id: person,
+        person_id: person_id,
         activity_id: activity.id,
         should_send_email: true,
       }
     end)
-
-    notifications = Enum.filter(notifications, fn n -> n.person_id != activity.author_id end)
-
-    Operately.Notifications.bulk_create(notifications)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/goals/notifications.ex
+++ b/lib/operately/goals/notifications.ex
@@ -1,0 +1,61 @@
+defmodule Operately.Goals.Notifications do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  def get_goal_update_subscribers(update_id, opts \\ []) do
+    ignore = Keyword.get(opts, :ignore, [])
+
+    update_id
+    |> fetch_update()
+    |> filter_subscribers()
+    |> Enum.filter(&(not Enum.member?(ignore, &1)))
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_update(update_id) do
+    from(u in Operately.Goals.Update,
+      where: u.id == ^update_id,
+
+      # subscriptions
+      join: list in assoc(u, :subscription_list),
+      join: subs in assoc(list, :subscriptions),
+      preload: [subscription_list: {list, [subscriptions: subs]}],
+
+      # permissions
+      join: goal in assoc(u, :goal),
+      join: context in assoc(goal, :access_context),
+      join: space in assoc(goal, :group),
+      join: person in assoc(space, :members),
+      join: m in assoc(person, :access_group_memberships),
+      join: g in assoc(m, :group),
+      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
+      preload: [goal: {goal, group: {space, members: person}}]
+    )
+    |> Repo.one()
+  end
+
+  defp filter_subscribers(%{goal: g, subscription_list: l = %{send_to_everyone: true}}) do
+    Enum.filter(g.group.members, fn p ->
+      case Enum.find(l.subscriptions, &(&1.person_id == p.id)) do
+        nil -> true
+        %{canceled: false} -> true
+        _ -> false
+      end
+    end)
+    |> Enum.map(&(&1.id))
+  end
+
+  defp filter_subscribers(%{goal: g, subscription_list: l = %{send_to_everyone: false}}) do
+    Enum.filter(l.subscriptions, fn s ->
+      Enum.any?(g.group.members, &(&1.id == s.person_id))
+    end)
+    |> Enum.map(&(&1.person_id))
+  end
+
+  defp filter_subscribers(nil), do: []
+end

--- a/lib/operately/operations/comment_adding/subscriptions.ex
+++ b/lib/operately/operations/comment_adding/subscriptions.ex
@@ -3,12 +3,15 @@ defmodule Operately.Operations.CommentAdding.Subscriptions do
   alias Operately.{Notifications, RichContent}
   alias Operately.Notifications.SubscriptionList
 
-  def update(multi, :project_check_in_commented, content) do
+  def update(multi, :project_check_in_commented, content), do: execute_update(multi, content)
+  def update(multi, :goal_check_in_commented, content), do: execute_update(multi, content)
+  def update(multi, _, _), do: multi
+
+  defp execute_update(multi, content) do
     multi
     |> fetch_subscriptions()
     |> update_subscriptions(content)
   end
-  def update(multi, _, _), do: multi
 
   defp fetch_subscriptions(multi) do
     multi

--- a/test/operately/operations/comment_adding_test.exs
+++ b/test/operately/operations/comment_adding_test.exs
@@ -3,13 +3,15 @@ defmodule Operately.Operations.CommentAddingTest do
   use Operately.Support.Notifications
 
   import Operately.CompaniesFixtures
+  import Operately.GroupsFixtures
   import Operately.PeopleFixtures
   import Operately.ProjectsFixtures
+  import Operately.GoalsFixtures
 
+  alias Operately.Groups
   alias Operately.Support.RichText
   alias Operately.Access.Binding
-  alias Operately.Operations.ProjectCheckIn
-  alias Operately.Operations.CommentAdding
+  alias Operately.Operations.{GoalCheckIn, ProjectCheckIn, CommentAdding}
 
   setup do
     company = company_fixture()
@@ -101,6 +103,123 @@ defmodule Operately.Operations.CommentAddingTest do
       contributor_fixture(ctx.creator, %{project_id: ctx.project.id, person_id: person.id})
 
       {:ok, comment} = CommentAdding.run(ctx.champion, check_in, "project_check_in", content)
+
+      activity = get_activity(comment, action)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      assert notifications_count(action: action) == 1
+      assert hd(notifications).person_id == person.id
+    end
+  end
+
+  describe "Commenting on goal update" do
+    setup ctx do
+      champion = person_fixture_with_account(%{company_id: ctx.company.id})
+      reviewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      space = group_fixture(champion)
+      goal = goal_fixture(champion, %{
+        space_id: space.id,
+        reviewer_id: reviewer.id,
+        champion_id: champion.id,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.comment_access(),
+      })
+
+      people = Enum.map(1..3, fn _ -> person_fixture_with_account(%{company_id: ctx.company.id}) end)
+      attrs = Enum.map(people ++ [champion, reviewer], fn p -> %{id: p.id, permissions: Binding.edit_access()} end)
+      {:ok, _} = Groups.add_members(ctx.creator, space.id, attrs)
+      members = Groups.list_members(space)
+
+      Map.merge(ctx, %{space: space, champion: champion, reviewer: reviewer, goal: goal, members: members})
+    end
+
+    test "Commenting on update notifies everyone", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal,%{
+        goal_id: ctx.goal.id,
+        target_values: [],
+        content: RichText.rich_text("Some content"),
+        send_to_everyone: true,
+        subscriber_ids: [],
+        subscription_parent_type: :goal_update,
+      })
+
+      {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
+        CommentAdding.run(ctx.champion, update, "goal_update", RichText.rich_text("Some comment"))
+      end)
+      action = "goal_check_in_commented"
+      activity = get_activity(comment, action)
+
+      assert 0 == notifications_count(action: action)
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      assert 4 == notifications_count(action: action) # 3 members + reviewer
+
+      ctx.members
+      |> Enum.filter(&(&1.id != ctx.champion.id))
+      |> Enum.each(fn p ->
+        assert Enum.find(notifications, &(&1.person_id == p.id))
+      end)
+    end
+
+    test "Commenting on update notifies selected people", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.creator, ctx.goal,%{
+        goal_id: ctx.goal.id,
+        target_values: [],
+        content: RichText.rich_text("Some content"),
+        send_to_everyone: false,
+        subscriber_ids: [ctx.reviewer.id, ctx.champion.id],
+        subscription_parent_type: :goal_update,
+      })
+
+      {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
+        CommentAdding.run(ctx.creator, update, "goal_update", RichText.rich_text("Some comment"))
+      end)
+      action = "goal_check_in_commented"
+      activity = get_activity(comment, action)
+
+      assert 0 == notifications_count(action: action)
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      assert 2 == notifications_count(action: action) # champion + reviewer
+
+      [ctx.reviewer, ctx.champion]
+      |> Enum.each(fn p ->
+        assert Enum.find(notifications, &(&1.person_id == p.id))
+      end)
+    end
+
+    test "Mentioned person is notified", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.creator, ctx.goal,%{
+        goal_id: ctx.goal.id,
+        target_values: [],
+        content: RichText.rich_text("Some content"),
+        send_to_everyone: false,
+        subscriber_ids: [],
+        subscription_parent_type: :goal_update,
+      })
+
+      # Without permissions
+      person = person_fixture_with_account(%{company_id: ctx.company.id})
+      content = RichText.rich_text(mentioned_people: [person]) |> Jason.decode!()
+
+      {:ok, comment} = CommentAdding.run(ctx.champion, update, "goal_update", content)
+
+      action = "goal_check_in_commented"
+      activity = get_activity(comment, action)
+
+      assert notifications_count(action: action) == 0
+      assert fetch_notifications(activity.id, action: action) == []
+
+      # With permissions
+      {:ok, _} = Groups.add_members(ctx.creator, ctx.space.id, [
+        %{id: person.id, permissions: Binding.view_access()}
+      ])
+
+      {:ok, comment} = CommentAdding.run(ctx.champion, update, "goal_update", content)
 
       activity = get_activity(comment, action)
       notifications = fetch_notifications(activity.id, action: action)


### PR DESCRIPTION
I've updated `Operately.Operations.CommentAdding.Subscriptions` so that, when someone is mentioned in Goal Update comment, the person is added to the Update's subscriptions list.

I've also updated `Operately.Activities.Notifications.GoalCheckInCommented` so that it uses the Update's subscriptions list to send notifications.