### PR TITLE
chore: Migrate Discussions to its own table

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1187,6 +1187,7 @@ export interface GetDiscussionInput {
   includeAuthor?: boolean | null;
   includeComments?: boolean | null;
   includeReactions?: boolean | null;
+  includeSpace?: boolean | null;
 }
 
 export interface GetDiscussionResult {

--- a/assets/js/features/CommentSection/CommentSection.tsx
+++ b/assets/js/features/CommentSection/CommentSection.tsx
@@ -18,7 +18,7 @@ import { compareIds } from "@/routes/paths";
 interface CommentSectionProps {
   form: FormState;
   refresh: () => void;
-  commentParentType: "project_check_in" | "comment_thread" | "goal_update" | "discussion" | "milestone";
+  commentParentType: "project_check_in" | "comment_thread" | "goal_update" | "message" | "milestone";
 }
 
 export function CommentSection(props: CommentSectionProps) {

--- a/assets/js/features/CommentSection/useForDiscussion.tsx
+++ b/assets/js/features/CommentSection/useForDiscussion.tsx
@@ -19,7 +19,7 @@ export function useForDiscussion(discussion: Discussions.Discussion): FormState 
   const postComment = async (content: string) => {
     await post({
       entityId: discussion.id,
-      entityType: "discussion",
+      entityType: "message",
       content: JSON.stringify(content),
     });
   };
@@ -28,7 +28,7 @@ export function useForDiscussion(discussion: Discussions.Discussion): FormState 
     await edit({
       commentId: commentID,
       content: JSON.stringify(content),
-      parentType: "discussion",
+      parentType: "message",
     });
   };
 

--- a/assets/js/pages/DiscussionPage/loader.tsx
+++ b/assets/js/pages/DiscussionPage/loader.tsx
@@ -12,6 +12,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeAuthor: true,
       includeComments: true,
       includeReactions: true,
+      includeSpace: true,
     }).then((d) => d.discussion!),
   };
 }

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -46,7 +46,7 @@ export function Page() {
 
             <Spacer size={4} />
             <div className="border-t border-stroke-base mt-8" />
-            <CommentSection form={commentsForm} refresh={refresh} commentParentType="discussion" />
+            <CommentSection form={commentsForm} refresh={refresh} commentParentType="message" />
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -57,7 +57,7 @@ export function Page() {
 function Reactions() {
   const { discussion } = useLoadedData();
   const reactions = discussion.reactions!.map((r) => r!);
-  const entity = { id: discussion.id!, type: "discussion" };
+  const entity = { id: discussion.id!, type: "message" };
   const addReactionForm = useReactionsForm(entity, reactions);
 
   return <ReactionList size={24} form={addReactionForm} />;

--- a/assets/js/pages/ProjectContributorsPage/loader.tsx
+++ b/assets/js/pages/ProjectContributorsPage/loader.tsx
@@ -6,7 +6,7 @@ import * as People from "@/models/people";
 import { useGetBindedPeople } from "@/api";
 import { compareIds } from "@/routes/paths";
 
-export interface LoaderData {
+interface LoaderData {
   project: Projects.Project;
   champion: Projects.ProjectContributor | null;
   reviewer: Projects.ProjectContributor | null;

--- a/lib/operately/activities/content/discussion_comment_submitted.ex
+++ b/lib/operately/activities/content/discussion_comment_submitted.ex
@@ -4,7 +4,7 @@ defmodule Operately.Activities.Content.DiscussionCommentSubmitted do
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
     belongs_to :space, Operately.Groups.Group
-    belongs_to :discussion, Operately.Updates.Update
+    belongs_to :discussion, Operately.Messages.Message
     belongs_to :comment, Operately.Updates.Comment
   end
 

--- a/lib/operately/activities/content/discussion_editing.ex
+++ b/lib/operately/activities/content/discussion_editing.ex
@@ -4,7 +4,7 @@ defmodule Operately.Activities.Content.DiscussionEditing do
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
     belongs_to :space, Operately.Groups.Group
-    belongs_to :discussion, Operately.Updates.Update
+    belongs_to :discussion, Operately.Messages.Message
   end
 
   def changeset(attrs) do

--- a/lib/operately/activities/content/discussion_posting.ex
+++ b/lib/operately/activities/content/discussion_posting.ex
@@ -4,7 +4,7 @@ defmodule Operately.Activities.Content.DiscussionPosting do
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
     belongs_to :space, Operately.Groups.Group
-    belongs_to :discussion, Operately.Updates.Update
+    belongs_to :discussion, Operately.Messages.Message
 
     field :title, :string
   end

--- a/lib/operately/activities/content/project_discussion_submitted.ex
+++ b/lib/operately/activities/content/project_discussion_submitted.ex
@@ -4,7 +4,7 @@ defmodule Operately.Activities.Content.ProjectDiscussionSubmitted do
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
     belongs_to :project, Operately.Projects.Project
-    belongs_to :discussion, Operately.Updates.Update
+    belongs_to :discussion, Operately.Messages.Message
 
     field :title, :string
   end

--- a/lib/operately/activities/notifications/discussion_posting.ex
+++ b/lib/operately/activities/notifications/discussion_posting.ex
@@ -6,9 +6,9 @@ defmodule Operately.Activities.Notifications.DiscussionPosting do
 
     space = Operately.Groups.get_group!(space_id)
     members = Operately.Groups.list_members(space)
-    discussion = Operately.Updates.get_update!(discussion_id)
+    {:ok, message} = Operately.Messages.Message.get(:system, id: discussion_id)
 
-    mentioned = Operately.RichContent.lookup_mentioned_people(discussion.content["body"])
+    mentioned = Operately.RichContent.lookup_mentioned_people(message.body)
     people = Enum.uniq_by(members ++ mentioned, & &1.id)
 
     notifications = Enum.map(people, fn member ->

--- a/lib/operately/activities/preloader.ex
+++ b/lib/operately/activities/preloader.ex
@@ -20,6 +20,7 @@ defmodule Operately.Activities.Preloader do
     |> preload(Operately.Projects.Milestone)
     |> preload(Operately.Updates.Comment)
     |> preload(Operately.Companies.Company)
+    |> preload(Operately.Messages.Message)
     |> preload_sub_activities()
   end
 
@@ -111,7 +112,7 @@ defmodule Operately.Activities.Preloader do
   #
   # > is_field_a_not_loaded_ref("project", %Ecto.Association.NotLoaded{}, Operately.Projects.Project)
   #   => true
-  # 
+  #
   defp is_field_a_not_loaded_ref(_key, value, schema) do
     case value do
       %Ecto.Association.NotLoaded{__owner__: owner_schema, __field__: field} ->
@@ -157,8 +158,8 @@ defmodule Operately.Activities.Preloader do
   end
 
   defp inject(activity, references, records) do
-    found = Enum.filter(references, fn {activity_id, _, _, ref_id} -> 
-      activity_id == activity.id && Map.has_key?(records, ref_id) 
+    found = Enum.filter(references, fn {activity_id, _, _, ref_id} ->
+      activity_id == activity.id && Map.has_key?(records, ref_id)
     end)
 
     content = Enum.reduce(found, activity.content, fn {_, path, _, ref_id}, acc ->

--- a/lib/operately/groups/permissions.ex
+++ b/lib/operately/groups/permissions.ex
@@ -13,6 +13,7 @@ defmodule Operately.Groups.Permissions do
     :can_post_discussions,
     :can_remove_member,
     :can_view,
+    :can_view_message,
   ]
 
   def calculate_permissions(access_level) do
@@ -28,6 +29,7 @@ defmodule Operately.Groups.Permissions do
       can_post_discussions: can_post_discussions(access_level),
       can_remove_member: can_remove_member(access_level),
       can_view: can_view(access_level),
+      can_view_message: can_view_message(access_level),
     }
   end
 
@@ -42,6 +44,7 @@ defmodule Operately.Groups.Permissions do
   def can_post_discussions(access_level), do: access_level >= Binding.edit_access()
   def can_remove_member(access_level), do: access_level >= Binding.full_access()
   def can_view(access_level), do: access_level >= Binding.view_access()
+  def can_view_message(access_level), do: access_level >= Binding.view_access()
 
   def check(access_level, permission) do
     permissions = calculate_permissions(access_level)

--- a/lib/operately/messages.ex
+++ b/lib/operately/messages.ex
@@ -1,0 +1,3 @@
+defmodule Operately.Messages do
+
+end

--- a/lib/operately/messages.ex
+++ b/lib/operately/messages.ex
@@ -1,3 +1,10 @@
 defmodule Operately.Messages do
+  alias Operately.Repo
+  alias Operately.Messages.Message
 
+  def create_message(attrs) do
+    %Message{}
+    |> Message.changeset(attrs)
+    |> Repo.insert()
+  end
 end

--- a/lib/operately/messages.ex
+++ b/lib/operately/messages.ex
@@ -1,6 +1,13 @@
 defmodule Operately.Messages do
+  import Ecto.Query
+
   alias Operately.Repo
   alias Operately.Messages.Message
+
+  def list_messages(space_id) do
+    from(m in Message, where: m.space_id == ^space_id)
+    |> Repo.all()
+  end
 
   def create_message(attrs) do
     %Message{}

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -6,6 +6,10 @@ defmodule Operately.Messages.Message do
     belongs_to :space, Operately.Groups.Group
     belongs_to :author, Operately.People.Person
 
+    has_one :access_context, through: [:space, :access_context]
+    has_many :reactions, Operately.Updates.Reaction, where: [entity_type: :message], foreign_key: :entity_id
+    has_many :comments, Operately.Updates.Comment, where: [entity_type: :message], foreign_key: :entity_id
+
     field :title
     field :body, :map
 

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -1,0 +1,26 @@
+defmodule Operately.Messages.Message do
+  use Operately.Schema
+  use Operately.Repo.Getter
+
+  schema "messages" do
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :author, Operately.People.Person
+
+    field :title
+    field :body, :map
+
+    timestamps()
+    requester_access_level()
+    request_info()
+  end
+
+  def changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(update, attrs) do
+    update
+    |> cast(attrs, [:space_id, :author_id, :title, :body])
+    |> validate_required([:space_id, :author_id, :title, :body])
+  end
+end

--- a/lib/operately/operations/comment_adding.ex
+++ b/lib/operately/operations/comment_adding.ex
@@ -32,7 +32,7 @@ defmodule Operately.Operations.CommentAdding do
   # Helpers
   #
 
-  defp find_action(%Operately.Updates.Update{type: :project_discussion}), do: :discussion_comment_submitted
+  defp find_action(%Operately.Messages.Message{}), do: :discussion_comment_submitted
   defp find_action(%Operately.Goals.Update{}), do: :goal_check_in_commented
   defp find_action(%Operately.Projects.CheckIn{}), do: :project_check_in_commented
   defp find_action(%Operately.Comments.CommentThread{}), do: :comment_added

--- a/lib/operately/operations/comment_adding/activity.ex
+++ b/lib/operately/operations/comment_adding/activity.ex
@@ -5,7 +5,7 @@ defmodule Operately.Operations.CommentAdding.Activity do
     Activities.insert_sync(multi, creator.id, action, fn changes ->
       %{
         company_id: creator.company_id,
-        space_id: entity.updatable_id,
+        space_id: entity.space_id,
         discussion_id: entity.id,
         comment_id: changes.comment.id
       }

--- a/lib/operately/operations/discussion_editing.ex
+++ b/lib/operately/operations/discussion_editing.ex
@@ -2,23 +2,20 @@ defmodule Operately.Operations.DiscussionEditing do
   alias Ecto.Multi
   alias Operately.Repo
   alias Operately.Activities
+  alias Operately.Messages.Message
 
-  def run(creator, discussion, space, attrs) do
-    update = Operately.Updates.Update.changeset(discussion, %{
-      content: %{
-        title: attrs.title,
-        body: Jason.decode!(attrs.body)
-      }
-    })
-
+  def run(creator, message, attrs) do
     Multi.new()
-    |> Multi.update(:update, update)
-    |> Activities.insert_sync(creator.id, :discussion_editing, fn changes -> %{
-      company_id: space.company_id,
-      space_id: space.id,
-      discussion_id: changes.update.id,
+    |> Multi.update(:message, Message.changeset(message, %{
+      title: attrs.title,
+      body: Jason.decode!(attrs.body),
+    }))
+    |> Activities.insert_sync(creator.id, :discussion_editing, fn _ -> %{
+      company_id: creator.company_id,
+      space_id: message.space_id,
+      discussion_id: message.id,
     } end)
     |> Repo.transaction()
-    |> Repo.extract_result(:update)
+    |> Repo.extract_result(:message)
   end
 end

--- a/lib/operately/operations/discussion_posting.ex
+++ b/lib/operately/operations/discussion_posting.ex
@@ -4,26 +4,22 @@ defmodule Operately.Operations.DiscussionPosting do
   alias Operately.Activities
 
   def run(creator, space, title, message) do
-    update = Operately.Updates.Update.changeset(%{
+    message = Operately.Messages.Message.changeset(%{
       author_id: creator.id,
-      updatable_id: space.id,
-      updatable_type: "space",
-      type: "project_discussion",
-      content: %{
-        title: title,
-        body: Jason.decode!(message)
-      }
+      space_id: space.id,
+      title: title,
+      body: Jason.decode!(message),
     })
 
     Multi.new()
-    |> Multi.insert(:update, update)
+    |> Multi.insert(:message, message)
     |> Activities.insert_sync(creator.id, :discussion_posting, fn changes -> %{
       company_id: space.company_id,
       space_id: space.id,
-      discussion_id: changes.update.id,
+      discussion_id: changes.message.id,
       title: title,
     } end)
     |> Repo.transaction()
-    |> Repo.extract_result(:update)
+    |> Repo.extract_result(:message)
   end
 end

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -355,10 +355,9 @@ defmodule Operately.Updates do
           join: u in Operately.Goals.Update, on: u.id == c.entity_id, as: :resource,
           where: c.id == ^id
         )
-      :discussion ->
+     :message ->
         from(c in Comment, as: :comment,
-          join: u in Update, on: u.id == c.entity_id,
-          join: s in Operately.Groups.Group, on: u.updatable_id == s.id, as: :resource,
+          join: m in Operately.Messages.Message, on: m.id == c.entity_id, as: :resource,
           where: c.id == ^id
         )
       :milestone ->

--- a/lib/operately/updates/comment.ex
+++ b/lib/operately/updates/comment.ex
@@ -7,7 +7,7 @@ defmodule Operately.Updates.Comment do
     belongs_to :author, Operately.People.Person
 
     field :entity_id, Ecto.UUID
-    field :entity_type, Ecto.Enum, values: [:project_check_in, :goal_update, :update, :comment_thread]
+    field :entity_type, Ecto.Enum, values: [:project_check_in, :goal_update, :message, :update, :comment_thread]
 
     field :content, :map
 

--- a/lib/operately/updates/reaction.ex
+++ b/lib/operately/updates/reaction.ex
@@ -6,7 +6,7 @@ defmodule Operately.Updates.Reaction do
     belongs_to :person, Operately.People.Person
 
     field :entity_id, Ecto.UUID
-    field :entity_type, Ecto.Enum, values: [:update, :goal_update, :comment, :project_check_in, :comment_thread]
+    field :entity_type, Ecto.Enum, values: [:message, :update, :goal_update, :comment, :project_check_in, :comment_thread]
     field :emoji, :string
 
     # deprecated

--- a/lib/operately_email/emails/comment_added_email.ex
+++ b/lib/operately_email/emails/comment_added_email.ex
@@ -52,7 +52,7 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
         "commented on: #{parent_comment_thread.title}"
 
       true ->
-        raise "Unsupported action"
+        raise "Unsupported action: #{activity.action}"
     end
   end
 

--- a/lib/operately_email/emails/discussion_comment_submitted_email.ex
+++ b/lib/operately_email/emails/discussion_comment_submitted_email.ex
@@ -4,15 +4,15 @@ defmodule OperatelyEmail.Emails.DiscussionCommentSubmittedEmail do
   alias Operately.Repo
   alias Operately.Updates
   alias OperatelyWeb.Paths
+  alias Operately.Messages.Message
 
   def send(person, activity) do
     author = Repo.preload(activity, :author).author
     company = Repo.preload(author, :company).company
 
-    discussion = Updates.get_update!(activity.content["discussion_id"])
+    {:ok, %{title: title} = message} = Message.get(:system, id: activity.content["discussion_id"])
     comment = Updates.get_comment!(activity.content["comment_id"])
     space = Operately.Groups.get_group!(activity.content["space_id"])
-    title = discussion.content["title"]
 
     company
     |> new()
@@ -20,11 +20,11 @@ defmodule OperatelyEmail.Emails.DiscussionCommentSubmittedEmail do
     |> to(person)
     |> subject(where: space.name, who: author, action: "commented on: #{title}")
     |> assign(:author, author)
-    |> assign(:discussion, discussion)
+    |> assign(:discussion, message)
     |> assign(:title, title)
     |> assign(:comment, comment)
     |> assign(:space, space)
-    |> assign(:cta_url, Paths.discussion_path(company, discussion) |> Paths.to_url())
+    |> assign(:cta_url, Paths.message_path(company, message) |> Paths.to_url())
     |> render("discussion_comment_submitted")
   end
 end

--- a/lib/operately_email/templates/discussion_posting.html.eex
+++ b/lib/operately_email/templates/discussion_posting.html.eex
@@ -3,7 +3,7 @@
 <%= spacer() %>
 
 <%= row do %>
-  <%= rich_text(@discussion.content["body"]) %>
+  <%= rich_text(@message.body) %>
 <% end %>
 
 <%= spacer() %>

--- a/lib/operately_web/api/mutations/edit_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_discussion.ex
@@ -2,9 +2,9 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
   use TurboConnect.Mutation
   use OperatelyWeb.Api.Helpers
 
-  alias Operately.Groups
   alias Operately.Groups.Permissions
   alias Operately.Operations.DiscussionEditing
+  alias Operately.Messages.Message
 
   inputs do
     field :discussion_id, :string
@@ -20,10 +20,9 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
     |> run(:id, fn -> decode_id(inputs.discussion_id) end)
-    |> run(:discussion, fn ctx -> {:ok, Operately.Updates.get_update!(ctx.id)} end)
-    |> run(:space, fn ctx -> Groups.get_group_with_access_level(ctx.discussion.updatable_id, ctx.me.id) end)
-    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.requester_access_level, :can_edit_discussions) end)
-    |> run(:operation, fn ctx -> DiscussionEditing.run(ctx.me, ctx.discussion, ctx.space, inputs) end)
+    |> run(:message, fn ctx -> Message.get(ctx.me, id: ctx.id) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.message.request_info.access_level, :can_edit_discussions) end)
+    |> run(:operation, fn ctx -> DiscussionEditing.run(ctx.me, ctx.message, inputs) end)
     |> run(:serialized, fn ctx -> {:ok, %{discussion: Serializer.serialize(ctx.operation, level: :essential)}} end)
     |> respond()
   end

--- a/lib/operately_web/api/mutations/edit_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_discussion.ex
@@ -31,8 +31,7 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
       {:error, :id, _} -> {:error, :bad_request}
-      {:error, :discussion, _} -> {:error, :not_found}
-      {:error, :space, _} -> {:error, :not_found}
+      {:error, :message, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}

--- a/lib/operately_web/api/queries/get_comments.ex
+++ b/lib/operately_web/api/queries/get_comments.ex
@@ -4,8 +4,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
 
   import Operately.Access.Filters, only: [filter_by_view_access: 3]
 
-  alias Operately.Updates.{Update, Comment}
-  alias Operately.Groups.Group
+  alias Operately.Updates.Comment
   alias Operately.Projects.CheckIn
   alias Operately.Comments.CommentThread
   alias Operately.Activities.Activity
@@ -49,14 +48,13 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     |> Repo.all()
   end
 
-  defp load(id, :discussion, person) do
+  defp load(id, :message, person) do
     from(c in Comment,
-      join: u in Update, on: c.entity_id == u.id,
-      join: g in Group, on: u.updatable_id == g.id, as: :group,
-      where: c.entity_id == ^id and c.entity_type == :update
+      join: m in Operately.Messages.Message, on: c.entity_id == m.id, as: :message,
+      where: m.id == ^id
     )
     |> preload_resources()
-    |> filter_by_view_access(person.id, named_binding: :group)
+    |> filter_by_view_access(person.id, named_binding: :message)
     |> Repo.all()
   end
 

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -2,15 +2,15 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  alias Operately.Access.Filters
-  alias Operately.Updates.Update
-  alias Operately.Groups.Group
+  alias Operately.Messages.Message
+  alias Operately.Groups.Permissions
 
   inputs do
     field :id, :string
     field :include_author, :boolean
     field :include_comments, :boolean
     field :include_reactions, :boolean
+    field :include_space, :boolean
   end
 
   outputs do
@@ -18,47 +18,46 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   end
 
   def call(conn, inputs) do
-    update = load_update(inputs)
-    update = preload_space(update, me(conn))
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.id) end)
+    |> run(:preload, fn -> include_requested(inputs) end)
+    |> run(:message, fn ctx -> load(ctx) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.message.request_info.access_level, :can_view_message) end)
+    |> run(:serialized, fn ctx -> {:ok, %{discussion: OperatelyWeb.Api.Serializer.serialize(ctx.message, level: :full)}} end)
+    |> respond()
+   end
 
-    if update do
-      {:ok, %{discussion: OperatelyWeb.Api.Serializer.serialize(update, level: :full)}}
-    else
-      {:error, :not_found}
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :message, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :not_found}
+      _ -> {:error, :not_found}
     end
   end
 
-  defp load_update(inputs) do
-    {:ok, id} = decode_id(inputs.id)
+  defp load(ctx) do
+    Message.get(ctx.me, id: ctx.id, opts: [
+      preload: ctx.preload,
+    ])
+  end
+
+  defp include_requested(inputs) do
     requested = extract_include_filters(inputs)
 
-    from(u in Update, where: u.id == ^id)
-    |> include_requested(requested)
-    |> Repo.one()
-  end
+    preload =
+      Enum.reduce(requested, [], fn include, result ->
+        case include do
+          :include_author -> [:author | result]
+          :include_comments -> [[comments: [:author, [reactions: :person]]] | result]
+          :include_reactions -> [[reactions: :person] | result]
+          :include_space -> [:space | result]
+          e -> raise "Unknown include filter: #{e}"
+        end
+      end)
 
-  defp include_requested(query, requested) do
-    Enum.reduce(requested, query, fn include, q ->
-      case include do
-        :include_author -> from p in q, preload: [:author]
-        :include_comments -> from p in q, preload: [comments: [:author, [reactions: :person]]]
-        :include_reactions -> from p in q, preload: [reactions: :person]
-        :include_space -> q # this is done after the load
-        e -> raise "Unknown include filter: #{e}"
-      end
-    end)
-  end
-
-  defp preload_space(nil, _), do: nil
-  defp preload_space(update, person) do
-    from(s in Group, where: s.id == ^update.updatable_id)
-    |> Filters.filter_by_view_access(person.id)
-    |> Repo.one()
-    |> space_into_update(update)
-  end
-
-  defp space_into_update(nil, _), do: nil
-  defp space_into_update(space, update) do
-    %{update | space: space}
+    {:ok, preload}
   end
 end

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -89,7 +89,7 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
       space: serialize_space(content["space"]),
       discussion: serialize_discussion(content["discussion"]),
       space_id: Paths.space_id(content["space"]),
-      discussion_id: Paths.discussion_id(content["discussion"]),
+      discussion_id: Paths.message_id(content["discussion"]),
       title: content["title"]
     }
   end
@@ -409,11 +409,11 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_discussion(discussion) do
+  def serialize_discussion(message) do
     %{
-      id: OperatelyWeb.Paths.discussion_id(discussion),
-      title: discussion.content["title"],
-      body: discussion.content["body"],
+      id: OperatelyWeb.Paths.message_id(message),
+      title: message.title,
+      body: message.body,
     }
   end
 

--- a/lib/operately_web/api/serializers/message.ex
+++ b/lib/operately_web/api/serializers/message.ex
@@ -1,0 +1,26 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
+  def serialize(message, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.message_id(message),
+      title: message.title,
+      body: Jason.encode!(message.body),
+      inserted_at: OperatelyWeb.Api.Serializer.serialize(message.inserted_at),
+      updated_at: OperatelyWeb.Api.Serializer.serialize(message.updated_at),
+      author: OperatelyWeb.Api.Serializer.serialize(message.author),
+    }
+  end
+
+  def serialize(message, level: :full) do
+    %{
+      id: OperatelyWeb.Paths.message_id(message),
+      title: message.title,
+      body: Jason.encode!(message.body),
+      inserted_at: OperatelyWeb.Api.Serializer.serialize(message.inserted_at),
+      updated_at: OperatelyWeb.Api.Serializer.serialize(message.updated_at),
+      author: OperatelyWeb.Api.Serializer.serialize(message.author),
+      space: OperatelyWeb.Api.Serializer.serialize(message.space),
+      reactions: OperatelyWeb.Api.Serializer.serialize(message.reactions),
+      comments: OperatelyWeb.Api.Serializer.serialize(message.comments)
+    }
+  end
+end

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -70,6 +70,10 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company), "discussions", discussion_id(discussion)])
   end
 
