### PR TITLE
fix: Migration 027 also updated check_in.subscription_list_id

### DIFF
--- a/lib/operately/data/change_027_create_subscriptions_list_for_check_ins.ex
+++ b/lib/operately/data/change_027_create_subscriptions_list_for_check_ins.ex
@@ -32,6 +32,14 @@ defmodule Operately.Data.Chenge027CreateSubscriptionsListForCheckIns do
 
       {:ok, subscriptions_list} -> subscriptions_list
     end
+    |> edit_check_in(check_in)
+  end
+
+  defp edit_check_in(subscriptions_list, check_in) do
+    if subscriptions_list.id != check_in.subscription_list_id do
+      {:ok, _} = Operately.Projects.update_check_in(check_in, %{subscription_list_id: subscriptions_list.id})
+    end
+    subscriptions_list
   end
 
   defp create_subscriptions(subscriptions_list) when is_list(subscriptions_list) do

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -44,6 +44,12 @@ defmodule Operately.Projects do
     |> Fetch.get_resource_with_access_level(person_id)
   end
 
+  def update_check_in(%CheckIn{} = check_in, attrs) do
+    check_in
+    |> CheckIn.changeset(attrs)
+    |> Repo.update()
+  end
+
   defdelegate create_project(params), to: Operately.Operations.ProjectCreation, as: :run
   defdelegate list_projects(person, filters), to: Operately.Projects.ListOperation, as: :run
 

--- a/priv/repo/migrations/20240916184443_create_subcriptions_list_for_existing_project_check_ins.exs
+++ b/priv/repo/migrations/20240916184443_create_subcriptions_list_for_existing_project_check_ins.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.CreateSubcriptionsListForExistingProjectCheckIns do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Chenge027CreateSubscriptionsListForCheckIns.run()
+  end
+
+  def down do
+
+  end
+end


### PR DESCRIPTION
The migration 027 was creating a subscriptions list for a project check-in, but it wasn't updating the check-in `subscription_list_id` field.

I've fixed this issue in the migration and I've also added it to `priv/repo/migrations`, so we don't have to run it manually.

It's worth mentioning that, if the migration hasn't been run yet, it will create the subscriptions list and subscriptions, and update the check-in. 
However, if the migration has already been run, it won't create duplicate resources; it will only update the check-in subscription_list_id.