### PR TITLE
feat: Add Goals V2 page

### DIFF
--- a/assets/js/features/goals/GoalTree/tree-v2.tsx
+++ b/assets/js/features/goals/GoalTree/tree-v2.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { GhostButton } from "@/components/Buttons";
+
+import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
+import { useExpandable } from "./context/Expandable";
+import { Node } from "./tree";
+import { NodeIcon } from "./components/NodeIcon";
+import { NodeName } from "./components/NodeName";
+
+export function GoalTree(props: TreeContextProviderProps) {
+  return (
+    <TreeContextProvider {...props}>
+      <GoalTreeRoots />
+    </TreeContextProvider>
+  );
+}
+
+function GoalTreeRoots() {
+  const context = useTreeContext();
+
+  return (
+    <div>
+      <Controls />
+
+      {context.tree.map((root) => (
+        <NodeView key={root.id} node={root} />
+      ))}
+    </div>
+  );
+}
+
+function Controls() {
+  return (
+    <div className="flex mb-4 items-center gap-2">
+      <GhostButton size="sm">Expand all</GhostButton>
+      <GhostButton size="sm">View options</GhostButton>
+    </div>
+  );
+}
+
+function NodeView({ node }: { node: Node }) {
+  return (
+    <div>
+      <NodeHeader node={node} />
+      <NodeChildren node={node} />
+    </div>
+  );
+}
+
+function NodeHeader({ node }: { node: Node }) {
+  return (
+    <div className="border-t last:border-b border-surface-outline py-3">
+      <div
+        className="inline-flex items-center gap-1.5 truncate flex-1 group pr-2"
+        style={{ paddingLeft: node.depth * 30 }}
+      >
+        <NodeExpandCollapseToggle node={node} />
+        <NodeIcon node={node} />
+        <NodeName node={node} />
+      </div>
+    </div>
+  );
+}
+
+function NodeChildren({ node }: { node: Node }) {
+  const { expanded } = useExpandable();
+
+  if (!expanded[node.id] || !node.hasChildren) return <></>;
+
+  return <>{node.children?.map((node) => <NodeView key={node.id} node={node} />)}</>;
+}
+
+function NodeExpandCollapseToggle({ node }: { node: Node }) {
+  const { expanded, toggleExpanded } = useExpandable();
+
+  if (!node.hasChildren) return null;
+
+  const handleClick = () => toggleExpanded(node.id);
+  const size = 16;
+  const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
+
+  return <ChevronIcon size={size} className="cursor-pointer" onClick={handleClick} />;
+}

--- a/assets/js/pages/GoalsAndProjectsPage/index.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/index.tsx
@@ -1,0 +1,2 @@
+export { loader } from "./loader";
+export { Page } from "./page";

--- a/assets/js/pages/GoalsAndProjectsPage/loader.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/loader.tsx
@@ -1,0 +1,34 @@
+import * as Pages from "@/components/Pages";
+import * as Goals from "@/models/goals";
+import * as Projects from "@/models/projects";
+
+interface LoaderResult {
+  goals: Goals.Goal[];
+  projects: Projects.Project[];
+}
+
+export async function loader(): Promise<LoaderResult> {
+  const [goals, projects] = await Promise.all([
+    Goals.getGoals({
+      includeTargets: true,
+      includeSpace: true,
+      includeLastCheckIn: true,
+      includeChampion: true,
+      includeReviewer: true,
+    }).then((data) => data.goals!),
+    Projects.getProjects({
+      includeGoal: true,
+      includeSpace: true,
+      includeLastCheckIn: true,
+      includeChampion: true,
+      includeMilestones: true,
+      includePrivacy: true,
+    }).then((data) => data.projects!),
+  ]);
+
+  return { goals, projects };
+}
+
+export function useLoadedData(): LoaderResult {
+  return Pages.useLoadedData() as LoaderResult;
+}

--- a/assets/js/pages/GoalsAndProjectsPage/page.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/page.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+
+import { GoalTree } from "@/features/goals/GoalTree/tree-v2";
+import { useLoadedData } from "./loader";
+
+export function Page() {
+  const { goals, projects } = useLoadedData();
+
+  return (
+    <Pages.Page title="Goals & Projects">
+      <Paper.Root size="xlarge">
+        <Paper.Body>
+          <Title />
+          <GoalTree goals={goals} projects={projects} options={{}} />
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
+  );
+}
+
+function Title() {
+  return (
+    <div className="mb-8">
+      <h1 className="text-3xl font-bold">Goals & Projects</h1>
+    </div>
+  );
+}

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -32,6 +32,7 @@ import * as GoalProgressUpdateNewPage from "./GoalProgressUpdateNewPage";
 import * as GoalProgressUpdatePage from "./GoalProgressUpdatePage";
 import * as GoalReopenPage from "./GoalReopenPage";
 import * as GoalSubgoalsPage from "./GoalSubgoalsPage";
+import * as GoalsAndProjectsPage from "./GoalsAndProjectsPage";
 import * as GoalsPage from "./GoalsPage";
 import * as JoinPage from "./JoinPage";
 import * as LobbyPage from "./LobbyPage";
@@ -234,6 +235,11 @@ export default {
     name: "GoalSubgoalsPage",
     loader: GoalSubgoalsPage.loader,
     Page: GoalSubgoalsPage.Page,
+  },
+  GoalsAndProjectsPage: {
+    name: "GoalsAndProjectsPage",
+    loader: GoalsAndProjectsPage.loader,
+    Page: GoalsAndProjectsPage.Page,
   },
   GoalsPage: {
     name: "GoalsPage",

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -89,6 +89,7 @@ export function createAppRoutes() {
         pageRoute("discussions/:id", pages.DiscussionPage),
         pageRoute("discussions/:id/edit", pages.DiscussionEditPage),
 
+        pageRoute("goals-v2", pages.GoalsAndProjectsPage),
         pageRoute("goals", pages.GoalsPage),
         pageRoute("goals/new", pages.GoalAddPage),
         pageRoute("goals/:id", pages.GoalPage),


### PR DESCRIPTION
I've added the Goals V2 page. 

![tmp](https://github.com/user-attachments/assets/86cdbc80-6ee5-49c7-b148-4004c0d63e8b)


So far, the page only shows the existing Goals and Projects and the only functionality that is supported is collapse/expand a Goal's children.

The only way to access this page is to manually go to `/company-id/goals-v2`. The idea here is to add to the page all features it needs, test it well, then swap it with the old Goals page.