### PR TITLE
chore: Add tests for space and company feed

### DIFF
--- a/assets/js/features/activities/ProjectGoalConnection/index.tsx
+++ b/assets/js/features/activities/ProjectGoalConnection/index.tsx
@@ -33,11 +33,11 @@ const ProjectGoalConnection: ActivityHandler = {
     const goal = goalLink(content(activity).goal!);
 
     if (page === "project") {
-      return feedTitle(activity, "connected the project from the", goal, "goal");
+      return feedTitle(activity, "connected the project to the", goal, "goal");
     } else if (page === "goal") {
-      return feedTitle(activity, "connected the", project, "project from the goal");
+      return feedTitle(activity, "connected the", project, "project to the goal");
     } else {
-      return feedTitle(activity, "connected the", project, "project from the", goal, "goal");
+      return feedTitle(activity, "connected the", project, "project to the", goal, "goal");
     }
   },
 

--- a/test/features/goal_progress_update_test.exs
+++ b/test/features/goal_progress_update_test.exs
@@ -49,7 +49,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
     |> Steps.visit_page()
     |> Steps.update_progress(params)
     |> Steps.comment_on_progress_update_as_reviewer("Great job!")
+    |> Steps.assert_progress_update_commented_in_feed("Great job!")
     |> Steps.assert_comment_email_sent()
   end
-
 end

--- a/test/features/goal_progress_update_test.exs
+++ b/test/features/goal_progress_update_test.exs
@@ -12,7 +12,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
     |> Steps.visit_page()
     |> Steps.update_progress(params)
     |> Steps.assert_progress_updated(params)
-    |> Steps.assert_progress_update_in_feed()
+    |> Steps.assert_progress_update_in_feed(params)
     |> Steps.assert_progress_update_in_notifications()
   end
 
@@ -51,5 +51,5 @@ defmodule Operately.Features.GoalProgressUpdateTest do
     |> Steps.comment_on_progress_update_as_reviewer("Great job!")
     |> Steps.assert_comment_email_sent()
   end
-  
+
 end

--- a/test/features/project_check_ins_test.exs
+++ b/test/features/project_check_ins_test.exs
@@ -26,7 +26,7 @@ defmodule Operately.Features.ProjectCheckInsTest do
   feature "acknowledge a check-in in the web app", ctx do
     values = %{status: "on_track", description: "This is a check-in."}
 
-    ctx 
+    ctx
     |> Steps.submit_check_in(values)
     |> Steps.open_check_in_from_notifications(values)
     |> Steps.acknowledge_check_in()
@@ -40,7 +40,7 @@ defmodule Operately.Features.ProjectCheckInsTest do
   feature "acknowledge a check-in from the email", ctx do
     values = %{status: "on_track", description: "This is a check-in."}
 
-    ctx 
+    ctx
     |> Steps.submit_check_in(values)
     |> Steps.acknowledge_check_in_from_email(values)
     |> Steps.assert_check_in_acknowledged(values)
@@ -54,6 +54,7 @@ defmodule Operately.Features.ProjectCheckInsTest do
     |> Steps.submit_check_in(values)
     |> Steps.open_check_in_from_notifications(values)
     |> Steps.leave_comment_on_check_in()
+    |> Steps.assert_check_in_comment_visible_on_feed()
     |> Steps.assert_comment_on_check_in_received_in_notifications()
     |> Steps.assert_comment_on_check_in_received_in_email()
   end
@@ -69,5 +70,4 @@ defmodule Operately.Features.ProjectCheckInsTest do
     |> Steps.edit_check_in(new_values)
     |> Steps.assert_check_in_submitted(new_values)
   end
-
 end

--- a/test/features/project_check_ins_test.exs
+++ b/test/features/project_check_ins_test.exs
@@ -33,7 +33,7 @@ defmodule Operately.Features.ProjectCheckInsTest do
     |> Steps.assert_check_in_acknowledged(values)
     |> Steps.assert_acknowledgement_email_sent_to_champion(values)
     |> Steps.assert_acknowledgement_notification_sent_to_champion(values)
