### PR TITLE
fix: Add space to project_archived, project_goal_connection and project_goal_disconnection

### DIFF
--- a/lib/operately/activities/content/project_archived.ex
+++ b/lib/operately/activities/content/project_archived.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectArchived do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
   end
 

--- a/lib/operately/activities/content/project_goal_connection.ex
+++ b/lib/operately/activities/content/project_goal_connection.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectGoalConnection do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :goal, Operately.Goals.Goal
   end

--- a/lib/operately/activities/content/project_goal_disconnection.ex
+++ b/lib/operately/activities/content/project_goal_disconnection.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.ProjectGoalDisconnection do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :goal, Operately.Goals.Goal
   end

--- a/lib/operately/data/change_036_add_space_to_project_activities.ex
+++ b/lib/operately/data/change_036_add_space_to_project_activities.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change036AddSpaceToProjectActivities do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action in [
+          "project_archived",
+          "project_goal_connection",
+          "project_goal_disconnection",
+        ]
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/project_goal_connection.ex
+++ b/lib/operately/operations/project_goal_connection.ex
@@ -2,7 +2,7 @@ defmodule Operately.Operations.ProjectGoalConnection do
   alias Ecto.Multi
   alias Operately.Activities
   alias Operately.Repo
-  
+
   def run(person, project, goal) do
     project_changeset = Operately.Projects.change_project(project, %{
       goal_id: goal.id
@@ -12,6 +12,7 @@ defmodule Operately.Operations.ProjectGoalConnection do
     |> Multi.update(:project, project_changeset)
     |> Activities.insert_sync(person.id, :project_goal_connection, fn _ -> %{
       company_id: person.company_id,
+      space_id: project.group_id,
       project_id: project.id,
       goal_id: goal.id
     } end)

--- a/lib/operately/operations/project_goal_disconnection.ex
+++ b/lib/operately/operations/project_goal_disconnection.ex
@@ -12,6 +12,7 @@ defmodule Operately.Operations.ProjectGoalDisconnection do
     |> Multi.update(:project, project_changeset)
     |> Activities.insert_sync(person.id, :project_goal_disconnection, fn _ -> %{
       company_id: person.company_id,
+      space_id: project.group_id,
       project_id: project.id,
       goal_id: project.goal_id
     } end)

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -78,6 +78,7 @@ defmodule Operately.Projects do
     |> Multi.run(:project, fn repo, _ -> repo.soft_delete(project) end)
     |> Activities.insert_sync(author.id, :project_archived, fn changes -> %{
       company_id: project.company_id,
+      space_id: project.group_id,
       project_id: changes.project.id
     } end)
     |> Repo.transaction()

--- a/priv/repo/migrations/20241011101759_add_space_key_to_project_activities.exs
+++ b/priv/repo/migrations/20241011101759_add_space_key_to_project_activities.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceKeyToProjectActivities do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change036AddSpaceToProjectActivities.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -386,7 +386,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_archived",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id }
       }
 
       create_activity(attrs)
@@ -482,7 +482,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_goal_connection",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
       }
 
       create_activity(attrs)
