### PR TITLE
chore: Custom primitive types for the API

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -116,6 +116,10 @@ export function useMutation<InputT, ResultT>(
   return [execute, { data, loading, error }];
 }
 
+export type CompanyId = string;
+
+export type Id = string;
+
 export interface AccessLevels {
   public?: number | null;
   company?: number | null;
@@ -543,7 +547,7 @@ export interface ActivityEventDataProjectCreate {
 }
 
 export interface AddMemberInput {
-  id?: string | null;
+  id?: Id | null;
   permissions?: number | null;
 }
 

--- a/lib/operately_web/api/helpers.ex
+++ b/lib/operately_web/api/helpers.ex
@@ -79,20 +79,25 @@ defmodule OperatelyWeb.Api.Helpers do
     parts <> "-" <> id
   end
 
-  def decode_id(ids) when is_list(ids) do
+  def decode_id(ids, nil_handling \\ :dont_allow_nil)
+
+  def decode_id(ids, nil_handling) when is_list(ids) do
     Enum.reduce(ids, {:ok, []}, fn id, {:ok, acc} ->
-      case decode_id(id) do
+      case decode_id(id, nil_handling) do
         {:ok, id} -> {:ok, [id | acc]}
         e -> e
       end
     end)
   end
 
-  def decode_id(id, nil_handling \\ :dont_allow_nil) do
-    if nil_handling != :allow_nil && id == nil do
+  def decode_id(id, nil_handling) do
+    if nil_handling == :dont_allow_nil && id == nil do
       {:error, :bad_request}
     else
-      OperatelyWeb.Api.Ids.decode_id(id)
+      case Ecto.UUID.cast(id) do
+        {:ok, id} -> {:ok, id}
+        _ -> OperatelyWeb.Api.Ids.decode_id(id)
+      end
     end
   end
 

--- a/lib/operately_web/api/helpers.ex
+++ b/lib/operately_web/api/helpers.ex
@@ -79,38 +79,8 @@ defmodule OperatelyWeb.Api.Helpers do
     parts <> "-" <> id
   end
 
-  def decode_company_id(id) do
-    id_without_comments(id)
-    |> Operately.Companies.ShortId.decode()
-  end
-
-  def decode_id(ids) when is_list(ids) do
-    Enum.reduce(ids, {:ok, []}, fn id, {:ok, acc} ->
-      case decode_id(id) do
-        {:ok, id} -> {:ok, [id | acc]}
-        e -> e
-      end
-    end)
-  end
-
-  def decode_id(id) do
-    case Ecto.UUID.cast(id) do
-      {:ok, id} -> {:ok, id}
-      :error -> decode_short_id(id)
-    end
-  end
-
-  def decode_id(id, :allow_nil) do
-    if id == nil || id == "" do
-      {:ok, nil}
-    else
-      decode_id(id)
-    end
-  end
-
-  defp decode_short_id(id) do
-    id_without_comments(id) |> Operately.ShortUuid.decode()
-  end
+  defdelegate decode_id(id), to: OperatelyWeb.Api.Ids
+  defdelegate decode_company_id(id), to: OperatelyWeb.Api.Ids
 
   defmodule Inputs do
     def parse_includes(inputs, includes) do

--- a/lib/operately_web/api/helpers.ex
+++ b/lib/operately_web/api/helpers.ex
@@ -79,7 +79,23 @@ defmodule OperatelyWeb.Api.Helpers do
     parts <> "-" <> id
   end
 
-  defdelegate decode_id(id), to: OperatelyWeb.Api.Ids
+  def decode_id(ids) when is_list(ids) do
+    Enum.reduce(ids, {:ok, []}, fn id, {:ok, acc} ->
+      case decode_id(id) do
+        {:ok, id} -> {:ok, [id | acc]}
+        e -> e
+      end
+    end)
+  end
+
+  def decode_id(id, nil_handling \\ :dont_allow_nil) do
+    if nil_handling != :allow_nil && id == nil do
+      {:error, :bad_request}
+    else
+      OperatelyWeb.Api.Ids.decode_id(id)
+    end
+  end
+
   defdelegate decode_company_id(id), to: OperatelyWeb.Api.Ids
 
   defmodule Inputs do

--- a/lib/operately_web/api/ids.ex
+++ b/lib/operately_web/api/ids.ex
@@ -1,5 +1,5 @@
 defmodule OperatelyWeb.Api.Ids do
-  def decode_id(id) when id == nil do
+  def decode_id(id) when id == nil or id == "" do
     {:ok, nil}
   end
 

--- a/lib/operately_web/api/ids.ex
+++ b/lib/operately_web/api/ids.ex
@@ -1,0 +1,44 @@
+defmodule OperatelyWeb.Api.Ids do
+  def decode_id(ids) when is_list(ids) do
+    Enum.reduce(ids, {:ok, []}, fn id, {:ok, acc} ->
+      case decode_id(id) do
+        {:ok, id} -> {:ok, [id | acc]}
+        e -> e
+      end
+    end)
+  end
+
+  def decode_id(id) do
+    case Ecto.UUID.cast(id) do
+      {:ok, id} -> {:ok, id}
+      :error -> decode_short_id(id)
+    end
+  end
+
+  def decode_id(id, :allow_nil) do
+    if id == nil || id == "" do
+      {:ok, nil}
+    else
+      decode_id(id)
+    end
+  end
+
+  def decode_company_id(id) do
+    id_without_comments(id)
+    |> Operately.Companies.ShortId.decode()
+    |> handle_error()
+  end
+
+  defp decode_short_id(id) do
+    id_without_comments(id) 
+    |> Operately.ShortUuid.decode()
+    |> handle_error()
+  end
+
+  defp id_without_comments(id) do
+    id |> String.split("-") |> List.last()
+  end
+
+  defp handle_error({:ok, id}), do: {:ok, id}
+  defp handle_error(:error), do: {:error, 422, "Invalid id format"}
+end

--- a/lib/operately_web/api/ids.ex
+++ b/lib/operately_web/api/ids.ex
@@ -1,41 +1,25 @@
 defmodule OperatelyWeb.Api.Ids do
-  def decode_id(ids) when is_list(ids) do
-    Enum.reduce(ids, {:ok, []}, fn id, {:ok, acc} ->
-      case decode_id(id) do
-        {:ok, id} -> {:ok, [id | acc]}
-        e -> e
-      end
-    end)
+  def decode_id(id) when id == nil do
+    {:ok, nil}
   end
 
-  def decode_id(id) do
-    case Ecto.UUID.cast(id) do
-      {:ok, id} -> {:ok, id}
-      :error -> decode_short_id(id)
-    end
-  end
-
-  def decode_id(id, :allow_nil) do
-    if id == nil || id == "" do
-      {:ok, nil}
-    else
-      decode_id(id)
-    end
-  end
-
-  def decode_company_id(id) do
-    id_without_comments(id)
-    |> Operately.Companies.ShortId.decode()
-    |> handle_error()
-  end
-
-  defp decode_short_id(id) do
-    id_without_comments(id) 
+  def decode_id(id) when is_binary(id) do
+    remove_comments(id)
     |> Operately.ShortUuid.decode()
     |> handle_error()
   end
 
-  defp id_without_comments(id) do
+  def decode_company_id(id) when id == nil do
+    {:ok, nil}
+  end
+
+  def decode_company_id(id) do
+    remove_comments(id)
+    |> Operately.Companies.ShortId.decode()
+    |> handle_error()
+  end
+
+  defp remove_comments(id) do
     id |> String.split("-") |> List.last()
   end
 

--- a/lib/operately_web/api/mutations/add_group_members.ex
+++ b/lib/operately_web/api/mutations/add_group_members.ex
@@ -11,24 +11,15 @@ defmodule OperatelyWeb.Api.Mutations.AddGroupMembers do
 
   def call(conn, inputs) do
     {:ok, id} = decode_id(inputs.group_id)
-    members = decode_member_ids(inputs)
-
+    
     case check_permissions(me(conn), id) do
       {:error, reason} ->
         {:error, reason}
 
       :ok ->
-        Operately.Operations.GroupMembersAdding.run(me(conn), id, members)
+        Operately.Operations.GroupMembersAdding.run(me(conn), id, inputs.members)
         {:ok, %{}}
     end
-  end
-
-  defp decode_member_ids(inputs) do
-    Enum.map(inputs.members, fn member ->
-      {:ok, id} = decode_id(member.id)
-
-      %{member | id: id}
-    end)
   end
 
   defp check_permissions(person, space_id) do

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1027,7 +1027,7 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :add_member_input do
-    field :id, :string
+    field :id, :id
     field :permissions, :integer
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1,6 +1,16 @@
 defmodule OperatelyWeb.Api.Types do
   use TurboConnect.Types
 
+  primitive :id, 
+    encoded_type: :string,
+    decoded_type: :string,
+    decode_with: &OperatelyWeb.Api.Ids.decode_id/1
+
+  primitive :company_id, 
+    encoded_type: :string, 
+    decoded_type: :number, 
+    decode_with: &OperatelyWeb.Api.Ids.decode_company_id/1
+
   object :access_levels do
     field :public, :integer
     field :company, :integer

--- a/lib/turbo_connect/api.ex
+++ b/lib/turbo_connect/api.ex
@@ -49,14 +49,16 @@ defmodule TurboConnect.Api do
       plug TurboConnect.Plugs.Dispatch
 
       def __types__() do
-        Enum.reduce(@typemodules, %{objects: %{}, unions: %{}}, fn module, acc ->
+        Enum.reduce(@typemodules, %{primitives: %{}, objects: %{}, unions: %{}}, fn module, acc ->
+          primitives = apply(module, :__primitives__, [])
           objects = apply(module, :__objects__, [])
           unions = apply(module, :__unions__, [])
 
+          primitives = Map.merge(acc.primitives, primitives)
           objects = Map.merge(acc.objects, objects)
           unions = Map.merge(acc.unions, unions)
 
-          %{objects: objects, unions: unions}
+          %{objects: objects, unions: unions, primitives: primitives}
         end)
       end
 

--- a/lib/turbo_connect/ts_gen/typescript.ex
+++ b/lib/turbo_connect/ts_gen/typescript.ex
@@ -14,6 +14,12 @@ defmodule TurboConnect.TsGen.Typescript do
     """
   end
 
+  def ts_type_alias(name, type) do
+    """
+    export type #{ts_type(name)} = #{ts_type(type)};
+    """
+  end
+
   def ts_function_name(name) do
     result = name |> Atom.to_string() |> Macro.camelize()
     String.downcase(String.at(result, 0)) <> String.slice(result, 1, String.length(result) - 1)

--- a/lib/turbo_connect/types.ex
+++ b/lib/turbo_connect/types.ex
@@ -5,8 +5,17 @@ defmodule TurboConnect.Types do
       use TurboConnect.Fields
 
       import TurboConnect.Types
+
       Module.register_attribute(__MODULE__, :unions, accumulate: true)
+      Module.register_attribute(__MODULE__, :primitives, accumulate: true)
+
       @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro primitive(name, opts) do
+    quote do
+      @primitives {unquote(name), unquote(opts)}
     end
   end
 
@@ -26,6 +35,7 @@ defmodule TurboConnect.Types do
 
   defmacro __before_compile__(_) do
     quote do
+      def __primitives__(), do: Enum.reverse(@primitives) |> Enum.into(%{})
       def __objects__(), do: __fields__()
       def __unions__(), do: Enum.reverse(@unions) |> Enum.into(%{})
     end

--- a/test/turbo_connect/api_test.exs
+++ b/test/turbo_connect/api_test.exs
@@ -5,6 +5,8 @@ defmodule TurboConnect.ApiTest do
   defmodule ExampleTypes do
     use TurboConnect.Types
 
+    primitive :id, encoded_type: :string, decode_with: &String.to_integer/1
+
     object :user do
       field :full_name, :string
       field :address, :address
@@ -72,6 +74,9 @@ defmodule TurboConnect.ApiTest do
 
   test "__types__ returns the types defined in the module" do
     assert ExampleApi.__types__() == %{
+      primitives: %{
+        id: [encoded_type: :string, decode_with: &String.to_integer/1]
+      },
       objects: %{
         address: %{
           fields: [

--- a/test/turbo_connect/ts_gen_test.exs
+++ b/test/turbo_connect/ts_gen_test.exs
@@ -3,6 +3,8 @@ defmodule TurboConnect.TsGenTest do
 
   defmodule ExampleTypes do
     use TurboConnect.Types
+    
+    primitive :id, encoded_type: :integer, decode_with: &String.to_integer/1
 
     object :user do
       field :full_name, :string
@@ -102,6 +104,8 @@ defmodule TurboConnect.TsGenTest do
   """
 
   @ts_types """
+  export type Id = number;
+
   export interface Address {
     street?: string | null;
     city?: string | null;


### PR DESCRIPTION
Now, we can define custom primitive types for the API, for example, a primitive type for IDs.

Here is how it works: In the api type definition we can use the `primitive` to define a new primitive, what it will be encoded to in Typescript, and decoder for the values:

``` elixir
primitive :id, encoded_type: :string, decode_with: &Operately.Ids.decode_id/1
```

### How we did it before?

Before this Pull-Request, we would have to manually decode the types in the API handlers. For single values, this was manageable, but for nested or repeated values this would be a major pain. e.g:

``` elixir
inputs do
  field :space_id, :string
  field :members, :add_member_input
end

object :add_member_input do
  field :id, :string
  field :access_level, :string
end
```

To parse this in the API handler, you would need to do something crazy as:

``` elixir
def parse_members(members) do
  Enum.reduce(members, {:ok, []}, fn m, acc ->
    case acc do
      {:ok, accumulated} ->
         case decode_id(m.id) do
           {:ok, id} ->
             {:ok, accumulated ++ [Map.put(m, :id, id}}
           e ->
             {:error, 422, "Unparsable ID field"}
         end
        
       e ->
         e
    end
  end)
end
```

### What can we do now?

If you have an `:id` primitive type defined, you can simply use it as the incoming type.

``` elixir
inputs do
  field :space_id, :id  # <--- here
  field :members, :add_member_input
end

object :add_member_input do
  field :id, :id        # <---- here
  field :access_level, :string
end
```

And it will be automatically handled without any extra work in the API handler.