-    |> Steps.assert_acknowledgement_visible_on_project_feed(values)
+    |> Steps.assert_acknowledgement_visible_on_feed()
   end
 
   @tag login_as: :champion

--- a/test/features/project_creation_test.exs
+++ b/test/features/project_creation_test.exs
@@ -14,6 +14,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
+    |> Steps.assert_project_created_feed()
   end
 
   @tag login_as: :reviewer
@@ -26,6 +27,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
+    |> Steps.assert_project_created_feed(ctx.reviewer)
   end
 
   @tag login_as: :non_contributor
@@ -38,6 +40,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
+    |> Steps.assert_project_created_feed(ctx.non_contributor)
   end
 
 
@@ -51,6 +54,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
+    |> Steps.assert_project_created_feed(ctx.project_manager)
   end
 
   @tag login_as: :champion
@@ -69,6 +73,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_project_created_email_sent(params)
     |> Steps.assert_project_created_notification_sent(params)
+    |> Steps.assert_project_created_feed()
   end
 
   @tag login_as: :champion
@@ -80,6 +85,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.start_adding_project()
     |> Steps.submit_project_form(params)
     |> Steps.assert_project_created(params)
+    |> Steps.assert_project_created_feed()
     |> Steps.assert_reviewer_is_champions_manager(params)
   end
 
@@ -105,6 +111,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_review_placeholder_showing()
     |> Steps.follow_add_reviewer_link_and_add_reviewer()
     |> Steps.assert_project_has_reviewer(params)
+    |> Steps.assert_project_created_feed()
   end
 
   @tag login_as: :champion
@@ -119,6 +126,7 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_company_members_cant_see_project(params)
     |> Steps.assert_space_members_can_see_project(params)
+    |> Steps.assert_project_created_feed()
   end
 
   @tag login_as: :champion
@@ -134,5 +142,6 @@ defmodule Operately.Features.ProjectCreationTest do
     |> Steps.assert_project_created(params)
     |> Steps.assert_company_members_cant_see_project(params)
     |> Steps.assert_space_members_cant_see_project(params)
+    |> Steps.assert_project_created_feed()
   end
 end

--- a/test/features/project_milestones_test.exs
+++ b/test/features/project_milestones_test.exs
@@ -22,7 +22,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
     |> Steps.given_that_a_milestone_exists("Contract Signed")
     |> Steps.visit_milestone_page()
     |> Steps.leave_a_comment("Hello world")
-    |> Steps.assert_comment_visible_in_project_feed("Hello world")
+    |> Steps.assert_comment_visible_in_feed("Hello world")
     |> Steps.assert_comment_email_sent_to_project_reviewer()
     |> Steps.assert_comment_notification_sent_to_project_reviewer()
   end

--- a/test/features/projects_test.exs
+++ b/test/features/projects_test.exs
@@ -35,7 +35,7 @@ defmodule Operately.Features.ProjectsTest do
     |> Steps.pause_project()
     |> Steps.assert_project_paused()
     |> Steps.assert_pause_notification_sent_to_reviewer()
-    |> Steps.assert_pause_visible_on_project_feed()
+    |> Steps.assert_pause_visible_on_feed()
     |> Steps.assert_pause_email_sent_to_reviewer()
   end
 

--- a/test/features/projects_test.exs
+++ b/test/features/projects_test.exs
@@ -16,6 +16,7 @@ defmodule Operately.Features.ProjectsTest do
     |> Steps.visit_project_page()
     |> Steps.rename_project(new_name: "New Name")
     |> Steps.assert_project_renamed(new_name: "New Name")
+    |> Steps.assert_project_renamed_visible_on_feed()
   end
 
   @tag login_as: :champion

--- a/test/features/projects_test.exs
+++ b/test/features/projects_test.exs
@@ -55,13 +55,15 @@ defmodule Operately.Features.ProjectsTest do
 
   @tag login_as: :champion
   feature "connect a goal to a project", ctx do