+  def message_path(company = %Company{}, message) do
+    create_path([company_id(company), "discussions", message_id(message)])
+  end
+
   def project_path(company = %Company{}, project = %Project{}) do
     create_path([company_id(company), "projects", project_id(project)])
   end

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -140,6 +140,12 @@ defmodule OperatelyWeb.Paths do
     OperatelyWeb.Api.Helpers.id_with_comments(title, id)
   end
 
+  def message_id(message) do
+    id = Operately.ShortUuid.encode!(message.id)
+    title = message.title
+    OperatelyWeb.Api.Helpers.id_with_comments(title, id)
+  end
+
   def project_check_in_id(check_in) do
     id = Operately.ShortUuid.encode!(check_in.id)
     date = check_in.inserted_at |> NaiveDateTime.to_date() |> Date.to_string()

--- a/priv/repo/migrations/20240917173757_copy_discussions_from_updates_to_messages_table.exs
+++ b/priv/repo/migrations/20240917173757_copy_discussions_from_updates_to_messages_table.exs
@@ -1,0 +1,58 @@
+defmodule Operately.Repo.Migrations.CopyDiscussionsFromUpdatesToMessagesTable do
+  use Ecto.Migration
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  def up do
+    execute("CREATE TABLE messages AS SELECT * FROM updates WHERE updates.type = 'project_discussion';")
+    execute("ALTER TABLE messages ADD CONSTRAINT messages_pkey PRIMARY KEY (id);")
+
+    alter table(:messages) do
+      add :space_id, references(:groups, type: :binary_id, on_delete: :nothing)
+      add :body, :jsonb
+    end
+
+    create index(:messages, [:space_id])
+    create index(:messages, [:author_id])
+
+    flush()
+
+    update_fields()
+
+    alter table(:messages) do
+      remove :updatable_id, :uuid
+      remove :updatable_type, :string
+      remove :type, :string
+      remove :content, :jsonb
+      remove :acknowledged, :boolean
+      remove :acknowledged_at, :utc_datetime
+      remove :acknowledging_person_id, :binary_id
+      remove :previous_phase, :string
+      remove :new_phase, :string
+      remove :previous_health, :string
+      remove :new_health, :string
+    end
+  end
+
+  def down do
+    drop index(:messages, [:space_id])
+    drop index(:messages, [:author_id])
+
+    drop table("messages")
+  end
+
+  defp update_fields do
+    from(c in "messages", select: [:id, :updatable_id, :content])
+    |> Repo.all()
+    |> Enum.each(fn update ->
+      from(c in "messages", where: c.id == ^update.id)
+      |> Repo.update_all(set: [
+        space_id: update.updatable_id,
+        title: update.content["title"],
+        body: update.content["body"],
+      ])
+    end)
+  end
+end

