### PR TITLE
chore: subscriptions_list_id required in project retrospective

### DIFF
--- a/lib/operately/projects/retrospective.ex
+++ b/lib/operately/projects/retrospective.ex
@@ -28,7 +28,7 @@ defmodule Operately.Projects.Retrospective do
   def changeset(retrospective, attrs) do
     retrospective
     |> cast(attrs, [:author_id, :project_id, :subscription_list_id, :content, :closed_at])
-    |> validate_required([:author_id, :project_id, :content, :closed_at])
+    |> validate_required([:author_id, :project_id, :subscription_list_id, :content, :closed_at])
   end
 
   # After load hooks

--- a/test/operately/data/change_030_create_subscriptions_list_for_project_retrospectives_test.exs
+++ b/test/operately/data/change_030_create_subscriptions_list_for_project_retrospectives_test.exs
@@ -3,7 +3,7 @@ defmodule Operately.Data.Change030CreateSubscriptionsListForProjectRetrospective
 
   import Ecto.Query, only: [from: 2]
 
-  alias Operately.Notifications.{Subscription, SubscriptionList}
+  alias Operately.Notifications.Subscription
 
   setup ctx do
     ctx =
@@ -27,11 +27,6 @@ defmodule Operately.Data.Change030CreateSubscriptionsListForProjectRetrospective
 
   test "creates subscriptions list for existing project retrospective", ctx do
     retrospectives = [ctx.retrospective_1, ctx.retrospective_2, ctx.retrospective_3]
-
-    Enum.each(retrospectives, fn r ->
-      refute r.subscription_list_id
-      assert {:error, :not_found} = SubscriptionList.get(:system, parent_id: r.id)
-    end)
 
     Operately.Data.Change030CreateSubscriptionsListForProjectRetrospectives.run()
 

--- a/test/support/fixtures/projects_fixtures.ex
+++ b/test/support/fixtures/projects_fixtures.ex
@@ -130,6 +130,8 @@ defmodule Operately.ProjectsFixtures do
   Generate a project retrospective.
   """
   def retrospective_fixture(attrs) do
+    subscription_list = Operately.NotificationsFixtures.subscriptions_list_fixture()
+
     {:ok, retrospective} =
       attrs
       |> Enum.into(%{
@@ -139,8 +141,14 @@ defmodule Operately.ProjectsFixtures do
           whatCouldHaveGoneBetter: RichText.rich_text("some content"),
         },
         closed_at: DateTime.utc_now(),
+        subscription_list_id: subscription_list.id,
       })
       |> Operately.Projects.create_retrospective()
+
+    {:ok, _} = Operately.Notifications.update_subscription_list(subscription_list, %{
+      parent_type: :project_retrospective,
+      parent_id: retrospective.id,
+    })
 
     retrospective
   end


### PR DESCRIPTION
A subscriptions list ID is now required when creating a project retrospective. 