-    ctx
-    |> Steps.given_a_goal_exists(name: "Improve support first response time")
-    |> Steps.visit_project_page()
-    |> Steps.choose_new_goal(goal_name: "Improve support first response time")
-    |> Steps.assert_goal_connected(goal_name: "Improve support first response time")
-    |> Steps.assert_goal_link_on_project_page(goal_name: "Improve support first response time")
-    |> Steps.assert_goal_connected_email_sent_to_champion(goal_name: "Improve support first response time")
-  end
+    goal_name = "Improve support first response time"
 
+    ctx
+    |> Steps.given_a_goal_exists(name: goal_name)
+    |> Steps.visit_project_page()
+    |> Steps.choose_new_goal(goal_name: goal_name)
+    |> Steps.assert_goal_connected(goal_name: goal_name)
+    |> Steps.assert_goal_link_on_project_page(goal_name: goal_name)
+    |> Steps.assert_project_goal_connection_visible_on_feed(goal_name: goal_name)
+    |> Steps.assert_goal_connected_email_sent_to_champion(goal_name: goal_name)
+  end
 end

--- a/test/features/projects_test.exs
+++ b/test/features/projects_test.exs
@@ -48,7 +48,7 @@ defmodule Operately.Features.ProjectsTest do
     |> Steps.resume_project()
     |> Steps.assert_project_active()
     |> Steps.assert_resume_notification_sent_to_reviewer()
-    |> Steps.assert_resume_visible_on_project_feed()
+    |> Steps.assert_project_resumed_visible_on_feed()
     |> Steps.assert_resume_email_sent_to_reviewer()
   end
 

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -27,7 +27,11 @@ defmodule Operately.Support.Features.FeedSteps do
   end
 
   def assert_goal_check_in_acknowledgement(ctx, author: author) do
-    ctx |> assert_feed_item_exists(author, "acknowledged", "")
+    ctx |> assert_feed_item_exists(author, "acknowledged the Progress Update", "")
+  end
+
+  def assert_goal_check_in_acknowledgement(ctx, author: author, goal_name: goal_name) do
+    ctx |> assert_feed_item_exists(author, "acknowledged the Progress Update in the #{goal_name} goal", "")
   end
 
   #

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -50,6 +50,10 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "resumed the #{project_name} project", "")
   end
 
+  def assert_project_milestone_commented(ctx, author: author, milestone_tile: milestone_title, comment: comment) do
+    ctx |> assert_feed_item_exists(author, "commented on the #{milestone_title} milestone", comment)
+  end
+
   def assert_project_timeline_edited(ctx, attrs) do
     title = case Keyword.get(attrs, :project_name, nil) do
       nil -> "edited the timeline"

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -54,6 +54,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "resumed the #{project_name} project", "")
   end
 
+  def assert_project_renamed(ctx, author: author) do
+    ctx |> assert_feed_item_exists(author, "renamed the project", "")
+  end
+
+  def assert_project_renamed(ctx, author: author, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "renamed the #{project_name} project", "")
+  end
+
   def assert_project_milestone_commented(ctx, author: author, milestone_tile: milestone_title, comment: comment) do
     ctx |> assert_feed_item_exists(author, "commented on the #{milestone_title} milestone", comment)
   end

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -98,10 +98,26 @@ defmodule Operately.Support.Features.FeedSteps do
   # Project Check-ins
   #
 
-  def assert_project_check_in_submitted(ctx, author: author, status: status, description: description) do
+  def assert_project_check_in_submitted(ctx, author: author, description: description) do
     ctx
-    |> assert_feed_item_exists(author, "submitted a Check-In", status)
+    |> assert_feed_item_exists(author, "submitted a Check-In", "On Track")
     |> UI.assert_text(description)
+  end
+
+  def assert_project_check_in_submitted(ctx, author: author, project_name: project_name, description: description) do
+    ctx
+    |> assert_feed_item_exists(author, "submitted a Check-In in the #{project_name} project", "On Track")
+    |> UI.assert_text(description)
+  end
+
+  def assert_project_check_in_acknowledged(ctx, author: author) do
+    ctx
+    |> assert_feed_item_exists(author, "acknowledged a Check-In", "")
+  end
+
+  def assert_project_check_in_acknowledged(ctx, author: author, project_name: project_name) do
+    ctx
+    |> assert_feed_item_exists(author, "acknowledged a Check-In in the #{project_name} project", "")
   end
 
   def assert_project_check_in_commented(ctx, author: author, comment: comment) do

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -42,6 +42,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "paused the project with", "")
   end
 
