### PR TITLE
chore: Extract navigate back to a single Paper component

### DIFF
--- a/assets/js/components/PaperContainer/Navigation.tsx
+++ b/assets/js/components/PaperContainer/Navigation.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import * as Icons from "@tabler/icons-react";
+
+import { Link } from "@/components/Link";
+
+export function Navigation({ children }) {
+  return (
+    <div className="bg-surface-dimmed flex items-center justify-center gap-1 pt-2 pb-1 mx-10 font-semibold rounded-t border-t border-x border-surface-outline">
+      {children}
+    </div>
+  );
+}
+
+interface NavItemProps {
+  linkTo: string;
+  children: React.ReactNode;
+  testId?: string;
+}
+
+export function NavItem({ linkTo, children, testId }: NavItemProps) {
+  return (
+    <Link to={linkTo} testId={testId}>
+      <span className="flex items-center gap-1.5">{children}</span>
+    </Link>
+  );
+}
+
+export function NavSeparator() {
+  return (
+    <div className="shrink-0">
+      <Icons.IconSlash size={16} />
+    </div>
+  );
+}
+
+export function NavigateBack({ to, title }) {
+  return (
+    <div className="flex items-center justify-center mb-4">
+      <Link to={to}>
+        <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
+        {title}
+      </Link>
+    </div>
+  );
+}

--- a/assets/js/components/PaperContainer/index.tsx
+++ b/assets/js/components/PaperContainer/index.tsx
@@ -22,13 +22,14 @@
  */
 
 import React from "react";
-import { Link } from "@/components/Link";
+
+import classNames from "classnames";
 import { useLoaderData, useRevalidator } from "react-router-dom";
-import * as Icons from "@tabler/icons-react";
 
 import { Context } from "./Context";
 export { DimmedSection } from "./DimmedSection";
 export { Banner, Header } from "./Banner";
+export { Navigation, NavItem, NavSeparator, NavigateBack } from "./Navigation";
 
 export type Size = "small" | "medium" | "large" | "xlarge" | "xxlarge";
 
@@ -44,49 +45,21 @@ interface RootProps {
   size?: Size;
   children?: React.ReactNode;
   fluid?: boolean;
+  className?: string;
 }
 
