### PR TITLE
feat: Goal Activity notifications are cleared when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -137,6 +137,7 @@ export interface Activity {
   person?: Person | null;
   eventData?: ActivityDataUnion | null;
   content?: ActivityContent | null;
+  notifications?: Notification[] | null;
 }
 
 export interface ActivityContentCommentAdded {
@@ -1188,6 +1189,7 @@ export interface GetActivitiesResult {
 
 export interface GetActivityInput {
   id?: string | null;
+  includeUnreadGoalNotifications?: boolean | null;
 }
 
 export interface GetActivityResult {

--- a/assets/js/pages/GoalActivityPage/index.tsx
+++ b/assets/js/pages/GoalActivityPage/index.tsx
@@ -12,6 +12,8 @@ import { CommentSection, useForCommentThread } from "@/features/CommentSection";
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
 import ActivityHandler from "@/features/activities";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 interface LoaderResult {
   activity: Activities.Activity;
@@ -19,13 +21,19 @@ interface LoaderResult {
 
 export async function loader({ params }): Promise<LoaderResult> {
   return {
-    activity: await Activities.getActivity({ id: params.id }),
+    activity: await Activities.getActivity({
+      id: params.id,
+      includeUnreadGoalNotifications: true,
+    }),
   };
 }
 
 export function Page() {
   const { activity } = Pages.useLoadedData<LoaderResult>();
   const goal = Activities.getGoal(activity);
+
+  assertPresent(activity.notifications, "Activity notifications must be defined");
+  useClearNotificationsOnLoad(activity.notifications);
 
   return (
     <Pages.Page title={[ActivityHandler.pageHtmlTitle(activity), goal.name!]}>

--- a/lib/operately/activities/permissions.ex
+++ b/lib/operately/activities/permissions.ex
@@ -3,11 +3,13 @@ defmodule Operately.Activities.Permissions do
 
   defstruct [
     :can_comment_on_thread,
+    :can_view,
   ]
 
   def calculate_permissions(access_level) do
     %__MODULE__{
       can_comment_on_thread: access_level >= Binding.comment_access(),
+      can_view: access_level >= Binding.view_access(),
     }
   end
 

--- a/lib/operately_web/api/helpers.ex
+++ b/lib/operately_web/api/helpers.ex
@@ -114,6 +114,8 @@ defmodule OperatelyWeb.Api.Helpers do
 
   defmodule Inputs do
     def parse_includes(inputs, includes) do
+      always_include = Keyword.get_values(includes, :always_include)
+
       Enum.reduce(inputs, [], fn {key, value}, acc ->
         rule = Keyword.get(includes, key)
 
@@ -123,6 +125,7 @@ defmodule OperatelyWeb.Api.Helpers do
           acc
         end
       end)
+      |> Enum.concat(always_include)
     end
   end
 end

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -18,6 +18,7 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
       author: OperatelyWeb.Api.Serializer.serialize(activity.author, level: :essential),
       comment_thread: activity.comment_thread && serialize_comment_thread(activity.comment_thread, comment_thread),
       content: serialize_content(activity.action, activity.content),
+      notifications: OperatelyWeb.Api.Serializer.serialize(activity.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -223,6 +223,7 @@ defmodule OperatelyWeb.Api.Types do
     field :person, :person
     field :event_data, :activity_data_union
     field :content, :activity_content
+    field :notifications, list_of(:notification)
   end
 
   object :activity_event_data_project_create do

--- a/test/operately_web/api/queries/get_activity_test.exs
+++ b/test/operately_web/api/queries/get_activity_test.exs
@@ -8,6 +8,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
 
   alias Operately.{Repo, Groups}
   alias Operately.Access.Binding
+  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -107,24 +108,63 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
     end
   end
 
+  describe "get_activity functionality" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.log_in_person(:creator)
+      |> Factory.add_space(:space)
+      |> Factory.add_space_member(:reviewer, :space)
+      |> Factory.add_goal(:goal, :space, reviewer: :reviewer)
+    end
+
+    test "with no includes", ctx do
+      {:ok, _} = Operately.Operations.GoalClosing.run(ctx.creator, ctx.goal, "success", RichText.rich_text("content", :as_string))
+      activity = fetch_activity("goal_closing")
+
+      assert {200, res} = query(ctx.conn, :get_activity, %{id: Paths.activity_id(activity)})
+
+      assert res.activity.author == Serializer.serialize(ctx.creator)
+      assert res.activity.action == "goal_closing"
+      assert res.activity.content.goal.id == ctx.goal.id
+      assert res.activity.comment_thread.message == RichText.rich_text("content", :as_string)
+    end
+
+    test "include_unread_goal_notifications", ctx do
+      {:ok, _} = Operately.Operations.GoalClosing.run(ctx.reviewer, ctx.goal, "success", RichText.rich_text("content", :as_string))
+      activity = fetch_activity("goal_closing")
+
+      assert {200, res} = query(ctx.conn, :get_activity, %{id: Paths.activity_id(activity)})
+      assert res.activity.notifications == []
+
+      assert {200, res} = query(ctx.conn, :get_activity, %{
+        id: Paths.activity_id(activity),
+        include_unread_goal_notifications: true,
+      })
+
+      assert length(res.activity.notifications) == 1
+      assert hd(res.activity.notifications).read == false
+    end
+  end
+
   #
   # Helpers
   #
 
-  defp fetch_activity() do
-    from(a in Operately.Activities.Activity, where: a.action == "goal_created")
+  defp fetch_activity(action \\ "goal_created") do
+    from(a in Operately.Activities.Activity, where: a.action == ^action)
     |> Repo.one!()
   end
 
   defp refute_activity(conn, activity) do
     assert {404, %{message: msg} = _res} = query(conn, :get_activity, %{id: activity.id})
-    assert msg == "Activity not found"
+    assert msg == "The requested resource was not found"
   end
 
   defp assert_activity(conn, activity, goal) do
     assert {200, res} = query(conn, :get_activity, %{id: activity.id})
 
-    assert res.activity.id == OperatelyWeb.Paths.activity_id(activity)
+    assert res.activity.id == Paths.activity_id(activity)
     assert res.activity.action == "goal_created"
     assert res.activity.content.goal.id == goal.id
   end


### PR DESCRIPTION
Now, when a user opens a goal activity page, if there are unread notifications related to the goal activity, the notifications will be marked as read.

The notifications that will be marked as read are the following:
- goal_closing
- goal_reopening
- goal_timeframe_editing

Those are the notifications that redirect the user to the goal activity page. 