### PR TITLE
feat: Goal notifications are cleared when goal page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -649,6 +649,7 @@ export interface Goal {
   myRole?: string | null;
   accessLevels?: AccessLevels | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface GoalEditingUpdatedTarget {

--- a/assets/js/pages/GoalPage/index.tsx
+++ b/assets/js/pages/GoalPage/index.tsx
@@ -8,6 +8,8 @@ import { Navigation } from "@/features/goals/GoalPageNavigation";
 import { Header } from "@/features/goals/GoalPageHeader";
 import { SuccessConditions } from "@/features/goals/SuccessConditions";
 import { LastCheckInMessage } from "@/features/goals/GoalCheckIn";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 interface LoaderResult {
   goal: Goals.Goal;
@@ -28,6 +30,9 @@ export async function loader({ params }): Promise<LoaderResult> {
 
 export function Page() {
   const { goal } = Pages.useLoadedData<LoaderResult>();
+
+  assertPresent(goal.notifications, "Goal notifications must be defined");
+  useClearNotificationsOnLoad(goal.notifications);
 
   return (
     <Pages.Page title={[goal.name!]}>

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -53,7 +53,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
     Goal.get(ctx.me, id: ctx.id, company_id: ctx.me.company_id, opts: [
       with_deleted: true,
       preload: [:parent_goal] ++ preload(inputs),
-      after_load: after_load(inputs, ctx.me),
+      after_load: [load_unread_notifications(ctx.me)] ++ after_load(inputs, ctx.me),
     ])
   end
 
@@ -82,6 +82,12 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
   defp load_permissions(person) do
     fn goal ->
       Goal.preload_permissions(goal, person)
+    end
+  end
+
+  defp load_unread_notifications(person) do
+    fn goal ->
+      Goal.load_unread_notifications(goal, person)
     end
   end
 end

--- a/lib/operately_web/api/serializers/goal.ex
+++ b/lib/operately_web/api/serializers/goal.ex
@@ -39,6 +39,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Goal do
       permissions: OperatelyWeb.Api.Serializer.serialize(goal.permissions, level: :full),
       access_levels: OperatelyWeb.Api.Serializer.serialize(goal.access_levels, level: :full),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(goal.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(goal.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -611,6 +611,7 @@ defmodule OperatelyWeb.Api.Types do
     field :my_role, :string
     field :access_levels, :access_levels
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :activity_content_project_resuming do


### PR DESCRIPTION
Now, when a user opens a goal page, if there are unread notifications related to the goal, the notifications will be marked as read.

The notifications that will be marked as read are the following:
- goal_created
- goal_editing
- goal_archived

Those are the notifications that redirect the user to the goal page.