### PR TITLE
fix: Unread notifications are loaded only when necessary

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1252,6 +1252,7 @@ export interface GetDiscussionInput {
   includeSpaceMembers?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetDiscussionResult {
@@ -1279,6 +1280,7 @@ export interface GetGoalInput {
   includeTargets?: boolean | null;
   includeAccessLevels?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetGoalResult {
@@ -1406,6 +1408,7 @@ export interface GetProjectInput {
   includePrivacy?: boolean | null;
   includeRetrospective?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetProjectResult {
@@ -1420,6 +1423,7 @@ export interface GetProjectCheckInInput {
   includeReactions?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetProjectCheckInResult {

--- a/assets/js/pages/DiscussionPage/loader.tsx
+++ b/assets/js/pages/DiscussionPage/loader.tsx
@@ -16,6 +16,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeSpaceMembers: true,
       includeSubscriptionsList: true,
       includePotentialSubscribers: true,
+      includeUnreadNotifications: true,
     }).then((d) => d.discussion!),
     Comments.getComments({
       entityId: params.id,

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -21,15 +21,18 @@ import { useMe } from "@/contexts/CurrentUserContext";
 import { Paths, compareIds } from "@/routes/paths";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const me = useMe()!;
   const { discussion, comments } = useLoadedData();
   const refresh = useRefresh();
-  useClearNotificationsOnLoad(discussion.notifications || []);
 
   const commentsForm = useForDiscussion(discussion, comments);
   useDiscussionCommentsChangeSignal(refresh, { discussionId: discussion.id! });
+
+  assertPresent(discussion.notifications, "Discussion notifications must be defined");
+  useClearNotificationsOnLoad(discussion.notifications);
 
   return (
     <Pages.Page title={discussion.title!}>

--- a/assets/js/pages/GoalPage/index.tsx
+++ b/assets/js/pages/GoalPage/index.tsx
@@ -24,6 +24,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeProjects: true,
       includeLastCheckIn: true,
       includePermissions: true,
+      includeUnreadNotifications: true,
     }).then((data) => data.goal!),
   };
 }

--- a/assets/js/pages/ProjectCheckInPage/loader.tsx
+++ b/assets/js/pages/ProjectCheckInPage/loader.tsx
@@ -15,6 +15,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeAcknowledgedBy: true,
       includeSubscriptionsList: true,
       includePotentialSubscribers: true,
+      includeUnreadNotifications: true,
     }).then((data) => data.projectCheckIn!),
   };
 }

--- a/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -23,11 +23,14 @@ import { useLoadedData, useRefresh } from "./loader";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const { checkIn } = useLoadedData();
   const refresh = useRefresh();
-  useClearNotificationsOnLoad(checkIn.notifications || []);
+
+  assertPresent(checkIn.notifications, "Check-in notifications must be defined");
+  useClearNotificationsOnLoad(checkIn.notifications);
 
   return (
     <Pages.Page title={["Check-In", checkIn.project!.name!]}>

--- a/assets/js/pages/ProjectPage/index.tsx
+++ b/assets/js/pages/ProjectPage/index.tsx
@@ -36,6 +36,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeLastCheckIn: true,
       includePrivacy: true,
       includeRetrospective: true,
+      includeUnreadNotifications: true,
     }).then((data) => data.project!),
   };
 }

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -18,7 +18,7 @@ defmodule Operately.Messages.Message do
 
     # populated with after load hooks
     field :potential_subscribers, :any, virtual: true
-    field :notifications, :any, virtual: true
+    field :notifications, :any, virtual: true, default: []
 
     timestamps()
     requester_access_level()

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -13,6 +13,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
     field :include_space_members, :boolean
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -42,7 +43,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   defp load(ctx, inputs) do
     Message.get(ctx.me, id: ctx.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs) ++ [load_unread_notifications(ctx.me)],
+      after_load: after_load(inputs, ctx.me),
     ])
   end
 
@@ -57,9 +58,10 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
     ])
   end
 
-  defp after_load(inputs) do
+  defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &Message.set_potential_subscribers/1,
+      include_unread_notifications: load_unread_notifications(me),
     ])
   end
 

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -19,6 +19,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
     field :include_targets, :boolean
     field :include_access_levels, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -52,8 +53,8 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
   defp load(ctx, inputs) do
     Goal.get(ctx.me, id: ctx.id, company_id: ctx.me.company_id, opts: [
       with_deleted: true,
-      preload: [:parent_goal] ++ preload(inputs),
-      after_load: [load_unread_notifications(ctx.me)] ++ after_load(inputs, ctx.me),
+      preload: preload(inputs),
+      after_load: after_load(inputs, ctx.me),
     ])
   end
 
@@ -67,6 +68,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
         include_space_members: [group: [:members, :company]],
         include_targets: :targets,
         include_potential_subscribers: [:reviewer, :champion, group: :members],
+        always_include: :parent_goal,
     ])
   end
 
@@ -76,6 +78,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
       include_permissions: load_permissions(me),
       include_access_levels: &Goal.preload_access_levels/1,
       include_potential_subscribers: &Goal.set_potential_subscribers/1,
