### PR TITLE
feat: Editing a retrospective comment updates subscriptions

### DIFF
--- a/lib/operately/operations/comment_editing/subscriptions.ex
+++ b/lib/operately/operations/comment_editing/subscriptions.ex
@@ -3,6 +3,7 @@ defmodule Operately.Operations.CommentEditing.Subscriptions do
   alias Operately.Notifications.SubscriptionList
 
   def update(multi, :project_check_in, content), do: execute_update(multi, content)
+  def update(multi, :project_retrospective, content), do: execute_update(multi, content)
   def update(multi, :goal_update, content), do: execute_update(multi, content)
   def update(multi, :message, content), do: execute_update(multi, content)
   def update(multi, _, _), do: multi


### PR DESCRIPTION
I've updated `Operately.Operations.CommentEditing` so that editing a project retrospective comment also updates the retrospective's subscriptions.