--- a/priv/repo/migrations/20240918101843_update_comment_entity_type_value_to_message.exs
+++ b/priv/repo/migrations/20240918101843_update_comment_entity_type_value_to_message.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.UpdateCommentEntityTypeValueToMessage do
+  use Ecto.Migration
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Updates.Comment
+  alias Operately.Messages.Message
+
+  def up do
+    from(c in Comment, where: c.entity_id in subquery(from(m in Message, select: m.id)))
+    |> Repo.update_all(set: [entity_type: :message])
+  end
+
+  def down do
+    from(c in Comment, where: c.entity_type == :message)
+    |> Repo.update_all(set: [entity_type: :update])
+  end
+end

--- a/priv/repo/migrations/20240918102916_update_reaction_entity_type_value_to_message.exs
+++ b/priv/repo/migrations/20240918102916_update_reaction_entity_type_value_to_message.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.UpdateReactionEntityTypeValueToMessage do
+  use Ecto.Migration
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Updates.Reaction
+  alias Operately.Messages.Message
+
+  def up do
+    from(r in Reaction, where: r.entity_id in subquery(from(m in Message, select: m.id)))
+    |> Repo.update_all(set: [entity_type: :message])
+  end
+
+  def down do
+    from(r in Reaction, where: r.entity_type == :message)
+    |> Repo.update_all(set: [entity_type: :update])
+  end
+end

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -56,11 +56,11 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.click(testid: "post-discussion")
     |> UI.assert_text("Posted on")
 
