### PR TITLE
chore: GetGoalProgressUpdate query can include potential subscribers

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -657,6 +657,7 @@ export interface GoalProgressUpdate {
   commentsCount?: number | null;
   goal?: Goal | null;
   subscriptionList?: SubscriptionList | null;
+  potentialSubscribers?: Subscriber[] | null;
 }
 
 export interface GoalTargetUpdates {
@@ -1252,6 +1253,7 @@ export interface GetGoalProgressUpdateInput {
   includeChampion?: boolean | null;
   includeSpaceMembers?: boolean | null;
   includeSubscriptions?: boolean | null;
+  includePotentialSubscribers?: boolean | null;
 }
 
 export interface GetGoalProgressUpdateResult {

--- a/lib/operately/notifications/subscriber.ex
+++ b/lib/operately/notifications/subscriber.ex
@@ -1,6 +1,8 @@
 defmodule Operately.Notifications.Subscriber do
   alias Operately.Projects.{Contributor, CheckIn}
+  alias Operately.Goals.{Update, Goal}
   alias Operately.Notifications.Subscription
+  alias Operately.People.Person
 
   defstruct [
     :person,
@@ -16,24 +18,34 @@ defmodule Operately.Notifications.Subscriber do
   def from_project_contributor(%Contributor{} = contributor) do
     [role: role, priority: priority] = find_role_and_priority(contributor)
 
-    %__MODULE__{
-      person: contributor.person,
-      role: role,
-      priority: priority,
-      is_subscribed: false,
-    }
+    build_struct(contributor.person, role, priority: priority)
   end
 
   def from_project_check_in(%CheckIn{} = check_in) do
-    subs = Enum.map(check_in.subscription_list.subscriptions, fn s ->
+    subs = Enum.into(check_in.subscription_list.subscriptions, %{}, fn s ->
       {s.person.id, from_subscription(s)}
     end)
 
-    potential_subs = Enum.map(check_in.project.contributors, fn c ->
+    potential_subs = Enum.into(check_in.project.contributors, %{}, fn c ->
       {c.person.id, from_project_contributor(c)}
     end)
 
-    Map.merge(Map.new(subs), Map.new(potential_subs), fn _id, _sub, potential_sub ->
+    Map.merge(subs, potential_subs, fn _id, _sub, potential_sub ->
+      Map.put(potential_sub, :is_subscribed, true)
+    end)
+    |> Map.values()
+  end
+
+  def from_goal_update(%Update{} = update) do
+    subs = Enum.into(update.subscription_list.subscriptions, %{}, fn s ->
+      {s.person.id, from_subscription(s)}
+    end)
+
+    potential_subs = Enum.into(from_goal(update.goal), %{}, fn sub ->
+      {sub.person.id, sub}
+    end)
+
+    Map.merge(subs, potential_subs, fn _id, _sub, potential_sub ->
       Map.put(potential_sub, :is_subscribed, true)
     end)
     |> Map.values()
@@ -43,13 +55,34 @@ defmodule Operately.Notifications.Subscriber do
   # Helpers
   #
 
-  defp from_subscription(%Subscription{} = subscription) do
-    %__MODULE__{
-      person: subscription.person,
-      role: subscription.person.title,
-      priority: false,
-      is_subscribed: true,
+  defp from_goal(goal = %Goal{}) do
+    members = Enum.into(goal.group.members, %{}, fn p ->
+      {p.id, from_person(p)}
+    end)
+
+    contribs = %{
+      goal.champion_id => from_goal_champion(goal.champion),
+      goal.reviewer_id => from_goal_reviewer(goal.reviewer),
     }
+
+    Map.merge(members, contribs)
+    |> Map.values()
+  end
+
+  defp from_subscription(subscription = %Subscription{}) do
+    build_struct(subscription.person, subscription.person.title, is_subscribed: true)
+  end
+
+  defp from_person(person = %Person{}) do
+    build_struct(person, person.title)
+  end
+
+  defp from_goal_reviewer(reviewer = %Person{}) do
+    build_struct(reviewer, "Reviewer", priority: true)
+  end
+
+  defp from_goal_champion(champion = %Person{}) do
+    build_struct(champion, "Champion", priority: true)
   end
 
   defp find_role_and_priority(%Contributor{} = contributor) do
@@ -58,5 +91,17 @@ defmodule Operately.Notifications.Subscriber do
       :reviewer -> [role: "Reviewer", priority: true]
       _ -> [role: contributor.responsibility, priority: false]
     end
+  end
+
+  defp build_struct(person, role, opts \\ []) do
+    priority = Keyword.get(opts, :priority, :false)
+    is_subscribed = Keyword.get(opts, :is_subscribed, false)
+
+    %__MODULE__{
+      person: person,
+      role: role,
+      priority: priority,
+      is_subscribed: is_subscribed,
+    }
   end
 end

--- a/lib/operately_web/api/queries/get_goal_progress_update.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_update.ex
@@ -16,6 +16,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
     field :include_champion, :boolean
     field :include_space_members, :boolean
     field :include_subscriptions, :boolean
+    field :include_potential_subscribers, :boolean
   end
 
   outputs do
@@ -26,10 +27,9 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
     Action.new()
     |> Action.run(:me, fn -> find_me(conn) end)
     |> Action.run(:id, fn -> decode_id(inputs.id) end)
-    |> Action.run(:preload, fn -> include_requested(inputs) end)
-    |> Action.run(:check_in, fn ctx -> load(ctx) end)
-    |> Action.run(:check_permissions, fn ctx -> Permissions.check(ctx.check_in.requester_access_level, :can_view) end)
-    |> Action.run(:serialized, fn ctx -> {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(ctx.check_in, level: :full)}} end)
+    |> Action.run(:update, fn ctx -> load(ctx, inputs) end)
+    |> Action.run(:check_permissions, fn ctx -> Permissions.check(ctx.update.requester_access_level, :can_view) end)
+    |> Action.run(:serialized, fn ctx -> {:ok, %{update: OperatelyWeb.Api.Serializer.serialize(ctx.update, level: :full)}} end)
     |> respond()
   end
 
@@ -37,44 +37,50 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
       {:error, :id, _} -> {:error, :bad_request}
-      {:error, :check_in, _} -> {:error, :not_found}
+      {:error, :update, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :not_found}
       _ -> {:error, :not_found}
     end
   end
 
-  defp load(ctx) do
+  defp load(ctx, inputs) do
     Update.get(ctx.me, id: ctx.id, opts: [
-      preload: ctx.preload,
+      preload: preload(inputs),
+      after_load: after_load(inputs, ctx.me),
     ])
-    |> load_goal_permissions(ctx.me)
   end
 
-  defp include_requested(inputs) do
-    requested = extract_include_filters(inputs)
-
-    preload =
-      Enum.reduce(requested, [], fn include, result ->
-        case include do
-          :include_author -> [:author | result]
-          :include_acknowledged_by -> [:acknowledged_by | result]
-          :include_reactions -> [[reactions: :person] | result]
-          :include_goal -> [:goal | result]
-          :include_goal_targets -> [[goal: :targets] | result]
-          :include_champion -> [[goal: :champion] | result]
-          :include_reviewer -> [[goal: :reviewer] | result]
-          :include_space_members -> [[goal: [group: [:members, :company]]] | result]
-          :include_subscriptions -> [Subscription.preload_subscriptions() | result]
-          _ -> result
-        end
-      end)
-
-    {:ok, preload}
+  defp preload(inputs) do
+    Inputs.parse_includes(inputs, [
+      include_author: :author,
+      include_acknowledged_by: :acknowledged_by,
+      include_reactions: [reactions: :person],
+      include_goal: :goal,
+      include_goal_targets: [goal: :targets],
+      include_champion: [goal: :champion],
+      include_reviewer: [goal: :reviewer],
+      include_space_members: [goal: [group: [:members, :company]]],
+      include_subscriptions: Subscription.preload_subscriptions(),
+      include_potential_subscribers: [:access_context, goal: [:champion, :reviewer, group: :members]],
+    ])
   end
 
-  defp load_goal_permissions({:error, reason}, _), do: {:error, reason}
-  defp load_goal_permissions({:ok, check_in}, person) do
-    goal = Goal.preload_permissions(check_in.goal, person)
-    {:ok, %{check_in | goal: goal}}
+  defp after_load(inputs, me) do
+    Inputs.parse_includes(inputs, [
+      include_potential_subscribers: &Update.set_potential_subscribers/1,
+    ])
+    ++
+    [load_goal_permissions(me)]
+  end
+
+  defp load_goal_permissions(person) do
+    fn update ->
+      if Ecto.assoc_loaded?(update.goal) do
+        goal = Goal.preload_permissions(update.goal, person)
+        %{update | goal: goal}
+      else
+        update
+      end
+    end
   end
 end

--- a/lib/operately_web/api/serializers/goal_update.ex
+++ b/lib/operately_web/api/serializers/goal_update.ex
@@ -13,6 +13,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update  do
       comments_count: Operately.Updates.count_comments(update.id, :goal_update),
       goal_target_updates: parse_targets(update.targets),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(update.subscription_list),
+      potential_subscribers: OperatelyWeb.Api.Serializer.serialize(update.potential_subscribers),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1008,6 +1008,7 @@ defmodule OperatelyWeb.Api.Types do
     field :comments_count, :integer
     field :goal, :goal
     field :subscription_list, :subscription_list
+    field :potential_subscribers, list_of(:subscriber)
   end
 
   object :goal_target_updates do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Support.Factory do
-  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages}
+  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages, Goals}
 
   def setup(ctx) do
     ctx = add_account(ctx, :account)
@@ -20,6 +20,10 @@ defmodule Operately.Support.Factory do
   # spaces
   defdelegate add_space(ctx, testid, opts \\ []), to: Spaces
   defdelegate add_space_member(ctx, testid, space_name, opts \\ []), to: Spaces
+
+  # goals
+  defdelegate add_goal(ctx, testid, space_name, opts \\ []), to: Goals
+  defdelegate add_goal_update(ctx, testid, goal_name, person_name) , to: Goals
 
   # projects
   defdelegate add_project(ctx, testid, space_name), to: Projects

--- a/test/support/factory/goals.ex
+++ b/test/support/factory/goals.ex
@@ -1,0 +1,29 @@
+defmodule Operately.Support.Factory.Goals do
+  alias Operately.Access.Binding
+
+  def add_goal(ctx, testid, space_name, opts \\ []) do
+    company_access = Keyword.get(opts, :company_access, Binding.view_access())
+    space_access = Keyword.get(opts, :space_access, Binding.comment_access())
+    champion = Keyword.get(opts, :champion, :creator)
+    reviewer = Keyword.get(opts, :reviewer, :creator)
+
+    goal = Operately.GoalsFixtures.goal_fixture(ctx.creator, %{
+      space_id: ctx[space_name].id,
+      champion_id: ctx[champion].id,
+      reviewer_id: ctx[reviewer].id,
+      company_access_level: company_access,
+      space_access_level: space_access,
+    })
+
+    Map.put(ctx, testid, goal)
+  end
+
+  def add_goal_update(ctx, testid, goal_name, person_name) do
+    goal = Map.fetch!(ctx, goal_name)
+    person = Map.fetch!(ctx, person_name)
+
+    update = Operately.GoalsFixtures.goal_update_fixture(person, goal)
+
+    Map.put(ctx, testid, update)
+  end
+end


### PR DESCRIPTION
Now, `OperatelyWeb.Api.Queries.GetGoalProgressUpdate` can also include potential subscribers.