### PR TITLE
fix: Add space to project_timeline_edtied activity

### DIFF
--- a/lib/operately/activities/content/project_timeline_edited.ex
+++ b/lib/operately/activities/content/project_timeline_edited.ex
@@ -39,6 +39,7 @@ defmodule Operately.Activities.Content.ProjectTimelineEdited do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
 
     field :old_start_date, :utc_datetime
@@ -53,10 +54,10 @@ defmodule Operately.Activities.Content.ProjectTimelineEdited do
 
   def changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, [:company_id, :project_id, :old_start_date, :old_end_date, :new_start_date, :new_end_date])
+    |> cast(attrs, [:company_id, :space_id, :project_id, :old_start_date, :old_end_date, :new_start_date, :new_end_date])
     |> cast_embed(:milestone_updates)
     |> cast_embed(:new_milestones)
-    |> validate_required([:company_id, :project_id, :new_start_date])
+    |> validate_required([:company_id, :space_id, :project_id, :new_start_date])
   end
 
   def build(params) do

--- a/lib/operately/data/change_039_add_space_to_project_timeline_edited_activity.ex
+++ b/lib/operately/data/change_039_add_space_to_project_timeline_edited_activity.ex
@@ -1,0 +1,37 @@
+defmodule Operately.Data.Change039AddSpaceToProjectTimelineEditedActivity do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Projects.Project
+
+  def run do
+    Repo.transaction(fn ->
+      from(a in Activity, where: a.action == "project_timeline_edited")
+      |> Repo.all()
+      |> update_activities()
+    end)
+  end
+
+  defp update_activities(activities) when is_list(activities) do
+    Enum.each(activities, fn a ->
+      update_activities(a)
+    end)
+  end
+
+  defp update_activities(activity) do
+    Project.get(:system, id: activity.content["project_id"], opts: [
+      with_deleted: true,
+    ])
+    |> case do
+      {:ok, %{group_id: space_id}} ->
+        content = Map.put(activity.content, :space_id, space_id)
+
+        {:ok, _} = Activity.changeset(activity, %{content: content})
+        |> Repo.update()
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/operately/projects/edit_timeline_operation.ex
+++ b/lib/operately/projects/edit_timeline_operation.ex
@@ -7,7 +7,7 @@ defmodule Operately.Projects.EditTimelineOperation do
 
   def run(author, project, attrs) do
     changeset = Project.changeset(project, %{
-      started_at: attrs.project_start_date, 
+      started_at: attrs.project_start_date,
       deadline: attrs.project_due_date
     })
 
@@ -52,9 +52,10 @@ defmodule Operately.Projects.EditTimelineOperation do
 
   defp record_activity(multi, author, project, attrs) do
     multi
