### PR TITLE
feat: Any comment notification is cleared when user sees comment

### DIFF
--- a/assets/js/pages/GoalActivityPage/index.tsx
+++ b/assets/js/pages/GoalActivityPage/index.tsx
@@ -74,8 +74,7 @@ function Reactions({ commentThread }: { commentThread: CommentThread }) {
 }
 
 function Comments({ commentThread, goal }: { commentThread: CommentThread; goal: Goals.Goal }) {
-  const refresh = Pages.useRefresh();
   const commentsForm = useForCommentThread(commentThread, { type: "goal", id: goal.id! });
 
-  return <CommentSection form={commentsForm} refresh={refresh} commentParentType="comment_thread" />;
+  return <CommentSection form={commentsForm} refresh={() => {}} commentParentType="comment_thread" />;
 }

--- a/lib/operately_web/api/queries/get_activity.ex
+++ b/lib/operately_web/api/queries/get_activity.ex
@@ -35,7 +35,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivity do
   defp load(person, id) do
     query = from a in Activity,
       where: a.id == ^id,
-      preload: [:author, comment_thread: [comments: [:author, reactions: :person], reactions: :person]]
+      preload: [:author, comment_thread: [reactions: :person]]
 
     query
     |> filter_by_view_access(person.id)

--- a/lib/operately_web/api/queries/get_comments.ex
+++ b/lib/operately_web/api/queries/get_comments.ex
@@ -36,6 +36,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :project)
     |> Repo.all()
+    |> load_notifications(person, action: "project_check_in_commented")
   end
 
   defp load(id, :project_retrospective, person) do
@@ -47,6 +48,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :project)
     |> Repo.all()
+    |> load_notifications(person, action: "project_retrospective_commented")
   end
 
   defp load(id, :goal_update, person) do
@@ -57,6 +59,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :update)
     |> Repo.all()
+    |> load_notifications(person, action: "goal_check_in_commented")
   end
 
   defp load(id, :message, person) do
@@ -79,6 +82,7 @@ defmodule OperatelyWeb.Api.Queries.GetComments do
     |> preload_resources()
     |> filter_by_view_access(person.id, named_binding: :activity)
     |> Repo.all()
+    |> load_notifications(person, action: "comment_added")
   end
 
   defp preload_resources(query) do

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -35,7 +35,7 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
       message: Jason.encode!(comment_thread.message),
       title: comment_thread.title,
       reactions: OperatelyWeb.Api.Serializer.serialize(comment_thread.reactions),
-      comments: Enum.map(comment_thread.comments, fn c ->
+      comments: Ecto.assoc_loaded?(comment_thread.comments) && Enum.map(comment_thread.comments, fn c ->
         %{
           id: c.id,
           content: Jason.encode!(c.content),


### PR DESCRIPTION
Continuation of https://github.com/operately/operately/pull/1279.

Now, when a user sees a comment in a project check-in, project retrospective, goal update or goal discussion, if there is an unread notification for this comment, the notification is marked as read. 