+  def assert_project_resumed(ctx, author: author) do
+    ctx |> assert_feed_item_exists(author, "resumed the project", "")
+  end
+
+  def assert_project_resumed(ctx, author: author, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "resumed the #{project_name} project", "")
+  end
+
   def assert_project_timeline_edited(ctx, attrs) do
     title = case Keyword.get(attrs, :project_name, nil) do
       nil -> "edited the timeline"

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -98,6 +98,12 @@ defmodule Operately.Support.Features.FeedSteps do
   # Project Check-ins
   #
 
+  def assert_project_check_in_submitted(ctx, author: author, status: status, description: description) do
+    ctx
+    |> assert_feed_item_exists(author, "submitted a Check-In", status)
+    |> UI.assert_text(description)
+  end
+
   def assert_project_check_in_commented(ctx, author: author, comment: comment) do
     ctx |> assert_feed_item_exists(author, "commented on Check-In", comment)
   end

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -74,6 +74,18 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "commented on the #{milestone_title} milestone", comment)
   end
 
+  def assert_project_goal_connection(ctx, author: author, goal_name: goal_name) do
+    ctx |> assert_feed_item_exists(author, "connected the project to the #{goal_name} goal", "")
+  end
+
+  def assert_project_goal_connection(ctx, author: author, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "connected the #{project_name} project to the goal", "")
+  end
+
+  def assert_project_goal_connection(ctx, author: author, project_name: project_name, goal_name: goal_name) do
+    ctx |> assert_feed_item_exists(author, "connected the #{project_name} project to the #{goal_name} goal", "")
+  end
+
   def assert_project_timeline_edited(ctx, attrs) do
     title = case Keyword.get(attrs, :project_name, nil) do
       nil -> "edited the timeline"

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -18,6 +18,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "edited the #{name} goal", "")
   end
 
+  def assert_goal_checked_in(ctx, author: author, message: message) do
+    ctx |> assert_feed_item_exists(author, "updated the progress", message)
+  end
+
+  def assert_goal_checked_in(ctx, author: author, goal_name: goal_name, message: message) do
+    ctx |> assert_feed_item_exists(author, "updated the progress in the #{goal_name}", message)
+  end
+
   def assert_goal_check_in_acknowledgement(ctx, author: author) do
     ctx |> assert_feed_item_exists(author, "acknowledged", "")
   end

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -2,6 +2,10 @@ defmodule Operately.Support.Features.FeedSteps do
   alias Operately.Support.Features.UI
   alias Operately.People.Person
 
+  #
+  # Goals
+  #
+
   def assert_goal_added(ctx, author: author) do
     ctx |> assert_feed_item_exists(author, "added this goal", "")
   end
@@ -17,6 +21,10 @@ defmodule Operately.Support.Features.FeedSteps do
   def assert_goal_check_in_acknowledgement(ctx, author: author) do
     ctx |> assert_feed_item_exists(author, "acknowledged", "")
   end
+
+  #
+  # Projects
+  #
 
   def assert_project_created(ctx, author: author) do
     ctx |> assert_feed_item_exists(author, "created the project", "")
@@ -84,6 +92,14 @@ defmodule Operately.Support.Features.FeedSteps do
 
       ctx
     end)
+  end
+
+  #
+  # Project Check-ins
+  #
+
+  def assert_project_check_in_commented(ctx, author: author, comment: comment) do
+    ctx |> assert_feed_item_exists(author, "commented on Check-In", comment)
   end
 
   #

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -34,6 +34,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "acknowledged the Progress Update in the #{goal_name} goal", "")
   end
 
