### PR TITLE
chore: Migration to add missing fields to project_closed activity

### DIFF
--- a/lib/operately/activities/content/project_closed.ex
+++ b/lib/operately/activities/content/project_closed.ex
@@ -3,7 +3,9 @@ defmodule Operately.Activities.Content.ProjectClosed do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
+    belongs_to :retrospective, Operately.Projects.Retrospective
   end
 
   def changeset(attrs) do

--- a/lib/operately/data/change_031_add_retrospective_to_project_closed_activity.ex
+++ b/lib/operately/data/change_031_add_retrospective_to_project_closed_activity.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change031AddRetrospectiveToProjectClosedActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action == "project_closed"
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    {:ok, project} = Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+      preload: :retrospective
+    ])
+
+    case project.retrospective do
+      %{id: id} ->
+        content =
+          activity.content
+          |> Map.put(:retrospective_id, id)
+          |> Map.put(:space_id, project.group_id)
+
+        Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ -> :ok
+    end
+  end
+end

--- a/lib/operately/operations/project_closed.ex
+++ b/lib/operately/operations/project_closed.ex
@@ -25,9 +25,11 @@ defmodule Operately.Operations.ProjectClosed do
         closed_at: changes.retrospective.closed_at,
       })
     end)
-    |> Activities.insert_sync(author.id, :project_closed, fn _changes -> %{
+    |> Activities.insert_sync(author.id, :project_closed, fn changes -> %{
       company_id: project.company_id,
-      project_id: project.id
+      space_id: project.group_id,
+      project_id: project.id,
+      retrospective_id: changes.retrospective.id,
     } end)
     |> Repo.transaction()
     |> Repo.extract_result(:retrospective)

--- a/priv/repo/migrations/20241003135919_add_retrospective_to_project_closed_activity.exs
+++ b/priv/repo/migrations/20241003135919_add_retrospective_to_project_closed_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddRetrospectiveToProjectClosedActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change031AddRetrospectiveToProjectClosedActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -438,10 +438,16 @@ defmodule Operately.AccessActivityContextAssignerTest do
     end
 
     test "project_closed action", ctx do
+      retrospective = retrospective_fixture(%{author_id: ctx.author.id, project_id: ctx.project.id})
       attrs = %{
         action: "project_closed",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+        content: %{
+          project_id: ctx.project.id,
+          space_id: ctx.group.id,
+          company_id: ctx.company.id,
+          retrospective_id: retrospective.id,
+        }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_031_add_retrospective_to_project_closed_activity_test.exs
+++ b/test/operately/data/change_031_add_retrospective_to_project_closed_activity_test.exs
@@ -1,0 +1,55 @@
+defmodule Operately.Data.Change031AddRetrospectiveToProjectClosedActivityTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.ProjectsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  test "migration doesn't delete current data in activity content", ctx do
+    projects = Enum.map(1..3, fn _ ->
+      project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id})
+    end)
+
+    projects = Enum.map(projects, fn p ->
+      attrs = %{
+        retrospective: %{},
+        content: %{},
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [],
+      }
+      {:ok, _} = Operately.Operations.ProjectClosed.run(ctx.creator, p, attrs)
+
+      Repo.preload(p, :retrospective)
+    end)
+
+    Operately.Data.Change031AddRetrospectiveToProjectClosedActivity.run()
+
+    fetch_activities()
+    |> Enum.each(fn activity ->
+      project = Enum.find(projects, &(&1.id == activity.content["project_id"]))
+
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["space_id"] == ctx.space.id
+      assert activity.content["retrospective_id"] == project.retrospective.id
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities() do
+    from(a in Operately.Activities.Activity,
+      where: a.action == "project_closed"
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration to add the retrospective_id and space_id fields to `Operately.Activities.Content.ProjectClosed`.

I've also updated `Operately.Operations.ProjectClosed` so that new activities include the new fields.