### PR TITLE
feat: Add goal success conditions to Goals V2 page

### DIFF
--- a/assets/js/components/ProgressBar/index.tsx
+++ b/assets/js/components/ProgressBar/index.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import classNames from "classnames";
+
+export function ProgressBar({ percentage, className }: { percentage: number; className?: string }) {
+  className = classNames("w-24 h-2.5 bg-surface-outline rounded relative", className || "");
+
+  return (
+    <div className={className}>
+      <div className="bg-accent-1 rounded absolute top-0 bottom-0 left-0" style={{ width: `${percentage}%` }} />
+    </div>
+  );
+}

--- a/assets/js/features/goals/GoalTree/context/Expandable.tsx
+++ b/assets/js/features/goals/GoalTree/context/Expandable.tsx
@@ -6,11 +6,13 @@
 // 2. Use the `useExpandable` hook to access the context
 // 3. Use the `expanded` and `toggleExpanded` properties from the context to manage expanded nodes
 // 4. Use the `expandAll` and `collapseAll` properties from the context to expand/collapse all nodes
+// 5. Use the `goalExpanded` and `toggleGoalExpanded` properties from the context to manage expanded goal nodes
 //
 
 import React from "react";
 
 import { Tree, getAllIds } from "../tree";
+import { compareIds, includesId } from "@/routes/paths";
 
 type ExpandedNodesMap = Record<string, boolean>;
 
@@ -19,6 +21,8 @@ interface ExpandableContextValue {
   toggleExpanded: (id: string) => void;
   expandAll: () => void;
   collapseAll: () => void;
+  goalExpanded: string[];
+  toggleGoalExpanded: (id: string) => void;
 }
 
 interface ExpandableProviderProps {
@@ -30,6 +34,15 @@ const ExpandableContext = React.createContext<ExpandableContextValue | null>(nul
 
 export function ExpandableProvider({ children, tree }: ExpandableProviderProps) {
   const [expanded, setExpanded] = React.useState<ExpandedNodesMap>({});
+  const [goalExpanded, setGoalExpanded] = React.useState<string[]>([]);
+
+  const toggleGoalExpanded = (goalId: string) => {
+    if (includesId(goalExpanded, goalId)) {
+      setGoalExpanded((prev) => prev.filter((id) => !compareIds(goalId, id)));
+    } else {
+      setGoalExpanded((prev) => [...prev, goalId]);
+    }
+  };
 
   const toggleExpanded = (id: string) => {
     setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
@@ -50,6 +63,8 @@ export function ExpandableProvider({ children, tree }: ExpandableProviderProps) 
     toggleExpanded,
     expandAll,
     collapseAll,
+    goalExpanded,
+    toggleGoalExpanded,
   };
 
   return <ExpandableContext.Provider value={state}>{children}</ExpandableContext.Provider>;

--- a/assets/js/features/goals/GoalTree/tree-v2.tsx
+++ b/assets/js/features/goals/GoalTree/tree-v2.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 
-import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight, IconMinus, IconPlus } from "@tabler/icons-react";
 import { GhostButton } from "@/components/Buttons";
+import { MiniPieChart } from "@/components/MiniPieChart";
+import { assertPresent } from "@/utils/assertions";
+import { includesId } from "@/routes/paths";
 
 import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
+import { GoalNode, Node, ProjectNode } from "./tree";
 import { useExpandable } from "./context/Expandable";
-import { GoalNode, Node } from "./tree";
 import { NodeIcon } from "./components/NodeIcon";
 import { NodeName } from "./components/NodeName";
+import { ProgressBar } from "@/components/ProgressBar";
 
 export function GoalTree(props: TreeContextProviderProps) {
   return (
@@ -62,7 +66,10 @@ function NodeHeader({ node }: { node: Node }) {
         <NodeIcon node={node} />
         <NodeName node={node} />
         {node.type === "goal" && <GoalProgressBar node={node as GoalNode} />}
+        {node.type == "goal" && <ExpandGoalSuccessConditions node={node as GoalNode} />}
       </div>
+
+      <ResourceDetails node={node} />
     </div>
   );
 }
@@ -78,7 +85,7 @@ function NodeChildren({ node }: { node: Node }) {
 function NodeExpandCollapseToggle({ node }: { node: Node }) {
   const { expanded, toggleExpanded } = useExpandable();
 
-  if (!node.hasChildren) return null;
+  if (!node.hasChildren) return <></>;
 
   const handleClick = () => toggleExpanded(node.id);
   const size = 16;
@@ -88,12 +95,68 @@ function NodeExpandCollapseToggle({ node }: { node: Node }) {
 }
 
 function GoalProgressBar({ node }: { node: GoalNode }) {
+  assertPresent(node.goal.progressPercentage, "progressPercentage must be present in goal");
+
+  return <ProgressBar percentage={node.goal.progressPercentage} className="ml-2" />;
+}
+
+function ResourceDetails({ node }: { node: Node }) {
+  switch (node.type) {
+    case "goal":
+      return <GoalDetails node={node as GoalNode} />;
+    case "project":
+      return <ProjectDetails node={node as ProjectNode} />;
+  }
+}
+
+function GoalDetails({ node }: { node: GoalNode }) {
   return (
-    <div className={"ml-2 w-24 h-2.5 bg-surface-outline rounded relative"}>
-      <div
-        className="bg-accent-1 rounded absolute top-0 bottom-0 left-0"
-        style={{ width: `${node.goal.progressPercentage}%` }}
-      />
+    <div>
+      <GoalSuccessConditions node={node} />
     </div>
   );
+}
+
+function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
+  const { goalExpanded, toggleGoalExpanded } = useExpandable();
+
+  return (
+    <div
+      onClick={() => toggleGoalExpanded(node.goal.id!)}
+      className="ml-2 h-[20px] w-[20px] rounded-full border-2 border-surface-outline flex items-center justify-center cursor-pointer"
+    >
+      {includesId(goalExpanded, node.goal.id) ? (
+        <IconMinus size={12} stroke={3} className="border-surface-outline shrink-0" />
+      ) : (
+        <IconPlus size={12} stroke={3} className="border-surface-outline shrink-0" />
+      )}
+    </div>
+  );
+}
+
+function GoalSuccessConditions({ node }: { node: GoalNode }) {
+  const { goalExpanded } = useExpandable();
+  assertPresent(node.goal.targets, "targets must be present in goal");
+
+  if (!includesId(goalExpanded, node.goal.id)) return <></>;
+
+  return (
+    <div style={{ paddingLeft: node.depth * 30 + 42 }}>
+      {node.goal.targets.map((t) => {
+        const total = t.to! - t.from!;
+        const completed = t.value! - t.from!;
+
+        return (
+          <div key={t.id} className="flex items-center gap-2">
+            <MiniPieChart total={total} completed={completed} />
+            {t.name}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ProjectDetails({}: { node: ProjectNode }) {
+  return <></>;
 }


### PR DESCRIPTION
Now, a goal's success conditions can be expanded and collapsed on the Goals V2 page:

https://github.com/user-attachments/assets/8e8cebca-c36e-4374-800d-51f22aeeef71