+  def assert_goal_check_in_commented(ctx, author: author, comment: comment) do
+    ctx |> assert_feed_item_exists(author, "commented on Update", comment)
+  end
+
+  def assert_goal_check_in_commented(ctx, author: author, goal_name: goal_name, comment: comment) do
+    ctx |> assert_feed_item_exists(author, "commented on Update in the #{goal_name} goal", comment)
+  end
+
   #
   # Projects
   #

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -39,7 +39,11 @@ defmodule Operately.Support.Features.FeedSteps do
   end
 
   def assert_project_paused(ctx, author: author) do
-    ctx |> assert_feed_item_exists(author, "paused the project with", "")
+    ctx |> assert_feed_item_exists(author, "paused the project", "")
+  end
+
+  def assert_project_paused(ctx, author: author, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "paused the #{project_name} project", "")
   end
 
   def assert_project_resumed(ctx, author: author) do

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -18,6 +18,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "acknowledged", "")
   end
 
+  def assert_project_created(ctx, author: author) do
+    ctx |> assert_feed_item_exists(author, "created the project", "")
+  end
+
+  def assert_project_created(ctx, author: author, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "created the #{project_name} project", "")
+  end
+
   def assert_project_moved(ctx, author: author, old_space: old_space, new_space: new_space) do
     ctx |> assert_feed_item_exists(author, "moved the project", "From #{old_space.name} to #{new_space.name}")
   end

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -15,7 +15,7 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     company = company_fixture(%{name: "Test Org", enabled_experimental_features: ["goals"]})
     champion = person_fixture_with_account(%{company_id: company.id, full_name: "John Champion"})
     reviewer = person_fixture_with_account(%{company_id: company.id, full_name: "Leonardo Reviewer"})
-    group = group_fixture(champion, %{company_id: company.id, name: "Test Group"})
+    group = group_fixture(champion, %{company_id: company.id, name: "Test Group", company_permissions: Binding.view_access()})
 
     timeframe = %{
       start_date: ~D[2023-01-01],
@@ -136,9 +136,11 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
   step :assert_progress_update_acknowledged_in_feed, ctx do
     ctx
     |> visit_page()
-    |> FeedSteps.assert_feed_item_exists(%{author: ctx.champion, title: "acknowledged"})
+    |> FeedSteps.assert_goal_check_in_acknowledgement(author: ctx.champion)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_goal_check_in_acknowledgement(author: ctx.champion, goal_name: ctx.goal.name)
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_feed_item_exists(%{author: ctx.champion, title: "acknowledged"})
+    |> FeedSteps.assert_goal_check_in_acknowledgement(author: ctx.champion, goal_name: ctx.goal.name)
   end
 
   step :assert_progress_update_acknowledged_in_notifications, ctx do

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -178,6 +178,16 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     |> UI.click(testid: "post-comment")
   end
 
+  step :assert_progress_update_commented_in_feed, ctx, comment do
+    ctx
+    |> visit_page()
+    |> FeedSteps.assert_goal_check_in_commented(author: ctx.champion, comment: comment)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_goal_check_in_commented(author: ctx.champion, goal_name: ctx.goal.name, comment: comment)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_goal_check_in_commented(author: ctx.champion, goal_name: ctx.goal.name, comment: comment)
+  end
+
   step :assert_comment_email_sent, ctx do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -80,12 +80,14 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     |> UI.assert_text("#{Enum.at(target_values, 0)} / 15")
   end
 
-  step :assert_progress_update_in_feed, ctx do
+  step :assert_progress_update_in_feed, ctx, attrs do
     ctx
     |> visit_page()
-    |> FeedSteps.assert_feed_item_exists(%{author: ctx.champion, title: "updated the progress"})
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, message: attrs.message)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, message: attrs.message)
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_feed_item_exists(%{author: ctx.champion, title: "updated the progress"})
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, message: attrs.message)
   end
 
   step :assert_progress_update_email_sent_to_reviewer, ctx do

--- a/test/support/features/project_check_ins_steps.ex
+++ b/test/support/features/project_check_ins_steps.ex
@@ -52,13 +52,14 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
     |> UI.assert_text(@status_to_on_screen[status])
   end
 
