### PR TITLE
fix: Add space to project_resuming activity content

### DIFF
--- a/lib/operately/activities/content/project_resuming.ex
+++ b/lib/operately/activities/content/project_resuming.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectResuming do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
   end
 

--- a/lib/operately/data/change_033_add_space_to_project_resuming_activity.ex
+++ b/lib/operately/data/change_033_add_space_to_project_resuming_activity.ex
@@ -1,0 +1,39 @@
+defmodule Operately.Data.Change033AddSpaceToProjectResumingActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action == "project_resuming"
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/project_resuming.ex
+++ b/lib/operately/operations/project_resuming.ex
@@ -12,6 +12,7 @@ defmodule Operately.Operations.ProjectResuming do
     |> Activities.insert_sync(author.id, :project_resuming, fn _changes ->
       %{
         company_id: project.company_id,
+        space_id: project.group_id,
         project_id: project.id,
       }
     end)

--- a/priv/repo/migrations/20241010162832_add_space_field_to_project_resuming_activity.exs
+++ b/priv/repo/migrations/20241010162832_add_space_field_to_project_resuming_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceFieldToProjectResumingActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change033AddSpaceToProjectResumingActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -548,7 +548,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_resuming",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
+++ b/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change032AddSpaceToProjectCreatedActivityTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.ProjectsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  test "migration doesn't delete existing data in activity content", ctx do
+    projects = Enum.map(1..3, fn _ ->
+      p = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id})
+      Operately.Operations.ProjectPausing.run(ctx.creator, p)
+      Operately.Operations.ProjectResuming.run(ctx.creator, p)
+      p
+    end)
+
+    Operately.Data.Change033AddSpaceToProjectResumingActivity.run()
+
+    fetch_activities()
+    |> Enum.each(fn activity ->
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["space_id"] == ctx.space.id
+      assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities() do
+    from(a in Operately.Activities.Activity,
+      where: a.action == "project_resuming"
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `project_resuming` activities.

I've also updated the `ProjectResuming` operation so that it adds the space_id key to new activities.

Now, these activities will also appear in the space feed.