### PR TITLE
fix: Display message comments sorted

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1185,7 +1185,6 @@ export interface GetCompanyResult {
 export interface GetDiscussionInput {
   id?: string | null;
   includeAuthor?: boolean | null;
-  includeComments?: boolean | null;
   includeReactions?: boolean | null;
   includeSpace?: boolean | null;
 }

--- a/assets/js/features/CommentSection/form.tsx
+++ b/assets/js/features/CommentSection/form.tsx
@@ -11,4 +11,5 @@ export interface FormState {
   postComment: (content: string) => void;
   editComment: (commentID: string, content: string) => void;
   submitting: boolean;
+  refetch?: () => void;
 }

--- a/assets/js/features/CommentSection/useForDiscussion.tsx
+++ b/assets/js/features/CommentSection/useForDiscussion.tsx
@@ -5,16 +5,31 @@ import * as Time from "@/utils/time";
 import { ItemType, FormState } from "./form";
 
 export function useForDiscussion(discussion: Discussions.Discussion): FormState {
-  const items = discussion.comments!.map((c) => {
-    return {
-      type: "comment" as ItemType,
-      insertedAt: Time.parse(c.insertedAt)!,
-      value: c,
-    };
+  const { data, loading, error, refetch } = Comments.useGetComments({
+    entityId: discussion.id!,
+    entityType: "message",
   });
 
   const [post, { loading: submittingPost }] = Comments.useCreateComment();
   const [edit, { loading: submittingEdit }] = Comments.useEditComment();
+
+  if (loading)
+    return {
+      items: [],
+      postComment: async (_content: string) => {},
+      editComment: async (_commentID: string, _content: string) => {},
+      submitting: false,
+    };
+
+  if (error) throw error;
+
+  const items = data!.comments!.map((comment) => {
+    return {
+      type: "comment" as ItemType,
+      insertedAt: Time.parse(comment.insertedAt)!,
+      value: comment,
+    };
+  });
 
   const postComment = async (content: string) => {
     await post({
@@ -37,5 +52,6 @@ export function useForDiscussion(discussion: Discussions.Discussion): FormState 
     postComment,
     editComment,
     submitting: submittingPost || submittingEdit,
+    refetch,
   };
 }

--- a/assets/js/pages/DiscussionPage/loader.tsx
+++ b/assets/js/pages/DiscussionPage/loader.tsx
@@ -10,7 +10,6 @@ export async function loader({ params }): Promise<LoaderResult> {
     discussion: await Discussions.getDiscussion({
       id: params.id,
       includeAuthor: true,
-      includeComments: true,
       includeReactions: true,
       includeSpace: true,
     }).then((d) => d.discussion!),
@@ -19,8 +18,4 @@ export async function loader({ params }): Promise<LoaderResult> {
 
 export function useLoadedData(): LoaderResult {
   return Pages.useLoadedData() as LoaderResult;
-}
-
-export function useRefresh() {
-  return Pages.useRefresh();
 }

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -15,7 +15,7 @@ import { Spacer } from "@/components/Spacer";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useForDiscussion } from "@/features/CommentSection";
 
-import { useRefresh, useLoadedData } from "./loader";
+import { useLoadedData } from "./loader";
 import { useDiscussionCommentsChangeSignal } from "@/models/comments";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths, compareIds } from "@/routes/paths";
@@ -24,9 +24,8 @@ export function Page() {
   const me = useMe()!;
   const { discussion } = useLoadedData();
 
-  const refresh = useRefresh();
   const commentsForm = useForDiscussion(discussion);
-  useDiscussionCommentsChangeSignal(refresh, { discussionId: discussion.id! });
+  useDiscussionCommentsChangeSignal(commentsForm.refetch!, { discussionId: discussion.id! });
 
   return (
     <Pages.Page title={discussion.title!}>
@@ -46,7 +45,7 @@ export function Page() {
 
             <Spacer size={4} />
             <div className="border-t border-stroke-base mt-8" />
-            <CommentSection form={commentsForm} refresh={refresh} commentParentType="message" />
+            <CommentSection form={commentsForm} refresh={() => {}} commentParentType="message" />
           </div>
         </Paper.Body>
       </Paper.Root>

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -8,7 +8,6 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   inputs do
     field :id, :string
     field :include_author, :boolean
-    field :include_comments, :boolean
     field :include_reactions, :boolean
     field :include_space, :boolean
   end
@@ -51,7 +50,6 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
       Enum.reduce(requested, [], fn include, result ->
         case include do
           :include_author -> [:author | result]
-          :include_comments -> [[comments: [:author, [reactions: :person]]] | result]
           :include_reactions -> [[reactions: :person] | result]
           :include_space -> [:space | result]
           e -> raise "Unknown include filter: #{e}"


### PR DESCRIPTION
While migrating discussions to their own table, the comments ended up being displayed unsorted.

To fix this, I changed the way comments are loaded on a discussion page. Now, the comments are loaded in a separate request using the GetComments query, similar to how comments are loaded on other pages.

The advantage is that when comments need to be refreshed, we don't have to refresh all the data on the page; only comments are refreshed.