### PR TITLE
feat: Editing discussion body updates subscriptions

### DIFF
--- a/lib/operately/operations/discussion_editing.ex
+++ b/lib/operately/operations/discussion_editing.ex
@@ -3,13 +3,17 @@ defmodule Operately.Operations.DiscussionEditing do
   alias Operately.Repo
   alias Operately.Activities
   alias Operately.Messages.Message
+  alias Operately.Notifications.SubscriptionList
 
   def run(creator, message, attrs) do
     Multi.new()
-    |> Multi.update(:message, Message.changeset(message, %{
-      title: attrs.title,
-      body: Jason.decode!(attrs.body),
-    }))
+    |> Multi.update(:message, Message.changeset(message, attrs))
+    |> Multi.run(:subscription_list, fn _, changes ->
+      SubscriptionList.get(:system, parent_id: changes.message.id, opts: [
+        preload: :subscriptions
+      ])
+    end)
+    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(attrs.body)
     |> Activities.insert_sync(creator.id, :discussion_editing, fn _ -> %{
       company_id: creator.company_id,
       space_id: message.space_id,


### PR DESCRIPTION
I've updated `Operately.Operations.DiscussionEditing` so that subscriptions are also updated if someone is mentioned in the discussion body.