-  step :assert_check_in_visible_on_feed, ctx, %{status: status, description: description} do
+  step :assert_check_in_visible_on_feed, ctx, %{description: description} do
     ctx
-    |> UI.find(UI.query(testid: "project-feed"), fn el ->
-      el
-      |> UI.assert_text(description)
-      |> UI.assert_text(@status_to_on_screen[status])
-    end)
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
   end
 
   step :assert_email_sent_to_reviewer, ctx, %{status: _status, description: _description} do

--- a/test/support/features/project_check_ins_steps.ex
+++ b/test/support/features/project_check_ins_steps.ex
@@ -55,11 +55,11 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   step :assert_check_in_visible_on_feed, ctx, %{description: description} do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
-    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, description: description)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
-    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, project_name: ctx.project.name, description: description)
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, status: "On Track", description: description)
+    |> FeedSteps.assert_project_check_in_submitted(author: ctx.champion, project_name: ctx.project.name, description: description)
   end
 
   step :assert_email_sent_to_reviewer, ctx, %{status: _status, description: _description} do
@@ -120,12 +120,14 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
     })
   end
 
-  step :assert_acknowledgement_visible_on_project_feed, ctx, %{status: _status, description: _description} do
+  step :assert_acknowledgement_visible_on_feed, ctx do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
-    |> UI.find(UI.query(testid: "project-feed"), fn el ->
-      el |> UI.assert_text("acknowledged")
-    end)
+    |> FeedSteps.assert_project_check_in_acknowledged(author: ctx.champion)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_check_in_acknowledged(author: ctx.champion, project_name: ctx.project.name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_check_in_acknowledged(author: ctx.champion, project_name: ctx.project.name)
   end
 
   step :acknowledge_check_in_from_email, ctx, %{status: _status, description: _description} do

--- a/test/support/features/project_check_ins_steps.ex
+++ b/test/support/features/project_check_ins_steps.ex
@@ -2,6 +2,7 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   use Operately.FeatureCase
 
   alias Operately.Support.Features.UI
+  alias Operately.Support.Features.FeedSteps
   alias Operately.Support.Features.EmailSteps
   alias Operately.Support.Features.ProjectSteps
   alias Operately.Support.Features.NotificationsSteps
@@ -87,7 +88,7 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   end
 
   step :acknowledge_check_in, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "acknowledge-check-in")
     |> UI.sleep(300) # Wait for the check-in to be acknowledged
   end
@@ -97,7 +98,7 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   end
 
   step :assert_acknowledgement_email_sent_to_champion, ctx, %{status: _status, description: _description} do
-    ctx 
+    ctx
     |> UI.login_as(ctx.champion)
     |> EmailSteps.assert_activity_email_sent(%{
       where: ctx.project.name,
@@ -160,5 +161,15 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
       action: "commented on a check-in",
       author: ctx.reviewer,
     })
+  end
+
+  step :assert_check_in_comment_visible_on_feed, ctx do
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+    |> FeedSteps.assert_project_check_in_commented(author: ctx.champion, comment: "This is a comment.")
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_check_in_commented(author: ctx.champion, comment: "This is a comment.")
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_check_in_commented(author: ctx.champion, comment: "This is a comment.")
   end
 end

--- a/test/support/features/project_creation_steps.ex
+++ b/test/support/features/project_creation_steps.ex
@@ -4,7 +4,9 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
   alias Operately.Access
   alias Operately.Access.Binding
   alias Operately.People.Person
+  alias Operately.Projects.Project
   alias Operately.Support.Features.UI
+  alias Operately.Support.Features.FeedSteps
   alias Operately.Support.Features.EmailSteps
   alias Operately.Support.Features.NotificationsSteps
 
@@ -105,7 +107,7 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
       assert reviewer.person.full_name == fields.reviewer.full_name
     end
 
-    ctx 
+    ctx
   end
 
   step :assert_project_created_email_sent, ctx, fields do
@@ -232,6 +234,19 @@ defmodule Operately.Support.Features.ProjectCreationSteps do
     assert Access.get_binding(context_id: context.id, group_id: group.id).access_level == Binding.no_access()
 
     ctx
