### PR TITLE
chore: GetProjectRetrospective query can include potential subscribers

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -844,6 +844,8 @@ export interface ProjectRetrospective {
   closedAt?: string | null;
   permissions?: ProjectPermissions | null;
   reactions?: Reaction[] | null;
+  subscriptionList?: SubscriptionList | null;
+  potentialSubscribers?: Subscriber[] | null;
 }
 
 export interface ProjectReviewRequest {
@@ -1414,6 +1416,8 @@ export interface GetProjectRetrospectiveInput {
   includeProject?: boolean | null;
   includePermissions?: boolean | null;
   includeReactions?: boolean | null;
+  includeSubscriptionsList?: boolean | null;
+  includePotentialSubscribers?: boolean | null;
 }
 
 export interface GetProjectRetrospectiveResult {

--- a/lib/operately/notifications/subscriber.ex
+++ b/lib/operately/notifications/subscriber.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Notifications.Subscriber do
-  alias Operately.Projects.{Contributor, CheckIn}
+  alias Operately.Projects.Contributor
   alias Operately.Goals.{Update, Goal}
   alias Operately.Notifications.{Subscription, SubscriptionList}
   alias Operately.People.Person
@@ -28,14 +28,14 @@ defmodule Operately.Notifications.Subscriber do
     end)
   end
 
-  def from_project_check_in(%CheckIn{} = check_in) do
+  def from_project_child(project_child) do
     subs =
-      exclude_canceled_subscriptions(check_in.subscription_list)
+      exclude_canceled_subscriptions(project_child.subscription_list)
       |> Enum.into(%{}, fn s ->
       {s.person.id, from_subscription(s)}
     end)
 
-    potential_subs = Enum.into(check_in.project.contributors, %{}, fn c ->
+    potential_subs = Enum.into(project_child.project.contributors, %{}, fn c ->
       {c.person.id, from_project_contributor(c)}
     end)
 
@@ -111,6 +111,8 @@ defmodule Operately.Notifications.Subscriber do
       _ -> [role: contributor.responsibility, priority: false]
     end
   end
+
+  defp exclude_canceled_subscriptions(nil), do: []
 
   defp exclude_canceled_subscriptions(subscription_list = %SubscriptionList{}) do
     Enum.filter(subscription_list.subscriptions, &(not &1.canceled))

--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -43,7 +43,7 @@ defmodule Operately.Projects.CheckIn do
     subs =
       check_in
       |> Notifications.SubscribersLoader.preload_subscriptions()
-      |> Notifications.Subscriber.from_project_check_in()
+      |> Notifications.Subscriber.from_project_child()
 
     %{check_in | potential_subscribers: subs}
   end

--- a/lib/operately_web/api/queries/get_project_retrospective.ex
+++ b/lib/operately_web/api/queries/get_project_retrospective.ex
@@ -10,6 +10,8 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
     field :include_project, :boolean
     field :include_permissions, :boolean
     field :include_reactions, :boolean
+    field :include_subscriptions_list, :boolean
+    field :include_potential_subscribers, :boolean
   end
 
   outputs do
@@ -48,18 +50,15 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
       include_author: [:author],
       include_project: [:project],
       include_reactions: [reactions: :person],
+      include_subscriptions_list: :subscription_list,
+      include_potential_subscribers: [:access_context, project: [contributors: :person]],
     ])
   end
 
   def after_load(inputs) do
-    filter_what_to_run([
-      %{run: &Retrospective.set_permissions/1, if: inputs[:include_permissions]},
+    Inputs.parse_includes(inputs, [
+      include_permissions: &Retrospective.set_permissions/1,
+      include_potential_subscribers: &Retrospective.set_potential_subscribers/1,
     ])
-  end
-
-  defp filter_what_to_run(list) do
-    list
-    |> Enum.filter(fn %{if: c} -> c end)
-    |> Enum.map(fn %{run: f} -> f end)
   end
 end

--- a/lib/operately_web/api/serializers/project_retrospective.ex
+++ b/lib/operately_web/api/serializers/project_retrospective.ex
@@ -8,6 +8,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Retrospective do
       closed_at: OperatelyWeb.Api.Serializer.serialize(retrospective.closed_at),
       permissions: OperatelyWeb.Api.Serializer.serialize(retrospective.permissions),
       reactions: OperatelyWeb.Api.Serializer.serialize(retrospective.reactions),
+      subscription_list: OperatelyWeb.Api.Serializer.serialize(retrospective.subscription_list),
+      potential_subscribers: OperatelyWeb.Api.Serializer.serialize(retrospective.potential_subscribers),
     }
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -181,6 +181,8 @@ defmodule OperatelyWeb.Api.Types do
     field :closed_at, :date
     field :permissions, :project_permissions
     field :reactions, list_of(:reaction)
+    field :subscription_list, :subscription_list
+    field :potential_subscribers, list_of(:subscriber)
   end
 
   object :discussion do


### PR DESCRIPTION
`OperatelyWeb.Api.Queries.GetProjectRetrospective` can now include potential subscribers.