### PR TITLE
fix: Add space to project check-in activities

### DIFF
--- a/lib/operately/activities/content/project_check_in_acknowledged.ex
+++ b/lib/operately/activities/content/project_check_in_acknowledged.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectCheckInAcknowledged do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :check_in, Operately.Projects.CheckIn
   end

--- a/lib/operately/activities/content/project_check_in_commented.ex
+++ b/lib/operately/activities/content/project_check_in_commented.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectCheckInCommented do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :check_in, Operately.Projects.CheckIn
     belongs_to :comment, Operately.Updates.Comment

--- a/lib/operately/activities/content/project_check_in_submitted.ex
+++ b/lib/operately/activities/content/project_check_in_submitted.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectCheckInSubmitted do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :check_in, Operately.Projects.CheckIn
   end

--- a/lib/operately/data/change_035_add_space_to_project_activities.ex
+++ b/lib/operately/data/change_035_add_space_to_project_activities.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change035AddSpaceToProjectActivities do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action in [
+          "project_check_in_commented",
+          "project_check_in_submitted",
+          "project_check_in_acknowledged",
+        ]
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/comment_adding/activity.ex
+++ b/lib/operately/operations/comment_adding/activity.ex
@@ -27,6 +27,7 @@ defmodule Operately.Operations.CommentAdding.Activity do
     Activities.insert_sync(multi, creator.id, action, fn changes ->
       %{
         company_id: creator.company_id,
+        space_id: entity.project.group_id,
         project_id: entity.project_id,
         check_in_id: entity.id,
         comment_id: changes.comment.id

--- a/lib/operately/operations/project_check_in.ex
+++ b/lib/operately/operations/project_check_in.ex
@@ -35,6 +35,7 @@ defmodule Operately.Operations.ProjectCheckIn do
     |> Activities.insert_sync(author.id, :project_check_in_submitted, fn changes ->
       %{
         company_id: project.company_id,
+        space_id: project.group_id,
         project_id: project.id,
         check_in_id: changes.check_in.id
       }

--- a/lib/operately/operations/project_check_in_acknowledgement.ex
+++ b/lib/operately/operations/project_check_in_acknowledgement.ex
@@ -16,6 +16,7 @@ defmodule Operately.Operations.ProjectCheckInAcknowledgement do
     |> Activities.insert_sync(author.id, :project_check_in_acknowledged, fn _changes ->
       %{
         company_id: author.company_id,
+        space_id: check_in.project.group_id,
         project_id: check_in.project_id,
         check_in_id: check_in.id
       }

--- a/lib/operately_web/api/mutations/acknowledge_project_check_in.ex
+++ b/lib/operately_web/api/mutations/acknowledge_project_check_in.ex
@@ -32,6 +32,7 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeProjectCheckIn do
     from(check_in in Operately.Projects.CheckIn,
       join: project in assoc(check_in, :project),
       join: reviewer in assoc(project, :reviewer_contributor),
+      preload: [project: project],
       where: check_in.id == ^check_in_id and reviewer.person_id == ^person_id
     )
     |> Repo.one()

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -11,7 +11,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
   }
   alias Operately.Goals.Update
   alias Operately.Messages.Message
-  alias Operately.Projects.Retrospective
+  alias Operately.Projects.{CheckIn, Retrospective}
   alias Operately.Operations.CommentAdding
 
   inputs do
@@ -52,7 +52,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
 
   defp fetch_parent(person, id, type) do
     case type do
-      :project_check_in -> Projects.get_check_in_with_access_level(id, person.id)
+      :project_check_in -> CheckIn.get(person, id: id, opts: [preload: :project])
       :project_retrospective -> Retrospective.get(person, id: id, opts: [preload: :project])
       :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person.id)
       :goal_update -> Update.get(person, id: id)
@@ -62,7 +62,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
 
   defp check_permissions(parent, type) do
     case type do
-      :project_check_in -> Projects.Permissions.check(parent.requester_access_level, :can_comment_on_check_in)
+      :project_check_in -> Projects.Permissions.check(parent.request_info.access_level, :can_comment_on_check_in)
       :project_retrospective -> Projects.Permissions.check(parent.request_info.access_level, :can_comment_on_retrospective)
       :comment_thread -> Activities.Permissions.check(parent.activity.requester_access_level, :can_comment_on_thread)
       :goal_update -> Goals.Permissions.check(parent.request_info.access_level, :can_comment_on_update)

--- a/priv/repo/migrations/20241010185006_add_space_to_project_check_in_activities.exs
+++ b/priv/repo/migrations/20241010185006_add_space_to_project_check_in_activities.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceToProjectCheckInActivities do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change035AddSpaceToProjectActivities.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -397,7 +397,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_check_in_acknowledged",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
       }
 
       create_activity(attrs)
@@ -408,7 +408,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_check_in_commented",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
       }
 
       create_activity(attrs)
