### PR TITLE
fix: Add space to goal update activities

### DIFF
--- a/lib/operately/activities/content/goal_check_in.ex
+++ b/lib/operately/activities/content/goal_check_in.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.GoalCheckIn do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :goal, Operately.Goals.Goal
     belongs_to :update, Operately.Goals.Update
   end

--- a/lib/operately/activities/content/goal_check_in_acknowledgement.ex
+++ b/lib/operately/activities/content/goal_check_in_acknowledgement.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.GoalCheckInAcknowledgement do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :goal, Operately.Goals.Goal
     belongs_to :update, Operately.Goals.Update
   end

--- a/lib/operately/activities/content/goal_check_in_commented.ex
+++ b/lib/operately/activities/content/goal_check_in_commented.ex
@@ -3,6 +3,7 @@ defmodule Operately.Activities.Content.GoalCheckInCommented do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :goal, Operately.Goals.Goal
     belongs_to :goal_check_in, Operately.Goals.Update
     belongs_to :comment, Operately.Updates.Comment

--- a/lib/operately/data/change_037_add_space_to_goal_update_activities.ex
+++ b/lib/operately/data/change_037_add_space_to_goal_update_activities.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Data.Change037AddSpaceToGoalUpdateActivities do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Goals.Goal
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity,
+        where: a.action in [
+          "goal_check_in",
+          "goal_check_in_acknowledgement",
+          "goal_check_in_commented",
+        ]
+      )
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Goal.get(:system, id: activity.content["goal_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/comment_adding/activity.ex
+++ b/lib/operately/operations/comment_adding/activity.ex
@@ -16,6 +16,7 @@ defmodule Operately.Operations.CommentAdding.Activity do
     Activities.insert_sync(multi, creator.id, action, fn changes ->
       %{
         company_id: creator.company_id,
+        space_id: entity.goal.group_id,
         goal_id: entity.goal_id,
         goal_check_in_id: entity.id,
         comment_id: changes.comment.id

--- a/lib/operately/operations/goal_check_in.ex
+++ b/lib/operately/operations/goal_check_in.ex
@@ -50,6 +50,7 @@ defmodule Operately.Operations.GoalCheckIn do
     multi
     |> Activities.insert_sync(author.id, :goal_check_in, fn changes -> %{
       company_id: goal.company_id,
+      space_id: goal.group_id,
       goal_id: goal.id,
       update_id: changes.update.id,
     } end)

--- a/lib/operately/operations/goal_update_acknowledging.ex
+++ b/lib/operately/operations/goal_update_acknowledging.ex
@@ -13,6 +13,7 @@ defmodule Operately.Operations.GoalUpdateAcknowledging do
     |> Activities.insert_sync(person.id, :goal_check_in_acknowledgement, fn _changes ->
       %{
         company_id: person.company_id,
+        space_id: update.goal.group_id,
         goal_id: update.goal_id,
         update_id: update.id,
       }

--- a/lib/operately_web/api/mutations/acknowledge_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/acknowledge_goal_progress_update.ex
@@ -17,7 +17,7 @@ defmodule OperatelyWeb.Api.Mutations.AcknowledgeGoalProgressUpdate do
     Action.new()
     |> run(:id, fn -> decode_id(inputs.id) end)
     |> run(:me, fn -> find_me(conn) end)
-    |> run(:update, fn ctx -> Update.get(ctx.me, id: ctx.id) end)
+    |> run(:update, fn ctx -> Update.get(ctx.me, id: ctx.id, opts: [preload: :goal]) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.update.request_info.access_level, :can_acknowledge_check_in) end)
     |> run(:operation, fn ctx -> GoalUpdateAcknowledging.run(ctx.me, ctx.update) end)
     |> run(:serialized, fn ctx -> {:ok, %{update: Serializer.serialize(ctx.operation, level: :full)}} end)

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -55,7 +55,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
       :project_check_in -> CheckIn.get(person, id: id, opts: [preload: :project])
       :project_retrospective -> Retrospective.get(person, id: id, opts: [preload: :project])
       :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person.id)
-      :goal_update -> Update.get(person, id: id)
+      :goal_update -> Update.get(person, id: id, opts: [preload: :goal])
       :message -> Message.get(person, id: id)
     end
   end

--- a/priv/repo/migrations/20241011111805_add_space_key_to_goal_update_activities.exs
+++ b/priv/repo/migrations/20241011111805_add_space_key_to_goal_update_activities.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceKeyToGoalUpdateActivities do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change037AddSpaceToGoalUpdateActivities.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -232,7 +232,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "goal_check_in",
         author_id: ctx.author.id,
-        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, update_id: ctx.update.id }
+        content: %{ goal_id: ctx.goal.id, space_id: ctx.group.id, company_id: ctx.company.id, update_id: ctx.update.id }
       }
 
       create_activity(attrs)
@@ -243,7 +243,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "goal_check_in_acknowledgement",
         author_id: ctx.author.id,
-        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, update_id: ctx.update.id }
+        content: %{ goal_id: ctx.goal.id, space_id: ctx.group.id, company_id: ctx.company.id, update_id: ctx.update.id }
       }
 
       create_activity(attrs)
