### PR TITLE
feat: Add subscriptions to project retrospective creation form

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1669,6 +1669,8 @@ export interface CloseGoalResult {
 export interface CloseProjectInput {
   projectId?: string | null;
   retrospective?: string | null;
+  sendNotificationsToEveryone?: boolean | null;
+  subscriberIds?: string[] | null;
 }
 
 export interface CloseProjectResult {

--- a/assets/js/features/ProjectRetrospectiveForm/Form.tsx
+++ b/assets/js/features/ProjectRetrospectiveForm/Form.tsx
@@ -5,6 +5,7 @@ import * as TipTapEditor from "@/components/Editor";
 import { PrimaryButton } from "@/components/Buttons";
 import { createTestId } from "@/utils/testid";
 import { FormState } from "./useForm";
+import { SubscribersSelector } from "@/features/Subscriptions";
 
 export function Form({ form }: { form: FormState }) {
   return (
@@ -24,6 +25,10 @@ export function Form({ form }: { form: FormState }) {
         editor={form.whatDidYouLearn.editor}
         error={form.errors.find((e) => e.field === "whatDidYouLearn")}
       />
+
+      {form.mode === "create" && (
+        <SubscribersSelector state={form.subscriptionsState} projectName={form.project!.name!} />
+      )}
 
       <SubmitButton form={form} />
     </>

--- a/assets/js/features/ProjectRetrospectiveForm/useForm.tsx
+++ b/assets/js/features/ProjectRetrospectiveForm/useForm.tsx
@@ -5,6 +5,8 @@ import * as TipTapEditor from "@/components/Editor";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { Paths } from "@/routes/paths";
+import { Subscriber } from "@/models/notifications";
+import { Options, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
 
 interface Error {
   field: string;
@@ -15,6 +17,7 @@ interface FormOptions {
   project?: Projects.Project;
   retrospective?: Projects.ProjectRetrospective;
   mode: "create" | "edit";
+  potentialSubscribers?: Subscriber[];
 }
 export interface FormState {
   project?: Projects.Project;
@@ -28,9 +31,14 @@ export interface FormState {
 
   submit: () => void;
   submittable: boolean;
+  subscriptionsState: SubscriptionsState;
 }
 
 export function useForm(options: FormOptions): FormState {
+  const subscriptionsState = useSubscriptions(options.potentialSubscribers || [], {
+    ignoreMe: true,
+    notifyPrioritySubscribers: true,
+  });
   const [errors, setErrors] = React.useState<Error[]>([]);
 
   const whatWentWell = useWhatWentWellEditor(options);
@@ -64,6 +72,8 @@ export function useForm(options: FormOptions): FormState {
           whatCouldHaveGoneBetter: whatCouldHaveGoneBetter.editor.getJSON(),
           whatDidYouLearn: whatDidYouLearn.editor.getJSON(),
         }),
+        sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
+        subscriberIds: subscriptionsState.currentSubscribersList,
       });
     } else {
       await edit({
@@ -94,6 +104,7 @@ export function useForm(options: FormOptions): FormState {
 
     submit,
     submittable,
+    subscriptionsState,
   };
 }
 

--- a/assets/js/pages/ProjectClosePage/loader.tsx
+++ b/assets/js/pages/ProjectClosePage/loader.tsx
@@ -11,6 +11,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       id: params.projectID,
       includeSpace: true,
       includePermissions: true,
+      includePotentialSubscribers: true,
     }).then((data) => data.project!),
   };
 }

--- a/assets/js/pages/ProjectClosePage/page.tsx
+++ b/assets/js/pages/ProjectClosePage/page.tsx
@@ -8,7 +8,7 @@ import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 
 export function Page() {
   const { project } = useLoadedData();
-  const form = useForm({ project, mode: "create" });
+  const form = useForm({ project, mode: "create", potentialSubscribers: project.potentialSubscribers! });
 
   return (
     <Pages.Page title={"Closing " + project.name}>

--- a/lib/operately/notifications/subscription_list.ex
+++ b/lib/operately/notifications/subscription_list.ex
@@ -4,7 +4,7 @@ defmodule Operately.Notifications.SubscriptionList do
 
   schema "subscription_lists" do
     field :parent_id, Ecto.UUID
-    field :parent_type, Ecto.Enum, values: [:project_check_in, :goal_update, :message]
+    field :parent_type, Ecto.Enum, values: [:project_check_in, :project_retrospective, :goal_update, :message]
     field :send_to_everyone, :boolean, default: false
 
     has_many :subscriptions, Operately.Notifications.Subscription, foreign_key: :subscription_list_id

--- a/lib/operately/operations/project_closed.ex
+++ b/lib/operately/operations/project_closed.ex
@@ -3,15 +3,22 @@ defmodule Operately.Operations.ProjectClosed do
   alias Operately.Repo
   alias Operately.Activities
   alias Operately.Projects.{Project, Retrospective}
+  alias Operately.Operations.Notifications.{Subscription, SubscriptionList}
 
-  def run(author, project, retrospective) do
+  def run(author, project, attrs) do
     Multi.new()
-    |> Multi.insert(:retrospective, Retrospective.changeset(%{
-      author_id: author.id,
-      project_id: project.id,
-      content: Jason.decode!(retrospective),
-      closed_at: DateTime.utc_now(),
-    }))
+    |> SubscriptionList.insert(attrs)
+    |> Subscription.insert(author, attrs)
+    |> Multi.insert(:retrospective, fn changes ->
+      Retrospective.changeset(%{
+        author_id: author.id,
+        project_id: project.id,
+        content: attrs.retrospective,
+        closed_at: DateTime.utc_now(),
+        subscription_list_id: changes.subscription_list.id,
+      })
+    end)
+    |> SubscriptionList.update(:retrospective)
     |> Multi.update(:project, fn changes ->
       Project.changeset(project,%{
         status: "closed",

--- a/lib/operately_web/api/mutations/close_project.ex
+++ b/lib/operately_web/api/mutations/close_project.ex
@@ -8,6 +8,8 @@ defmodule OperatelyWeb.Api.Mutations.CloseProject do
   inputs do
     field :project_id, :string
     field :retrospective, :string
+    field :send_notifications_to_everyone, :boolean
+    field :subscriber_ids, list_of(:string)
   end
 
   outputs do
@@ -17,10 +19,10 @@ defmodule OperatelyWeb.Api.Mutations.CloseProject do
   def call(conn, inputs) do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
-    |> run(:id, fn -> decode_id(inputs.project_id) end)
-    |> run(:project, fn ctx -> Project.get(ctx.me, id: ctx.id) end)
+    |> run(:attrs, fn -> parse_inputs(inputs) end)
+    |> run(:project, fn ctx -> Project.get(ctx.me, id: ctx.attrs.project_id) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.project.request_info.access_level, :can_close) end)
-    |> run(:operation, fn ctx -> ProjectClosed.run(ctx.me, ctx.project, inputs.retrospective) end)
+    |> run(:operation, fn ctx -> ProjectClosed.run(ctx.me, ctx.project, ctx.attrs) end)
     |> run(:serialized, fn ctx -> {:ok, %{retrospective: Serializer.serialize(ctx.operation)}} end)
     |> respond()
   end
@@ -28,11 +30,33 @@ defmodule OperatelyWeb.Api.Mutations.CloseProject do
   def respond(result) do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
-      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :attrs, _} -> {:error, :bad_request}
       {:error, :project, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}
     end
+  end
+
+  defp parse_inputs(inputs) do
+    {:ok, project_id} = decode_id(inputs.project_id)
+    {:ok, subscriber_ids} = decode_id(inputs[:subscriber_ids], :allow_nil)
+    retrospective = Jason.decode!(inputs.retrospective)
+
+    {:ok, %{
+      project_id: project_id,
+      retrospective: retrospective,
+      # "content" is used to create subscriptions for mentioned people
+      content: %{
+        "content" => [
+          retrospective["whatWentWell"],
+          retrospective["whatDidYouLearn"],
+          retrospective["whatCouldHaveGoneBetter"],
+        ],
+      },
+      send_to_everyone: inputs[:send_notifications_to_everyone] || false,
+      subscription_parent_type: :project_retrospective,
+      subscriber_ids: subscriber_ids || []
+    }}
   end
 end

--- a/test/support/factory/projects.ex
+++ b/test/support/factory/projects.ex
@@ -41,7 +41,16 @@ defmodule Operately.Support.Factory.Projects do
     Map.put(ctx, testid, reviewer)
   end
 
-  def add_project_contributor(ctx, testid, project_name, opts \\ []) do
+  def add_project_contributor(ctx, testid, project_name, opts \\ [])
+
+  def add_project_contributor(ctx, testid, project_name, :as_person) do
+    ctx = add_project_contributor(ctx, testid, project_name)
+    person = Repo.preload(ctx[testid], :person).person
+
+    Map.put(ctx, testid, person)
+  end
+
+  def add_project_contributor(ctx, testid, project_name, opts) do
     project = Map.fetch!(ctx, project_name)
 
     name = Keyword.get(opts, :name, Utils.testid_to_name(testid))


### PR DESCRIPTION
I've updated the project retrospective creation form, mutation and operation so that a subscriptions list is created for the new project retrospective.