### PR TITLE
fix: Notification subscribers were sometimes not loaded

### DIFF
--- a/lib/operately/goals/notifications.ex
+++ b/lib/operately/goals/notifications.ex
@@ -2,82 +2,22 @@ defmodule Operately.Goals.Notifications do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
-  alias Operately.Access.Binding
+  alias Operately.Notifications.SubscribersLoader
 
   def get_goal_update_subscribers(update_id, opts \\ []) do
     ignore = Keyword.get(opts, :ignore, [])
 
-    update_id
-    |> fetch_update()
-    |> filter_subscribers()
-    |> Enum.filter(&(not Enum.member?(ignore, &1)))
-  end
+    update =
+      from(u in Operately.Goals.Update,
+        join: g in assoc(u, :goal),
+        join: c in assoc(g, :access_context),
+        join: s in assoc(g, :group),
+        join: p in assoc(s, :members),
+        preload: [goal: {g, group: {s, members: p}}, access_context: c],
+        where: u.id == ^update_id
+      )
+      |> Repo.one()
 
-  #
-  # Helpers
-  #
-
-  defp fetch_update(update_id) do
-    from(u in Operately.Goals.Update,
-      where: u.id == ^update_id,
-
-      # members
-      join: goal in assoc(u, :goal),
-      join: context in assoc(goal, :access_context),
-      join: space in assoc(goal, :group),
-      join: person in assoc(space, :members),
-      join: m in assoc(person, :access_group_memberships),
-      join: g in assoc(m, :group),
-      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
-      preload: [goal: {goal, group: {space, members: person}}],
-
-      # subscriptions
-      join: list in assoc(u, :subscription_list),
-      join: subs in assoc(list, :subscriptions),
-      join: sp in assoc(subs, :person),
-      join: sm in assoc(sp, :access_group_memberships),
-      join: sg in assoc(sm, :group),
-      join: sb in Binding, on: sb.group_id == sg.id and sb.context_id == context.id and sb.access_level >= ^Binding.view_access(),
-      preload: [subscription_list: {list, [subscriptions: subs]}]
-    )
-    |> Repo.one()
-  end
-
-  defp filter_subscribers(%{goal: g, subscription_list: l = %{send_to_everyone: true}}) do
-    g.group.members
-    |> maybe_add_missing_members(l.subscriptions)
-    |> Enum.filter(fn p ->
-      case Enum.find(l.subscriptions, &(&1.person_id == p.id)) do
-        nil -> true
-        %{canceled: false} -> true
-        _ -> false
-      end
-    end)
-    |> Enum.map(&(&1.id))
-  end
-
-  defp filter_subscribers(%{goal: g, subscription_list: l = %{send_to_everyone: false}}) do
-    Enum.filter(l.subscriptions, fn s ->
-      Enum.any?(g.group.members, &(&1.id == s.person_id))
-    end)
-    |> Enum.map(&(&1.person_id))
-  end
-
-  defp filter_subscribers(nil), do: []
-
-  # If someone is not part of the space, they will not be present the members list
-  # So, if they have a subscription, they have to be added to the members list manually
-  defp maybe_add_missing_members(members, subscriptions) do
-    people_ids = MapSet.new(Enum.map(members, & &1.id))
-
-    missing_member_ids =
-      subscriptions
-      |> Enum.map(& &1.person_id)
-      |> Enum.filter(fn person_id -> not MapSet.member?(people_ids, person_id) end)
-      |> Enum.uniq()
-
-    missing_members = Enum.map(missing_member_ids, fn id -> %{id: id} end)
-
-    members ++ missing_members
+    SubscribersLoader.load(update, update.goal.group.members, ignore)
   end
 end

--- a/lib/operately/messages/notifications.ex
+++ b/lib/operately/messages/notifications.ex
@@ -2,79 +2,21 @@ defmodule Operately.Messages.Notifications do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
-  alias Operately.Access.Binding
+  alias Operately.Notifications.SubscribersLoader
 
   def get_subscribers(message_id, opts \\ []) do
     ignore = Keyword.get(opts, :ignore, [])
 
