### PR TITLE
feat: Milestone Comments notifications are cleared when comment is seen

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -713,7 +713,7 @@ export interface Invitation {
 
 export interface Milestone {
   id?: string | null;
-  projectId?: string | null;
+  project?: Project | null;
   title?: string | null;
   status?: string | null;
   insertedAt?: string | null;
@@ -722,6 +722,7 @@ export interface Milestone {
   description?: string | null;
   comments?: MilestoneComment[] | null;
   tasksKanbanState?: string | null;
+  permissions?: ProjectPermissions | null;
 }
 
 export interface MilestoneComment {
@@ -1365,8 +1366,8 @@ export interface GetMeResult {
 export interface GetMilestoneInput {
   id?: string | null;
   includeComments?: boolean | null;
-  includeTasksKanban?: boolean | null;
   includeProject?: boolean | null;
+  includePermissions?: boolean | null;
 }
 
 export interface GetMilestoneResult {

--- a/assets/js/features/CommentSection/useForMilestone.tsx
+++ b/assets/js/features/CommentSection/useForMilestone.tsx
@@ -49,7 +49,7 @@ export function useForMilestone(milestone: Milestones.Milestone): FormState {
     postComment,
     editComment,
     submitting: submittingPost || submittingEdit,
-    mentionSearchScope: { type: "project", id: milestone.projectId! } as People.SearchScope,
+    mentionSearchScope: { type: "project", id: milestone.project!.id } as People.SearchScope,
   };
 
   return res;

--- a/assets/js/features/Tasks/NewTaskModal/index.tsx
+++ b/assets/js/features/Tasks/NewTaskModal/index.tsx
@@ -75,7 +75,15 @@ function useForm({ onSubmit, milestone, mentionSearchScope }: UseFormProps) {
   };
 }
 
-export function NewTaskModal({ isOpen, hideModal, modalTitle, milestone, onSubmit }) {
+interface NewTaskModalProps {
+  isOpen: boolean;
+  hideModal: () => void;
+  modalTitle: string;
+  onSubmit: () => void;
+  milestone: Milestones.Milestone;
+}
+
+export function NewTaskModal({ isOpen, hideModal, modalTitle, milestone, onSubmit }: NewTaskModalProps) {
   const handleSubmit = () => {
     onSubmit();
     hideModal();
@@ -89,7 +97,7 @@ export function NewTaskModal({ isOpen, hideModal, modalTitle, milestone, onSubmi
   const form = useForm({
     onSubmit: handleSubmit,
     milestone,
-    mentionSearchScope: { type: "project", id: milestone.projectId! },
+    mentionSearchScope: { type: "project", id: milestone.project!.id! },
   });
 
   return (

--- a/assets/js/pages/ProjectMilestonePage/Options.tsx
+++ b/assets/js/pages/ProjectMilestonePage/Options.tsx
@@ -1,24 +1,29 @@
 import * as React from "react";
 import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import { FormState } from "./useForm";
 
-export function Options({ form }) {
+export function Options({ form }: { form: FormState }) {
   if (form.titleAndDeadline.state === "edit") return null;
 
   return (
     <PageOptions.Root testId="project-options-button" position="top-right">
-      <PageOptions.Action
-        icon={Icons.IconEdit}
-        title="Edit Name and Due Date"
-        onClick={form.titleAndDeadline.startEditing}
-        testId="edit-project-name-button"
-      />
-      <PageOptions.Action
-        icon={Icons.IconArchive}
-        title="Archive this milestone"
-        onClick={form.archive}
-        testId="archive-milestone-button"
-      />
+      {form.milestone.permissions?.canEditMilestone && (
+        <PageOptions.Action
+          icon={Icons.IconEdit}
+          title="Edit Name and Due Date"
+          onClick={form.titleAndDeadline.startEditing}
+          testId="edit-project-name-button"
+        />
+      )}
+      {form.milestone.permissions?.canEditMilestone && (
+        <PageOptions.Action
+          icon={Icons.IconArchive}
+          title="Archive this milestone"
+          onClick={form.archive}
+          testId="archive-milestone-button"
+        />
+      )}
     </PageOptions.Root>
   );
 }

--- a/assets/js/pages/ProjectMilestonePage/loader.tsx
+++ b/assets/js/pages/ProjectMilestonePage/loader.tsx
@@ -1,23 +1,18 @@
-import * as Projects from "@/models/projects";
 import * as Milestones from "@/models/milestones";
 import * as Pages from "@/components/Pages";
 
 interface LoaderResult {
-  project: Projects.Project;
   milestone: Milestones.Milestone;
 }
 
 export async function loader({ params }): Promise<LoaderResult> {
-  const milestone = await Milestones.getMilestone({ id: params.id }).then((data) => data.milestone!);
-  const project = await Projects.getProject({
-    id: milestone.projectId,
-    includeSpace: true,
-    includePermissions: true,
-  }).then((data) => data.project!);
-
   return {
-    project: project,
-    milestone: milestone,
+    milestone: await Milestones.getMilestone({
+      id: params.id,
+      includeProject: true,
+      includeComments: true,
+      includePermissions: true,
+    }).then((data) => data.milestone!),
   };
 }
 

--- a/assets/js/pages/ProjectMilestonePage/page.tsx
+++ b/assets/js/pages/ProjectMilestonePage/page.tsx
@@ -17,18 +17,20 @@ import { TaskBoard } from "@/features/Tasks/TaskBoard";
 import { NewTaskModal } from "@/features/Tasks/NewTaskModal";
 
 import classNames from "classnames";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const refresh = useRefresh();
-  const { project, milestone } = useLoadedData();
+  const { milestone } = useLoadedData();
+  assertPresent(milestone.project, "project must be present in milestone");
 
-  const form = useFormState(project, milestone);
+  const form = useFormState(milestone.project, milestone);
   const commentsForm = useForMilestone(milestone);
 
   return (
-    <Pages.Page title={[milestone.title!, project.name!]}>
+    <Pages.Page title={[milestone.title!, milestone.project.name!]}>
       <Paper.Root size="large">
-        <ProjectMilestonesNavigation project={project} />
+        <ProjectMilestonesNavigation project={milestone.project} />
 
         <Paper.Body minHeight="none">
           <Options form={form} />

--- a/assets/js/pages/ProjectMilestonePage/useForm.tsx
+++ b/assets/js/pages/ProjectMilestonePage/useForm.tsx
@@ -100,7 +100,7 @@ function useDescriptionState(milestone: Milestones.Milestone): DescriptionState 
     content: JSON.parse(milestone.description || "{}"),
     editable: true,
     className: "p-2 min-h-[200px]",
-    mentionSearchScope: { type: "project", id: milestone.projectId! },
+    mentionSearchScope: { type: "project", id: milestone.project!.id! },
   });
 
   const startEditing = React.useCallback(() => {

--- a/lib/operately/projects/milestone.ex
+++ b/lib/operately/projects/milestone.ex
@@ -20,8 +20,12 @@ defmodule Operately.Projects.Milestone do
 
     has_many :comments, Operately.Comments.MilestoneComment
 
+    # populated with after load hooks
+    field :permissions, :any, virtual: true
+
     timestamps()
     soft_delete()
+    request_info()
     requester_access_level()
   end
 
@@ -45,5 +49,44 @@ defmodule Operately.Projects.Milestone do
     milestone
     |> changeset(%{status: :done, completed_at: DateTime.utc_now()})
     |> Operately.Repo.update()
+  end
+
+  #
+  # After load hooks
+  #
+
+  def set_permissions(milestone = %__MODULE__{}) do
+    perms = Operately.Projects.Permissions.calculate(milestone.request_info.access_level)
+    Map.put(milestone, :permissions, perms)
+  end
+
+  def load_comment_notifications(person) do
+    fn milestone ->
+      comment_ids = Enum.map(milestone.comments, &(&1.comment_id))
+
+      notifications_map =
+        from(n in Operately.Notifications.Notification,
+          join: a in assoc(n, :activity),
+          where: a.action == "project_milestone_commented",
+          where: a.content["comment_id"] in ^comment_ids,
+          where: n.person_id == ^person.id,
+          where: not n.read,
+          select: {a.content["comment_id"], n}
+        )
+        |> Repo.all()
+        |> Map.new()
+
+      comments =
+        Enum.map(milestone.comments, fn comment ->
+          case Map.get(notifications_map, comment.comment_id) do
+            nil -> comment
+            notification ->
+              milestone_comment = Map.put(comment.comment, :notification, notification)
+              Map.put(comment, :comment, milestone_comment)
+          end
+        end)
+
+      Map.put(milestone, :comments, comments)
+    end
   end
 end

--- a/lib/operately_web/api/queries/get_milestone.ex
+++ b/lib/operately_web/api/queries/get_milestone.ex
@@ -2,15 +2,13 @@ defmodule OperatelyWeb.Api.Queries.GetMilestone do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  import Operately.Access.Filters, only: [filter_by_view_access: 3]
-
-  alias Operately.Projects.Milestone
+  alias Operately.Projects.{Milestone, Permissions}
 
   inputs do
     field :id, :string
     field :include_comments, :boolean
-    field :include_tasks_kanban, :boolean
     field :include_project, :boolean
+    field :include_permissions, :boolean
   end
 
   outputs do
@@ -18,23 +16,43 @@ defmodule OperatelyWeb.Api.Queries.GetMilestone do
   end
 
   def call(conn, inputs) do
-    {:ok, id} = decode_id(inputs.id)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:id, fn -> decode_id(inputs.id) end)
+    |> run(:milestone, fn ctx -> load(ctx, inputs) end)
+    |> run(:check_permissions, fn ctx -> Permissions.check(ctx.milestone.request_info.access_level, :can_view) end)
+    |> run(:serialized, fn ctx -> {:ok, %{milestone: Serializer.serialize(ctx.milestone)}} end)
+    |> respond()
+  end
 
-    milestone = load(me(conn), id)
-
-    if milestone do
-      {:ok, %{milestone: Serializer.serialize(milestone)}}
-    else
-      {:error, :not_found}
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :milestone, _} -> {:error, :not_found}
+      {:error, :check_permissions, _} -> {:error, :not_found}
+      _ -> {:error, :internal_server_error}
     end
   end
 
-  defp load(person, id) do
-    from(m in Milestone,
-      preload: [:project, comments: [comment: [:author, reactions: :person]]],
-      where: m.id == ^id
-    )
-    |> filter_by_view_access(person.id, join_parent: :project)
-    |> Repo.one()
+  defp load(ctx, inputs) do
+    Milestone.get(ctx.me, id: ctx.id, opts: [
+      preload: preload(inputs),
+      after_load: after_load(inputs, ctx.me),
+    ])
+  end
+
+  defp preload(inputs) do
+    Inputs.parse_includes(inputs, [
+      include_project: :project,
+      include_comments: [comments: [comment: [:author, reactions: :person]]],
+    ])
+  end
+
+  def after_load(inputs, person) do
+    Inputs.parse_includes(inputs, [
+      include_permissions: &Milestone.set_permissions/1,
+      include_comments: Milestone.load_comment_notifications(person),
+    ])
   end
 end

--- a/lib/operately_web/api/serializers/milestone.ex
+++ b/lib/operately_web/api/serializers/milestone.ex
@@ -2,7 +2,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Milestone do
   def serialize(milestone, level: :essential) do
     %{
       id: OperatelyWeb.Paths.milestone_id(milestone),
-      project_id: OperatelyWeb.Paths.project_id(milestone.project),
+      project: OperatelyWeb.Api.Serializer.serialize(milestone.project),
       title: milestone.title,
       status: to_string(milestone.status),
       description: milestone.description && Jason.encode!(milestone.description),
@@ -15,6 +15,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Milestone do
         done: encode_task_ids(milestone.tasks_kanban_state["done"]),
       },
       comments: OperatelyWeb.Api.Serializer.serialize(milestone.comments),
+      permissions: OperatelyWeb.Api.Serializer.serialize(milestone.permissions),
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -786,7 +786,7 @@ defmodule OperatelyWeb.Api.Types do
 
   object :milestone do
     field :id, :string
-    field :project_id, :string
+    field :project, :project
     field :title, :string
     field :status, :string
     field :inserted_at, :date
@@ -795,6 +795,7 @@ defmodule OperatelyWeb.Api.Types do
     field :description, :string
     field :comments, list_of(:milestone_comment)
     field :tasks_kanban_state, :string
+    field :permissions, :project_permissions
   end
 
   object :activity_content_goal_check_in_edit do


### PR DESCRIPTION
Now, when a user sees a comment in a project milestone, if there is an unread notification for this comment, the notification is marked as read.

The `GetMilestone` query was including every resource in every request. Since I was editing this query, I took the opportunity to fix it. 

Also, in the milestone page loader, `project` was being loaded in a separate request. That's because `GetMilestone` was returning only the project ID. After fixing `GetMilestone`, I've update the page loader so that both the milestone and project are loaded in a single request.