### PR TITLE
chore: GetDiscussion query can include potential subscribers

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -583,6 +583,7 @@ export interface Discussion {
   reactions?: Reaction[] | null;
   comments?: Comment[] | null;
   subscriptionList?: SubscriptionList | null;
+  potentialSubscribers?: Subscriber[] | null;
 }
 
 export interface EditMemberPermissionsInput {
@@ -1210,6 +1211,7 @@ export interface GetDiscussionInput {
   includeSpace?: boolean | null;
   includeSpaceMembers?: boolean | null;
   includeSubscriptions?: boolean | null;
+  includePotentialSubscribers?: boolean | null;
 }
 
 export interface GetDiscussionResult {

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -2,10 +2,12 @@ defmodule Operately.Messages.Message do
   use Operately.Schema
   use Operately.Repo.Getter
 
+  alias Operately.Notifications
+
   schema "messages" do
     belongs_to :space, Operately.Groups.Group
     belongs_to :author, Operately.People.Person
-    belongs_to :subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id
+    belongs_to :subscription_list, Notifications.SubscriptionList, foreign_key: :subscription_list_id
 
     has_one :access_context, through: [:space, :access_context]
     has_many :reactions, Operately.Updates.Reaction, where: [entity_type: :message], foreign_key: :entity_id
@@ -13,6 +15,9 @@ defmodule Operately.Messages.Message do
 
     field :title
     field :body, :map
+
+    # populated with after load hooks
+    field :potential_subscribers, :any, virtual: true
 
     timestamps()
     requester_access_level()
@@ -27,5 +32,18 @@ defmodule Operately.Messages.Message do
     update
     |> cast(attrs, [:space_id, :author_id, :title, :body, :subscription_list_id])
     |> validate_required([:space_id, :author_id, :title, :body, :subscription_list_id])
+  end
+
+  #
+  # After load hooks
+  #
+
+  def set_potential_subscribers(message = %__MODULE__{}) do
+    subs =
+      message
+      |> Notifications.SubscribersLoader.preload_subscriptions()
+      |> Notifications.Subscriber.from_message()
+
+    %{message | potential_subscribers: subs}
   end
 end

--- a/lib/operately_web/api/serializers/message.ex
+++ b/lib/operately_web/api/serializers/message.ex
@@ -22,6 +22,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
       reactions: OperatelyWeb.Api.Serializer.serialize(message.reactions),
       comments: OperatelyWeb.Api.Serializer.serialize(message.comments),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(message.subscription_list),
+      potential_subscribers: OperatelyWeb.Api.Serializer.serialize(message.potential_subscribers),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -195,6 +195,7 @@ defmodule OperatelyWeb.Api.Types do
     field :reactions, list_of(:reaction)
     field :comments, list_of(:comment)
     field :subscription_list, :subscription_list
+    field :potential_subscribers, list_of(:subscriber)
   end
 
   object :activity do


### PR DESCRIPTION
`OperatelyWeb.Api.Queries.GetDiscussion` can now include potential subscribers.