-    message_id
-    |> fetch_message()
-    |> filter_subscribers()
-    |> Enum.filter(&(not Enum.member?(ignore, &1)))
-  end
+    message =
+      from(message in Operately.Messages.Message,
+        join: c in assoc(message, :access_context), as: :context,
+        join: s in assoc(message, :space),
+        join: m in assoc(s, :members),
+        preload: [space: {s, members: m}, access_context: c],
+        where: message.id == ^message_id
+      )
+      |> Repo.one()
 
-  #
-  # Helpers
-  #
-
-  defp fetch_message(message_id) do
-    from(message in Operately.Messages.Message,
-      where: message.id == ^message_id,
-
-      # members
-      join: context in assoc(message, :access_context),
-      join: space in assoc(message, :space),
-      join: person in assoc(space, :members),
-      join: m in assoc(person, :access_group_memberships),
-      join: g in assoc(m, :group),
-      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
-      preload: [space: {space, members: person}],
-
-      # subscriptions
-      join: list in assoc(message, :subscription_list),
-      join: subs in assoc(list, :subscriptions),
-      join: sp in assoc(subs, :person),
-      join: sm in assoc(sp, :access_group_memberships),
-      join: sg in assoc(sm, :group),
-      join: sb in Binding, on: sb.group_id == sg.id and sb.context_id == context.id and sb.access_level >= ^Binding.view_access(),
-      preload: [subscription_list: {list, [subscriptions: subs]}]
-    )
-    |> Repo.one()
-  end
-
-  defp filter_subscribers(%{space: space, subscription_list: list = %{send_to_everyone: true}}) do
-    space.members
-    |> maybe_add_missing_members(list.subscriptions)
-    |> Enum.filter(fn p ->
-      case Enum.find(list.subscriptions, &(&1.person_id == p.id)) do
-        nil -> true
-        %{canceled: false} -> true
-        _ -> false
-      end
-    end)
-    |> Enum.map(&(&1.id))
-  end
-
-  defp filter_subscribers(%{subscription_list: list = %{send_to_everyone: false}}) do
-    Enum.filter(list.subscriptions, fn s -> not s.canceled end)
-    |> Enum.map(&(&1.person_id))
-  end
-
-  defp filter_subscribers(nil), do: []
-
-  # If someone is not part of the space, they will not be present in the members list
-  # So, if they have a subscription, they have to be added to the members list manually
-  defp maybe_add_missing_members(members, subscriptions) do
-    people_ids = MapSet.new(Enum.map(members, & &1.id))
-
-    missing_member_ids =
-      subscriptions
-      |> Enum.map(& &1.person_id)
-      |> Enum.filter(fn person_id -> not MapSet.member?(people_ids, person_id) end)
-      |> Enum.uniq()
-
-    missing_members = Enum.map(missing_member_ids, fn id -> %{id: id} end)
-
-    members ++ missing_members
+    SubscribersLoader.load(message, message.space.members, ignore)
   end
 end

