### PR TITLE
feat: Build a demo company

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1526,6 +1526,7 @@ export interface AcknowledgeProjectCheckInResult {
 export interface AddCompanyInput {
   companyName?: string | null;
   title?: string | null;
+  isDemo?: boolean | null;
 }
 
 export interface AddCompanyResult {

--- a/assets/js/pages/NewCompanyPage/index.tsx
+++ b/assets/js/pages/NewCompanyPage/index.tsx
@@ -16,9 +16,18 @@ export function Page() {
   const [add] = Api.useAddCompany();
 
   const form = Forms.useForm({
-    fields: { companyName: "", title: "" },
+    fields: {
+      companyName: "",
+      title: "",
+      isDemo: "false",
+    },
     submit: async () => {
-      const res = await add({ ...form.values });
+      const res = await add({
+        companyName: form.values.companyName,
+        title: form.values.title,
+        isDemo: form.values.isDemo == "true",
+      });
+
       navigate(Paths.companyHomePath(res.company.id));
     },
   });
@@ -34,6 +43,17 @@ export function Page() {
             <Forms.FieldGroup>
               <Forms.TextInput field="companyName" label="Name of the company" placeholder="e.g. Acme Co." />
               <Forms.TextInput field="title" label="What's your title in the company?" placeholder="e.g. Founder" />
+
+              {window.appConfig.demoBuilder && (
+                <Forms.RadioButtons
+                  field="isDemo"
+                  label="Is this a demo company?"
+                  options={[
+                    { label: "Yes", value: "true" },
+                    { label: "No", value: "false" },
+                  ]}
+                />
+              )}
             </Forms.FieldGroup>
 
             <Forms.Submit saveText="Create Company" buttonSize="sm" />

--- a/assets/js/window.d.ts
+++ b/assets/js/window.d.ts
@@ -10,6 +10,7 @@ declare global {
 
   interface AppConfig {
     environment: string;
+    demoBuilder: boolean;
 
     sentry: SentryConfig;
     api: ApiConfig;

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,11 +20,10 @@ if System.get_env("PHX_SERVER") do
   config :operately, OperatelyWeb.Endpoint, server: true
 end
 
+config :operately, :demo_builder_allowed, System.get_env("OPERATELY_DEMO_BUILDER_ALLOWED") == "true"
 config :operately, :blob_token_secret_key, System.get_env("OPERATELY_BLOB_TOKEN_SECRET_KEY")
-
 config :operately, :js_sentry_enabled, System.get_env("OPERATELY_JS_SENTRY_ENABLED") == "true"
 config :operately, :js_sentry_dsn, System.get_env("OPERATELY_JS_SENTRY_DSN")
-
 config :operately, :storage_type, System.get_env("OPERATELY_STORAGE_TYPE", "local")
 
 # Determines if the 'Sign in with Google' feature is enabled.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - NOTIFICATION_EMAIL=notifications@locahost.dev
       - OPERATELY_JS_SENTRY_ENABLED=false
       - OPERATELY_JS_SENTRY_DSN=not-set
+      - OPERATELY_DEMO_BUILDER_ALLOWED=true
       - CERT_DOMAIN=localhost
       - CERT_DB_DIR=/home/dev/certs
     env_file:

--- a/lib/operately/demo.ex
+++ b/lib/operately/demo.ex
@@ -1,9 +1,13 @@
 defmodule Operately.Demo do
   alias Operately.Demo.{Company, Employees, Spaces, Goals}
 
-  def run(owner_email) do
+  def run(account, company_name, title) do
+    verify_if_demo_can_be_run()
+
     context = %{
-      account: find_account!(owner_email)
+      account: account,
+      company_name: company_name,
+      title: title,
     }
 
     {:ok, context} = Operately.Repo.transaction(fn ->
@@ -17,6 +21,8 @@ defmodule Operately.Demo do
 
     :timer.sleep(2000) # wait for background job to finish
     mark_all_notifications_as_read(context)
+
+    {:ok, context.company}
   end
 
   def find_account!(email) do
@@ -28,6 +34,14 @@ defmodule Operately.Demo do
 
   def mark_all_notifications_as_read(context) do
     {:ok, _} = Operately.Notifications.mark_all_as_read(context.owner)
+  end
+
+  def verify_if_demo_can_be_run do
+    if Application.get_env(:operately, :demo_builder_allowed) do
+      :ok
+    else
+      raise "Demo builder is not allowed"
+    end
   end
 
 end

--- a/lib/operately/demo/company.ex
+++ b/lib/operately/demo/company.ex
@@ -9,8 +9,8 @@ defmodule Operately.Demo.Company do
     cleanup_acme_companies()
 
     {:ok, company} = Operately.Operations.CompanyAdding.run(%{
-      company_name: "Acme Inc.",
-      title: "Founder"
+      company_name: context.company_name,
+      title: context.title,
     }, context.account)
 
     owner = Operately.People.get_person!(context.account, company)

--- a/lib/operately_web/api/mutations/add_company.ex
+++ b/lib/operately_web/api/mutations/add_company.ex
@@ -4,6 +4,7 @@ defmodule OperatelyWeb.Api.Mutations.AddCompany do
   inputs do
     field :company_name, :string
     field :title, :string
+    field :is_demo, :boolean
   end
 
   outputs do
@@ -12,8 +13,15 @@ defmodule OperatelyWeb.Api.Mutations.AddCompany do
 
   def call(conn, inputs) do
     account = conn.assigns.current_account
-    {:ok, company} = Operately.Operations.CompanyAdding.run(inputs, account)
-
+    {:ok, company} = add_company(inputs, account)
     {:ok, %{company: OperatelyWeb.Api.Serializer.serialize(company)}}
+  end
+
+  def add_company(inputs, account) do
+    if inputs[:is_demo] do
+      Operately.Demo.run(account, inputs[:company_name], inputs[:title])
+    else
+      Operately.Operations.CompanyAdding.run(inputs, account)
+    end
   end
 end

--- a/lib/operately_web/components/layouts/root.html.heex
+++ b/lib/operately_web/components/layouts/root.html.heex
@@ -24,6 +24,7 @@
       window.appConfig = {};
 
       window.appConfig.environment = "<%= Application.get_env(:operately, :app_env) %>";
+      window.appConfig.demoBuilder = <%= Application.get_env(:operately, :demo_builder_allowed) %>;
 
       <%= if @current_account do %>
         window.appConfig.api = {};

--- a/test/operately/demo_test.exs
+++ b/test/operately/demo_test.exs
@@ -4,9 +4,10 @@ defmodule Operately.DemoTest do
   import Operately.PeopleFixtures
 
   test "it creates a demo company without failures" do
-    account_fixture(%{full_name: "Peter Parker", email: "peter.parker@localhost"})
+    account = account_fixture(%{full_name: "Peter Parker", email: "peter.parker@localhost"})
 
-    assert {:ok, _} = Operately.Demo.run("peter.parker@localhost")
+    assert {:ok, company} = Operately.Demo.run(account, "Acme Inc.", "CEO")
+    assert %Operately.Companies.Company{} = company
     assert Operately.Companies.get_company_by_name("Acme Inc.")
   end
 end


### PR DESCRIPTION
Turns out that with a couple of lines of code we can expose this in the UI. The new option is only available if the OPERATELY_DEMO_BUILDER_ALLOWED environment is set to true.