+      include_unread_notifications: load_unread_notifications(me),
     ])
   end
 

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -22,6 +22,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     field :include_privacy, :boolean
     field :include_retrospective, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -40,7 +41,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     Project.get(requester, id: id, opts: [
       with_deleted: true,
       preload: preload(inputs),
-      after_load: after_load(inputs) ++ [load_unread_notifications(requester)],
+      after_load: after_load(inputs, requester),
     ])
   end
 
@@ -58,7 +59,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
     ])
   end
 
-  def after_load(inputs) do
+  def after_load(inputs, person) do
     Inputs.parse_includes(inputs, [
       include_milestones: &Project.load_milestones/1,
       include_permissions: &Project.set_permissions/1,
@@ -66,6 +67,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
       include_access_levels: &Project.load_access_levels/1,
       include_privacy: &Project.load_privacy/1,
       include_potential_subscribers: &Project.set_potential_subscribers/1,
+      include_unread_notifications: load_unread_notifications(person),
     ])
   end
 

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -12,6 +12,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
     field :include_reactions, :boolean
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -39,7 +40,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   defp load(ctx, inputs) do
     CheckIn.get(ctx.me, id: ctx.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs) ++ [load_unread_notifications(ctx.me)],
+      after_load: after_load(inputs, ctx.me),
     ])
   end
 
@@ -54,10 +55,11 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
     ])
   end
 
-  defp after_load(inputs) do
+  defp after_load(inputs, person) do
     Inputs.parse_includes(inputs, [
       include_project: &Project.set_permissions/1,
       include_potential_subscribers: &CheckIn.set_potential_subscribers/1,
+      include_unread_notifications: load_unread_notifications(person),
     ])
   end
 

--- a/test/operately_web/api/queries/get_discussion_test.exs
+++ b/test/operately_web/api/queries/get_discussion_test.exs
@@ -60,16 +60,18 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionTest do
   describe "get_discussion functionality" do
     setup :register_and_log_in_account
 
-    test "includes notifications by default", ctx do
+    test "include_unread_notifications", ctx do
       message = message_fixture(ctx.person.id, ctx.company.company_space_id)
-
-      assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
-      assert res.discussion.notifications == []
-
       a = activity_fixture(author_id: ctx.person.id, action: "discussion_posting", content: %{discussion_id: message.id})
       n = notification_fixture(person_id: ctx.person.id, read: false, activity_id: a.id)
 
       assert {200, res} = query(ctx.conn, :get_discussion, %{id: Paths.message_id(message)})
+      assert res.discussion.notifications == []
+
+      assert {200, res} = query(ctx.conn, :get_discussion, %{
+        id: Paths.message_id(message),
+        include_unread_notifications: true,
+      })
 
       assert length(res.discussion.notifications) == 1
       assert Serializer.serialize(n) == hd(res.discussion.notifications)

--- a/test/operately_web/api/queries/get_goal_test.exs
+++ b/test/operately_web/api/queries/get_goal_test.exs
@@ -128,16 +128,18 @@ defmodule OperatelyWeb.Api.Queries.GetGoalTest do
       assert query(ctx.conn, :get_goal, %{id: id}) == not_found_response()
     end
 
-    test "includes notifications by default", ctx do
+    test "include_unread_notifications", ctx do
       goal = goal_fixture(ctx.person, company_id: ctx.company.id, space_id: ctx.company.company_space_id)
-
-      assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal)})
-      assert res.goal.notifications == []
-
       a = activity_fixture(author_id: ctx.person.id, action: "goal_created", content: %{goal_id: goal.id})
       n = notification_fixture(person_id: ctx.person.id, read: false, activity_id: a.id)
 
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal)})
+      assert res.goal.notifications == []
+
+      assert {200, res} = query(ctx.conn, :get_goal, %{
+        id: Paths.goal_id(goal),
+        include_unread_notifications: true,
+      })
 
       assert length(res.goal.notifications) == 1
       assert Serializer.serialize(n) == hd(res.goal.notifications)

--- a/test/operately_web/api/queries/get_project_check_in_test.exs
+++ b/test/operately_web/api/queries/get_project_check_in_test.exs
@@ -99,14 +99,17 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckInTest do
       |> Factory.add_project_check_in(:check_in, :project, :creator)
     end
 
-    test "includes notifications by default", ctx do
-      assert {200, res} = query(ctx.conn, :get_project_check_in, %{id: Paths.project_check_in_id(ctx.check_in)})
-      assert res.project_check_in.notifications == []
-
+    test "include_unread_notifications", ctx do
       a = activity_fixture(author_id: ctx.creator.id, action: "project_check_in_submitted", content: %{check_in_id: ctx.check_in.id})
       n = notification_fixture(person_id: ctx.creator.id, read: false, activity_id: a.id)
 
       assert {200, res} = query(ctx.conn, :get_project_check_in, %{id: Paths.project_check_in_id(ctx.check_in)})
+      assert res.project_check_in.notifications == []
+
+      assert {200, res} = query(ctx.conn, :get_project_check_in, %{
+        id: Paths.project_check_in_id(ctx.check_in),
+        include_unread_notifications: true,
+      })
 
       assert length(res.project_check_in.notifications) == 1
       assert Serializer.serialize(n) == hd(res.project_check_in.notifications)


### PR DESCRIPTION
Now, unread notifications are included in the query result only if the user add `include_unread_notifications: true` to the request.