### PR TITLE
feat: Goal discussion notifications are cleared when page loads

### DIFF
--- a/lib/operately/activities/activity.ex
+++ b/lib/operately/activities/activity.ex
@@ -53,6 +53,7 @@ defmodule Operately.Activities.Activity do
       "goal_closing",
       "goal_reopening",
       "goal_timeframe_editing",
+      "goal_discussion_creation",
     ]
 
     if Enum.member?(actions, activity.action) do


### PR DESCRIPTION
I've add `goal_discussion_creation` to actions in `Operately.Activities.Activity.load_unread_goal_notifications\2`. Now, when the discussion page loads, this notification is also marked as read.