### PR TITLE
feat: Improve how discussion posted time is displayed

### DIFF
--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -22,6 +22,7 @@ import { Paths, compareIds } from "@/routes/paths";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
+import { hoursBetween, parse } from "@/utils/time";
 
 export function Page() {
   const me = useMe()!;
@@ -90,11 +91,26 @@ function Title({ discussion }) {
           <Avatar person={discussion.author} size="tiny" /> {discussion.author.fullName}
         </div>
         <TextSeparator />
-        <span>
-          Posted on <FormattedTime time={discussion.insertedAt} format="short-date" />
-        </span>
+
+        <DiscussionPostedTime insertedAt={discussion.insertedAt} />
       </div>
     </div>
+  );
+}
+
+function DiscussionPostedTime({ insertedAt }: { insertedAt: string }) {
+  const parsedInsertedAt = parse(insertedAt)!;
+  const now = new Date();
+  const delta = hoursBetween(parsedInsertedAt, now);
+
+  return delta < 24 ? (
+    <span>
+      Posted <FormattedTime time={insertedAt} format="relative" />
+    </span>
+  ) : (
+    <span>
+      Posted on <FormattedTime time={insertedAt} format="short-date" />
+    </span>
   );
 }
 

--- a/assets/js/utils/time.tsx
+++ b/assets/js/utils/time.tsx
@@ -125,6 +125,10 @@ export function daysBetween(start: Date, end: Date) {
   return datefsn.differenceInDays(end, start);
 }
 
+export function hoursBetween(start: Date, end: Date) {
+  return datefsn.differenceInHours(end, start);
+}
+
 export function getMonthName(date: Date) {
   return datefsn.format(date, "MMMM");
 }

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -54,7 +54,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.fill(testid: "discussion-title", with: "This is a discussion")
     |> UI.fill_rich_text("This is the body of the discussion.")
     |> UI.click(testid: "post-discussion")
-    |> UI.assert_text("Posted on")
+    |> UI.assert_text("Posted just now")
 
     message = last_message(ctx)
 
@@ -86,7 +86,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.fill(testid: "discussion-title", with: "This is a discussion")
     |> UI.fill_rich_text("This is the body of the discussion.")
     |> UI.click(testid: "post-discussion")
-    |> UI.assert_text("Posted on")
+    |> UI.assert_text("Posted just now")
 
     ctx
     |> UI.click(testid: "options-button")
@@ -96,7 +96,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.click(testid: "save-changes")
 
     ctx
-    |> UI.assert_text("Posted on")
+    |> UI.assert_text("Posted just now")
     |> UI.assert_text("This is an edited discussion")
     |> UI.assert_text("This is the edited body of the discussion")
   end


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/751.

First, I thought about displaying both the date and time when the discussion was posted, but it didn't look good. 

So, the approach I took was to render the `FormattedTime` component with `format="relative"` if the discussion was posted less than 24 hours ago, but render it with `format="short-date"` if the discussion was posted more than 24 hours. 

Here is how it looks:


https://github.com/user-attachments/assets/cf549698-59f6-4e19-adf9-63c4edb08639

