### PR TITLE
fix: Notify people who are not part of the space

### DIFF
--- a/assets/js/features/Subscriptions/utils.tsx
+++ b/assets/js/features/Subscriptions/utils.tsx
@@ -44,8 +44,19 @@ export function findNotifiableProjectContributors(project: Project, me?: Person)
 }
 
 export function findGoalNotifiablePeople(goal: Goal, me?: Person): NotifiablePerson[] {
-  const people = goal
-    .space!.members!.filter((member) => !compareIds(me?.id, member.id))
+  const members = goal.space!.members!;
+
+  // Ensure reviewer and champion are in the list
+  if (!members.some((member) => compareIds(member.id, goal.champion?.id))) {
+    members.push(goal.champion!);
+  }
+  if (!members.some((member) => compareIds(member.id, goal.reviewer?.id))) {
+    members.push(goal.reviewer!);
+  }
+
+  // Parse Person into NotifiablePerson
+  const people = members
+    .filter((member) => !compareIds(me?.id, member.id))
     .map((member) => {
       const person = {
         id: member.id!,

--- a/test/operately/operations/goal_check_in_test.exs
+++ b/test/operately/operations/goal_check_in_test.exs
@@ -94,7 +94,7 @@ defmodule Operately.Operations.GoalCheckInTest do
       goal_id: ctx.goal.id,
       target_values: [],
       content: content,
-      send_to_everyone: false,
+      send_to_everyone: true,
       subscriber_ids: [],
       subscription_parent_type: :goal_update,
     })
@@ -114,7 +114,7 @@ defmodule Operately.Operations.GoalCheckInTest do
       goal_id: ctx.goal.id,
       target_values: [],
       content: content,
-      send_to_everyone: false,
+      send_to_everyone: true,
       subscriber_ids: [],
       subscription_parent_type: :goal_update,
     })


### PR DESCRIPTION
If someone is not part of a Goal's Space and has a subscription to a Goal Update, they are not being notified. 

This PR fixes this issue.