-    discussion = last_discussion(ctx)
+    message = last_message(ctx)
 
     ctx
     |> UI.login_as(ctx.reader)
-    |> UI.visit(Paths.discussion_path(ctx.company, discussion))
+    |> UI.visit(Paths.message_path(ctx.company, message))
     |> UI.click(testid: "add-comment")
     |> UI.fill_rich_text("This is a comment.")
     |> UI.click(testid: "post-comment")
@@ -114,16 +114,16 @@ defmodule Operately.Features.DiscussionsTest do
   #
   # Utilities
   #
-  defp last_discussion(ctx) do
-    discussions = Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion)
+  defp last_message(ctx) do
+    messages = Operately.Messages.list_messages(ctx.space.id)
 
-    if discussions != [] do
-      hd(discussions)
+    if messages != [] do
+      hd(messages)
     else
       # sometimes the updates are not immediately available
       # so we wait a bit and try again
       :timer.sleep(300)
-      Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion) |> hd()
+      Operately.Messages.list_messages(ctx.space.id) |> hd()
     end
   end
 end

--- a/test/operately_web/api/mutations/create_comment_test.exs
+++ b/test/operately_web/api/mutations/create_comment_test.exs
@@ -7,7 +7,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
   import Operately.ProjectsFixtures
   import Operately.GoalsFixtures
   import Operately.CommentsFixtures
