### PR TITLE
feat: Project Retrospective notifications are cleared when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -880,6 +880,7 @@ export interface ProjectRetrospective {
   reactions?: Reaction[] | null;
   subscriptionList?: SubscriptionList | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface ProjectReviewRequest {
@@ -1454,6 +1455,7 @@ export interface GetProjectRetrospectiveInput {
   includeReactions?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetProjectRetrospectiveResult {

--- a/assets/js/pages/ProjectRetrospectivePage/loader.tsx
+++ b/assets/js/pages/ProjectRetrospectivePage/loader.tsx
@@ -17,6 +17,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeReactions: true,
       includePotentialSubscribers: true,
       includeSubscriptionsList: true,
+      includeUnreadNotifications: true,
     }).then((data) => data.retrospective!),
     Comments.getComments({
       entityId: params.projectID,

--- a/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -16,9 +16,14 @@ import FormattedTime from "@/components/FormattedTime";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 
 import { useLoadedData, useRefresh } from "./loader";
+import { assertPresent } from "@/utils/assertions";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 export function Page() {
   const { retrospective } = useLoadedData();
+
+  assertPresent(retrospective.notifications, "Retrospective notifications must be defined");
+  useClearNotificationsOnLoad(retrospective.notifications);
 
   return (
     <Pages.Page title={["Retrospective", retrospective.project!.name!]}>

--- a/lib/operately_web/api/serializers/project_retrospective.ex
+++ b/lib/operately_web/api/serializers/project_retrospective.ex
@@ -10,6 +10,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Retrospective do
       reactions: OperatelyWeb.Api.Serializer.serialize(retrospective.reactions),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(retrospective.subscription_list),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(retrospective.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(retrospective.notifications),
     }
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -190,6 +190,7 @@ defmodule OperatelyWeb.Api.Types do
     field :reactions, list_of(:reaction)
     field :subscription_list, :subscription_list
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :discussion do


### PR DESCRIPTION
Now, when a user opens a project retrospective page, if there are unread notifications of the type `project_closed`, the notifications will be marked as read.