### PR TITLE
fix: Add space to goal_editing activity

### DIFF
--- a/lib/operately/activities/content/goal_editing.ex
+++ b/lib/operately/activities/content/goal_editing.ex
@@ -70,6 +70,7 @@ defmodule Operately.Activities.Content.GoalEditing do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :goal, Operately.Goals.Goal
 
     field :old_name, :string
@@ -94,13 +95,13 @@ defmodule Operately.Activities.Content.GoalEditing do
 
   def changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, [:company_id, :goal_id, :old_name, :new_name, :old_champion_id, :new_champion_id, :old_reviewer_id, :new_reviewer_id] -- [:old_timeframe, :new_timeframe])
+    |> cast(attrs, [:company_id, :space_id, :goal_id, :old_name, :new_name, :old_champion_id, :new_champion_id, :old_reviewer_id, :new_reviewer_id] -- [:old_timeframe, :new_timeframe])
     |> cast_embed(:previous_timeframe)
     |> cast_embed(:current_timeframe)
     |> cast_embed(:added_targets)
     |> cast_embed(:updated_targets)
     |> cast_embed(:deleted_targets)
-    |> validate_required([:company_id, :goal_id, :old_name, :new_name, :old_champion_id, :new_champion_id, :old_reviewer_id, :new_reviewer_id] -- [:old_timeframe, :new_timeframe])
+    |> validate_required([:company_id, :space_id, :goal_id, :old_name, :new_name, :old_champion_id, :new_champion_id, :old_reviewer_id, :new_reviewer_id] -- [:old_timeframe, :new_timeframe])
   end
 
   def build(params) do

--- a/lib/operately/data/change_038_add_space_to_goal_editing_activity.ex
+++ b/lib/operately/data/change_038_add_space_to_goal_editing_activity.ex
@@ -1,0 +1,37 @@
+defmodule Operately.Data.Change038AddSpaceToGoalEditingActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Goals.Goal
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity, where: a.action == "goal_editing")
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Goal.get(:system, id: activity.content["goal_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/operations/goal_editing.ex
+++ b/lib/operately/operations/goal_editing.ex
@@ -96,6 +96,7 @@ defmodule Operately.Operations.GoalEditing do
     Activities.insert_sync(multi, author.id, :goal_editing, fn changes ->
       %{
         company_id: goal.company_id,
+        space_id: goal.group_id,
         goal_id: changes.goal.id,
         old_name: goal.name,
         new_name: changes.goal.name,

--- a/priv/repo/migrations/20241011142317_add_space_to_goal_editing_activity.exs
+++ b/priv/repo/migrations/20241011142317_add_space_to_goal_editing_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceToGoalEditingActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change038AddSpaceToGoalEditingActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/features/goals_test.exs
+++ b/test/features/goals_test.exs
@@ -28,6 +28,8 @@ defmodule Operately.Features.GoalTest do
     |> Steps.assert_goal_edited()
     |> Steps.assert_goal_edited_email_sent()
     |> Steps.assert_goal_edited_feed_posted()
+    |> Steps.assert_goal_edited_space_feed_posted()
+    |> Steps.assert_goal_edited_company_feed_posted()
   end
 
   @parent_goal_params %{
@@ -120,5 +122,5 @@ defmodule Operately.Features.GoalTest do
     |> Steps.assert_comment_on_the_timeframe_change_email_sent()
     |> Steps.assert_comment_on_the_timeframe_change_notification_sent()
   end
-  
+
 end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -325,7 +325,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "goal_editing",
         author_id: ctx.author.id,
-        content: %{ goal_id: ctx.goal.id, company_id: ctx.company.id, old_name: "-", new_name: "-", old_champion_id: ctx.author.id, new_champion_id: ctx.author.id, old_reviewer_id: ctx.author.id, new_reviewer_id: ctx.author.id, }
+        content: %{ goal_id: ctx.goal.id, space_id: ctx.group.id, company_id: ctx.company.id, old_name: "-", new_name: "-", old_champion_id: ctx.author.id, new_champion_id: ctx.author.id, old_reviewer_id: ctx.author.id, new_reviewer_id: ctx.author.id, }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_038_add_space_to_goal_editing_activity_test.exs
+++ b/test/operately/data/change_038_add_space_to_goal_editing_activity_test.exs
@@ -1,0 +1,67 @@
+defmodule Operately.Data.Change038AddSpaceToGoalEditingActivityTest do
+  use Operately.DataCase
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_goal(:goal, :space)
+  end
+
+  test "migration doesn't delete existing data in activity content", ctx do
+    attrs = %{
+      name: "Edited name",
+      description: RichText.rich_text("content", :as_string),
+      added_targets: [%{index: 0, name: "Added Target", unit: "New Unit", to: 30, from: 0}],
+      updated_targets: [],
+      goal_id: ctx.goal.id,
+      champion_id: ctx.creator.id,
+      reviewer_id: ctx.creator.id,
+      timeframe: %{type: "days", start_date: ~D[2024-10-01], end_date: ~D[2025-02-28]},
+      anonymous_access_level: 0,
+      company_access_level: 0,
+      space_access_level: 0
+    }
+
+    Enum.each(1..3, fn _ ->
+      {:ok, _} = Operately.Operations.GoalEditing.run(ctx.creator, ctx.goal, attrs)
+    end)
+
+    Operately.Data.Change038AddSpaceToGoalEditingActivity.run()
+
+    fetch_activities("goal_editing")
+    |> Enum.each(fn activity ->
+      added_targets = activity.content["added_targets"]
+      assert length(added_targets) == 1
+      assert hd(added_targets)["name"] == "Added Target"
+      assert hd(added_targets)["unit"] == "New Unit"
+
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["space_id"] == ctx.space.id
+      assert activity.content["goal_id"] == ctx.goal.id
+
+      current_timeframe = activity.content["current_timeframe"]
+      assert current_timeframe["start_date"] == "2024-10-01"
+      assert current_timeframe["end_date"] == "2025-02-28"
+
+      assert activity.content["new_name"] == "Edited name"
+      assert activity.content["new_champion_id"] == ctx.creator.id
+      assert activity.content["new_reviewer_id"] == ctx.creator.id
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -10,6 +10,10 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "edited the goal", "")
   end
 
+  def assert_goal_edited(ctx, author: author, goal_name: name) do
+    ctx |> assert_feed_item_exists(author, "edited the #{name} goal", "")
+  end
+
   def assert_goal_check_in_acknowledgement(ctx, author: author) do
     ctx |> assert_feed_item_exists(author, "acknowledged", "")
   end

--- a/test/support/features/goal_steps.ex
+++ b/test/support/features/goal_steps.ex
@@ -208,6 +208,22 @@ defmodule Operately.Support.Features.GoalSteps do
     ctx |> FeedSteps.assert_goal_edited(author: ctx.champion)
   end
 
+  step :assert_goal_edited_space_feed_posted, ctx do
+    goal = Repo.reload(ctx.goal)
+
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_goal_edited(author: ctx.champion, goal_name: goal.name)
+  end
+
+  step :assert_goal_edited_company_feed_posted, ctx do
+    goal = Repo.reload(ctx.goal)
+
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_goal_edited(author: ctx.champion, goal_name: goal.name)
+  end
+
   step :edit_goal_timeframe, ctx do
     ctx
     |> UI.click(testid: "goal-options")


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `goal_editing` activities.

I've also updated the `GoalEditing` operation so that it adds the space_id key to new activities.

Now, these activities will also appear in the space feed.