-  import Operately.UpdatesFixtures
+  import Operately.MessagesFixtures
 
   alias Operately.{Notifications, Updates}
   alias Operately.Notifications.SubscriptionList
@@ -144,18 +144,18 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
     tabletest @space_table do
       test "if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        discussion = create_discussion(ctx, space)
+        message = message_fixture(ctx.creator.id, space.id)
 
         assert {code, res} = mutation(ctx.conn, :create_comment, %{
-          entity_id: Paths.discussion_id(discussion),
-          entity_type: "discussion",
+          entity_id: Paths.message_id(message),
+          entity_type: "message",
           content: RichText.rich_text("Content", :as_string)
         })
 
         assert code == @test.expected
 
         case @test.expected do
-          200 -> assert Updates.count_comments(discussion.id, :update) == 1
+          200 -> assert Updates.count_comments(message.id, :message) == 1
           403 -> assert res.message == "You don't have permission to perform this action"
           404 -> assert res.message == "The requested resource was not found"
         end
@@ -328,18 +328,5 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
 
   defp create_goal_update(ctx, goal) do
     goal_update_fixture(ctx.creator, goal)
-  end
-
-  defp create_discussion(ctx, space) do
-    update_fixture(%{
-      author_id: ctx.creator.id,
-      updatable_id: space.id,
-      updatable_type: :space,
-      type: :project_discussion,
-      content: %{
-        title: "Title",
-        body: RichText.rich_text("Content")
-      }
-    })
   end
 end