@@ -430,7 +430,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_check_in_submitted",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, check_in_id: ctx.check_in.id }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_035_add_space_to_project_activities_test.exs
+++ b/test/operately/data/change_035_add_space_to_project_activities_test.exs
@@ -1,0 +1,92 @@
+defmodule Operately.Data.Change035AddSpaceToProjectActivitiesTest do
+  use Operately.DataCase
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  describe "project_check_in_submitted and project_check_in_acknowledged" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:project, :space)
+    end
+
+    test "migration doesn't delete existing data in activity content", ctx do
+      check_ins = Enum.map(1..3, fn _ ->
+        {:ok, c} = Operately.Operations.ProjectCheckIn.run(ctx.creator, ctx.project, %{
+          project_id: ctx.project.id,
+          status: "on_track",
+          content: RichText.rich_text("content"),
+          send_to_everyone: false,
+          subscription_parent_type: :project_check_in,
+          subscriber_ids: []
+        })
+        c = Repo.preload(c, :project)
+        {:ok, _} = Operately.Operations.ProjectCheckInAcknowledgement.run(ctx.creator, c)
+        c
+      end)
+
+      Operately.Data.Change035AddSpaceToProjectActivities.run()
+
+      fetch_activities("project_check_in_submitted")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["project_id"] == ctx.project.id
+        assert Enum.find(check_ins, &(&1.id == activity.content["check_in_id"]))
+      end)
+
+      fetch_activities("project_check_in_acknowledged")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["project_id"] == ctx.project.id
+        assert Enum.find(check_ins, &(&1.id == activity.content["check_in_id"]))
+      end)
+    end
+  end
+
+  describe "project_check_in_commented" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_project_check_in(:check_in, :project, :creator)
+      |> Factory.preload(:check_in, :project)
+    end
+
+    test "migration doesn't delete existing data in activity content", ctx do
+      comments = Enum.map(1..3, fn _ ->
+        {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.creator, ctx.check_in, "project_check_in", RichText.rich_text("content"))
+        comment
+      end)
+
+      Operately.Data.Change035AddSpaceToProjectActivities.run()
+
+      fetch_activities("project_check_in_commented")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["check_in_id"] == ctx.check_in.id
+        assert activity.content["project_id"] == ctx.project.id
+        assert Enum.find(comments, &(&1.id == activity.content["comment_id"]))
+      end)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end

--- a/test/operately/operations/comment_adding_test.exs
+++ b/test/operately/operations/comment_adding_test.exs
@@ -56,6 +56,7 @@ defmodule Operately.Operations.CommentAddingTest do
         subscriber_ids: Enum.map(ctx.contribs, &(&1.person_id)),
         subscription_parent_type: :project_check_in
       })
+      check_in = Repo.preload(check_in, :project)
 
       {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
         CommentAdding.run(ctx.champion, check_in, "project_check_in", RichText.rich_text("Some comment"))
@@ -85,6 +86,7 @@ defmodule Operately.Operations.CommentAddingTest do
         subscriber_ids: [ctx.champion.id],
         subscription_parent_type: :project_check_in
       })
+      check_in = Repo.preload(check_in, :project)
 
       # Without permissions
       person = person_fixture_with_account(%{company_id: ctx.company.id})

--- a/test/operately_web/api/mutations/acknowledge_project_check_in_test.exs
+++ b/test/operately_web/api/mutations/acknowledge_project_check_in_test.exs
@@ -97,7 +97,7 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeProjectCheckInTest do
   end
 
   defp assert_response(res, check_in) do
-    check_in = Repo.reload(check_in)
+    check_in = Repo.reload(check_in) |> Repo.preload(:project)
 
     assert check_in.acknowledged_at
     assert check_in.acknowledged_by_id

--- a/test/operately_web/api/mutations/add_reaction_test.exs
+++ b/test/operately_web/api/mutations/add_reaction_test.exs
@@ -457,6 +457,7 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
 
   defp create_check_in(author, project) do
     check_in_fixture(%{author_id: author.id, project_id: project.id})
+    |> Repo.preload(:project)
   end
 
   defp create_comment(ctx, parent, type) do

--- a/test/operately_web/api/mutations/edit_comment_test.exs
+++ b/test/operately_web/api/mutations/edit_comment_test.exs
@@ -237,6 +237,7 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
       |> Factory.add_space_member(:person, :space)
       |> Factory.add_project(:project, :space)
       |> Factory.add_project_check_in(:check_in, :project, :creator)
+      |> Factory.preload(:check_in, :project)
       |> Factory.add_project(:project, :space)
       |> Factory.add_project_retrospective(:retrospective, :project, :creator)
       |> Factory.preload(:retrospective, :project)
@@ -302,6 +303,7 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
 
   defp create_check_in(author, project) do
     check_in_fixture(%{author_id: author.id, project_id: project.id})
+    |> Repo.preload(:project)
   end
 
   def create_project(ctx, space, company_members_level, space_members_level, project_member_level) do

--- a/test/operately_web/api/queries/get_comments_test.exs
+++ b/test/operately_web/api/queries/get_comments_test.exs
@@ -473,6 +473,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     })
 
     check_in_fixture(%{author_id: ctx.creator.id, project_id: project.id})
+    |> Repo.preload(:project)
   end
 
   defp create_goal_update(ctx, opts) do


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `project_check_in_commented`, `project_check_in_submitted` and `project_check_in_acknowledged` activities.

I've also updated the operations which create these activities so that the space_id is added to new activities.

Now, these activities will also appear in the space feed.