### PR TITLE
fix: Add space to project_pausing, project_renamed and project_milestone_commented

### DIFF
--- a/lib/operately/activities/content/project_milestone_commented.ex
+++ b/lib/operately/activities/content/project_milestone_commented.ex
@@ -3,10 +3,11 @@ defmodule Operately.Activities.Content.ProjectMilestoneCommented do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :milestone, Operately.Projects.Milestone
     belongs_to :comment, Operately.Updates.Comment
-    
+
     field :comment_action, :string
   end
 

--- a/lib/operately/activities/content/project_pausing.ex
+++ b/lib/operately/activities/content/project_pausing.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectPausing do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
   end
 

--- a/lib/operately/activities/content/project_renamed.ex
+++ b/lib/operately/activities/content/project_renamed.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectRenamed do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
 
     field :old_name, :string

--- a/lib/operately/comments/create_milestone_comment_operation.ex
+++ b/lib/operately/comments/create_milestone_comment_operation.ex
@@ -15,7 +15,7 @@ defmodule Operately.Comments.CreateMilestoneCommentOperation do
     |> Repo.transaction()
     |> Repo.extract_result(:milestone_comment)
   end
-  
+
   defp insert_milestone_comment(multi, milestone, action) do
     Multi.insert(multi, :milestone_comment, fn changes ->
       MilestoneComment.changeset(%{
@@ -53,6 +53,7 @@ defmodule Operately.Comments.CreateMilestoneCommentOperation do
 
       %{
         company_id: project.company_id,
+        space_id: project.group_id,
         project_id: project.id,
         milestone_id: milestone.id,
         comment_id: changes[:comment].id,

--- a/lib/operately/data/change_034_add_space_project_pausing_to_activity.ex
+++ b/lib/operately/data/change_034_add_space_project_pausing_to_activity.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change034AddSpaceProjectPausingToActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action in [
+          "project_pausing",
+          "project_renamed",
+          "project_milestone_commented",
+        ]
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/project_pausing.ex
+++ b/lib/operately/operations/project_pausing.ex
@@ -12,6 +12,7 @@ defmodule Operately.Operations.ProjectPausing do
     |> Activities.insert_sync(author.id, :project_pausing, fn _changes ->
       %{
         company_id: project.company_id,
+        space_id: project.group_id,
         project_id: project.id,
       }
     end)

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -64,6 +64,7 @@ defmodule Operately.Projects do
     |> Multi.update(:project, change_project(project, %{name: new_name}))
     |> Activities.insert_sync(author.id, :project_renamed, fn changes -> %{
       company_id: project.company_id,
+      space_id: project.group_id,
       project_id: project.id,
       old_name: project.name,
       new_name: changes.project.name

--- a/priv/repo/migrations/20241010172454_add_space_key_to_project_pausing_activity.exs
+++ b/priv/repo/migrations/20241010172454_add_space_key_to_project_pausing_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceKeyToProjectPausingActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change034AddSpaceProjectPausingToActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -504,7 +504,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_milestone_commented",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, milestone_id: "-", comment_id: ctx.comment.id, comment_action: "-" }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, milestone_id: "-", comment_id: ctx.comment.id, comment_action: "-" }
       }
 
       create_activity(attrs)
@@ -526,7 +526,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_pausing",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id }
       }
 
       create_activity(attrs)
@@ -537,7 +537,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_renamed",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_name: "-", new_name: "-" }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, old_name: "-", new_name: "-" }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
+++ b/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
@@ -1,4 +1,4 @@
-defmodule Operately.Data.Change032AddSpaceToProjectCreatedActivityTest do
+defmodule Operately.Data.Change033AddSpaceToProjectResumingActivityTest do
   use Operately.DataCase
 
   alias Operately.Repo

--- a/test/operately/data/change_034_add_space_project_pausing_to_activity_test.exs
+++ b/test/operately/data/change_034_add_space_project_pausing_to_activity_test.exs
@@ -1,0 +1,85 @@
+defmodule Operately.Data.Change034AddSpaceProjectPausingToActivityTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.ProjectsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  describe "project_pausing and project_renamed" do
+    test "migration doesn't delete existing data in activity content", ctx do
+      projects = Enum.map(1..3, fn _ ->
+        p = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id, name: "name"})
+        {:ok, _} = Operately.Operations.ProjectPausing.run(ctx.creator, p)
+        {:ok, p} = Operately.Projects.rename_project(ctx.creator, p, "new name")
+        p
+      end)
+
+      Operately.Data.Change034AddSpaceProjectPausingToActivity.run()
+
+      fetch_activities("project_pausing")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+      end)
+
+      fetch_activities("project_renamed")
+      |> Enum.each(fn activity ->
+        assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["old_name"] == "name"
+        assert activity.content["new_name"] == "new name"
+      end)
+    end
+  end
+
+  describe "project_milestone_commented" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_project_milestone(:milestone, :project, :creator)
+    end
+
+    test "migration doesn't delete existing data in activity content", ctx do
+      comments = Enum.map(1..3, fn _ ->
+        {:ok, comment} = Operately.Comments.create_milestone_comment(ctx.creator, ctx.milestone, "none", %{
+          content: %{"message" => RichText.rich_text("message")},
+          author_id: ctx.creator.id,
+        })
+        comment
+      end)
+
+      Operately.Data.Change034AddSpaceProjectPausingToActivity.run()
+
+      fetch_activities("project_milestone_commented")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["project_id"] == ctx.project.id
+        assert activity.content["milestone_id"] == ctx.milestone.id
+        assert activity.content["comment_action"] == "none"
+        assert Enum.find(comments, &(&1.comment_id == activity.content["comment_id"]))
+      end)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `project_pausing`, `project_renamed` and `project_milestone_commented` activities.

I've also updated the operations which create these activities so that the space_id is added to new activities.

Now, these activities will also appear in the space feed.