### PR TITLE
feat: Commenting on retrospective sends notifications

### DIFF
--- a/lib/operately/activities/notifications/project_retrospective_commented.ex
+++ b/lib/operately/activities/notifications/project_retrospective_commented.ex
@@ -1,6 +1,15 @@
 defmodule Operately.Activities.Notifications.ProjectRetrospectiveCommented do
-  def dispatch(_activity) do
-    # Notification dispatcher for ProjectRetrospectiveCommented not implemented yet
-    {:ok, []}
+  alias Operately.Projects.Notifications
+
+  def dispatch(activity) do
+    Notifications.get_retrospective_subscribers(activity.content["retrospective_id"], ignore: [activity.author_id])
+    |> Enum.map(fn person_id ->
+      %{
+        person_id: person_id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/operations/comment_adding/subscriptions.ex
+++ b/lib/operately/operations/comment_adding/subscriptions.ex
@@ -3,6 +3,7 @@ defmodule Operately.Operations.CommentAdding.Subscriptions do
   alias Operately.Notifications.SubscriptionList
 
   def update(multi, :project_check_in_commented, content), do: execute_update(multi, content)
+  def update(multi, :project_retrospective_commented, content), do: execute_update(multi, content)
   def update(multi, :goal_check_in_commented, content), do: execute_update(multi, content)
   def update(multi, :discussion_comment_submitted, content), do: execute_update(multi, content)
   def update(multi, _, _), do: multi

--- a/lib/operately_email/emails/project_retrospective_commented_email.ex
+++ b/lib/operately_email/emails/project_retrospective_commented_email.ex
@@ -1,0 +1,28 @@
+defmodule OperatelyEmail.Emails.ProjectRetrospectiveCommentedEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.{Repo, Updates}
+  alias Operately.Projects.Project
+  alias OperatelyWeb.Paths
+
+  def send(person, activity) do
+    %{author: author} = Repo.preload(activity, [:author])
+    {:ok, project = %{group: space, company: company}} = Project.get(:system, id: activity.content["project_id"], opts: [
+      preload: [:group, :company]
+    ])
+    comment = Updates.get_comment!(activity.content["comment_id"])
+    action = "commented on the project retrospective"
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: space.name, who: author, action: action)
+    |> assign(:author, author)
+    |> assign(:project, project)
+    |> assign(:comment, comment)
+    |> assign(:cta_text, "View Retrospective")
+    |> assign(:cta_url, Paths.project_retrospective_path(company, project) |> Paths.to_url())
+    |> render("project_retrospective_commented")
+  end
+end

--- a/lib/operately_email/templates/project_retrospective_commented.html.eex
+++ b/lib/operately_email/templates/project_retrospective_commented.html.eex
@@ -1,0 +1,11 @@
+<%= title("#{short_name(@author)} commented on the retrospective for the #{@project.name} project") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= rich_text(@comment.content["message"]) %>
+<% end %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, @cta_text) %>
+<% end %>

--- a/lib/operately_email/templates/project_retrospective_commented.text.eex
+++ b/lib/operately_email/templates/project_retrospective_commented.text.eex
@@ -1,0 +1,3 @@
+<%= short_name(@author) %> commented on a retrospective for <%= @project.name %>.
+
+Link: <%= @cta_url %>

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,6 +8,14 @@ defmodule Operately.Support.Factory do
     Map.put(ctx, :creator, Ecto.assoc(ctx.company, :people) |> Operately.Repo.all() |> hd())
   end
 
+  def preload(ctx, resource_name, preload) do
+    resource = Map.fetch!(ctx, resource_name)
+
+    resource = Operately.Repo.preload(resource, preload)
+
+    Map.put(ctx, resource_name, resource)
+  end
+
   # accounts
   defdelegate add_account(ctx, testid), to: Accounts
   defdelegate log_in_person(ctx, person_name), to: Accounts


### PR DESCRIPTION
Commenting on a project retrospective now notifies users who are subscribed to the retrospective. 