### PR TITLE
feat: Editing a comment updates subscriptions

### DIFF
--- a/lib/operately/operations/comment_editing.ex
+++ b/lib/operately/operations/comment_editing.ex
@@ -1,16 +1,15 @@
 defmodule Operately.Operations.CommentEditing do
   alias Ecto.Multi
   alias Operately.Updates.Comment
-  alias Operately.Notifications.SubscriptionList
-  alias Operately.{Repo, RichContent, Notifications}
+  alias Operately.Operations.CommentEditing.Subscriptions
+  alias Operately.Repo
 
   def run(comment, new_content) do
     changeset = Comment.changeset(comment, %{content: %{"message" => new_content}})
-    ids = RichContent.find_mentioned_ids(new_content, :decode_ids)
 
     Multi.new()
     |> Multi.update(:comment, changeset)
-    |> update_subscriptions(comment, ids)
+    |> Subscriptions.update(comment.entity_type, new_content)
     |> Repo.transaction()
     |> Repo.extract_result(:comment)
     |> case do
@@ -20,39 +19,5 @@ defmodule Operately.Operations.CommentEditing do
 
       error -> error
     end
-  end
-
-  defp update_subscriptions(multi, _, []), do: multi
-
-  # When subscriptions are added to all resources that use Operately.Operations.CommentEditing,
-  # the entity_type pattern match should be removed.
-  defp update_subscriptions(multi, comment = %{entity_type: :project_check_in}, ids) do
-    {:ok, list} = SubscriptionList.get(:system, parent_id: comment.entity_id, opts: [preload: :subscriptions])
-
-    Enum.reduce(ids, multi, fn id, multi ->
-      name = "subscription_" <> id
-
-      Multi.run(multi, name, fn _, _ ->
-        if subscription_exists?(list.subscriptions, id) do
-          {:ok, nil}
-        else
-          Notifications.create_subscription(%{
-            subscription_list_id: list.id,
-            person_id: id,
-            type: :mentioned,
-          })
-        end
-      end)
-    end)
-  end
-
-  defp update_subscriptions(multi, _, _), do: multi
-
-  #
-  # Helpers
-  #
-
-  defp subscription_exists?(subscriptions, id) do
-    Enum.any?(subscriptions, &(&1.person_id == id))
   end
 end

--- a/lib/operately/operations/comment_editing/subscriptions.ex
+++ b/lib/operately/operations/comment_editing/subscriptions.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Operations.CommentEditing.Subscriptions do
+  alias Ecto.Multi
+  alias Operately.Notifications.SubscriptionList
+
+  def update(multi, :project_check_in, content), do: execute_update(multi, content)
+  def update(multi, :goal_update, content), do: execute_update(multi, content)
+  def update(multi, _, _), do: multi
+
+  defp execute_update(multi, content) do
+    multi
+    |> fetch_subscriptions()
+    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(content)
+  end
+
+  defp fetch_subscriptions(multi) do
+    multi
+    |> Multi.run(:subscription_list, fn _, %{comment: comment} ->
+      SubscriptionList.get(:system, parent_id: comment.entity_id, opts: [
+        preload: :subscriptions
+      ])
+    end)
+  end
+end

--- a/lib/operately/operations/notifications/subscription.ex
+++ b/lib/operately/operations/notifications/subscription.ex
@@ -27,7 +27,8 @@ defmodule Operately.Operations.Notifications.Subscription do
   if they don't have a subscription yet, creates it.
 
   Before calling update_mentioned_people/2,
-  "subscription_list" must be part of multi.
+  "subscription_list" and "subscription_list.subscriptions"
+  must be part of multi.
 
   Example:
     Multi.run(multi, :subscription_list, fn _, _ ->

--- a/lib/operately/operations/notifications/subscription.ex
+++ b/lib/operately/operations/notifications/subscription.ex
@@ -1,6 +1,6 @@
 defmodule Operately.Operations.Notifications.Subscription do
   alias Ecto.Multi
-  alias Operately.RichContent
+  alias Operately.{Notifications, RichContent}
   alias Operately.Notifications.Subscription
 
   def insert(multi, author, attrs) do
@@ -22,6 +22,38 @@ defmodule Operately.Operations.Notifications.Subscription do
     end)
   end
 
+  @doc """
+  Finds people who are mentioned in a rich content and,
+  if they don't have a subscription yet, creates it.
+
+  Before calling update_mentioned_people/2,
+  "subscription_list" must be part of multi.
+
+  Example:
+    Multi.run(multi, :subscription_list, fn _, _ ->
+      SubscriptionList.get(:system, parent_id: parent.id, opts: [preload: :subscriptions]
+    )
+  """
+  def update_mentioned_people(multi, content) do
+    ids = RichContent.find_mentioned_ids(content, :decode_ids)
+
+    Enum.reduce(ids, multi, fn id, multi ->
+      name = "subscription_" <> id
+
+      Multi.run(multi, name, fn _, changes ->
+        if subscription_exists?(changes, id) do
+          {:ok, nil}
+        else
+          Notifications.create_subscription(%{
+            subscription_list_id: changes.subscription_list.id,
+            person_id: id,
+            type: :mentioned,
+          })
+        end
+      end)
+    end)
+  end
+
   #
   # Helpers
   #
@@ -36,5 +68,9 @@ defmodule Operately.Operations.Notifications.Subscription do
         {id, :mentioned}
       end
     end)
+  end
+
+  defp subscription_exists?(changes, id) do
+    Enum.any?(changes.subscription_list.subscriptions, &(&1.person_id == id))
   end
 end


### PR DESCRIPTION
I've updated `Operately.Operations.CommentEditing` so that it updates the Goal Update's subscriptions if someone is mentioned in the comment.