### PR TITLE
feat: Notifications are cleared when discussion comments are seen by user

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -549,6 +549,7 @@ export interface Comment {
   content?: string | null;
   author?: Person | null;
   reactions?: Reaction[] | null;
+  notification?: Notification | null;
 }
 
 export interface CommentThread {

--- a/assets/js/features/CommentSection/CommentSection.tsx
+++ b/assets/js/features/CommentSection/CommentSection.tsx
@@ -8,6 +8,7 @@ import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
 import RichContent from "@/components/RichContent";
 import { PrimaryButton, SecondaryButton } from "@/components/Buttons";
+import { useClearNotificationOnIntersection } from "@/features/notifications";
 
 import { FormState } from "./form";
 import { useBoolState } from "@/utils/useBoolState";
@@ -165,8 +166,11 @@ function MilestoneReopened({ comment }) {
 
 function ViewComment({ comment, onEdit, commentParentType }) {
   const me = useMe()!;
+  const commentRef = useClearNotificationOnIntersection(comment.notification);
+
   const entity = { id: comment.id, type: "comment", parentType: commentParentType };
   const addReactionForm = useReactionsForm(entity, comment.reactions);
+
   const testId = "comment-" + comment.id;
   const content = JSON.parse(comment.content)["message"];
 
@@ -174,6 +178,7 @@ function ViewComment({ comment, onEdit, commentParentType }) {
     <div
       className="flex items-start justify-between gap-3 py-3 not-first:border-t border-stroke-base text-content-accent relative"
       data-test-id={testId}
+      ref={commentRef}
     >
       <div className="shrink-0">
         <Avatar person={comment.author} size="normal" />

--- a/assets/js/features/notifications/index.tsx
+++ b/assets/js/features/notifications/index.tsx
@@ -1,0 +1,1 @@
+export { useClearNotificationOnIntersection } from "./useClearNotificationOnIntersection";

--- a/assets/js/features/notifications/useClearNotificationOnIntersection.tsx
+++ b/assets/js/features/notifications/useClearNotificationOnIntersection.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import { useMarkNotificationAsRead, Notification } from "@/models/notifications";
+
+export function useClearNotificationOnIntersection(notification: Notification) {
+  const [markNotificationAsRead] = useMarkNotificationAsRead();
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const options = {
+      root: null,
+      threshold: 0.1,
+    };
+
+    const observer = new IntersectionObserver(handleIntersect, options);
+
+    function handleIntersect(entries, observer) {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          markNotificationAsRead({ id: notification.id });
+          observer.unobserve(entry.target);
+        }
+      });
+    }
+
+    if (ref.current && notification && !notification.read) {
+      // setTimeout prevents the callback function from being fired when IntersectionObserver
+      // is instantiated, which is its default behavior.
+      setTimeout(() => observer.observe(ref.current!), 500);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return ref;
+}

--- a/assets/js/models/notifications.tsx
+++ b/assets/js/models/notifications.tsx
@@ -3,7 +3,7 @@ import Api from "@/api";
 
 import { useUnreadNotificationCount } from "@/api/socket";
 
-export type { SubscriptionList, Subscription, Subscriber } from "@/api";
+export type { SubscriptionList, Subscription, Subscriber, Notification } from "@/api";
 export { useSubscribeToNotifications, useUnsubscribeFromNotifications, useEditSubscriptionsList } from "@/api";
 
 export function useUnreadCount() {

--- a/lib/operately/updates/comment.ex
+++ b/lib/operately/updates/comment.ex
@@ -13,6 +13,9 @@ defmodule Operately.Updates.Comment do
 
     has_many :reactions, Operately.Updates.Reaction, foreign_key: :entity_id, where: [entity_type: :comment]
 
+    # populated with after load hooks
+    field :notification, :any, virtual: true
+
     timestamps()
     requester_access_level()
   end

--- a/lib/operately_web/api/serializers/comment.ex
+++ b/lib/operately_web/api/serializers/comment.ex
@@ -6,6 +6,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Updates.Comment do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(comment.inserted_at),
       author: OperatelyWeb.Api.Serializer.serialize(comment.author),
       reactions: OperatelyWeb.Api.Serializer.serialize(comment.reactions),
+      notification: OperatelyWeb.Api.Serializer.serialize(comment.notification),
     }
   end
 

--- a/lib/operately_web/api/serializers/notifications.ex
+++ b/lib/operately_web/api/serializers/notifications.ex
@@ -1,0 +1,20 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Notifications.Notification do
+  def serialize(notification, level: :essential) do
+    %{
+      id: notification.id,
+      inserted_at: notification.inserted_at,
+      read: notification.read,
+      read_at: notification.read_at,
+    }
+  end
+
+  def serialize(notification, level: :full) do
+    %{
+      id: notification.id,
+      inserted_at: notification.inserted_at,
+      read: notification.read,
+      read_at: notification.read_at,
+      activity: OperatelyWeb.Api.Serializers.Activity.serialize(notification.activity, [comment_thread: :minimal])
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -863,6 +863,7 @@ defmodule OperatelyWeb.Api.Types do
     field :content, :string
     field :author, :person
     field :reactions, list_of(:reaction)
+    field :notification, :notification
   end
 
   union :assignment_resource, types: [


### PR DESCRIPTION
When a user sees a comment in a discussion, if there is an unread notification for this comment, the notification is marked as read.

https://github.com/user-attachments/assets/0d5d2947-e4bd-4cda-beb3-df7399fa500c
