### PR TITLE
fix: Mentioning people in project retrospective comments now works

### DIFF
--- a/assets/js/features/CommentSection/useForProjectRetrospective.tsx
+++ b/assets/js/features/CommentSection/useForProjectRetrospective.tsx
@@ -4,7 +4,10 @@ import * as Time from "@/utils/time";
 
 import { ItemType, FormState } from "./form";
 
-export function useForProjectRetrospective(project: Projects.Project, comments: Comments.Comment[]): FormState {
+export function useForProjectRetrospective(
+  retrospective: Projects.ProjectRetrospective,
+  comments: Comments.Comment[],
+): FormState {
   const [post, { loading: submittingPost }] = Comments.useCreateComment();
   const [edit, { loading: submittingEdit }] = Comments.useEditComment();
 
@@ -18,7 +21,7 @@ export function useForProjectRetrospective(project: Projects.Project, comments: 
 
   const postComment = async (content: string) => {
     await post({
-      entityId: project.id,
+      entityId: retrospective.id,
       entityType: "project_retrospective",
       content: JSON.stringify(content),
     });
@@ -37,6 +40,6 @@ export function useForProjectRetrospective(project: Projects.Project, comments: 
     postComment,
     editComment,
     submitting: submittingPost || submittingEdit,
-    mentionSearchScope: { type: "project", id: project.id! },
+    mentionSearchScope: { type: "project", id: retrospective.project!.id! },
   };
 }


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1240.

This was a tricky one. For some reason TS is accepting the wrong type in the hook, but I can't figure out why. 

The function should take a `Project`:

https://github.com/operately/operately/blob/3d8f1f99e2dc83135ea6888a78bfba3ca021de34/assets/js/features/CommentSection/useForProjectRetrospective.tsx#L7-L9

However, it was accepting a `ProjectRetrospective`:

https://github.com/operately/operately/blob/3d8f1f99e2dc83135ea6888a78bfba3ca021de34/assets/js/pages/ProjectRetrospectivePage/page.tsx#L107-L110
