### PR TITLE
feat: DiscussionCommentSubmitted notification uses subscriptions list

### DIFF
--- a/lib/operately/activities/notifications/discussion_comment_submitted.ex
+++ b/lib/operately/activities/notifications/discussion_comment_submitted.ex
@@ -1,32 +1,11 @@
 defmodule Operately.Activities.Notifications.DiscussionCommentSubmitted do
-  alias Operately.Messages.Message
+  alias Operately.Messages.Notifications
 
   def dispatch(activity) do
-    author_id = activity.author_id
-    space_id = activity.content["space_id"]
-    message_id = activity.content["discussion_id"]
-
-    space = Operately.Groups.get_group!(space_id)
-    members = Operately.Groups.list_members(space)
-
-    {:ok, %{author: message_author}} = Message.get(:system, id: message_id, opts: [
-      preload: :author,
-    ])
-
-    comments = Operately.Updates.list_comments(message_id)
-    comment_authors = Enum.map(comments, fn comment ->
-      Operately.People.get_person!(comment.author_id)
-    end)
-
-    comment = Operately.Updates.get_comment!(activity.content["comment_id"])
-    mentioned = Operately.RichContent.lookup_mentioned_people(comment.content["message"])
-
-    members ++ [message_author] ++ comment_authors ++ mentioned
-    |> Enum.uniq_by(& &1.id)
-    |> Enum.filter(fn person -> person.id != author_id end)
-    |> Enum.map(fn person ->
+    Notifications.get_subscribers(activity.content["discussion_id"], ignore: [activity.author_id])
+    |> Enum.map(fn person_id ->
       %{
-        person_id: person.id,
+        person_id: person_id,
         activity_id: activity.id,
         should_send_email: true,
       }

--- a/lib/operately/operations/comment_adding/subscriptions.ex
+++ b/lib/operately/operations/comment_adding/subscriptions.ex
@@ -4,6 +4,7 @@ defmodule Operately.Operations.CommentAdding.Subscriptions do
 
   def update(multi, :project_check_in_commented, content), do: execute_update(multi, content)
   def update(multi, :goal_check_in_commented, content), do: execute_update(multi, content)
+  def update(multi, :discussion_comment_submitted, content), do: execute_update(multi, content)
   def update(multi, _, _), do: multi
 
   defp execute_update(multi, content) do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Support.Factory do
-  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts}
+  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages}
 
   def setup(ctx) do
     ctx = add_account(ctx, :account)
@@ -25,5 +25,8 @@ defmodule Operately.Support.Factory do
   defdelegate add_project_contributor(ctx, testid, project_name, opts \\ []), to: Projects
   defdelegate edit_project_company_members_access(ctx, project_name, access_level), to: Projects
   defdelegate edit_project_space_members_access(ctx, project_name, access_level), to: Projects
+
+  # messages
+  defdelegate add_message(ctx, testid, space_name, opts \\ []), to: Messages
 
 end

--- a/test/support/factory/messages.ex
+++ b/test/support/factory/messages.ex
@@ -1,0 +1,9 @@
+defmodule Operately.Support.Factory.Messages do
+  def add_message(ctx, testid, space_name, opts \\ []) do
+    creator = Keyword.get(opts, :creator, ctx.creator)
+
+    message = Operately.MessagesFixtures.message_fixture(creator.id, ctx[space_name].id, opts)
+
+    Map.put(ctx, testid, message)
+  end
+end

--- a/test/support/fixtures/messages_fixtures.ex
+++ b/test/support/fixtures/messages_fixtures.ex
@@ -1,6 +1,7 @@
 defmodule Operately.MessagesFixtures do
   def message_fixture(author_id, space_id, attrs \\ []) do
-    {:ok, subscription_list} = Operately.Notifications.create_subscription_list()
+    subscription_list = Operately.NotificationsFixtures.subscriptions_list_fixture(attrs)
+
     {:ok, message} =
       attrs
       |> Enum.into(%{

--- a/test/support/fixtures/notifications_fixtures.ex
+++ b/test/support/fixtures/notifications_fixtures.ex
@@ -21,4 +21,28 @@ defmodule Operately.NotificationsFixtures do
 
     notification
   end
+
+  def subscriptions_list_fixture(attrs \\ []) do
+    {:ok, subscriptions_list} = Operately.Notifications.create_subscription_list(%{
+      send_to_everyone: Keyword.get(attrs, :send_to_everyone, false),
+    })
+
+    Keyword.get(attrs, :person_ids, [])
+    |> Enum.each(fn id ->
+      subscription_fixture(subscription_list_id: subscriptions_list.id, person_id: id)
+    end)
+
+    subscriptions_list
+  end
+
+  def subscription_fixture(attrs \\ []) do
+    {:ok, subscription} =
+      attrs
+      |> Enum.into(%{
+        type: :invited,
+      })
+      |> Operately.Notifications.create_subscription()
+
+    subscription
+  end
 end


### PR DESCRIPTION
Now, `Operately.Activities.Notifications.DiscussionCommentSubmitted` sends notifications based on the discussion's subscriptions list.