--- a/test/operately_web/api/mutations/edit_comment_test.exs
+++ b/test/operately_web/api/mutations/edit_comment_test.exs
@@ -7,7 +7,7 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
   import Operately.ProjectsFixtures
   import Operately.GoalsFixtures
   import Operately.CommentsFixtures
-  import Operately.UpdatesFixtures
+  import Operately.MessagesFixtures
 
   alias Operately.Notifications
   alias Operately.Notifications.SubscriptionList
@@ -153,13 +153,13 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
     tabletest @space_table do
       test "if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        discussion = create_discussion(ctx, space)
-        comment = create_comment(ctx, discussion, "update")
+        message = message_fixture(ctx.creator.id, space.id)
+        comment = create_comment(ctx, message, "message")
 
         assert {code, res} = mutation(ctx.conn, :edit_comment, %{
           comment_id: Paths.comment_id(comment),
           content: RichText.rich_text("New content", :as_string),
-          parent_type: "discussion",
+          parent_type: "message",
         })
 
         assert code == @test.expected
@@ -347,19 +347,6 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
 
   defp create_goal_update(ctx, goal) do
     goal_update_fixture(ctx.creator, goal)
-  end
-
-  defp create_discussion(ctx, space) do
-    update_fixture(%{
-      author_id: ctx.creator.id,
-      updatable_id: space.id,
-      updatable_type: :space,
-      type: :project_discussion,
-      content: %{
-        title: "Title",
-        body: RichText.rich_text("Content")
-      }
-    })
   end
 
   defp create_milestone_comment(ctx, milestone) do

--- a/test/operately_web/api/mutations/post_discussion_test.exs
+++ b/test/operately_web/api/mutations/post_discussion_test.exs
@@ -1,11 +1,12 @@
 defmodule OperatelyWeb.Api.Mutations.PostDiscussionTest do
   use OperatelyWeb.TurboCase
 
