### PR TITLE
feat: Project check-in notifications are cleared when check-in page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -803,6 +803,7 @@ export interface ProjectCheckIn {
   reactions?: Reaction[] | null;
   subscriptionList?: SubscriptionList | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface ProjectContributor {

--- a/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -22,10 +22,12 @@ import { CommentSection, useForProjectCheckIn } from "@/features/CommentSection"
 import { useLoadedData, useRefresh } from "./loader";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 export function Page() {
   const { checkIn } = useLoadedData();
   const refresh = useRefresh();
+  useClearNotificationsOnLoad(checkIn.notifications || []);
 
   return (
     <Pages.Page title={["Check-In", checkIn.project!.name!]}>

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -39,7 +39,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   defp load(ctx, inputs) do
     CheckIn.get(ctx.me, id: ctx.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs),
+      after_load: after_load(inputs) ++ [load_unread_notifications(ctx.me)],
     ])
   end
 
@@ -59,5 +59,11 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
       include_project: &Project.set_permissions/1,
       include_potential_subscribers: &CheckIn.set_potential_subscribers/1,
     ])
+  end
+
+  defp load_unread_notifications(person) do
+    fn check_in ->
+      CheckIn.load_unread_notifications(check_in, person)
+    end
   end
 end

--- a/lib/operately_web/api/serializers/notifications.ex
+++ b/lib/operately_web/api/serializers/notifications.ex
@@ -2,18 +2,18 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Notifications.Notification
   def serialize(notification, level: :essential) do
     %{
       id: notification.id,
-      inserted_at: notification.inserted_at,
+      inserted_at: OperatelyWeb.Api.Serializer.serialize(notification.inserted_at),
       read: notification.read,
-      read_at: notification.read_at,
+      read_at: OperatelyWeb.Api.Serializer.serialize(notification.read_at),
     }
   end
 
   def serialize(notification, level: :full) do
     %{
       id: notification.id,
-      inserted_at: notification.inserted_at,
+      inserted_at: OperatelyWeb.Api.Serializer.serialize(notification.inserted_at),
       read: notification.read,
-      read_at: notification.read_at,
+      read_at: OperatelyWeb.Api.Serializer.serialize(notification.read_at),
       activity: OperatelyWeb.Api.Serializers.Activity.serialize(notification.activity, [comment_thread: :minimal])
     }
   end

--- a/lib/operately_web/api/serializers/project_check_in.ex
+++ b/lib/operately_web/api/serializers/project_check_in.ex
@@ -12,6 +12,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.CheckIn do
       author: OperatelyWeb.Api.Serializer.serialize(check_in.author),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(check_in.subscription_list),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(check_in.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(check_in.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -955,6 +955,7 @@ defmodule OperatelyWeb.Api.Types do
     field :reactions, list_of(:reaction)
     field :subscription_list, :subscription_list
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :activity_content_project_check_in_commented do


### PR DESCRIPTION
Now, when a user opens a project check-in page, if there are unread notifications of the type `project_check_in_submitted` or `project_check_in_acknowledged`, the notifications will be marked as read.