### PR TITLE
feat: New discussion notification is cleared when discussion page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -602,6 +602,7 @@ export interface Discussion {
   comments?: Comment[] | null;
   subscriptionList?: SubscriptionList | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface EditMemberPermissionsInput {
@@ -2018,6 +2019,12 @@ export interface MarkNotificationAsReadInput {
 
 export interface MarkNotificationAsReadResult {}
 
+export interface MarkNotificationsAsReadInput {
+  ids?: string[] | null;
+}
+
+export interface MarkNotificationsAsReadResult {}
+
 export interface MoveProjectToSpaceInput {
   projectId?: string | null;
   spaceId?: string | null;
@@ -2628,6 +2635,10 @@ export class ApiClient {
     return this.post("/mark_notification_as_read", input);
   }
 
+  async markNotificationsAsRead(input: MarkNotificationsAsReadInput): Promise<MarkNotificationsAsReadResult> {
+    return this.post("/mark_notifications_as_read", input);
+  }
+
   async moveProjectToSpace(input: MoveProjectToSpaceInput): Promise<MoveProjectToSpaceResult> {
     return this.post("/move_project_to_space", input);
   }
@@ -3016,6 +3027,11 @@ export async function markNotificationAsRead(
   input: MarkNotificationAsReadInput,
 ): Promise<MarkNotificationAsReadResult> {
   return defaultApiClient.markNotificationAsRead(input);
+}
+export async function markNotificationsAsRead(
+  input: MarkNotificationsAsReadInput,
+): Promise<MarkNotificationsAsReadResult> {
+  return defaultApiClient.markNotificationsAsRead(input);
 }
 export async function moveProjectToSpace(input: MoveProjectToSpaceInput): Promise<MoveProjectToSpaceResult> {
   return defaultApiClient.moveProjectToSpace(input);
@@ -3557,6 +3573,15 @@ export function useMarkNotificationAsRead(): UseMutationHookResult<
   );
 }
 
+export function useMarkNotificationsAsRead(): UseMutationHookResult<
+  MarkNotificationsAsReadInput,
+  MarkNotificationsAsReadResult
+> {
+  return useMutation<MarkNotificationsAsReadInput, MarkNotificationsAsReadResult>((input) =>
+    defaultApiClient.markNotificationsAsRead(input),
+  );
+}
+
 export function useMoveProjectToSpace(): UseMutationHookResult<MoveProjectToSpaceInput, MoveProjectToSpaceResult> {
   return useMutation<MoveProjectToSpaceInput, MoveProjectToSpaceResult>((input) =>
     defaultApiClient.moveProjectToSpace(input),
@@ -3899,6 +3924,8 @@ export default {
   useMarkAllNotificationsAsRead,
   markNotificationAsRead,
   useMarkNotificationAsRead,
+  markNotificationsAsRead,
+  useMarkNotificationsAsRead,
   moveProjectToSpace,
   useMoveProjectToSpace,
   newInvitationToken,

--- a/assets/js/features/notifications/index.tsx
+++ b/assets/js/features/notifications/index.tsx
@@ -1,1 +1,2 @@
 export { useClearNotificationOnIntersection } from "./useClearNotificationOnIntersection";
+export { useClearNotificationsOnLoad } from "./useClearNotificationsOnLoad";

--- a/assets/js/features/notifications/useClearNotificationsOnLoad.tsx
+++ b/assets/js/features/notifications/useClearNotificationsOnLoad.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useMarkNotificationsAsRead, Notification } from "@/models/notifications";
+
+export function useClearNotificationsOnLoad(notifications: Notification[]) {
+  const [markNotificationsAsRead] = useMarkNotificationsAsRead();
+
+  useEffect(() => {
+    const ids = notifications.filter((n) => !n.read).map((n) => n.id!);
+
+    markNotificationsAsRead({ ids: ids });
+  }, []);
+}

--- a/assets/js/models/notifications.tsx
+++ b/assets/js/models/notifications.tsx
@@ -4,7 +4,14 @@ import Api from "@/api";
 import { useUnreadNotificationCount } from "@/api/socket";
 
 export type { SubscriptionList, Subscription, Subscriber, Notification } from "@/api";
-export { useSubscribeToNotifications, useUnsubscribeFromNotifications, useEditSubscriptionsList } from "@/api";
+export {
+  useSubscribeToNotifications,
+  useUnsubscribeFromNotifications,
+  useEditSubscriptionsList,
+  useMarkAllNotificationsAsRead,
+  useMarkNotificationAsRead,
+  useMarkNotificationsAsRead,
+} from "@/api";
 
 export function useUnreadCount() {
   const [unread, setUnread] = React.useState(0);
@@ -20,6 +27,3 @@ export function useUnreadCount() {
 
   return unread;
 }
-
-export const useMarkAllNotificationsAsRead = Api.useMarkAllNotificationsAsRead;
-export const useMarkNotificationAsRead = Api.useMarkNotificationAsRead;

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -20,11 +20,13 @@ import { useDiscussionCommentsChangeSignal } from "@/models/comments";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths, compareIds } from "@/routes/paths";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 export function Page() {
   const me = useMe()!;
   const { discussion, comments } = useLoadedData();
   const refresh = useRefresh();
+  useClearNotificationsOnLoad(discussion.notifications || []);
 
   const commentsForm = useForDiscussion(discussion, comments);
   useDiscussionCommentsChangeSignal(refresh, { discussionId: discussion.id! });

--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -98,6 +98,7 @@ defmodule OperatelyWeb.Api do
   mutation :join_company, M.JoinCompany
   mutation :mark_all_notifications_as_read, M.MarkAllNotificationsAsRead
   mutation :mark_notification_as_read, M.MarkNotificationAsRead
+  mutation :mark_notifications_as_read, M.MarkNotificationsAsRead
   mutation :move_project_to_space, M.MoveProjectToSpace
   mutation :new_invitation_token, M.NewInvitationToken
   mutation :pause_project, M.PauseProject

--- a/lib/operately_web/api/mutations/mark_notifications_as_read.ex
+++ b/lib/operately_web/api/mutations/mark_notifications_as_read.ex
@@ -1,0 +1,24 @@
+defmodule OperatelyWeb.Api.Mutations.MarkNotificationsAsRead do
+  use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
+
+  inputs do
+    field :ids, list_of(:string)
+  end
+
+  def call(conn, inputs) do
+    notifications = Operately.Notifications.list_notifications(inputs.ids)
+    person = me(conn)
+
+    if allowed?(notifications, person) do
+      Operately.Notifications.mark_as_read(notifications, person)
+      {:ok, %{}}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp allowed?(notifications, person) do
+    Enum.all?(notifications, &(&1.person_id == person.id))
+  end
+end

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -42,7 +42,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   defp load(ctx, inputs) do
     Message.get(ctx.me, id: ctx.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs),
+      after_load: after_load(inputs) ++ [load_unread_notifications(ctx.me)],
     ])
   end
 
@@ -61,5 +61,11 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &Message.set_potential_subscribers/1,
     ])
+  end
+
+  defp load_unread_notifications(person) do
+    fn message ->
+      Message.load_unread_notifications(message, person)
+    end
   end
 end

--- a/lib/operately_web/api/serializers/message.ex
+++ b/lib/operately_web/api/serializers/message.ex
@@ -23,6 +23,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
       comments: OperatelyWeb.Api.Serializer.serialize(message.comments),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(message.subscription_list),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(message.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(message.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -204,6 +204,7 @@ defmodule OperatelyWeb.Api.Types do
     field :comments, list_of(:comment)
     field :subscription_list, :subscription_list
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :activity do

--- a/test/operately_web/api/mutations/mark_notifications_as_read_test.exs
+++ b/test/operately_web/api/mutations/mark_notifications_as_read_test.exs
@@ -1,0 +1,42 @@
+defmodule OperatelyWeb.Api.Mutations.MarkNotificationsAsReadTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.ActivitiesFixtures
+  import Operately.NotificationsFixtures
+  import Operately.PeopleFixtures
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :mark_notifications_as_read, %{})
+    end
+
+    test "you can't mark someone else's notification as read", ctx do
+      ctx = register_and_log_in_account(ctx)
+      someone_else = person_fixture(company_id: ctx.company.id)
+
+      a = activity_fixture(author_id: ctx.person.id)
+      n = notification_fixture(person_id: someone_else.id, read: false, activity_id: a.id)
+
+      assert {404, res} = mutation(ctx.conn, :mark_notifications_as_read, %{ids: [n.id]})
+      assert res.message == "The requested resource was not found"
+      refute Operately.Notifications.get_notification!(n.id).read
+    end
+  end
+
+  describe "mark_as_read functionality" do
+    setup :register_and_log_in_account
+
+    test "it marks notifications as read", ctx do
+      a1 = activity_fixture(author_id: ctx.company_creator.id)
+      a2 = activity_fixture(author_id: ctx.company_creator.id)
+
+      n1 = notification_fixture(person_id: ctx.person.id, read: false, activity_id: a1.id)
+      n2 = notification_fixture(person_id: ctx.person.id, read: false, activity_id: a2.id)
+
+      assert {200, %{}} = mutation(ctx.conn, :mark_notifications_as_read, %{ids: [n1.id, n2.id]})
+
+      assert Operately.Notifications.get_notification!(n1.id).read
+      assert Operately.Notifications.get_notification!(n2.id).read
+    end
+  end
+end


### PR DESCRIPTION
From now on, when a user opens a discussion page, if there is an unread notification of the type `discussion_posting`, the notification will be marked as read.

I've also added the `MarkNotificationsAsRead` mutation, which can mark many of a user's notifications as read at once. 

This new mutation was probably not necessary for the discussion page since we are clearing only notifications of the type `discussion_posting` and, for any given discussion, a user should only ever have a single notification of this type. 

However, this mutation should be quite useful when we add the "clear-notification" functionality to pages that will clear different types of notifications, such as the project page.