-  import Operately.Support.RichText
   import Operately.GroupsFixtures
 
   alias Operately.Access
   alias Operately.Access.Binding
+  alias Operately.Support.RichText
+  alias Operately.Messages.Message
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -121,14 +122,17 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussionTest do
   defp request(conn, space) do
     mutation(conn, :post_discussion, %{
       space_id: Paths.space_id(space),
-      title: "Discussion",
-      body: rich_text("Content") |> Jason.encode!(),
+      title: "Message",
+      body: RichText.rich_text("Content", :as_string),
     })
   end
 
   defp assert_discussion_created(res) do
     {:ok, id} = OperatelyWeb.Api.Helpers.decode_id(res.discussion.id)
-    assert Operately.Updates.get_update!(id)
+
+    assert {:ok, message} = Message.get(:system, id: id)
+    assert message.title == "Message"
+    assert message.body == RichText.rich_text("Content")
   end
 
   #

--- a/test/operately_web/api/queries/get_discussion_test.exs
+++ b/test/operately_web/api/queries/get_discussion_test.exs
@@ -3,7 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
 
   import Operately.PeopleFixtures
   import Operately.GroupsFixtures
-  import Operately.UpdatesFixtures
+  import Operately.MessagesFixtures
 
   alias Operately.Support.RichText
   alias Operately.Access.Binding
@@ -23,83 +23,95 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
     end
 
     test "(company space) - company members have access", ctx do
-      discussion = create_discussion(ctx, space_id: ctx.company.company_space_id)
+      message = message_fixture(ctx.creator.id,  ctx.company.company_space_id)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
-      assert_discussion(res)
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
+      assert_message(res)
     end
 
     test "company members have no access", ctx do
       space = create_space(ctx, company_access: Binding.no_access())
-      discussion = create_discussion(ctx, space_id: space.id)
+      message = message_fixture(ctx.creator.id,  space.id)
 
-      assert {404, %{message: msg} = _res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
+      assert {404, %{message: msg} = _res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
       assert msg == "The requested resource was not found"
     end
 
     test "company members have access", ctx do
       space = create_space(ctx, company_access: Binding.view_access())
-      discussion = create_discussion(ctx, space_id: space.id)
+      message = message_fixture(ctx.creator.id,  space.id)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
-      assert_discussion(res)
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
+      assert_message(res)
     end
 
     test "space members have access", ctx do
       space = create_space(ctx, company_access: Binding.no_access())
-      discussion = create_discussion(ctx, space_id: space.id)
+      message = message_fixture(ctx.creator.id,  space.id)
       add_person_to_space(ctx, space)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
-      assert_discussion(res)
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
+      assert_message(res)
     end
   end
 
   describe "get_discussion functionality" do
     setup :register_and_log_in_account
 
-    test "include_author", ctx do
-      discussion = create_discussion(ctx)
+    test "include_space", ctx do
+      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
+      assert res.discussion.space == nil
+
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_space: true})
+
+      space = Operately.Groups.get_group!(ctx.company.company_space_id)
+      assert res.discussion.space == Serializer.serialize(space, level: :essential)
+    end
+
+    test "include_author", ctx do
+      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
+
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
       assert res.discussion.author == nil
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion), include_author: true})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_author: true})
       assert res.discussion.author == Serializer.serialize(ctx.person, level: :essential)
     end
 
     test "include_reactions", ctx do
-      discussion = create_discussion(ctx)
+      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
       assert res.discussion.reactions == nil
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion), include_reactions: true})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_reactions: true})
       assert res.discussion.reactions == []
 
       {:ok, reaction} = Operately.Updates.create_reaction(%{
         person_id: ctx.person.id,
-        entity_id: discussion.id,
-        entity_type: :update,
+        entity_id: message.id,
+        entity_type: :message,
         emoji: "👍"
       })
 
       reaction = Operately.Repo.preload(reaction, [:person])
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion), include_reactions: true})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_reactions: true})
       assert res.discussion.reactions == [Serializer.serialize(reaction, level: :essential)]
     end
 
     test "include_comments", ctx do
-      discussion = create_discussion(ctx)
+      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion)})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
       assert res.discussion.comments == nil
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion), include_comments: true})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_comments: true})
       assert res.discussion.comments == []
 
-      {:ok, comment} = add_comment(ctx, discussion, "Hello World")
+      {:ok, comment} = add_comment(ctx, message, "Hello World")
       {:ok, _reaction} = Operately.Updates.create_reaction(%{
         person_id: ctx.person.id,
         entity_id: comment.id,
@@ -109,7 +121,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
 
       comment = Operately.Repo.preload(comment, [:author, [reactions: :person]])
 
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.discussion_id(discussion), include_comments: true})
+      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message), include_comments: true})
       assert res.discussion.comments == [Serializer.serialize(comment, level: :essential)]
     end
   end
@@ -118,10 +130,9 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
   # Helpers
   #
 
-  defp assert_discussion(res) do
+  defp assert_message(res) do
     assert res.discussion.title
     assert res.discussion.body
-    assert res.discussion.space
   end
 
   defp create_space(ctx, opts) do
@@ -138,20 +149,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
     }])
   end
 
-  defp create_discussion(ctx, opts \\ []) do
-    update_fixture(%{
-      author_id: ctx.person.id,
-      updatable_id: Keyword.get(opts, :space_id, ctx.company.company_space_id),
-      updatable_type: :space,
-      type: :project_discussion,
-      content: %{
-        title: Keyword.get(opts, :title, "Hello World"),
-        body: Keyword.get(opts, :body, "How are you doing?") |> RichText.rich_text()
-      }
-    })
-  end
-
-  defp add_comment(ctx, discussion, content) do
-    Operately.Operations.CommentAdding.run(ctx.person, discussion, "update", RichText.rich_text(content))
+  defp add_comment(ctx, message, content) do
+    Operately.Operations.CommentAdding.run(ctx.person, message, "message", RichText.rich_text(content))
   end
 end

