### PR TITLE
chore: Disable auto-submit in forms

### DIFF
--- a/assets/js/components/Forms/Form.tsx
+++ b/assets/js/components/Forms/Form.tsx
@@ -4,9 +4,12 @@ import { FormContext } from "./FormContext";
 import { FormState } from "./useForm";
 
 export function Form({ form, children }: { form: FormState<any>; children: React.ReactNode }) {
+  //
+  // Submit the form when the user presses Enter in a field.
+  //
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await form.actions.submit();
+    if (form.submitOnEnter) await form.actions.submit();
   };
 
   return (

--- a/assets/js/components/Forms/useForm.tsx
+++ b/assets/js/components/Forms/useForm.tsx
@@ -9,6 +9,7 @@ import { State } from "./useForm/state";
 
 interface FormProps<T extends FieldObject> {
   fields: T;
+  submitOnEnter?: boolean;
   validate?: (addError: AddErrorFn) => void;
   submit: () => Promise<void> | void;
   cancel?: () => Promise<void> | void;
@@ -20,6 +21,7 @@ export interface FormState<T extends FieldObject> {
   state: State;
   errors: ErrorMap;
   hasCancel: boolean;
+  submitOnEnter: boolean;
   actions: {
     clearErrors: () => void;
     submit: () => void | Promise<void>;
@@ -34,6 +36,7 @@ export interface FormState<T extends FieldObject> {
 }
 
 export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T> {
+  const { submitOnEnter } = { submitOnEnter: true, ...props };
   const hasCancel = !!props.cancel;
 
   const [errors, setErrors] = React.useState<ErrorMap>({});
@@ -48,6 +51,7 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
     state,
     errors,
     hasCancel,
+    submitOnEnter,
     actions: {
       clearErrors,
       addValidation,
@@ -61,8 +65,6 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
 
         const errors = runValidations(form, validations, props.validate);
         if (Object.keys(errors).length > 0) {
-          console.log("Values", values);
-          console.log("Errors", errors);
           setErrors(errors);
           setState("idle");
           return;

--- a/assets/js/pages/DesignPage/Forms.tsx
+++ b/assets/js/pages/DesignPage/Forms.tsx
@@ -193,6 +193,7 @@ function ArrayForm() {
     submit: async () => {
       console.log("Form submitted with values:", form);
     },
+    submitOnEnter: false,
   });
 
   return (


### PR DESCRIPTION
This pull request introduces a new feature to allow forms to be submitted by pressing the Enter key. It also includes some code cleanup by removing unnecessary console logs. The most important changes include the addition of the `submitOnEnter` property to the form state and its usage in the form submission logic.

### New Feature: Submit Form on Enter Key Press

* [`assets/js/components/Forms/Form.tsx`](diffhunk://#diff-8eef0f58df09182a53c7bc8ee57659df335bf95574d4bf23ebdec783a6236672R7-R12): Modified the `onSubmit` function to check the `submitOnEnter` property before submitting the form.
* [`assets/js/components/Forms/useForm.tsx`](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aR12): Added the `submitOnEnter` property to the `FormProps` and `FormState` interfaces, and provided a default value in the `useForm` hook. [[1]](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aR12) [[2]](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aR24) [[3]](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aR39) [[4]](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aR54)

### Code Cleanup

* [`assets/js/components/Forms/useForm.tsx`](diffhunk://#diff-0291ddca8539a3cd36562be11acf3381bd9defb19540f71b87594029d0fe449aL64-L65): Removed unnecessary console logs from the form validation logic.

### Usage Example

* [`assets/js/pages/DesignPage/Forms.tsx`](diffhunk://#diff-6e472d137aed0f50c899a1b58c30b9db48a33d03bbb6bfc64f64a9db7e55d25cR196): Set the `submitOnEnter` property to `false` in the `ArrayForm` function to demonstrate its usage.