### PR TITLE
chore: ProjectClosed notification uses subscriptions list

### DIFF
--- a/lib/operately/activities/notifications/project_closed.ex
+++ b/lib/operately/activities/notifications/project_closed.ex
@@ -1,30 +1,15 @@
 defmodule Operately.Activities.Notifications.ProjectClosed do
-  alias Operately.Projects
-  alias Operately.Projects.Retrospective
+  alias Operately.Projects.Notifications
 
   def dispatch(activity) do
-    author_id = activity.author_id
-    project_id = activity.content["project_id"]
-
-    {:ok, retrospective} = Retrospective.get(:system, project_id: project_id)
-    people = Projects.list_notification_subscribers(project_id, exclude: author_id)
-
-    mentioned = (
-      Operately.RichContent.lookup_mentioned_people(retrospective.content["whatWentWell"])
-      ++ Operately.RichContent.lookup_mentioned_people(retrospective.content["whatCouldHaveGoneBetter"])
-      ++ Operately.RichContent.lookup_mentioned_people(retrospective.content["whatDidYouLearn"])
-    )
-
-    people = Enum.uniq_by(people ++ mentioned, & &1.id)
-
-    notifications = Enum.map(people, fn person ->
+    Notifications.get_retrospective_subscribers(activity.content["retrospective_id"], ignore: [activity.author_id])
+    |> Enum.map(fn person_id ->
       %{
-        person_id: person.id,
+        person_id: person_id,
         activity_id: activity.id,
         should_send_email: true,
       }
     end)
-
-    Operately.Notifications.bulk_create(notifications)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/projects/notifications.ex
+++ b/lib/operately/projects/notifications.ex
@@ -8,18 +8,39 @@ defmodule Operately.Projects.Notifications do
     ignore = Keyword.get(opts, :ignore, [])
 
     check_in =
-      from(c in Operately.Projects.CheckIn,
-        join: project in assoc(c, :project),
-        join: context in assoc(project, :access_context),
-        join: contribs in assoc(project, :contributors),
-        join: person in assoc(contribs, :person),
-        preload: [project: {project, [contributors: {contribs, person: person}]}, access_context: context],
-        where: c.id == ^check_in_id
-      )
+      from(c in Operately.Projects.CheckIn, where: c.id == ^check_in_id)
+      |> preload_project_resources()
       |> Repo.one()
 
     people = Enum.map(check_in.project.contributors, &(&1.person))
 
     SubscribersLoader.load_for_notifications(check_in, people, ignore)
+  end
+
+  def get_retrospective_subscribers(retrospective_id, opts \\ []) do
+    ignore = Keyword.get(opts, :ignore, [])
+
+    retrospective =
+      from(r in Operately.Projects.Retrospective, where: r.id == ^retrospective_id)
+      |> preload_project_resources()
+      |> Repo.one()
+
+    people = Enum.map(retrospective.project.contributors, &(&1.person))
+
+    SubscribersLoader.load_for_notifications(retrospective, people, ignore)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp preload_project_resources(query) do
+    from(resource in query,
+      join: project in assoc(resource, :project),
+      join: context in assoc(project, :access_context),
+      join: contribs in assoc(project, :contributors),
+      join: person in assoc(contribs, :person),
+      preload: [project: {project, [contributors: {contribs, person: person}]}, access_context: context]
+    )
   end
 end

--- a/test/operately/operations/project_closed_test.exs
+++ b/test/operately/operations/project_closed_test.exs
@@ -1,0 +1,211 @@
+defmodule Operately.Operations.ProjectClosedTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Access.Binding
+  alias Operately.Support.RichText
+
+  @action "project_closed"
+  @retrospective_content %{
+    "whatWentWell" => RichText.rich_text("some content"),
+    "whatDidYouLearn" => RichText.rich_text("some content"),
+    "whatCouldHaveGoneBetter" => RichText.rich_text("some content"),
+  }
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_space_member(:reviewer, :space)
+    |> Factory.add_project(:project, :space, reviewer: :reviewer)
+    |> Factory.add_project_contributor(:contrib1, :project, :as_person)
+    |> Factory.add_project_contributor(:contrib2, :project, :as_person)
+    |> Factory.add_project_contributor(:contrib3, :project, :as_person)
+  end
+
+  test "Closing project notifies only reviewer", ctx do
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, ctx.project, %{
+        retrospective: @retrospective_content,
+        content: %{},
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [ctx.creator.id, ctx.reviewer.id]
+      })
+    end)
+    activity = get_activity(retrospective)
+
+    assert 0 == notifications_count(action: @action)
+
+    perform_job(activity.id)
+
+    assert 1 == notifications_count(action: @action)
+
+    notifications = fetch_notifications(activity.id, action: @action)
+
+    assert Enum.find(notifications, &(&1.person_id == ctx.reviewer.id))
+  end
+
+  test "Closing project notifies contributors", ctx do
+    contributors = Operately.Projects.list_project_contributors(ctx.project)
+
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, ctx.project, %{
+        retrospective: @retrospective_content,
+        content: %{},
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: Enum.map(contributors, &(&1.person_id)),
+      })
+    end)
+    activity = get_activity(retrospective)
+
+    assert 0 == notifications_count(action: @action)
+
+    perform_job(activity.id)
+
+    assert 4 == notifications_count(action: @action)
+
+    notifications = fetch_notifications(activity.id, action: @action)
+
+    contributors
+    |> Enum.filter(&(&1.person_id != ctx.creator.id))
+    |> Enum.each(fn c ->
+      assert Enum.find(notifications, &(&1.person_id == c.person_id))
+    end)
+  end
+
+  test "Closing project notifies all contributors if send_to_everyone is true", ctx do
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, ctx.project, %{
+        retrospective: @retrospective_content,
+        content: %{},
+        send_to_everyone: true,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [],
+      })
+    end)
+    activity = get_activity(retrospective)
+
+    assert 0 == notifications_count(action: @action)
+
+    perform_job(activity.id)
+
+    assert 4 == notifications_count(action: @action)
+
+    notifications = fetch_notifications(activity.id, action: @action)
+
+    Operately.Projects.list_project_contributors(ctx.project)
+    |> Enum.filter(&(&1.person_id != ctx.creator.id))
+    |> Enum.each(fn c ->
+      assert Enum.find(notifications, &(&1.person_id == c.person_id))
+    end)
+  end
+
+  test "Closing project does not notify creator", ctx do
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, ctx.project, %{
+        retrospective: @retrospective_content,
+        content: %{},
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [ctx.creator.id],
+      })
+    end)
+
+    activity = get_activity(retrospective)
+    perform_job(activity.id)
+
+    assert 0 == notifications_count(action: @action)
+  end
+
+  test "Closing project notifies mentioned person", ctx do
+    content = %{
+      "whatWentWell" => RichText.rich_text(mentioned_people: [ctx.reviewer, ctx.contrib1]) |> Jason.decode!(),
+      "whatDidYouLearn" => RichText.rich_text(mentioned_people: [ctx.contrib2]) |> Jason.decode!(),
+      "whatCouldHaveGoneBetter" => RichText.rich_text(mentioned_people: [ctx.contrib3]) |> Jason.decode!(),
+    }
+
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, ctx.project, %{
+        retrospective: content,
+        content: %{
+          "content" => [
+            content["whatWentWell"],
+            content["whatDidYouLearn"],
+            content["whatCouldHaveGoneBetter"],
+          ],
+        },
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [],
+      })
+    end)
+    activity = get_activity(retrospective)
+
+    assert 0 == notifications_count(action: @action)
+
+    perform_job(activity.id)
+
+    assert 4 == notifications_count(action: @action)
+
+    notifications = fetch_notifications(activity.id, action: @action)
+
+    Operately.Projects.list_project_contributors(ctx.project)
+    |> Enum.filter(&(&1.person_id != ctx.creator.id))
+    |> Enum.each(fn c ->
+      assert Enum.find(notifications, &(&1.person_id == c.person_id))
+    end)
+  end
+
+  test "Doesn't notify person without view access", ctx do
+    project = project_fixture(%{
+      company_id: ctx.company.id,
+      creator_id: ctx.creator.id,
+      group_id: ctx.space.id,
+      company_access_level: Binding.no_access(),
+    })
+    person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+    content = %{
+      "whatWentWell" => RichText.rich_text(mentioned_people: [person]) |> Jason.decode!(),
+      "whatDidYouLearn" => RichText.rich_text("Content"),
+      "whatCouldHaveGoneBetter" => RichText.rich_text("Content"),
+    }
+
+    {:ok, retrospective} = Oban.Testing.with_testing_mode(:manual, fn ->
+      Operately.Operations.ProjectClosed.run(ctx.creator, project, %{
+        retrospective: content,
+        content: %{
+          "content" => [
+            content["whatWentWell"],
+            content["whatDidYouLearn"],
+            content["whatCouldHaveGoneBetter"],
+          ],
+        },
+        send_to_everyone: false,
+        subscription_parent_type: :project_retrospective,
+        subscriber_ids: [],
+      })
+    end)
+
+    activity = get_activity(retrospective)
+
+    assert notifications_count(action: @action) == 0
+    assert fetch_notifications(activity.id, action: @action) == []
+  end
+
+  #
+  # Helpers
+  #
+
+  defp get_activity(retrospective) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^@action and a.content["retrospective_id"] == ^retrospective.id
+    )
+    |> Repo.one()
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,7 +26,7 @@ defmodule Operately.Support.Factory do
   defdelegate add_goal_update(ctx, testid, goal_name, person_name) , to: Goals
 
   # projects
-  defdelegate add_project(ctx, testid, space_name), to: Projects
+  defdelegate add_project(ctx, testid, space_name, opts \\ []), to: Projects
   defdelegate add_project_reviewer(ctx, testid, project_name, opts \\ []), to: Projects
   defdelegate add_project_contributor(ctx, testid, project_name, opts \\ []), to: Projects
   defdelegate add_project_retrospective(ctx, testid, project_name, author_name), to: Projects


### PR DESCRIPTION
Now, `Operately.Activities.Notifications.ProjectClosed` sends notifications based on the retrospective's subscriptions list.