### PR TITLE
chore: Migration to create subscriptions for existing project retrospectives

### DIFF
--- a/lib/operately/data/change_030_create_subscriptions_list_for_project_retrospectives.ex
+++ b/lib/operately/data/change_030_create_subscriptions_list_for_project_retrospectives.ex
@@ -1,0 +1,72 @@
+defmodule Operately.Data.Change030CreateSubscriptionsListForProjectRetrospectives do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.{Repo, Notifications}
+  alias Operately.Notifications.{Subscription, SubscriptionList}
+
+  def run do
+    Repo.transaction(fn ->
+      Operately.Projects.Retrospective
+      |> Repo.all()
+      |> create_subscriptions_list()
+      |> create_subscriptions()
+    end)
+  end
+
+  defp create_subscriptions_list(retrospectives) when is_list(retrospectives) do
+    Enum.map(retrospectives, fn r ->
+      create_subscriptions_list(r)
+    end)
+  end
+
+  defp create_subscriptions_list(retrospective) do
+    case SubscriptionList.get(:system, parent_id: retrospective.id) do
+      {:error, :not_found} ->
+        {:ok, subscriptions_list} = Notifications.create_subscription_list(%{
+          parent_id: retrospective.id,
+          parent_type: :project_retrospective,
+        })
+        subscriptions_list
+
+      {:ok, subscriptions_list} -> subscriptions_list
+    end
+    |> update_retrospective(retrospective)
+  end
+
+  defp update_retrospective(subscriptions_list, retrospective) do
+    if subscriptions_list.id != retrospective.subscription_list_id do
+      {:ok, _} = Operately.Projects.update_retrospective(retrospective, %{subscription_list_id: subscriptions_list.id})
+    end
+    subscriptions_list
+  end
+
+  defp create_subscriptions(subscriptions_list) when is_list(subscriptions_list) do
+    Enum.map(subscriptions_list, fn list ->
+      create_subscriptions(list)
+    end)
+  end
+
+  defp create_subscriptions(subscriptions_list) do
+    from(contrib in Operately.Projects.Contributor,
+      join: p in assoc(contrib, :project),
+      join: r in assoc(p, :retrospective),
+      where: r.id == ^subscriptions_list.parent_id
+    )
+    |> Repo.all()
+    |> Enum.map(fn contrib ->
+      find_or_create_subscription(subscriptions_list, contrib)
+    end)
+  end
+
+  defp find_or_create_subscription(subscriptions_list, contrib) do
+    case Subscription.get(:system, subscription_list_id: subscriptions_list.id, person_id: contrib.person_id) do
+      {:error, :not_found} ->
+        {:ok, _} = Notifications.create_subscription(%{
+          subscription_list_id: subscriptions_list.id,
+          person_id: contrib.person_id,
+          type: :invited,
+        })
+      _ -> :ok
+    end
+  end
+end

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -458,4 +458,10 @@ defmodule Operately.Projects do
     |> Retrospective.changeset(attrs)
     |> Repo.insert()
   end
+
+  def update_retrospective(%Retrospective{} = retrospective, attrs) do
+    retrospective
+    |> Retrospective.changeset(attrs)
+    |> Repo.update()
+  end
 end

--- a/priv/repo/migrations/20241002151620_create_subscriptions_list_for_existing_project_retrospective.exs
+++ b/priv/repo/migrations/20241002151620_create_subscriptions_list_for_existing_project_retrospective.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.CreateSubscriptionsListForExistingProjectRetrospective do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change030CreateSubscriptionsListForProjectRetrospectives.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/data/change_030_create_subscriptions_list_for_project_retrospectives_test.exs
+++ b/test/operately/data/change_030_create_subscriptions_list_for_project_retrospectives_test.exs
@@ -1,0 +1,64 @@
+defmodule Operately.Data.Change030CreateSubscriptionsListForProjectRetrospectivesTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Notifications.{Subscription, SubscriptionList}
+
+  setup ctx do
+    ctx =
+      Factory.setup(ctx)
+      |> Factory.add_space(:space)
+
+    Enum.reduce(1..3, ctx, fn num, ctx ->
+      project_name = resource_name("project", num)
+      retrospective_name = resource_name("retrospective", num)
+
+      ctx =
+        Factory.add_project(ctx, project_name, :space)
+        |> Factory.add_project_retrospective(retrospective_name, project_name, :creator)
+
+      Enum.reduce(1..3, ctx, fn member_num, ctx ->
+        member_name = resource_name("member", "#{num}_#{member_num}")
+        Factory.add_project_contributor(ctx, member_name, project_name, :as_person)
+      end)
+    end)
+  end
+
+  test "creates subscriptions list for existing project retrospective", ctx do
+    retrospectives = [ctx.retrospective_1, ctx.retrospective_2, ctx.retrospective_3]
+
+    Enum.each(retrospectives, fn r ->
+      refute r.subscription_list_id
+      assert {:error, :not_found} = SubscriptionList.get(:system, parent_id: r.id)
+    end)
+
+    Operately.Data.Change030CreateSubscriptionsListForProjectRetrospectives.run()
+
+    Enum.each(retrospectives, fn r ->
+      r = Repo.reload(r)
+
+      list_contributors(r)
+      |> Enum.each(fn person ->
+        assert {:ok, _} = Subscription.get(:system, subscription_list_id: r.subscription_list_id, person_id: person.id)
+      end)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp resource_name(name, num) do
+    String.to_atom("#{name}_#{num}")
+  end
+
+  defp list_contributors(retrospective) do
+    from(c in Operately.Projects.Contributor,
+      join: p in assoc(c, :person),
+      where: c.project_id == ^retrospective.project_id,
+      select: p
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration which creates subscriptions for existing project retrospectives.