### PR TITLE
chore: GetProjectCheckIn query can include potential subscribers

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1370,6 +1370,7 @@ export interface GetProjectResult {
 export interface GetProjectCheckInInput {
   id?: string | null;
   includeAuthor?: boolean | null;
+  includeAcknowledgedBy?: boolean | null;
   includeProject?: boolean | null;
   includeReactions?: boolean | null;
   includeSubscriptions?: boolean | null;

--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -780,6 +780,7 @@ export interface ProjectCheckIn {
   acknowledgedBy?: Person | null;
   reactions?: Reaction[] | null;
   subscriptionList?: SubscriptionList | null;
+  potentialSubscribers?: Subscriber[] | null;
 }
 
 export interface ProjectContributor {
@@ -884,6 +885,7 @@ export interface Space {
 export interface Subscriber {
   role?: string | null;
   priority?: boolean | null;
+  isSubscribed?: boolean | null;
   person?: Person | null;
 }
 
@@ -1371,6 +1373,7 @@ export interface GetProjectCheckInInput {
   includeProject?: boolean | null;
   includeReactions?: boolean | null;
   includeSubscriptions?: boolean | null;
+  includePotentialSubscribers?: boolean | null;
 }
 
 export interface GetProjectCheckInResult {
@@ -1470,14 +1473,6 @@ export interface GetUnreadNotificationCountInput {}
 
 export interface GetUnreadNotificationCountResult {
   unread?: number | null;
-}
-
-export interface ListProjectSubscribersCandidatesInput {
-  projectId?: string | null;
-}
-
-export interface ListProjectSubscribersCandidatesResult {
-  candidates?: boolean[] | null;
 }
 
 export interface SearchPeopleInput {
@@ -2364,12 +2359,6 @@ export class ApiClient {
     return this.get("/get_unread_notification_count", input);
   }
 
-  async listProjectSubscribersCandidates(
-    input: ListProjectSubscribersCandidatesInput,
-  ): Promise<ListProjectSubscribersCandidatesResult> {
-    return this.get("/list_project_subscribers_candidates", input);
-  }
-
   async searchPeople(input: SearchPeopleInput): Promise<SearchPeopleResult> {
     return this.get("/search_people", input);
   }
@@ -2789,11 +2778,6 @@ export async function getUnreadNotificationCount(
 ): Promise<GetUnreadNotificationCountResult> {
   return defaultApiClient.getUnreadNotificationCount(input);
 }
-export async function listProjectSubscribersCandidates(
-  input: ListProjectSubscribersCandidatesInput,
-): Promise<ListProjectSubscribersCandidatesResult> {
-  return defaultApiClient.listProjectSubscribersCandidates(input);
-}
 export async function searchPeople(input: SearchPeopleInput): Promise<SearchPeopleResult> {
   return defaultApiClient.searchPeople(input);
 }
@@ -3198,14 +3182,6 @@ export function useGetUnreadNotificationCount(
   input: GetUnreadNotificationCountInput,
 ): UseQueryHookResult<GetUnreadNotificationCountResult> {
   return useQuery<GetUnreadNotificationCountResult>(() => defaultApiClient.getUnreadNotificationCount(input));
-}
-
-export function useListProjectSubscribersCandidates(
-  input: ListProjectSubscribersCandidatesInput,
-): UseQueryHookResult<ListProjectSubscribersCandidatesResult> {
-  return useQuery<ListProjectSubscribersCandidatesResult>(() =>
-    defaultApiClient.listProjectSubscribersCandidates(input),
-  );
 }
 
 export function useSearchPeople(input: SearchPeopleInput): UseQueryHookResult<SearchPeopleResult> {
@@ -3746,8 +3722,6 @@ export default {
   useGetTasks,
   getUnreadNotificationCount,
   useGetUnreadNotificationCount,
-  listProjectSubscribersCandidates,
-  useListProjectSubscribersCandidates,
   searchPeople,
   useSearchPeople,
   searchPotentialSpaceMembers,

--- a/assets/js/pages/ProjectCheckInPage/loader.tsx
+++ b/assets/js/pages/ProjectCheckInPage/loader.tsx
@@ -13,6 +13,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeAuthor: true,
       includeReactions: true,
       includeSubscriptions: true,
+      includeAcknowledgedBy: true,
     }).then((data) => data.projectCheckIn!),
   };
 }

--- a/lib/operately/goals/notifications.ex
+++ b/lib/operately/goals/notifications.ex
@@ -18,6 +18,6 @@ defmodule Operately.Goals.Notifications do
       )
       |> Repo.one()
 
-    SubscribersLoader.load(update, update.goal.group.members, ignore)
+    SubscribersLoader.load_for_notifications(update, update.goal.group.members, ignore)
   end
 end

--- a/lib/operately/messages/notifications.ex
+++ b/lib/operately/messages/notifications.ex
@@ -17,6 +17,6 @@ defmodule Operately.Messages.Notifications do
       )
       |> Repo.one()
 
-    SubscribersLoader.load(message, message.space.members, ignore)
+    SubscribersLoader.load_for_notifications(message, message.space.members, ignore)
   end
 end

--- a/lib/operately/notifications/subscriber.ex
+++ b/lib/operately/notifications/subscriber.ex
@@ -1,28 +1,62 @@
 defmodule Operately.Notifications.Subscriber do
-  alias Operately.Projects.Contributor
+  alias Operately.Projects.{Contributor, CheckIn}
+  alias Operately.Notifications.Subscription
 
   defstruct [
     :person,
     :role,
     :priority,
+    :is_subscribed,
   ]
 
   def from_project_contributor(contributors) when is_list(contributors) do
     Enum.map(contributors, &from_project_contributor/1)
   end
 
-  def from_project_contributor(%Contributor{} = contriburor) do
-    case contriburor.role do
-      :champion -> %{ role: "Champion", priority: true }
-      :reviewer -> %{ role: "Reviewer", priority: true }
-      _ -> %{ role: contriburor.responsibility, priority: false }
-    end
-    |> then(fn result ->
-      %__MODULE__{
-        person: contriburor.person,
-        role: result.role,
-        priority: result.priority,
-      }
+  def from_project_contributor(%Contributor{} = contributor) do
+    [role: role, priority: priority] = find_role_and_priority(contributor)
+
+    %__MODULE__{
+      person: contributor.person,
+      role: role,
+      priority: priority,
+      is_subscribed: false,
+    }
+  end
+
+  def from_project_check_in(%CheckIn{} = check_in) do
+    subs = Enum.map(check_in.subscription_list.subscriptions, fn s ->
+      {s.person.id, from_subscription(s)}
     end)
+
+    potential_subs = Enum.map(check_in.project.contributors, fn c ->
+      {c.person.id, from_project_contributor(c)}
+    end)
+
+    Map.merge(Map.new(subs), Map.new(potential_subs), fn _id, _sub, potential_sub ->
+      Map.put(potential_sub, :is_subscribed, true)
+    end)
+    |> Map.values()
+  end
+
+  #
+  # Helpers
+  #
+
+  defp from_subscription(%Subscription{} = subscription) do
+    %__MODULE__{
+      person: subscription.person,
+      role: subscription.person.title,
+      priority: false,
+      is_subscribed: true,
+    }
+  end
+
+  defp find_role_and_priority(%Contributor{} = contributor) do
+    case contributor.role do
+      :champion -> [role: "Champion", priority: true]
+      :reviewer -> [role: "Reviewer", priority: true]
+      _ -> [role: contributor.responsibility, priority: false]
+    end
   end
 end

--- a/lib/operately/notifications/subscribers_loader.ex
+++ b/lib/operately/notifications/subscribers_loader.ex
@@ -15,7 +15,7 @@ defmodule Operately.Notifications.SubscribersLoader do
 
     - ignore_ids: list of person IDs to exclude from the final result.
   """
-  def load(resource, people, ignore_ids \\ []) do
+  def load_for_notifications(resource, people, ignore_ids \\ []) do
     query = from(subs in Operately.Notifications.Subscription,
       join: p in assoc(subs, :person),
       join: m in assoc(p, :access_group_memberships),

--- a/lib/operately/notifications/subscribers_loader.ex
+++ b/lib/operately/notifications/subscribers_loader.ex
@@ -16,19 +16,31 @@ defmodule Operately.Notifications.SubscribersLoader do
     - ignore_ids: list of person IDs to exclude from the final result.
   """
   def load_for_notifications(resource, people, ignore_ids \\ []) do
+    resource
+    |> preload_subscriptions()
+    |> filter_subscribers(people)
+    |> Enum.uniq()
+    |> Enum.filter(&(not Enum.member?(ignore_ids, &1)))
+  end
+
+  @doc """
+    Preloads a resource's subscriptions.
+
+    Parameters:
+    - resource: struct which has a subscriptions list (e.g. message, project check-in, goal update).
+      It must have `access_context` preloaded.
+  """
+  def preload_subscriptions(resource) do
     query = from(subs in Operately.Notifications.Subscription,
       join: p in assoc(subs, :person),
       join: m in assoc(p, :access_group_memberships),
       join: g in assoc(m, :group),
       join: b in Binding, on: b.group_id == g.id and b.context_id == ^resource.access_context.id and b.access_level >= ^Binding.view_access(),
+      preload: [person: p],
       select: subs
     )
 
-    resource
-    |> Repo.preload(subscription_list: [subscriptions: query])
-    |> filter_subscribers(people)
-    |> Enum.uniq()
-    |> Enum.filter(&(not Enum.member?(ignore_ids, &1)))
+    Repo.preload(resource, subscription_list: [subscriptions: query])
   end
 
   defp filter_subscribers(%{subscription_list: list = %{send_to_everyone: false}}, _) do

--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -1,10 +1,13 @@
 defmodule Operately.Projects.CheckIn do
   use Operately.Schema
+  use Operately.Repo.Getter
+
+  alias Operately.Notifications
 
   schema "project_check_ins" do
     belongs_to :author, Operately.People.Person, foreign_key: :author_id
     belongs_to :project, Operately.Projects.Project, foreign_key: :project_id, where: [deleted_at: nil]
-    belongs_to :subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id
+    belongs_to :subscription_list, Notifications.SubscriptionList, foreign_key: :subscription_list_id
 
     field :status, :string
     field :description, :map

--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -24,6 +24,7 @@ defmodule Operately.Projects.CheckIn do
 
     timestamps()
     requester_access_level()
+    request_info()
   end
 
   def changeset(attrs) do

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -20,6 +20,6 @@ defmodule Operately.Projects.Notifications do
 
     people = Enum.map(check_in.project.contributors, &(&1.person))
 
-    SubscribersLoader.load(check_in, people, ignore)
+    SubscribersLoader.load_for_notifications(check_in, people, ignore)
   end
 end

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -170,6 +170,13 @@ defmodule Operately.Projects.Project do
     Map.put(project, :permissions, perms)
   end
 
+  def set_permissions(%{project: project = %__MODULE__{}} = parent) do
+    perms = Permissions.calculate(parent.request_info.access_level)
+    project = Map.put(project, :permissions, perms)
+
+    %{parent | project: project}
+  end
+
   def set_potential_subscribers(project = %__MODULE__{}) do
     subscribers = Operately.Notifications.Subscriber.from_project_contributor(project.contributors)
     Map.put(project, :potential_subscribers, subscribers)

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -8,6 +8,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   inputs do
     field :id, :string
     field :include_author, :boolean
+    field :include_acknowledged_by, :boolean
     field :include_project, :boolean
     field :include_reactions, :boolean
     field :include_subscriptions, :boolean
@@ -46,6 +47,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   defp preload(inputs) do
     OperatelyWeb.Api.Helpers.Inputs.parse_includes(inputs, [
       include_author: [:author],
+      include_acknowledged_by: [:acknowledged_by],
       include_project: [project: [:reviewer, [contributors: :person]]],
       include_reactions: [reactions: :person],
       include_subscriptions: Subscription.preload_subscriptions(),

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -11,6 +11,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
     field :include_project, :boolean
     field :include_reactions, :boolean
     field :include_subscriptions, :boolean
+    field :include_potential_subscribers, :boolean
   end
 
   outputs do
@@ -45,15 +46,17 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   defp preload(inputs) do
     OperatelyWeb.Api.Helpers.Inputs.parse_includes(inputs, [
       include_author: [:author],
+      include_project: [project: [:reviewer, [contributors: :person]]],
       include_reactions: [reactions: :person],
       include_subscriptions: Subscription.preload_subscriptions(),
-      include_project: [project: [:reviewer, [contributors: :person]]],
+      include_potential_subscribers: [:access_context, project: [contributors: :person]],
     ])
   end
 
   defp after_load(inputs) do
     OperatelyWeb.Api.Helpers.Inputs.parse_includes(inputs, [
       include_project: &Project.set_permissions/1,
+      include_potential_subscribers: &CheckIn.set_potential_subscribers/1,
     ])
   end
 end

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -2,8 +2,6 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters
-
   alias Operately.Projects.{CheckIn, Project}
   alias Operately.Notifications.Subscription
 
@@ -20,56 +18,42 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   end
 
   def call(conn, inputs) do
-    case decode_id(inputs[:id]) do
-      {:ok, id} ->
-        project_check_in = load(me(conn), id, inputs)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.id) end)
+    |> run(:check_in, fn ctx -> load(ctx, inputs) end)
+    |> run(:serialized, fn ctx -> {:ok, %{project_check_in: Serializer.serialize(ctx.check_in, level: :full)}} end)
+    |> respond()
+ end
 
-        if nil == project_check_in do
-          {:error, :not_found}
-        else
-          {:ok, %{project_check_in: Serializer.serialize(project_check_in, level: :full)}}
-        end
-      {:error, _} -> {:error, :bad_request}
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :check_in, _} -> {:error, :not_found}
+      _ -> {:error, :internal_server_error}
     end
   end
 
-  defp load(person, id, inputs) do
-    requested = extract_include_filters(inputs)
-
-    query = from p in CheckIn,
-      where: p.id == ^id,
-      preload: [:acknowledged_by]
-
-    query
-    |> include_requested(requested)
-    |> filter_by_view_access(person.id, join_parent: :project)
-    |> Repo.one()
-    |> load_project(inputs, person)
+  defp load(ctx, inputs) do
+    CheckIn.get(ctx.me, id: ctx.id, opts: [
+      preload: preload(inputs),
+      after_load: after_load(inputs),
+    ])
   end
 
-  def include_requested(query, requested) do
-    Enum.reduce(requested, query, fn include, q ->
-      case include do
-        :include_author -> from p in q, preload: [:author]
-        :include_reactions -> from p in q, preload: [reactions: :person]
-        :include_subscriptions -> Subscription.preload_subscriptions(q)
-        _ -> q
-      end
-    end)
+  defp preload(inputs) do
+    OperatelyWeb.Api.Helpers.Inputs.parse_includes(inputs, [
+      include_author: [:author],
+      include_reactions: [reactions: :person],
+      include_subscriptions: Subscription.preload_subscriptions(),
+      include_project: [project: [:reviewer, [contributors: :person]]],
+    ])
   end
 
-  def load_project(check_in, inputs, person) do
-    if inputs[:include_project] do
-      {:ok, project} = Operately.Projects.Project.get(person, id: check_in.project_id, opts: [
-        with_deleted: true, 
-        preload: [:reviewer, [contributors: :person]],
-        after_load: [&Project.set_permissions/1]
-      ])
-
-      %{check_in | project: project}
-    else
-      check_in
-    end
+  defp after_load(inputs) do
+    OperatelyWeb.Api.Helpers.Inputs.parse_includes(inputs, [
+      include_project: &Project.set_permissions/1,
+    ])
   end
-
 end

--- a/lib/operately_web/api/serializers/project_check_in.ex
+++ b/lib/operately_web/api/serializers/project_check_in.ex
@@ -10,7 +10,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.CheckIn do
       project: OperatelyWeb.Api.Serializer.serialize(check_in.project, level: :full),
       reactions: OperatelyWeb.Api.Serializer.serialize(check_in.reactions),
       author: OperatelyWeb.Api.Serializer.serialize(check_in.author),
-      subscription_list: OperatelyWeb.Api.Serializer.serialize(check_in.subscription_list)
+      subscription_list: OperatelyWeb.Api.Serializer.serialize(check_in.subscription_list),
+      potential_subscribers: OperatelyWeb.Api.Serializer.serialize(check_in.potential_subscribers),
     }
   end
 

--- a/lib/operately_web/api/serializers/subscriber.ex
+++ b/lib/operately_web/api/serializers/subscriber.ex
@@ -3,6 +3,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Notifications.Subscriber d
     %{
       role: subscriber.role,
       priority: subscriber.priority,
+      is_subscribed: subscriber.is_subscribed,
       person: OperatelyWeb.Api.Serializer.serialize(subscriber.person),
     }
   end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -445,6 +445,7 @@ defmodule OperatelyWeb.Api.Types do
   object :subscriber do
     field :role, :string
     field :priority, :boolean
+    field :is_subscribed, :boolean
     field :person, :person
   end
 
@@ -929,6 +930,7 @@ defmodule OperatelyWeb.Api.Types do
     field :acknowledged_by, :person
     field :reactions, list_of(:reaction)
     field :subscription_list, :subscription_list
+    field :potential_subscribers, list_of(:subscriber)
   end
 
   object :activity_content_project_check_in_commented do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,6 +26,7 @@ defmodule Operately.Support.Factory do
   defdelegate add_project_reviewer(ctx, testid, project_name, opts \\ []), to: Projects
   defdelegate add_project_contributor(ctx, testid, project_name, opts \\ []), to: Projects
   defdelegate add_project_retrospective(ctx, testid, project_name, author_name), to: Projects
+  defdelegate add_project_check_in(ctx, testid, project_name, author_name), to: Projects
   defdelegate edit_project_company_members_access(ctx, project_name, access_level), to: Projects
   defdelegate edit_project_space_members_access(ctx, project_name, access_level), to: Projects
 

--- a/test/support/factory/projects.ex
+++ b/test/support/factory/projects.ex
@@ -76,6 +76,18 @@ defmodule Operately.Support.Factory.Projects do
     Map.put(ctx, testid, retrospective)
   end
 
+  def add_project_check_in(ctx, testid, project_name, author_name) do
+    project = Map.fetch!(ctx, project_name)
+    author = Map.fetch!(ctx, author_name)
+
+    check_in = Operately.ProjectsFixtures.check_in_fixture(%{
+      project_id: project.id,
+      author_id: author.id,
+    })
+
+    Map.put(ctx, testid, check_in)
+  end
+
   def edit_project_company_members_access(ctx, project_name, access_level) do
     project = Map.fetch!(ctx, project_name)
 


### PR DESCRIPTION
Now, `OperatelyWeb.Api.Queries.GetProjectCheckIn` can also include potential subscribers.