-export function Root({ size, children, fluid = false }: RootProps): JSX.Element {
+export function Root({ size, children, className, fluid = false }: RootProps): JSX.Element {
   size = size || "medium";
 
-  const className = fluid
-    ? "flex-1 mx-auto my-10 relative " + "w-[90%]"
-    : "flex-1 mx-auto my-10 relative " + sizes[size];
+  className = classNames(className, "flex-1 mx-auto my-10 relative", {
+    "w-[90%]": fluid,
+    [sizes[size]]: !fluid,
+  });
 
   return (
     <Context.Provider value={{ size }}>
       <div className={className}>{children}</div>
     </Context.Provider>
-  );
-}
-
-export function Navigation({ children }) {
-  return (
-    <div className="bg-surface-dimmed flex items-center justify-center gap-1 pt-2 pb-1 mx-10 font-semibold rounded-t border-t border-x border-surface-outline">
-      {children}
-    </div>
-  );
-}
-
-interface NavItemProps {
-  linkTo: string;
-  children: React.ReactNode;
-  testId?: string;
-}
-
-export function NavItem({ linkTo, children, testId }: NavItemProps) {
-  return (
-    <Link to={linkTo} testId={testId}>
-      <span className="flex items-center gap-1.5">{children}</span>
-    </Link>
-  );
-}
-
-export function NavSeparator() {
-  return (
-    <div className="shrink-0">
-      <Icons.IconSlash size={16} />
-    </div>
   );
 }
 

--- a/assets/js/pages/DesignPage/index.tsx
+++ b/assets/js/pages/DesignPage/index.tsx
@@ -1,11 +1,8 @@
 import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 
 import { Logo } from "@/layouts/DefaultLayout/Logo";
-import { Link } from "@/components/Link";
-
 import { Colors } from "./Colors";
 import { Links } from "./Links";
 import { Buttons } from "./Buttons";
@@ -20,7 +17,7 @@ export function Page() {
   return (
     <Pages.Page title={"Design System"}>
       <Paper.Root size="large">
-        <BackToLobbyLink />
+        <Paper.NavigateBack to={"/"} title="Back to the Lobby" />
         <Paper.Body>
           <TitleRow />
           <Colors />
@@ -33,17 +30,6 @@ export function Page() {
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>
-  );
-}
-
-function BackToLobbyLink() {
-  return (
-    <div className="flex items-center mb-4 mt-12">
-      <Link to={"/"}>
-        <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
-        Back to the Lobby
-      </Link>
-    </div>
   );
 }
 

--- a/assets/js/pages/GoalAddPage/page.tsx
+++ b/assets/js/pages/GoalAddPage/page.tsx
@@ -4,7 +4,6 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 
 import { PrimaryButton } from "@/components/Buttons";
-import { DimmedLink } from "@/components/Link";
 import { useLoadedData } from "./loader";
 import { FormState, useForm, Form } from "@/features/goals/GoalForm";
 import { useMe } from "@/contexts/CurrentUserContext";
@@ -35,9 +34,7 @@ function NewGoalForSpacePage({ form }: { form: FormState }) {
   return (
     <Pages.Page title="New Goal">
       <Paper.Root size="large">
-        <div className="flex items-center justify-center mb-4 gap-4">
-          <DimmedLink to={Paths.spacePath(space!.id!)}>Back to {space!.name} Space</DimmedLink>
-        </div>
+        <Paper.NavigateBack to={Paths.goalsPath()} title={`Back to ${space!.name} Space`} />
 
         <h1 className="mb-4 font-bold text-3xl text-center">Adding a new subgoal for {space!.name}</h1>
 
@@ -57,9 +54,7 @@ function NewGoalPage({ form }: { form: FormState }) {
   return (
     <Pages.Page title="New Goal">
       <Paper.Root size="large">
-        <div className="flex items-center justify-center mb-4 gap-4">
-          <DimmedLink to={Paths.goalsPath()}>Back to Goals</DimmedLink>
-        </div>
+        <Paper.NavigateBack to={Paths.goalsPath()} title="Back to Goals" />
 
         <h1 className="mb-4 font-bold text-3xl text-center">
           Adding a new {isCompanyWide ? "company-wide" : " "} goal

--- a/assets/js/pages/GroupAppearancePage/page.tsx
+++ b/assets/js/pages/GroupAppearancePage/page.tsx
@@ -2,10 +2,8 @@ import React from "react";
 
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import * as Spaces from "@/models/spaces";
 
-import { Link } from "@/components/Link";
 import { useLoadedData } from "./loader";
 import { GhostButton } from "@/components/Buttons";
 import { useNavigateTo } from "@/routes/useNavigateTo";
@@ -23,12 +21,7 @@ export function Page() {
   return (
     <Pages.Page title={["Appearance Settings", space.name!]}>
       <Paper.Root size="small">
-        <div className="flex items-center justify-center mb-2">
-          <Link to={Paths.spacePath(space.id!)}>
-            <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
-            Back to the {space.name} Space
-          </Link>
-        </div>
+        <Paper.NavigateBack to={Paths.spacePath(space.id!)} title={`Back to ${space.name} Space`} />
 
         <Paper.Body minHeight="none">
           <div className="font-extrabold text-2xl text-center">Appearance of {space.name}</div>

--- a/assets/js/pages/GroupMembersPage/index.tsx
+++ b/assets/js/pages/GroupMembersPage/index.tsx
@@ -1,16 +1,12 @@
-import React from "react";
-
-import { useDocumentTitle } from "@/layouts/header";
-
+import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import * as Spaces from "@/models/spaces";
+import * as Pages from "@/components/Pages";
 
 import Avatar from "@/components/Avatar";
 import { SecondaryButton } from "@/components/Buttons";
 
 import AddMembersModal from "./AddMembersModal";
-import { Link } from "@/components/Link";
 import { Paths } from "@/routes/paths";
 
 interface LoadedData {
@@ -25,23 +21,18 @@ export function Page() {
   const [{ space }] = Paper.useLoadedData() as [LoadedData, () => void];
   const [_, refetch] = Paper.useLoadedData() as [LoadedData, () => void];
 
-  useDocumentTitle(space.name + " Members");
-
   return (
-    <Paper.Root size="medium">
-      <div className="flex items-center justify-center mb-2">
-        <Link to={Paths.spacePath(space.id!)}>
-          <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
-          Back to the {space.name} Space
-        </Link>
-      </div>
+    <Pages.Page title={space.name + " Members"}>
+      <Paper.Root size="medium">
+        <Paper.NavigateBack to={Paths.spacePath(space.id!)} title={`Back to ${space.name} Space`} />
 
-      <Paper.Body minHeight="none">
-        <Header space={space} />
-        <AddMembersModal spaceId={space.id!} onSubmit={refetch} members={space.members} />
-        <MemberList space={space} />
-      </Paper.Body>
-    </Paper.Root>
+        <Paper.Body minHeight="none">
+          <Header space={space} />
+          <AddMembersModal spaceId={space.id!} onSubmit={refetch} members={space.members} />
+          <MemberList space={space} />
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
   );
 }
 

--- a/assets/js/pages/NewCompanyPage/index.tsx
+++ b/assets/js/pages/NewCompanyPage/index.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import * as Api from "@/api";
 
-import { Link } from "@/components/Link";
 import { Paths } from "@/routes/paths";
 import { TextInput } from "@/components/Form";
 import { PrimaryButton } from "@/components/Buttons";
@@ -20,13 +18,8 @@ export function Page() {
 
   return (
     <Pages.Page title={"New Company"}>
-      <Paper.Root size="small">
-        <div className="flex items-center justify-center mb-4 mt-24">
-          <Link to={Paths.lobbyPath()}>
-            <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
-            Back to the Lobby
-          </Link>
-        </div>
+      <Paper.Root size="small" className="mt-24">
+        <Paper.NavigateBack to={Paths.lobbyPath()} title="Back to the Lobby" />
 
         <Paper.Body>
           <div className="flex items-center justify-between">

--- a/assets/js/pages/ProjectAddPage/page.tsx
+++ b/assets/js/pages/ProjectAddPage/page.tsx
@@ -5,7 +5,6 @@ import * as Icons from "@tabler/icons-react";
 import * as Projects from "@/models/projects";
 
 import { useLoadedData } from "./loader";
-import { DimmedLink } from "@/components/Link";
 import { Paths, compareIds } from "@/routes/paths";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { useNavigate } from "react-router-dom";
@@ -44,17 +43,9 @@ function Navigation() {
   if (spaceID && space) {
     const spaceProjectsPath = Paths.spaceProjectsPath(spaceID!);
 
-    return (
-      <div className="flex items-center justify-center mb-4 gap-4">
-        <DimmedLink to={spaceProjectsPath}>Back to {space!.name} Space</DimmedLink>
-      </div>
-    );
+    return <Paper.NavigateBack to={spaceProjectsPath} title={`Back to ${space!.name} Space`} />;
   } else {
-    return (
-      <div className="flex items-center justify-center mb-4 gap-4">
-        <DimmedLink to={Paths.projectsPath()}>Back to Projects</DimmedLink>
-      </div>
-    );
+    return <Paper.NavigateBack to={Paths.projectsPath()} title="Back to Projects" />;
   }
 }
 

--- a/assets/js/pages/SpaceEditPage/page.tsx
+++ b/assets/js/pages/SpaceEditPage/page.tsx
@@ -1,13 +1,11 @@
 import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
 import * as Forms from "@/components/Form";
 
 import { useForm, FormState } from "./useForm";
 import { useLoadedData } from "./loader";
 import { PrimaryButton } from "@/components/Buttons";
-import { Link } from "@/components/Link";
 import { Paths } from "@/routes/paths";
 
 export function Page() {
@@ -17,12 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Appearance Settings", space.name!]}>
       <Paper.Root size="small">
-        <div className="flex items-center justify-center mb-2">
-          <Link to={Paths.spacePath(space.id!)}>
-            <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
-            Back to the {space.name} Space
-          </Link>
-        </div>
+        <Paper.NavigateBack to={Paths.spacePath(space.id!)} title={`Back to ${space.name} Space`} />
 
         <Paper.Body minHeight="none">
           <div className="font-extrabold text-2xl text-center">Editing {space.name}</div>


### PR DESCRIPTION
Reducing duplication by introducing a `<NavigateBack to={...} title="Back to Lobby />` component.

![Screenshot 2024-09-27 at 16 18 24](https://github.com/user-attachments/assets/bf220f79-78ff-4b93-8ade-2947ef39b225)