--- a/lib/operately/notifications/subscribers_loader.ex
+++ b/lib/operately/notifications/subscribers_loader.ex
@@ -1,0 +1,66 @@
+defmodule Operately.Notifications.SubscribersLoader do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access.Binding
+
+  @doc """
+    Loads the IDs of people who should receive notifications for the given "resource".
+
+    Parameters:
+    - resource: struct which has a subscriptions list (e.g. message, project check-in, goal update).
+      It must have `access_context` preloaded.
+
+    - people: list of people who will be notified if resource.subscription_list.send_to_everyone == true.
+
+    - ignore_ids: list of person IDs to exclude from the final result.
+  """
+  def load(resource, people, ignore_ids \\ []) do
+    query = from(subs in Operately.Notifications.Subscription,
+      join: p in assoc(subs, :person),
+      join: m in assoc(p, :access_group_memberships),
+      join: g in assoc(m, :group),
+      join: b in Binding, on: b.group_id == g.id and b.context_id == ^resource.access_context.id and b.access_level >= ^Binding.view_access(),
+      select: subs
+    )
+
+    resource
+    |> Repo.preload(subscription_list: [subscriptions: query])
+    |> filter_subscribers(people)
+    |> Enum.uniq()
+    |> Enum.filter(&(not Enum.member?(ignore_ids, &1)))
+  end
+
+  defp filter_subscribers(%{subscription_list: list = %{send_to_everyone: false}}, _) do
+    Enum.filter(list.subscriptions, fn s -> not s.canceled end)
+    |> Enum.map(&(&1.person_id))
+  end
+
+  defp filter_subscribers(%{subscription_list: list = %{send_to_everyone: true}}, people) do
+    people
+    |> maybe_add_missing_subscribers(list.subscriptions)
+    |> Enum.filter(fn p ->
+      case Enum.find(list.subscriptions, &(&1.person_id == p.id)) do
+        nil -> true
+        %{canceled: false} -> true
+        _ -> false
+      end
+    end)
+    |> Enum.map(&(&1.id))
+  end
+
+  # If for some reason someone is not part "people", but they have a subscription,
+  # they have to be added to the subscriptions list manually
+  defp maybe_add_missing_subscribers(people, subscriptions) do
+    people_ids = MapSet.new(Enum.map(people, & &1.id))
+
+    missing_member_ids =
+      subscriptions
+      |> Enum.map(& &1.person_id)
+      |> Enum.filter(fn person_id -> not MapSet.member?(people_ids, person_id) end)
+
+    missing_members = Enum.map(missing_member_ids, fn id -> %{id: id} end)
+
+    people ++ missing_members
+  end
+end

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -2,59 +2,24 @@ defmodule Operately.Projects.Notifications do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
-  alias Operately.Access.Binding
+  alias Operately.Notifications.SubscribersLoader
 
   def get_check_in_subscribers(check_in_id, opts \\ []) do
     ignore = Keyword.get(opts, :ignore, [])
 
-    check_in_id
-    |> fetch_check_in()
-    |> filter_subscribers()
-    |> Enum.map(&(&1.person_id))
-    |> Enum.filter(&(not Enum.member?(ignore, &1)))
+    check_in =
+      from(c in Operately.Projects.CheckIn,
+        join: project in assoc(c, :project),
+        join: context in assoc(project, :access_context),
+        join: contribs in assoc(project, :contributors),
+        join: person in assoc(contribs, :person),
+        preload: [project: {project, [contributors: {contribs, person: person}]}, access_context: context],
+        where: c.id == ^check_in_id
+      )
+      |> Repo.one()
+
+    people = Enum.map(check_in.project.contributors, &(&1.person))
+
+    SubscribersLoader.load(check_in, people, ignore)
   end
-
-  #
-  # Helpers
-  #
-
-  defp fetch_check_in(check_in_id) do
-    from(c in Operately.Projects.CheckIn,
-      where: c.id == ^check_in_id,
-
-      # subscriptions
-      join: list in assoc(c, :subscription_list),
-      join: subs in assoc(list, :subscriptions),
-      preload: [subscription_list: {list, [subscriptions: subs]}],
-
-      # permissions
-      join: project in assoc(c, :project),
-      join: context in assoc(project, :access_context),
-      join: contribs in assoc(project, :contributors),
-      join: person in assoc(contribs, :person),
-      join: m in assoc(person, :access_group_memberships),
-      join: g in assoc(m, :group),
-      join: b in Binding, on: b.group_id == g.id and b.context_id == context.id and b.access_level >= ^Binding.view_access(),
-      preload: [project: {project, [contributors: contribs]}]
-    )
-    |> Repo.one()
-  end
-
-  defp filter_subscribers(%{project: p, subscription_list: l = %{send_to_everyone: true}}) do
-    Enum.filter(p.contributors, fn c ->
-      case Enum.find(l.subscriptions, &(&1.person_id == c.person_id)) do
-        nil -> true
-        %{canceled: false} -> true
-        _ -> false
-      end
-    end)
-  end
-
-  defp filter_subscribers(%{project: p, subscription_list: l = %{send_to_everyone: false}}) do
-    Enum.filter(l.subscriptions, fn s ->
-      Enum.any?(p.contributors, &(&1.person_id == s.person_id))
-    end)
-  end
-
-  defp filter_subscribers(nil), do: []
 end


### PR DESCRIPTION
Previously, all the information needed for sending notifications was being loaded in a single query. However, in some edge cases, some notifications were not being sent.

To handle that, I separated the data loading process into two steps.

While working on this issue, I was able to identify a lot of repeated code, which I extracted to `Operately.Notifications.SubscribersLoader`.