### PR TITLE
feat: Include subscriptions and members in GetDiscussion

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -582,6 +582,7 @@ export interface Discussion {
   space?: Space | null;
   reactions?: Reaction[] | null;
   comments?: Comment[] | null;
+  subscriptionList?: SubscriptionList | null;
 }
 
 export interface EditMemberPermissionsInput {
@@ -1187,6 +1188,8 @@ export interface GetDiscussionInput {
   includeAuthor?: boolean | null;
   includeReactions?: boolean | null;
   includeSpace?: boolean | null;
+  includeSpaceMembers?: boolean | null;
+  includeSubscriptions?: boolean | null;
 }
 
 export interface GetDiscussionResult {

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -4,12 +4,15 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
 
   alias Operately.Messages.Message
   alias Operately.Groups.Permissions
+  alias Operately.Notifications.Subscription
 
   inputs do
     field :id, :string
     field :include_author, :boolean
     field :include_reactions, :boolean
     field :include_space, :boolean
+    field :include_space_members, :boolean
+    field :include_subscriptions, :boolean
   end
 
   outputs do
@@ -52,6 +55,8 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
           :include_author -> [:author | result]
           :include_reactions -> [[reactions: :person] | result]
           :include_space -> [:space | result]
+          :include_space_members -> [[space: [:members, :company]] | result]
+          :include_subscriptions -> [Subscription.preload_subscriptions() | result]
           e -> raise "Unknown include filter: #{e}"
         end
       end)

--- a/lib/operately_web/api/serializers/message.ex
+++ b/lib/operately_web/api/serializers/message.ex
@@ -18,9 +18,18 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(message.inserted_at),
       updated_at: OperatelyWeb.Api.Serializer.serialize(message.updated_at),
       author: OperatelyWeb.Api.Serializer.serialize(message.author),
-      space: OperatelyWeb.Api.Serializer.serialize(message.space),
+      space: serialize_space(message.space),
       reactions: OperatelyWeb.Api.Serializer.serialize(message.reactions),
-      comments: OperatelyWeb.Api.Serializer.serialize(message.comments)
+      comments: OperatelyWeb.Api.Serializer.serialize(message.comments),
+      subscription_list: OperatelyWeb.Api.Serializer.serialize(message.subscription_list),
     }
+  end
+
+  defp serialize_space(space) do
+    if Ecto.assoc_loaded?(space) and Ecto.assoc_loaded?(space.members) and Ecto.assoc_loaded?(space.company) do
+      OperatelyWeb.Api.Serializer.serialize(space, level: :full)
+    else
+      OperatelyWeb.Api.Serializer.serialize(space)
+    end
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -184,6 +184,7 @@ defmodule OperatelyWeb.Api.Types do
     field :space, :space
     field :reactions, list_of(:reaction)
     field :comments, list_of(:comment)
+    field :subscription_list, :subscription_list
   end
 
   object :activity do


### PR DESCRIPTION
I've updated `OperatelyWeb.Api.Queries.GetDiscussion`. Now, we can include the subscriptions and space members in the request.