### PR TITLE
feat: Project notifications are cleared when project page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -789,6 +789,7 @@ export interface Project {
   reviewer?: Person | null;
   accessLevels?: AccessLevels | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface ProjectCheckIn {

--- a/assets/js/pages/ProjectPage/index.tsx
+++ b/assets/js/pages/ProjectPage/index.tsx
@@ -14,6 +14,8 @@ import { TimelineSection } from "./TimelineSection";
 import { ResourcesSection } from "./ResourcesSection";
 import { ContributorsSection } from "./ContributorsSection";
 import { ProjectDescriptionSection } from "./ProjectDescriptionSection";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 interface LoaderResult {
   project: Projects.Project;
@@ -40,6 +42,9 @@ export async function loader({ params }): Promise<LoaderResult> {
 
 export function Page() {
   const { project } = Pages.useLoadedData() as LoaderResult;
+
+  assertPresent(project.notifications, "Project notifications must be defined");
+  useClearNotificationsOnLoad(project.notifications);
 
   return (
     <Pages.Page title={project.name!} testId="project-page">

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -48,6 +48,7 @@ defmodule Operately.Projects.Project do
     field :access_levels, :any, virtual: true
     field :privacy, :any, virtual: true
     field :potential_subscribers, :any, virtual: true
+    field :notifications, :any, virtual: true, default: []
 
     timestamps()
     soft_delete()
@@ -159,6 +160,29 @@ defmodule Operately.Projects.Project do
 
         Map.put(project, :next_milestone, next)
     end
+  end
+
+  def load_unread_notifications(project = %__MODULE__{}, person) do
+    actions = [
+      "project_created",
+      "project_closed",
+      "project_goal_connection",
+      "project_moved",
+      "project_pausing",
+      "project_resuming",
+      "project_timeline_edited"
+    ]
+
+    notifications =
+      from(n in Operately.Notifications.Notification,
+        join: a in assoc(n, :activity),
+        where: a.action in ^actions and a.content["project_id"] == ^project.id,
+        where: n.person_id == ^person.id and not n.read,
+        select: n
+      )
+      |> Repo.all()
+
+    Map.put(project, :notifications, notifications)
   end
 
   def load_contributor_access_levels(project) do

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -40,7 +40,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     Project.get(requester, id: id, opts: [
       with_deleted: true,
       preload: preload(inputs),
-      after_load: after_load(inputs),
+      after_load: after_load(inputs) ++ [load_unread_notifications(requester)],
     ])
   end
 
@@ -83,6 +83,12 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
 
       true ->
         :ok
+    end
+  end
+
+  defp load_unread_notifications(person) do
+    fn project ->
+      Project.load_unread_notifications(project, person)
     end
   end
 end

--- a/lib/operately_web/api/serializers/project.ex
+++ b/lib/operately_web/api/serializers/project.ex
@@ -36,6 +36,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       key_resources: OperatelyWeb.Api.Serializer.serialize(project.key_resources),
       access_levels: OperatelyWeb.Api.Serializer.serialize(project.access_levels, level: :full),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(project.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(project.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -177,6 +177,7 @@ defmodule OperatelyWeb.Api.Types do
     field :reviewer, :person
     field :access_levels, :access_levels
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :project_retrospective do


### PR DESCRIPTION
Now, when a user opens a project page, if there are unread notifications related to the project, the notifications will be marked as read.

The notifications that will be marked as read are the following: 
- project_created 
- project_closed
- project_goal_connection
- project_moved
- project_pausing
- project_resuming
- project_timeline_edited

Those are the notifications that redirect the user to project page. 