### PR TITLE
feat: Goal Update notifications are cleared when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -681,6 +681,7 @@ export interface GoalProgressUpdate {
   goal?: Goal | null;
   subscriptionList?: SubscriptionList | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface GoalTargetUpdates {
@@ -1297,6 +1298,7 @@ export interface GetGoalProgressUpdateInput {
   includeSpaceMembers?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetGoalProgressUpdateResult {

--- a/assets/js/pages/GoalProgressUpdatePage/loader.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/loader.tsx
@@ -14,6 +14,7 @@ export async function loader({ params }): Promise<LoaderResult> {
     includeAuthor: true,
     includeSubscriptionsList: true,
     includePotentialSubscribers: true,
+    includeUnreadNotifications: true,
   }).then((data) => data.update!);
 
   return {

--- a/assets/js/pages/GoalProgressUpdatePage/page.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/page.tsx
@@ -18,13 +18,18 @@ import RichContent from "@/components/RichContent";
 import { CommentSection, useForGoalCheckIn } from "@/features/CommentSection";
 import { Paths, compareIds } from "@/routes/paths";
 import { useMe } from "@/contexts/CurrentUserContext";
+import { assertPresent } from "@/utils/assertions";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 export function Page() {
   const me = useMe()!;
-  const { update } = useLoadedData();
   const refresh = useRefresh();
 
+  const { update } = useLoadedData();
   const commentsForm = useForGoalCheckIn(update);
+
+  assertPresent(update.notifications, "Update notifications must be defined");
+  useClearNotificationsOnLoad(update.notifications);
 
   return (
     <Pages.Page title={["Goal Progress Update", update.goal!.name!]}>

--- a/lib/operately_web/api/queries/get_goal_progress_update.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_update.ex
@@ -16,6 +16,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
     field :include_space_members, :boolean
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -67,9 +68,9 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &Update.set_potential_subscribers/1,
+      include_unread_notifications: load_unread_notifications(me),
+      always_include: load_goal_permissions(me),
     ])
-    ++
-    [load_goal_permissions(me)]
   end
 
   defp load_goal_permissions(person) do
@@ -80,6 +81,12 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
       else
         update
       end
+    end
+  end
+
+  defp load_unread_notifications(person) do
+    fn activity ->
+      Update.load_unread_notifications(activity, person)
     end
   end
 end

--- a/lib/operately_web/api/serializers/goal_update.ex
+++ b/lib/operately_web/api/serializers/goal_update.ex
@@ -14,6 +14,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update  do
       goal_target_updates: parse_targets(update.targets),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(update.subscription_list),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(update.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(update.notifications),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1043,6 +1043,7 @@ defmodule OperatelyWeb.Api.Types do
     field :goal, :goal
     field :subscription_list, :subscription_list
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :goal_target_updates do


### PR DESCRIPTION
Now, when a user opens a goal update page, if there are unread notifications of the type `goal_check_in` or `goal_check_in_acknowledgement`, the notifications will be marked as read.