### PR TITLE
fix: Request to clear notifications sent only when necessary

### DIFF
--- a/assets/js/features/notifications/useClearNotificationsOnLoad.tsx
+++ b/assets/js/features/notifications/useClearNotificationsOnLoad.tsx
@@ -7,6 +7,8 @@ export function useClearNotificationsOnLoad(notifications: Notification[]) {
   useEffect(() => {
     const ids = notifications.filter((n) => !n.read).map((n) => n.id!);
 
-    markNotificationsAsRead({ ids: ids });
+    if (ids.length > 0) {
+      markNotificationsAsRead({ ids: ids });
+    }
   }, []);
 }


### PR DESCRIPTION
It turned out that `useClearNotificationsOnLoad` was sending requests to clear notifications even when there were no unread notifications. Now, it only sends requests when necessary.