### PR TITLE
feat: Space notifications are cleared when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -920,6 +920,7 @@ export interface Space {
   members?: Person[] | null;
   accessLevels?: AccessLevels | null;
   potentialSubscribers?: Subscriber[] | null;
+  notifications?: Notification[] | null;
 }
 
 export interface Subscriber {
@@ -1486,6 +1487,7 @@ export interface GetSpaceInput {
   includeAccessLevels?: boolean | null;
   includeMembersAccessLevels?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetSpaceResult {

--- a/assets/js/pages/SpacePage/loader.tsx
+++ b/assets/js/pages/SpacePage/loader.tsx
@@ -9,12 +9,21 @@ interface LoadedData {
 }
 
 export async function loader({ params }): Promise<LoadedData> {
-  const companyPromise = Companies.getCompany({ id: params.companyId }).then((d) => d.company!);
-  const spacePromise = Spaces.getSpace({ id: params.id, includeMembers: true, includeAccessLevels: true });
+  const [company, space] = await Promise.all([
+    Companies.getCompany({
+      id: params.companyId,
+    }).then((d) => d.company!),
+    Spaces.getSpace({
+      id: params.id,
+      includeMembers: true,
+      includeAccessLevels: true,
+      includeUnreadNotifications: true,
+    }),
+  ]);
 
   return {
-    company: await companyPromise,
-    space: await spacePromise,
+    company,
+    space,
     loadedAt: new Date(),
   };
 }

--- a/assets/js/pages/SpacePage/page.tsx
+++ b/assets/js/pages/SpacePage/page.tsx
@@ -14,9 +14,14 @@ import { PrimaryButton } from "@/components/Buttons";
 
 import { useJoinSpace } from "@/models/spaces";
 import { PrivacyIndicator } from "@/features/spaces/PrivacyIndicator";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const { space } = useLoadedData();
+
+  assertPresent(space.notifications, "notifications must be present in space");
+  useClearNotificationsOnLoad(space.notifications);
 
   return (
     <Pages.Page title={space.name!}>

--- a/lib/operately_web/api/serializers/space.ex
+++ b/lib/operately_web/api/serializers/space.ex
@@ -20,6 +20,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Groups.Group do
       members: OperatelyWeb.Api.Serializer.serialize(space.members),
       access_levels: OperatelyWeb.Api.Serializer.serialize(space.access_levels, level: :full),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(space.potential_subscribers),
+      notifications: OperatelyWeb.Api.Serializer.serialize(space.notifications),
     }
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -270,6 +270,7 @@ defmodule OperatelyWeb.Api.Types do
     field :members, list_of(:person)
     field :access_levels, :access_levels
     field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :panel do


### PR DESCRIPTION
Now, when a user opens a space page, if there are unread notifications of the type `space_members_added`, the notifications will be marked as read.

We don't have many notifications for spaces yet, that's why I handled only `space_members_added`. As we add more notifications for spaces, we just have to add them to the `actions` list in `Operately.Groups.Group.load_unread_notifications/2`.