@@ -254,7 +254,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "goal_check_in_commented",
         author_id: ctx.author.id,
-        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, goal_check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
+        content: %{ goal_id: ctx.goal.id, space_id: ctx.group.id, company_id: ctx.company.id, goal_check_in_id: ctx.check_in.id, comment_id: ctx.comment.id }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_037_add_space_to_goal_update_activities_test.exs
+++ b/test/operately/data/change_037_add_space_to_goal_update_activities_test.exs
@@ -1,0 +1,86 @@
+defmodule Operately.Data.Change037AddSpaceToGoalUpdateActivitiesTest do
+  use Operately.DataCase
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+  end
+
+  describe "migration doesn't delete existing data in activity content" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_goal(:goal, :space)
+    end
+
+    test "goal_check_in and goal_check_in_acknowledgement", ctx do
+      updates = Enum.map(1..3, fn _ ->
+        {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, ctx.goal, %{
+          goal_id: ctx.goal.id,
+          target_values: [],
+          content: RichText.rich_text("content"),
+          send_to_everyone: false,
+          subscription_parent_type: :goal_update,
+          subscriber_ids: [],
+        })
+        {:ok, _} = Operately.Operations.GoalUpdateAcknowledging.run(ctx.creator, update)
+        update
+      end)
+
+      Operately.Data.Change037AddSpaceToGoalUpdateActivities.run()
+
+      fetch_activities("goal_check_in")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["goal_id"] == ctx.goal.id
+        assert Enum.find(updates, &(&1.id == activity.content["update_id"]))
+      end)
+
+      fetch_activities("goal_check_in_acknowledgement")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["goal_id"] == ctx.goal.id
+        assert Enum.find(updates, &(&1.id == activity.content["update_id"]))
+      end)
+    end
+
+    test "goal_check_in_commented", ctx do
+      ctx = Factory.add_goal_update(ctx, :update, :goal, :creator)
+
+      comments = Enum.map(1..3, fn _ ->
+        {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.creator, ctx.update, "goal_update", RichText.rich_text("content"))
+        comment
+      end)
+
+      Operately.Data.Change037AddSpaceToGoalUpdateActivities.run()
+
+      fetch_activities("goal_check_in_commented")
+      |> Enum.each(fn activity ->
+        assert activity.content["company_id"] == ctx.company.id
+        assert activity.content["space_id"] == ctx.space.id
+        assert activity.content["goal_id"] == ctx.goal.id
+        assert activity.content["goal_check_in_id"] == ctx.update.id
+        assert Enum.find(comments, &(&1.id == activity.content["comment_id"]))
+      end)
+    end
+ end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `goal_check_in`, `goal_check_in_acknowledgement` and `goal_check_in_commented` activities.

I've also updated the operations which create these activities so that the space_id is added to new activities.

Now, these activities will also appear in the space feed.