### PR TITLE
chore: Show testID annotations on input[text] elements

### DIFF
--- a/assets/js/features/PerfBar/index.tsx
+++ b/assets/js/features/PerfBar/index.tsx
@@ -37,6 +37,23 @@ function ToggleTestIds() {
   const toggle = () => setShow(!show);
   const className = color + " cursor-pointer";
 
+  React.useEffect(() => {
+    if (!show) return;
+
+    document.querySelectorAll("input[data-test-id][type='text']").forEach((el) => {
+      const message = document.createElement("div");
+      message.setAttribute("data-test-id", el.getAttribute("data-test-id")!);
+      message.setAttribute("data-test-id-annotation", "");
+      (el.parentNode! as HTMLElement).insertBefore(message, el);
+    });
+
+    return () => {
+      document.querySelectorAll("[data-test-id-annotation]").forEach((el) => {
+        el.remove();
+      });
+    };
+  }, [show]);
+
   return (
     <div className="">
       TestIDs [
@@ -47,7 +64,7 @@ function ToggleTestIds() {
       {show && (
         <style>
           {`
-          [data-test-id] {
+          [data-test-id]:not([data-test-id-annotation]) {
             outline: ${show ? "1px solid red" : "none"};
           }
           


### PR DESCRIPTION
Input type=text elements don't support ::before and ::after pseudo selectors. As a workaround, I'm injecting a mini label above every input field.