### PR TITLE
feat: DiscussionPosting notification uses subscriptions list

### DIFF
--- a/lib/operately/activities/notifications/discussion_posting.ex
+++ b/lib/operately/activities/notifications/discussion_posting.ex
@@ -1,28 +1,15 @@
 defmodule Operately.Activities.Notifications.DiscussionPosting do
+  alias Operately.Messages.Notifications
+
   def dispatch(activity) do
-    author_id = activity.author_id
-    space_id = activity.content["space_id"]
-    discussion_id = activity.content["discussion_id"]
-
-    space = Operately.Groups.get_group!(space_id)
-    members = Operately.Groups.list_members(space)
-    {:ok, message} = Operately.Messages.Message.get(:system, id: discussion_id)
-
-    mentioned = Operately.RichContent.lookup_mentioned_people(message.body)
-    people = Enum.uniq_by(members ++ mentioned, & &1.id)
-
-    notifications = Enum.map(people, fn member ->
+    Notifications.get_subscribers(activity.content["discussion_id"], ignore: [activity.author_id])
+    |> Enum.map(fn person_id ->
       %{
-        person_id: member.id,
+        person_id: person_id,
         activity_id: activity.id,
         should_send_email: true,
       }
     end)
-
-    notifications = Enum.filter(notifications, fn notification ->
-      notification.person_id != author_id
-    end)
-
-    Operately.Notifications.bulk_create(notifications)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/messages/notifications.ex
+++ b/lib/operately/messages/notifications.ex
@@ -1,0 +1,80 @@
+defmodule Operately.Messages.Notifications do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  def get_subscribers(message_id, opts \\ []) do
+    ignore = Keyword.get(opts, :ignore, [])
+
+    message_id
+    |> fetch_message()
+    |> filter_subscribers()
+    |> Enum.filter(&(not Enum.member?(ignore, &1)))
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_message(message_id) do
+    from(message in Operately.Messages.Message,
+      where: message.id == ^message_id,
+
+      # members
+      join: context in assoc(message, :access_context),
+      join: space in assoc(message, :space),
+      join: person in assoc(space, :members),
+      join: m in assoc(person, :access_group_memberships),
+      join: g in assoc(m, :group),
+      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
+      preload: [space: {space, members: person}],
+
+      # subscriptions
+      join: list in assoc(message, :subscription_list),
+      join: subs in assoc(list, :subscriptions),
+      join: sp in assoc(subs, :person),
+      join: sm in assoc(sp, :access_group_memberships),
+      join: sg in assoc(sm, :group),
+      join: sb in Binding, on: sb.group_id == sg.id and sb.context_id == context.id and sb.access_level >= ^Binding.view_access(),
+      preload: [subscription_list: {list, [subscriptions: subs]}]
+    )
+    |> Repo.one()
+  end
+
+  defp filter_subscribers(%{space: space, subscription_list: list = %{send_to_everyone: true}}) do
+    space.members
+    |> maybe_add_missing_members(list.subscriptions)
+    |> Enum.filter(fn p ->
+      case Enum.find(list.subscriptions, &(&1.person_id == p.id)) do
+        nil -> true
+        %{canceled: false} -> true
+        _ -> false
+      end
+    end)
+    |> Enum.map(&(&1.id))
+  end
+
+  defp filter_subscribers(%{subscription_list: list = %{send_to_everyone: false}}) do
+    Enum.filter(list.subscriptions, fn s -> not s.canceled end)
+    |> Enum.map(&(&1.person_id))
+  end
+
+  defp filter_subscribers(nil), do: []
+
+  # If someone is not part of the space, they will not be present in the members list
+  # So, if they have a subscription, they have to be added to the members list manually
+  defp maybe_add_missing_members(members, subscriptions) do
+    people_ids = MapSet.new(Enum.map(members, & &1.id))
+
+    missing_member_ids =
+      subscriptions
+      |> Enum.map(& &1.person_id)
+      |> Enum.filter(fn person_id -> not MapSet.member?(people_ids, person_id) end)
+      |> Enum.uniq()
+
+    missing_members = Enum.map(missing_member_ids, fn id -> %{id: id} end)
+
+    members ++ missing_members
+  end
+end

--- a/test/operately/operations/discussion_posting_test.exs
+++ b/test/operately/operations/discussion_posting_test.exs
@@ -1,0 +1,125 @@
+defmodule Operately.Operations.DiscussionPostingTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.PeopleFixtures
+
+  alias Operately.Support.{Factory, RichText}
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_space_member(:mike, :space)
+    |> Factory.add_space_member(:bob, :space)
+    |> Factory.add_space_member(:jane, :space)
+  end
+
+  test "Creating message sends notifications to everyone", ctx do
+    {:ok, message} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
+        space_id: ctx.space.id,
+        title: "Title",
+        content: RichText.rich_text("Content"),
+        send_to_everyone: true,
+        subscription_parent_type: :message,
+        subscriber_ids: [],
+      })
+    end)
+
+    action = "discussion_posting"
+    activity = get_activity(message, action)
+
+    assert 0 == notifications_count(action: action)
+
+    perform_job(activity.id)
+    notifications = fetch_notifications(activity.id, action: action)
+
+    assert 3 == notifications_count(action: action)
+
+    [ctx.mike, ctx.bob, ctx.jane]
+    |> Enum.each(fn p ->
+      assert Enum.find(notifications, &(&1.person_id == p.id))
+    end)
+  end
+
+  test "Creating message sends notifications to selected people", ctx do
+    {:ok, message} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
+        space_id: ctx.space.id,
+        title: "Title",
+        content: RichText.rich_text("Content"),
+        send_to_everyone: false,
+        subscription_parent_type: :message,
+        subscriber_ids: [ctx.mike.id, ctx.jane.id],
+      })
+    end)
+
+    action = "discussion_posting"
+    activity = get_activity(message, action)
+
+    assert 0 == notifications_count(action: action)
+
+    perform_job(activity.id)
+    notifications = fetch_notifications(activity.id, action: action)
+
+    assert 2 == notifications_count(action: action)
+
+    [ctx.mike, ctx.jane]
+    |> Enum.each(fn p ->
+      assert Enum.find(notifications, &(&1.person_id == p.id))
+    end)
+  end
+
+  test "Person without permissions is not notified", ctx do
+    # Without permissions
+    person = person_fixture_with_account(%{company_id: ctx.company.id})
+    content = RichText.rich_text(mentioned_people: [person]) |> Jason.decode!()
+
+    {:ok, message} = Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
+      space_id: ctx.space.id,
+      title: "Title",
+      content: content,
+      send_to_everyone: false,
+      subscription_parent_type: :message,
+      subscriber_ids: [],
+    })
+
+    action = "discussion_posting"
+    activity = get_activity(message, action)
+
+    assert notifications_count(action: action) == 0
+    assert fetch_notifications(activity.id, action: action) == []
+
+    # With permissions
+    {:ok, _} = Operately.Groups.add_members(ctx.creator, ctx.space.id, [
+      %{id: person.id, permissions: Operately.Access.Binding.view_access()}
+    ])
+
+    {:ok, message} = Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
+      space_id: ctx.space.id,
+      title: "Title",
+      content: content,
+      send_to_everyone: false,
+      subscription_parent_type: :message,
+      subscriber_ids: [],
+    })
+
+    activity = get_activity(message, action)
+    notifications = fetch_notifications(activity.id, action: action)
+
+    assert notifications_count(action: action) == 1
+    assert hd(notifications).person_id == person.id
+  end
+
+  #
+  # Helpers
+  #
+
+  defp get_activity(message, action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action and a.content["discussion_id"] == ^message.id
+    )
+    |> Repo.one()
+  end
+end


### PR DESCRIPTION
Now, `Operately.Activities.Notifications.DiscussionPosting` sends notifications based on the discussion's subscriptions list.