--- a/test/operately_web/api/queries/get_discussions_test.exs
+++ b/test/operately_web/api/queries/get_discussions_test.exs
@@ -3,10 +3,9 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
 
   import Operately.GroupsFixtures
   import Operately.PeopleFixtures
-  import Operately.UpdatesFixtures
+  import Operately.MessagesFixtures
 
   alias Operately.Access.Binding
-  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -23,19 +22,19 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
     end
 
     test "company space - company members have access", ctx do
-      discussions = Enum.map(1..3, fn _ ->
-        create_discussion(ctx, space_id: ctx.company.company_space_id)
+      messages = Enum.map(1..3, fn _ ->
+        message_fixture(ctx.creator.id, ctx.company.company_space_id)
       end)
       space = Operately.Groups.get_group!(ctx.company.company_space_id)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
-      assert_discussions(res, discussions)
+      assert_messages(res, messages)
     end
 
     test "company members have no access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        create_discussion(ctx, space_id: space.id)
+        message_fixture(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
@@ -44,18 +43,18 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
 
     test "company members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.view_access())
-      discussions = Enum.map(1..3, fn _ ->
-        create_discussion(ctx, space_id: space.id)
+      messages = Enum.map(1..3, fn _ ->
+        message_fixture(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
-      assert_discussions(res, discussions)
+      assert_messages(res, messages)
     end
 
     test "space members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
-      discussions = Enum.map(1..3, fn _ ->
-        create_discussion(ctx, space_id: space.id)
+      messages = Enum.map(1..3, fn _ ->
+        message_fixture(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
@@ -64,7 +63,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
       add_person_to_space(ctx, space)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
-      assert_discussions(res, discussions)
+      assert_messages(res, messages)
     end
   end
 
@@ -72,31 +71,18 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
   # Helpers
   #
 
-  defp assert_discussions(res, discussions) do
-    assert length(res.discussions) == length(discussions)
-    Enum.each(res.discussions, fn d ->
-      assert Enum.find(discussions, &(Paths.discussion_id(&1) == d.id))
-      assert d.author
-      assert d.body
-      assert d.title
+  defp assert_messages(res, messages) do
+    assert length(res.discussions) == length(messages)
+    Enum.each(res.discussions, fn m ->
+      assert Enum.find(messages, &(Paths.message_id(&1) == m.id))
+      assert m.author
+      assert m.body
+      assert m.title
     end)
   end
 
   defp create_space(ctx, attrs) do
     group_fixture(ctx.creator, Enum.into(attrs, %{company_id: ctx.company.id}))
-  end
-
-  defp create_discussion(ctx, attrs) do
-    update_fixture(%{
-      author_id: ctx.creator.id,
-      updatable_id: Keyword.get(attrs, :space_id, ctx.company.company_space_id),
-      updatable_type: :space,
-      type: :project_discussion,
-      content: %{
-        title: Keyword.get(attrs, :title, "Hello World"),
-        body: Keyword.get(attrs, :body, "How are you doing?") |> RichText.rich_text()
-      }
-    })
   end
 
   defp add_person_to_space(ctx, space) do

--- a/test/support/features/discussion_steps.ex
+++ b/test/support/features/discussion_steps.ex
@@ -15,10 +15,10 @@ defmodule Operately.Support.Features.DiscussionSteps do
   end
 
   step :assert_discussion_is_posted, ctx do
-    discussion = last_discussion(ctx)
+    message = last_message(ctx)
 
     ctx
-    |> UI.assert_page(Paths.discussion_path(ctx.company, discussion))
+    |> UI.assert_page(Paths.message_path(ctx.company, message))
     |> UI.assert_text("This is a discussion")
     |> UI.assert_text("This is the body of the discussion.")
   end
@@ -77,15 +77,15 @@ defmodule Operately.Support.Features.DiscussionSteps do
   end
 
   step :submit_discussion, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "post-discussion")
   end
 
   step :assert_discussion_is_posted_with_attachment, ctx do
-    discussion = last_discussion(ctx)
+    message = last_message(ctx)
 
     ctx
-    |> UI.assert_page(Paths.discussion_path(ctx.company, discussion))
+    |> UI.assert_page(Paths.message_path(ctx.company, message))
     |> UI.assert_text("Testing file attachment")
     |> UI.assert_text("README.md")
   end
@@ -94,16 +94,16 @@ defmodule Operately.Support.Features.DiscussionSteps do
   # Utilities
   #
 
-  defp last_discussion(ctx) do
-    discussions = Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion) 
+  defp last_message(ctx) do
+    messages = Operately.Messages.list_messages(ctx.space.id)
 
-    if discussions != [] do
-      hd(discussions)
+    if messages != [] do
+      hd(messages)
     else
       # sometimes the updates are not immediately available
       # so we wait a bit and try again
       :timer.sleep(300)
-      Operately.Updates.list_updates(ctx.space.id, :space, :project_discussion) |> hd()
+      Operately.Messages.list_messages(ctx.space.id) |> hd()
     end
   end
 end

--- a/test/support/fixtures/messages_fixtures.ex
+++ b/test/support/fixtures/messages_fixtures.ex
@@ -1,0 +1,15 @@
+defmodule Operately.MessagesFixtures do
+  def message_fixture(author_id, space_id, attrs \\ []) do
+    {:ok, message} =
+      attrs
+      |> Enum.into(%{
+        author_id: author_id,
+        space_id: space_id,
+        title: "Some message",
+        body: Operately.Support.RichText.rich_text("Some content"),
+      })
+      |> Operately.Messages.create_message()
+
+    message
+  end
+end


### PR DESCRIPTION
I've added migration files to create a new table for Discussions. The migrations should also handle the copying of existing data.

I've also updated our existing queries and mutations to use the new table.