@@ -493,7 +493,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_goal_disconnection",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, goal_id: ctx.goal.id }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_036_add_space_to_project_activities_test.exs
+++ b/test/operately/data/change_036_add_space_to_project_activities_test.exs
@@ -1,0 +1,89 @@
+defmodule Operately.Data.Change036AddSpaceToProjectActivitiesTest do
+  use Operately.DataCase
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  describe "migration doesn't delete existing data in activity content" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_goal(:goal1, :space)
+      |> Factory.add_goal(:goal2, :space)
+      |> Factory.add_project(:p1, :space, goal: :goal1)
+      |> Factory.add_project(:p2, :space, goal: :goal1)
+      |> Factory.add_project(:p3, :space, goal: :goal1)
+    end
+
+    test "project_archived", ctx do
+      projects = [ctx.p1, ctx.p2, ctx.p3]
+
+      Enum.each(projects, fn p ->
+        {:ok, _} = Operately.Projects.archive_project(ctx.creator, p)
+      end)
+
+      Operately.Data.Change036AddSpaceToProjectActivities.run()
+
+      fetch_activities("project_archived")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+      end)
+    end
+
+    test "project_goal_connection", ctx do
+      projects = [ctx.p1, ctx.p2, ctx.p3]
+
+      Enum.each(projects, fn p ->
+        {:ok, _} = Operately.Operations.ProjectGoalConnection.run(ctx.creator, p, ctx.goal2)
+      end)
+
+      Operately.Data.Change036AddSpaceToProjectActivities.run()
+
+      fetch_activities("project_goal_connection")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["goal_id"] == ctx.goal2.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+      end)
+    end
+
+    test "project_goal_disconnection", ctx do
+      projects = [ctx.p1, ctx.p2, ctx.p3]
+
+      Enum.each(projects, fn p ->
+        {:ok, _} = Operately.Operations.ProjectGoalDisconnection.run(ctx.creator, p)
+      end)
+
+      Operately.Data.Change036AddSpaceToProjectActivities.run()
+
+      fetch_activities("project_goal_disconnection")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["goal_id"] == ctx.goal1.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert Enum.find(projects, &(&1.id == activity.content["project_id"]))
+      end)
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end

--- a/test/operately/operations/project_goal_disconnection_test.exs
+++ b/test/operately/operations/project_goal_disconnection_test.exs
@@ -1,4 +1,4 @@
-defmodule Operately.Operations.ProjectGoalDisconnectionTest do
+  defmodule Operately.Operations.ProjectGoalDisconnectionTest do
   use Operately.DataCase
   use Operately.Support.Notifications
 
@@ -25,7 +25,7 @@ defmodule Operately.Operations.ProjectGoalDisconnectionTest do
       contributor_fixture(creator, %{project_id: project.id, person_id: contributor.id})
     end)
 
-    {:ok, creator: creator, contributor: contributor, project: project, goal: goal}
+    {:ok, company: company, group: group, creator: creator, contributor: contributor, project: project, goal: goal}
   end
 
   test "ProjectGoalDisconnection operation updates project.goal_id to nil", ctx do
@@ -44,6 +44,10 @@ defmodule Operately.Operations.ProjectGoalDisconnectionTest do
     end)
 
     activity = from(a in Activity, where: a.action == "project_goal_disconnection" and a.content["goal_id"] == ^ctx.goal.id) |> Repo.one()
+
+    assert activity.content["company_id"] == ctx.company.id
+    assert activity.content["space_id"] == ctx.group.id
+    assert activity.content["project_id"] == ctx.project.id
 
     assert 0 == notifications_count()
 

--- a/test/support/factory/projects.ex
+++ b/test/support/factory/projects.ex
@@ -8,6 +8,7 @@ defmodule Operately.Support.Factory.Projects do
     creator = Keyword.get(opts, :creator, :creator)
     champion = Keyword.get(opts, :champion, nil)
     reviewer = Keyword.get(opts, :reviewer, nil)
+    goal = Keyword.get(opts, :goal, nil)
 
     project =
       %{
@@ -20,6 +21,7 @@ defmodule Operately.Support.Factory.Projects do
       }
       |> maybe_add_key(:champion_id, champion && ctx[champion].id)
       |> maybe_add_key(:reviewer_id, reviewer && ctx[reviewer].id)
+      |> maybe_add_key(:goal_id, goal && ctx[goal].id)
       |> Operately.ProjectsFixtures.project_fixture()
 
     Map.put(ctx, testid, project)


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `project_archived`, `project_goal_connection` and `project_goal_disconnection` activities.

I've also updated the operations which create these activities so that the space_id is added to new activities.

Now, these activities will also appear in the space feed.