### PR TITLE
issue with notification count

### DIFF
--- a/test/features/notifications_test.exs
+++ b/test/features/notifications_test.exs
@@ -9,6 +9,9 @@ defmodule Operately.Features.NotificationsTest do
   alias Operately.Support.Features.NotificationsSteps, as: Steps
 
   setup ctx do
+    # Reset notifications
+    Operately.Notifications.clear_all()
+    
     ctx = Map.put(ctx, :company, company_fixture(%{name: "Test Org"}))
     ctx = Map.put(ctx, :champion, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "Dorcy Devonshire"}))
     ctx = Map.put(ctx, :reviewer, person_fixture_with_account(%{company_id: ctx.company.id, full_name: "John Reviewer"}))
@@ -29,17 +32,20 @@ defmodule Operately.Features.NotificationsTest do
     |> Steps.visit_notifications_page()
     |> Steps.click_on_notification("notification-item-space_members_added")
     |> Steps.assert_no_unread_notifications()
+    |> UI.logout() # Reset session
   end
 
   feature "mark all unread notifications as read", ctx do
     ctx
     |> UI.login_as(ctx.reviewer)
     |> Steps.given_a_project_creation_notification_exists()
+    |> UI.logout() # Logout before the next login
     |> UI.login_as(ctx.champion)
     |> Steps.assert_notification_count(2)
     |> Steps.visit_notifications_page()
     |> Steps.click_on_first_mark_all_as_read()
     |> Steps.assert_no_unread_notifications()
+    |> UI.logout() # Reset session
   end
 
 end


### PR DESCRIPTION
To solve the issue of inconsistent unread notification counts in the Operately tests, the following steps were implemented:

Notification Reset: Added a call to Operately.Notifications.clear_all() in the setup block to ensure a clean state for notifications before each test.

Session Management: Incorporated UI.logout() at the end of each feature test to clear user sessions, preventing carry-over of states between tests.

