### PR TITLE
fix: Add space to project_created activity content

### DIFF
--- a/lib/operately/activities/content/project_created.ex
+++ b/lib/operately/activities/content/project_created.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectCreated do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company, type: :string
+    belongs_to :space, Operately.Groups.Group, type: :string
     belongs_to :project, Operately.Projects.Project, type: :string
   end
 

--- a/lib/operately/data/change_032_add_space_to_project_created_activity.ex
+++ b/lib/operately/data/change_032_add_space_to_project_created_activity.ex
@@ -1,0 +1,39 @@
+defmodule Operately.Data.Change032AddSpaceToProjectCreatedActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action == "project_created"
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, "space_id", space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/project_creation.ex
+++ b/lib/operately/operations/project_creation.ex
@@ -138,6 +138,7 @@ defmodule Operately.Operations.ProjectCreation do
     Activities.insert_sync(multi, params.creator_id, :project_created, fn changes ->
       %{
         company_id: changes.project.company_id,
+        space_id: changes.project.group_id,
         project_id: changes.project.id
       }
     end)

--- a/priv/repo/migrations/20241010142306_add_space_field_to_project_created_activity.exs
+++ b/priv/repo/migrations/20241010142306_add_space_field_to_project_created_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceFieldToProjectCreatedActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change032AddSpaceToProjectCreatedActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -375,7 +375,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_created",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_032_add_space_to_project_created_activity_test.exs
+++ b/test/operately/data/change_032_add_space_to_project_created_activity_test.exs
@@ -1,0 +1,40 @@
+defmodule Operately.Data.Change032AddSpaceToProjectCreatedActivityTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.ProjectsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  test "migration doesn't delete current data in activity content", ctx do
+    projects = Enum.map(1..3, fn _ ->
+      project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id})
+    end)
+
+    Operately.Data.Change032AddSpaceToProjectCreatedActivity.run()
+
+    fetch_activities()
+    |> Enum.each(fn activity ->
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["space_id"] == ctx.space.id
+      assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities() do
+    from(a in Operately.Activities.Activity,
+      where: a.action == "project_created"
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration which adds the `space_id` key to all existing `project_created` activities.

I've also updated the `ProjectCreation` operation so that it adds the `space_id` key to new activities. 

Now, these activities will also appear in the space feed.