+  end
+
+  step :assert_project_created_feed, ctx, creator \\ nil do
+    project = Repo.one(Project)
+    creator = creator || ctx.champion
+
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, project))
+    |> FeedSteps.assert_project_created(author: creator)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_created(author: creator, project_name: project.name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_created(author: creator, project_name: project.name)
   end
 
   defp who_should_be_notified(fields) do

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -50,7 +50,7 @@ defmodule Operately.Support.Features.ProjectSteps do
     company = company_fixture(%{name: "Test Org"})
     champion = person_fixture_with_account(%{company_id: company.id, full_name: "John Champion"})
     reviewer = person_fixture_with_account(%{company_id: company.id, full_name: "Leonardo Reviewer"})
-    group = group_fixture(champion, %{company_id: company.id, name: "Test Group"})
+    group = group_fixture(champion, %{company_id: company.id, name: "Test Group", company_permissions: Binding.view_access()})
 
     params = %Operately.Operations.ProjectCreation{
       company_id: company.id,
@@ -300,7 +300,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_project_paused, ctx do
-    ctx 
+    ctx
     |> UI.assert_text("Paused")
     |> UI.assert_has(testid: "project-paused-banner")
   end
@@ -364,12 +364,14 @@ defmodule Operately.Support.Features.ProjectSteps do
     })
   end
 
-  step :assert_resume_visible_on_project_feed, ctx do
+  step :assert_project_resumed_visible_on_feed, ctx do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
-    |> UI.find(UI.query(testid: "project-feed"), fn el ->
-      el |> UI.assert_text("resumed the project")
-    end)
+    |> FeedSteps.assert_project_resumed(author: ctx.champion)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_resumed(author: ctx.champion, project_name: ctx.project.name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_resumed(author: ctx.champion, project_name: ctx.project.name)
   end
 
   step :rename_project, ctx, new_name: new_name do

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -325,11 +325,19 @@ defmodule Operately.Support.Features.ProjectSteps do
     })
   end
 
-  step :assert_pause_visible_on_project_feed, ctx do
+  step :assert_pause_visible_on_feed, ctx do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
     |> UI.find(UI.query(testid: "project-feed"), fn el ->
-      el |> UI.assert_text("paused the project")
+      el |> FeedSteps.assert_project_paused(author: ctx.champion)
+    end)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> UI.find(UI.query(testid: "space-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.champion, project_name: ctx.project.name)
+    end)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.find(UI.query(testid: "company-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.champion, project_name: ctx.project.name)
     end)
   end
 

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -409,6 +409,18 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> FeedSteps.assert_project_renamed(author: ctx.champion, project_name: project.name)
   end
 
+ step :assert_project_goal_connection_visible_on_feed, ctx, goal_name: goal_name do
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, goal_name: goal_name)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name, goal_name: goal_name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name, goal_name: goal_name)
+    |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name)
+  end
+
   step :assert_project_description_absent, ctx do
     ctx
     |> UI.assert_text("Describe your project to provide context and clarity.")

--- a/test/support/features/project_steps.ex
+++ b/test/support/features/project_steps.ex
@@ -397,6 +397,18 @@ defmodule Operately.Support.Features.ProjectSteps do
     ctx |> UI.assert_text(new_name)
   end
 
+  step :assert_project_renamed_visible_on_feed, ctx do
+    project = Repo.reload(ctx.project)
+
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+    |> FeedSteps.assert_project_renamed(author: ctx.champion)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_renamed(author: ctx.champion, project_name: project.name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_renamed(author: ctx.champion, project_name: project.name)
+  end
+
   step :assert_project_description_absent, ctx do
     ctx
     |> UI.assert_text("Describe your project to provide context and clarity.")


### PR DESCRIPTION
We had no tests to ensure that the following activities show up in the company and space feed:
- project_created
- project_resuming
- project_milestone_commented
- project_pausing
- project_renamed
- project_check_in_commented
- project_check_in_submitted
- project_check_in_acknowledged
- project_goal_connection
- goal_check_in
- goal_check_in_acknowledgement
- goal_check_in_commented