### PR TITLE
feat: Editing project check-in updates subscriptions

### DIFF
--- a/test/operately_web/api/mutations/edit_project_check_in_test.exs
+++ b/test/operately_web/api/mutations/edit_project_check_in_test.exs
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectCheckInTest do
 
   alias Operately.Support.RichText
   alias Operately.Access.Binding
+  alias Operately.Notifications.SubscriptionList
 
   import Operately.GroupsFixtures
   import Operately.PeopleFixtures
@@ -63,23 +64,56 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectCheckInTest do
 
   describe "edit_project_check_in functionality" do
     setup ctx do
-      ctx = register_and_log_in_account(ctx)
-      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
-
-      Map.merge(ctx, %{project: project})
+      ctx
+      |> Factory.setup()
+      |> Factory.log_in_person(:creator)
+      |> Factory.add_space(:space)
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_project_check_in(:check_in, :project, :creator)
     end
 
     test "edits project check-in", ctx do
-      check_in = create_check_in(ctx.person, ctx.project)
-
       assert {200, res} = mutation(ctx.conn, :edit_project_check_in, %{
-        check_in_id: Paths.project_check_in_id(check_in),
+        check_in_id: Paths.project_check_in_id(ctx.check_in),
         status: "on_track",
         description: RichText.rich_text("New description", :as_string),
       })
-      check_in = Repo.reload(check_in)
+      check_in = Repo.reload(ctx.check_in)
 
       assert res.check_in == Serializer.serialize(check_in)
+    end
+
+    test "mentioned people are added to subscriptions list", ctx do
+      ctx =
+        ctx
+        |> Factory.add_project_contributor(:contrib1, :project, :as_person)
+        |> Factory.add_project_contributor(:contrib2, :project, :as_person)
+        |> Factory.add_project_contributor(:contrib3, :project, :as_person)
+
+      people = [ctx.contrib1, ctx.contrib2, ctx.contrib3]
+
+      {:ok, list} = SubscriptionList.get(:system, parent_id: ctx.check_in.id, opts: [
+        preload: :subscriptions
+      ])
+
+      assert list.subscriptions == []
+
+      assert {200, _} = mutation(ctx.conn, :edit_project_check_in, %{
+        check_in_id: Paths.project_check_in_id(ctx.check_in),
+        status: "on_track",
+        description: RichText.rich_text(mentioned_people: people),
+      })
+
+      {:ok, list} = SubscriptionList.get(:system, parent_id: ctx.check_in.id, opts: [
+        preload: :subscriptions
+      ])
+
+      assert length(list.subscriptions) == 3
+
+      Enum.each(people, fn person ->
+        sub = Enum.find(list.subscriptions, &(&1.person_id == person.id))
+        assert sub.type == :mentioned
+      end)
     end
   end
 


### PR DESCRIPTION
I've updated `Operately.Operations.ProjectCheckInEdit` so that, if a project retrospective is edited and someone is mentioned in it, a subscription is created for the mentioned person.