### PR TITLE
feat: RelativeTime refreshes time on interval

### DIFF
--- a/assets/js/components/FormattedTime/RelativeTime.tsx
+++ b/assets/js/components/FormattedTime/RelativeTime.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { Fragment } from "react";
 import { useTranslation } from "react-i18next";
+import { useRenderInterval } from "./useRenderInterval";
 
 interface RelativeTimeProps {
   time: Date;
@@ -7,6 +8,7 @@ interface RelativeTimeProps {
 
 export default function RelativeTime({ time }: RelativeTimeProps): JSX.Element {
   const { t } = useTranslation();
+  const lastRender = useRenderInterval(time);
 
   const diff = +new Date() - +time;
 
@@ -19,32 +21,32 @@ export default function RelativeTime({ time }: RelativeTimeProps): JSX.Element {
   const years = Math.floor(days / 365);
 
   if (seconds < 10) {
-    return <>{t("intlRelativeDateTimeJustNow")}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTimeJustNow")}</Fragment>;
   }
 
   if (seconds < 60) {
-    return <>{t("intlRelativeDateTime", { val: -seconds, range: "second" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -seconds, range: "second" })}</Fragment>;
   }
 
   if (minutes < 60) {
-    return <>{t("intlRelativeDateTime", { val: -minutes, range: "minute" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -minutes, range: "minute" })}</Fragment>;
   }
 
   if (hours < 24) {
-    return <>{t("intlRelativeDateTime", { val: -hours, range: "hour" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -hours, range: "hour" })}</Fragment>;
   }
 
   if (days < 7) {
-    return <>{t("intlRelativeDateTime", { val: -days, range: "day" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -days, range: "day" })}</Fragment>;
   }
 
   if (weeks < 4) {
-    return <>{t("intlRelativeDateTime", { val: -weeks, range: "week" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -weeks, range: "week" })}</Fragment>;
   }
 
   if (months < 12) {
-    return <>{t("intlRelativeDateTime", { val: -months, range: "month" })}</>;
+    return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -months, range: "month" })}</Fragment>;
   }
 
-  return <>{t("intlRelativeDateTime", { val: -years, range: "year" })}</>;
+  return <Fragment key={lastRender}>{t("intlRelativeDateTime", { val: -years, range: "year" })}</Fragment>;
 }

--- a/assets/js/components/FormattedTime/RelativeTimeOrDate.tsx
+++ b/assets/js/components/FormattedTime/RelativeTimeOrDate.tsx
@@ -1,0 +1,19 @@
+import React, { Fragment } from "react";
+
+import RelativeWeekdayOrDate from "./RelativeWeekdayOrDate";
+import RelativeTime from "./RelativeTime";
+import { hoursBetween } from "@/utils/time";
+import { useRenderInterval } from "./useRenderInterval";
+
+export default function RelativeTimeOrDate({ time }) {
+  const lastRender = useRenderInterval(time);
+
+  const now = new Date();
+  const delta = hoursBetween(time, now);
+
+  return (
+    <Fragment key={lastRender}>
+      {delta < 24 ? <RelativeTime time={time} /> : <RelativeWeekdayOrDate time={time} />}
+    </Fragment>
+  );
+}

--- a/assets/js/components/FormattedTime/index.tsx
+++ b/assets/js/components/FormattedTime/index.tsx
@@ -7,6 +7,7 @@ import ShortDate from "./ShortDate";
 import RelativeTime from "./RelativeTime";
 import ShortDateWithWeekday from "./ShortDateWithWeekday";
 import RelativeWeekdayOrDate from "./RelativeWeekdayOrDate";
+import RelativeTimeOrDate from "./RelativeTimeOrDate";
 import { useTimezone } from "@/contexts/TimezoneContext";
 import { match } from "ts-pattern";
 
@@ -16,16 +17,18 @@ type Format =
   | "short-date-with-weekday"
   | "time-only"
   | "relative-weekday-or-date"
-  | "long-date";
+  | "long-date"
+  | "relative-time-or-date";
 
 //
 // Formats:
 //
-// time-only: "5:00pm"
+// relative: "just now", "5 minutes ago"
+// relative-time-or-date: "just now", "5 minutes ago", "1 hour ago", "Yesterday", "Wed, Sep 18"
+// relative-weekday-or-date: "Today", "Yesterday", "Mon", "Apr 5"
 // short-date: "Apr 5", "Apr 5, 2021"
 // short-date-with-weekday: "Mon, Apr 5", "Mon, Apr 5, 2021"
-// relative: "just now", "5 minutes ago"
-// relative-weekday-or-date: "Today", "Yesterday", "Mon", "Apr 5"
+// time-only: "5:00pm"
 // long-date: "April 5, 2021"
 //
 
