### PR TITLE
feat: Proof-of-Concept: Auto-refresh relative time

### DIFF
--- a/assets/js/components/FormattedTime/RelativeTime.tsx
+++ b/assets/js/components/FormattedTime/RelativeTime.tsx
@@ -18,6 +18,16 @@ export default function RelativeTime({ time }: RelativeTimeProps): JSX.Element {
   const months = Math.floor(days / 30);
   const years = Math.floor(days / 365);
 
+  const [lastRender, setLastRender] = React.useState(0);
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setLastRender(Date.now());
+    }, 10000);
+
+    return () => clearInterval(interval);
+  }, []);
+
   if (seconds < 10) {
     return <>{t("intlRelativeDateTimeJustNow")}</>;
   }
@@ -46,5 +56,5 @@ export default function RelativeTime({ time }: RelativeTimeProps): JSX.Element {
     return <>{t("intlRelativeDateTime", { val: -months, range: "month" })}</>;
   }
 
-  return <>{t("intlRelativeDateTime", { val: -years, range: "year" })}</>;
+  return <React.Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -years, range: "year" })}</React.Fragment>;
 }


### PR DESCRIPTION
Warning: Not fully tested, just on this example.

- [ ] some tweaks are needed for the refresh interval (not too fast, not too slow)
- [ ] a phase transition for when discussion time changes from relative time -> short-date

The current behaviour with refresh time 10seconds.

https://github.com/user-attachments/assets/573846e6-28bb-4fc3-a397-3ea75fe9dfc8