-    |> Activities.insert_sync(author.id, :project_timeline_edited, fn changes -> 
+    |> Activities.insert_sync(author.id, :project_timeline_edited, fn changes ->
       %{
         company_id: project.company_id,
+        space_id: project.group_id,
         project_id: project.id,
         old_start_date: project.started_at,
         new_start_date: changes.project.started_at,

--- a/priv/repo/migrations/20241014102321_add_space_to_project_timeline_edited_activity.exs
+++ b/priv/repo/migrations/20241014102321_add_space_to_project_timeline_edited_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddSpaceToProjectTimelineEditedActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change039AddSpaceToProjectTimelineEditedActivity.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/features/project_timeline_test.exs
+++ b/test/features/project_timeline_test.exs
@@ -9,6 +9,15 @@ defmodule Operately.Features.ProjectsTimelineTest do
 
   @tag login_as: :champion
   feature "setting initial start and due dates, and adding milestones", ctx do
+    messages = [
+      "The due date was set to #{Operately.Time.current_month()} 20th.",
+      "Total project duration is 10 days.",
+      "Added new milestones:",
+      "Contract Signed",
+      "#{Operately.Time.current_month()} 15th",
+      "Website Launched",
+      "#{Operately.Time.current_month()} 16th"
+    ]
     milestone1 = %{title: "Contract Signed", due_day: 15}
     milestone2 = %{title: "Website Launched", due_day: 16}
 
@@ -22,17 +31,9 @@ defmodule Operately.Features.ProjectsTimelineTest do
     |> Steps.assert_project_timeframe(%{start: "10th", due_day: "20th"})
     |> Steps.assert_milestone_added(milestone1)
     |> Steps.assert_milestone_added(milestone2)
-    |> Steps.assert_project_timeline_edited_feed(%{
-      messages: [
-        "The due date was set to #{Operately.Time.current_month()} 20th.",
-        "Total project duration is 10 days.",
-        "Added new milestones:",
-        "Contract Signed",
-        "#{Operately.Time.current_month()} 15th",
-        "Website Launched",
-        "#{Operately.Time.current_month()} 16th"
-      ]
-    })
+    |> Steps.assert_project_timeline_edited_feed(%{messages: messages})
+    |> Steps.assert_project_timeline_edited_space_feed_posted(%{messages: messages})
+    |> Steps.assert_project_timeline_edited_company_feed_posted(%{messages: messages})
     |> Steps.assert_project_timeline_edited_notification()
     |> Steps.assert_project_timeline_edited_email()
   end
@@ -66,6 +67,12 @@ defmodule Operately.Features.ProjectsTimelineTest do
 
   @tag login_as: :champion
   feature "editing existing milestones while editing project timeline", ctx do
+    messages = [
+      "Updated a milestone:",
+      "Contract Updated with Provider",
+      "#{Operately.Time.current_month()} 16th",
+    ]
+
     ctx
     |> Steps.give_a_milestone_exists(%{title: "Contract Signed"})
     |> Steps.start_editing_timeline()
@@ -77,13 +84,9 @@ defmodule Operately.Features.ProjectsTimelineTest do
     })
     |> Steps.submit_changes()
     |> Steps.assert_project_timeframe(%{start: "10th", due_day: "20th"})
-    |> Steps.assert_project_timeline_edited_feed(%{
-      messages: [
-        "Updated a milestone:",
-        "Contract Updated with Provider",
-        "#{Operately.Time.current_month()} 16th",
-      ]
-    })
+    |> Steps.assert_project_timeline_edited_feed(%{messages: messages})
+    |> Steps.assert_project_timeline_edited_space_feed_posted(%{messages: messages})
+    |> Steps.assert_project_timeline_edited_company_feed_posted(%{messages: messages})
     |> Steps.assert_project_timeline_edited_notification()
     |> Steps.assert_project_timeline_edited_email()
   end

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -559,7 +559,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "project_timeline_edited",
         author_id: ctx.author.id,
-        content: %{ project_id: ctx.project.id, company_id: ctx.company.id, old_start_date: DateTime.utc_now(), new_start_date: DateTime.utc_now(), old_end_date: DateTime.utc_now(), new_end_date: DateTime.utc_now() }
+        content: %{ project_id: ctx.project.id, space_id: ctx.group.id, company_id: ctx.company.id, old_start_date: DateTime.utc_now(), new_start_date: DateTime.utc_now(), old_end_date: DateTime.utc_now(), new_end_date: DateTime.utc_now() }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_039_add_space_to_project_timeline_edited_activity_test.exs
+++ b/test/operately/data/change_039_add_space_to_project_timeline_edited_activity_test.exs
@@ -1,0 +1,62 @@
+defmodule Operately.Data.Change039AddSpaceToProjectTimelineEditedActivityTest do
+  use Operately.DataCase
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_project(:project, :space)
+  end
+
+  test "migration doesn't delete existing data in activity content", ctx do
+    attrs = %{
+      project_id: ctx.project.id,
+      project_start_date: ~N[2024-10-14 00:00:00],
+      project_due_date: ~N[2024-11-14 00:00:00],
+      milestone_updates: [],
+      new_milestones: [
+        %{
+          title: "New milestone",
+          description: RichText.rich_text("description"),
+          due_time: ~N[2024-11-14 00:00:00],
+        }
+      ],
+    }
+
+    Enum.each(1..3, fn _ ->
+      {:ok, _} = Operately.Projects.EditTimelineOperation.run(ctx.creator, ctx.project, attrs)
+    end)
+
+    Operately.Data.Change039AddSpaceToProjectTimelineEditedActivity.run()
+
+    fetch_activities("project_timeline_edited")
+    |> Enum.each(fn activity ->
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["space_id"] == ctx.space.id
+      assert activity.content["project_id"] == ctx.project.id
+
+      milestones = activity.content["new_milestones"]
+      assert length(milestones) == 1
+      assert hd(milestones)["title"] == "New milestone"
+      assert hd(milestones)["due_date"] == "2024-11-14T00:00:00Z"
+
+      assert activity.content["new_start_date"] == "2024-10-14T00:00:00Z"
+      assert activity.content["new_end_date"] == "2024-11-14T00:00:00Z"
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_activities(action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action
+    )
+    |> Repo.all()
+  end
+end

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -34,10 +34,17 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "paused the project with", "")
   end
 
-  def assert_project_timeline_edited(ctx, author: author, messages: messages) do
+  def assert_project_timeline_edited(ctx, attrs) do
+    title = case Keyword.get(attrs, :project_name, nil) do
+      nil -> "edited the timeline"
+      name -> "edited the timeline on the #{name} project"
+    end
+    author = Keyword.get(attrs, :author)
+    messages = Keyword.get(attrs, :messages)
+
     ctx
     |> UI.assert_text(Person.first_name(author))
-    |> UI.assert_text("edited the timeline")
+    |> UI.assert_text(title)
     |> then(fn ctx ->
       Enum.each(messages, fn message ->
         ctx |> UI.assert_text(message)

--- a/test/support/features/project_timeline_steps.ex
+++ b/test/support/features/project_timeline_steps.ex
@@ -107,6 +107,18 @@ defmodule Operately.Support.Features.ProjectTimelineSteps do
     |> FeedSteps.assert_project_timeline_edited(author: ctx.champion, messages: messages)
   end
 
+  step :assert_project_timeline_edited_space_feed_posted, ctx, %{messages: messages} do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_timeline_edited(author: ctx.champion, project_name: ctx.project.name, messages: messages)
+  end
+
+  step :assert_project_timeline_edited_company_feed_posted, ctx, %{messages: messages} do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_timeline_edited(author: ctx.champion, project_name: ctx.project.name, messages: messages)
+  end
+
   step :assert_project_timeline_edited_notification, ctx do
     ctx
     |> UI.login_as(ctx.reviewer)


### PR DESCRIPTION
I've added a migration which adds the space_id key to all existing `project_timeline_edtied` activities.

I've also updated the `EditTimelineOperation` operation so that it adds the space_id key to new activities.

Now, these activities will also appear in the space feed.