@@ -40,6 +43,7 @@ export default function FormattedTime(props: FormattedTimeProps): JSX.Element {
   const parsedTime = match(props.format)
     .with("relative", () => Time.parse(props.time))
     .with("time-only", () => Time.parse(props.time))
+    .with("relative-time-or-date", () => Time.parse(props.time))
     .otherwise(() => Time.parseDate(props.time));
 
   if (!parsedTime) throw "Invalid date " + props.time;
@@ -51,6 +55,8 @@ export default function FormattedTime(props: FormattedTimeProps): JSX.Element {
       return <RelativeTime time={time} />;
     case "relative-weekday-or-date":
       return <RelativeWeekdayOrDate time={time} />;
+    case "relative-time-or-date":
+      return <RelativeTimeOrDate time={time} />;
     case "short-date":
       return <ShortDate time={time} weekday={false} />;
     case "short-date-with-weekday":

--- a/assets/js/components/FormattedTime/useRenderInterval.tsx
+++ b/assets/js/components/FormattedTime/useRenderInterval.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+
+export function useRenderInterval(time) {
+  const [lastRender, setLastRender] = useState(0);
+
+  useEffect(() => {
+    const diff = +new Date() - +time;
+
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+
+    if (seconds < 60) {
+      const interval = setInterval(() => {
+        setLastRender(Date.now());
+      }, 1000 * 15);
+
+      return () => clearInterval(interval);
+    } else if (minutes < 60) {
+      const interval = setInterval(() => {
+        setLastRender(Date.now());
+      }, 1000 * 60);
+
+      return () => clearInterval(interval);
+    } else if (hours < 24) {
+      const interval = setInterval(
+        () => {
+          setLastRender(Date.now());
+        },
+        1000 * 60 * 60,
+      );
+
+      return () => clearInterval(interval);
+    } else {
+      const interval = setInterval(
+        () => {
+          setLastRender(Date.now());
+        },
+        1000 * 60 * 60 * 24,
+      );
+
+      return () => clearInterval(interval);
+    }
+  }, []);
+
+  return lastRender;
+}

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -22,7 +22,6 @@ import { Paths, compareIds } from "@/routes/paths";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
-import { hoursBetween, parse } from "@/utils/time";
 
 export function Page() {
   const me = useMe()!;
@@ -91,26 +90,9 @@ function Title({ discussion }) {
           <Avatar person={discussion.author} size="tiny" /> {discussion.author.fullName}
         </div>
         <TextSeparator />
-
-        <DiscussionPostedTime insertedAt={discussion.insertedAt} />
+        <FormattedTime time={discussion.insertedAt} format="relative-time-or-date" />
       </div>
     </div>
-  );
-}
-
-function DiscussionPostedTime({ insertedAt }: { insertedAt: string }) {
-  const parsedInsertedAt = parse(insertedAt)!;
-  const now = new Date();
-  const delta = hoursBetween(parsedInsertedAt, now);
-
-  return delta < 24 ? (
-    <span>
-      Posted <FormattedTime time={insertedAt} format="relative" />
-    </span>
-  ) : (
-    <span>
-      Posted on <FormattedTime time={insertedAt} format="short-date" />
-    </span>
   );
 }
 

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -54,7 +54,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.fill(testid: "discussion-title", with: "This is a discussion")
     |> UI.fill_rich_text("This is the body of the discussion.")
     |> UI.click(testid: "post-discussion")
-    |> UI.assert_text("Posted just now")
+    |> UI.assert_text("just now")
 
     message = last_message(ctx)
 
@@ -86,7 +86,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.fill(testid: "discussion-title", with: "This is a discussion")
     |> UI.fill_rich_text("This is the body of the discussion.")
     |> UI.click(testid: "post-discussion")
-    |> UI.assert_text("Posted just now")
+    |> UI.assert_text("just now")
 
     ctx
     |> UI.click(testid: "options-button")
@@ -96,7 +96,7 @@ defmodule Operately.Features.DiscussionsTest do
     |> UI.click(testid: "save-changes")
 
     ctx
-    |> UI.assert_text("Posted just now")
+    |> UI.assert_text("just now")
     |> UI.assert_text("This is an edited discussion")
     |> UI.assert_text("This is the edited body of the discussion")
   end


### PR DESCRIPTION
Implementation of https://github.com/operately/operately/pull/1346.

Now, whenever we use `<FormattedTime time={time} format="relative" />`, the component will refresh on a specific interval. The refresh interval is shorter or longer depending on how long ago `time` is:
- if time < 1 minute, the interval is 15 seconds
- else if time < 1 hour, the interval is 60 seconds
- else if time < 1 day, the interval is 60 minutes
- else, the interval is a day

I've also added the format option `relative-time-or-date` to the `FormatTime` component, which displays the same result as ` format="relative"` if `time` is less than 24 hours ago, otherwise it displays the same result as ` format="relative-time-or-date"`.

