### PR TITLE
feat: Add latest project check-in to Goals V2 page

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1508,6 +1508,7 @@ export interface GetProjectsInput {
   includeContributors?: boolean | null;
   includeLastCheckIn?: boolean | null;
   includeChampion?: boolean | null;
+  includeReviewer?: boolean | null;
   includeGoal?: boolean | null;
   includeArchived?: boolean | null;
   includePrivacy?: boolean | null;
@@ -1624,7 +1625,7 @@ export interface AddCompanyResult {
 }
 
 export interface AddCompanyAdminsInput {
-  peopleIds?: string[] | null;
+  peopleIds?: Id[] | null;
 }
 
 export interface AddCompanyAdminsResult {}
@@ -2140,7 +2141,7 @@ export interface PostProjectCheckInResult {
 }
 
 export interface RemoveCompanyAdminInput {
-  personId?: string | null;
+  personId?: Id | null;
 }
 
 export interface RemoveCompanyAdminResult {

--- a/assets/js/features/ProjectListItem/StatusIndicator.tsx
+++ b/assets/js/features/ProjectListItem/StatusIndicator.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 
 import { SmallStatusIndicator } from "@/features/projectCheckIns/SmallStatusIndicator";
+import { Project } from "@/models/projects";
 
-export function StatusIndicator({ project }) {
+type Size = "std" | "sm";
+
+export function StatusIndicator({ project, size = "std" }: { project: Project; size?: Size }) {
   if (project.status === "closed") return null;
-  if (project.status === "paused") return <SmallStatusIndicator status="paused" />;
-  if (project.isOutdated) return <SmallStatusIndicator status="outdated" />;
+  if (project.status === "paused") return <SmallStatusIndicator status="paused" size={size} />;
+  if (project.isOutdated) return <SmallStatusIndicator status="outdated" size={size} />;
 
-  return <SmallStatusIndicator status={project.lastCheckIn?.status || "on_track"} />;
+  return <SmallStatusIndicator status={project.lastCheckIn?.status || "on_track"} size={size} />;
 }

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+
+import Modal from "@/components/Modal";
+import { assertPresent } from "@/utils/assertions";
+import { IconArrowUpRight } from "@tabler/icons-react";
+import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
+import { Project } from "@/models/projects";
+import { StatusSection } from "@/features/projectCheckIns/StatusSection";
+import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
+
+import { ProjectNode } from "../tree";
+
+export default function ProjectDetails({ node }: { node: ProjectNode }) {
+  return (
+    <div className="pl-[20px] flex">
+      <Status project={node.project} />
+    </div>
+  );
+}
+
+function Status({ project }: { project: Project }) {
+  const [showCheckIn, setShowCheckIn] = useState(false);
+
+  const toggleShowCheckIn = () => {
+    setShowCheckIn((prev) => !prev);
+  };
+
+  return (
+    <div>
+      <div onClick={toggleShowCheckIn} className="relative cursor-pointer">
+        <StatusIndicator project={project} size="sm" />
+        <IconArrowUpRight size={12} className="absolute top-0 right-[-14px]" />
+      </div>
+
+      <LatestProjectCheckIn project={project} showCheckIn={showCheckIn} toggleShowCheckIn={toggleShowCheckIn} />
+    </div>
+  );
+}
+
+interface LatestProjectCheckInProps {
+  project: Project;
+  showCheckIn: boolean;
+  toggleShowCheckIn: () => void;
+}
+
+function LatestProjectCheckIn({ project, showCheckIn, toggleShowCheckIn }: LatestProjectCheckInProps) {
+  assertPresent(project.lastCheckIn, "lastCheckIn must be present in project");
+  assertPresent(project.reviewer, "reviewer must be present in project");
+
+  return (
+    <Modal title="" hideModal={toggleShowCheckIn} isOpen={showCheckIn} minHeight="300px">
+      <div className="text-xl font-bold">{project.name}</div>
+
+      <StatusSection checkIn={project.lastCheckIn} reviewer={project.reviewer} />
+      <DescriptionSection checkIn={project.lastCheckIn} />
+    </Modal>
+  );
+}

--- a/assets/js/features/goals/GoalTree/tree-v2.tsx
+++ b/assets/js/features/goals/GoalTree/tree-v2.tsx
@@ -5,13 +5,14 @@ import { GhostButton } from "@/components/Buttons";
 import { MiniPieChart } from "@/components/MiniPieChart";
 import { assertPresent } from "@/utils/assertions";
 import { includesId } from "@/routes/paths";
+import { ProgressBar } from "@/components/ProgressBar";
 
 import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
 import { GoalNode, Node, ProjectNode } from "./tree";
 import { useExpandable } from "./context/Expandable";
 import { NodeIcon } from "./components/NodeIcon";
 import { NodeName } from "./components/NodeName";
-import { ProgressBar } from "@/components/ProgressBar";
+import ProjectDetails from "./components/ProjectDetails";
 
 export function GoalTree(props: TreeContextProviderProps) {
   return (
@@ -58,18 +59,17 @@ function NodeView({ node }: { node: Node }) {
 function NodeHeader({ node }: { node: Node }) {
   return (
     <div className="border-t border-surface-outline py-3">
-      <div
-        className="inline-flex items-center gap-1 truncate flex-1 group pr-2"
-        style={{ paddingLeft: node.depth * 30 }}
-      >
-        <NodeExpandCollapseToggle node={node} />
-        <NodeIcon node={node} />
-        <NodeName node={node} />
-        {node.type === "goal" && <GoalProgressBar node={node as GoalNode} />}
-        {node.type == "goal" && <ExpandGoalSuccessConditions node={node as GoalNode} />}
-      </div>
+      <div style={{ paddingLeft: node.depth * 30 }}>
+        <div className="inline-flex items-center gap-1 truncate flex-1 group pr-2">
+          <NodeExpandCollapseToggle node={node} />
+          <NodeIcon node={node} />
+          <NodeName node={node} />
+          {node.type === "goal" && <GoalProgressBar node={node as GoalNode} />}
+          {node.type == "goal" && <ExpandGoalSuccessConditions node={node as GoalNode} />}
+        </div>
 
-      <ResourceDetails node={node} />
+        <ResourceDetails node={node} />
+      </div>
     </div>
   );
 }
@@ -88,10 +88,9 @@ function NodeExpandCollapseToggle({ node }: { node: Node }) {
   if (!node.hasChildren) return <></>;
 
   const handleClick = () => toggleExpanded(node.id);
-  const size = 16;
   const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
 
-  return <ChevronIcon size={size} className="cursor-pointer" onClick={handleClick} />;
+  return <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} />;
 }
 
 function GoalProgressBar({ node }: { node: GoalNode }) {
@@ -111,7 +110,7 @@ function ResourceDetails({ node }: { node: Node }) {
 
 function GoalDetails({ node }: { node: GoalNode }) {
   return (
-    <div>
+    <div className="pl-[42px]">
       <GoalSuccessConditions node={node} />
     </div>
   );
@@ -141,7 +140,7 @@ function GoalSuccessConditions({ node }: { node: GoalNode }) {
   if (!includesId(goalExpanded, node.goal.id)) return <></>;
 
   return (
-    <div style={{ paddingLeft: node.depth * 30 + 42 }}>
+    <div>
       {node.goal.targets.map((t) => {
         const total = t.to! - t.from!;
         const completed = t.value! - t.from!;
@@ -155,8 +154,4 @@ function GoalSuccessConditions({ node }: { node: GoalNode }) {
       })}
     </div>
   );
-}
-
-function ProjectDetails({}: { node: ProjectNode }) {
-  return <></>;
 }

--- a/assets/js/features/projectCheckIns/DescriptionSection.tsx
+++ b/assets/js/features/projectCheckIns/DescriptionSection.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import RichContent from "@/components/RichContent";
+import { ProjectCheckIn } from "@/models/projectCheckIns";
+
+export function DescriptionSection({ checkIn }: { checkIn: ProjectCheckIn }) {
+  return (
+    <div className="my-8">
+      <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
+
+      <div className="mt-2 border border-stroke-base rounded p-4">
+        <RichContent jsonContent={checkIn.description!} className="text-lg" />
+      </div>
+    </div>
+  );
+}

--- a/assets/js/features/projectCheckIns/SmallStatusIndicator.tsx
+++ b/assets/js/features/projectCheckIns/SmallStatusIndicator.tsx
@@ -3,15 +3,21 @@ import * as React from "react";
 import classNames from "classnames";
 
 import { COLORS, TITLES, CIRCLE_BACKGROUND_COLORS } from "./constants";
+import { match } from "ts-pattern";
 
-export function SmallStatusIndicator({ status }: { status: string }) {
+type Size = "std" | "sm";
+
+export function SmallStatusIndicator({ status, size }: { status: string; size?: Size }) {
   const color = COLORS[status];
   const title = TITLES[status];
 
   const bgColor = CIRCLE_BACKGROUND_COLORS[color];
+  const contentSize = match(size)
+    .with("sm", () => "text-xm h-3 w-3")
+    .otherwise(() => "text-sm h-4 w-4");
 
   const outerClasses = classNames("flex items-center gap-1.5");
-  const innerClasses = classNames("text-sm px-2 py-1 rounded-full h-4 w-4", bgColor);
+  const innerClasses = classNames("py-1 rounded-full", contentSize, bgColor);
 
   return (
     <div className={outerClasses}>

--- a/assets/js/features/projectCheckIns/StatusSection.tsx
+++ b/assets/js/features/projectCheckIns/StatusSection.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { ProjectCheckIn } from "@/models/projectCheckIns";
+import { Status } from "./Status";
+import { Person } from "@/models/people";
+
+export function StatusSection({ checkIn, reviewer }: { checkIn: ProjectCheckIn; reviewer: Person }) {
+  return (
+    <div className="my-8">
+      <div className="text-lg font-bold mx-auto">1. How's the project going?</div>
+
+      <div className="flex flex-col gap-2 mt-2 border border-stroke-base rounded-lg p-2">
+        <Status status={checkIn.status!} reviewer={reviewer} />
+      </div>
+    </div>
+  );
+}

--- a/assets/js/pages/GoalsAndProjectsPage/loader.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/loader.tsx
@@ -23,6 +23,7 @@ export async function loader(): Promise<LoaderResult> {
       includeChampion: true,
       includeMilestones: true,
       includePrivacy: true,
+      includeReviewer: true,
     }).then((data) => data.projects!),
   ]);
 

--- a/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -7,14 +7,14 @@ import * as api from "@/api";
 
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
-import RichContent from "@/components/RichContent";
 
 import { TextSeparator } from "@/components/TextSeparator";
 import { Paths, compareIds } from "@/routes/paths";
 import { AckCTA } from "./AckCTA";
 
 import { Spacer } from "@/components/Spacer";
-import { Status } from "@/features/projectCheckIns/Status";
+import { StatusSection } from "@/features/projectCheckIns/StatusSection";
+import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
 
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useForProjectCheckIn } from "@/features/CommentSection";
@@ -30,6 +30,8 @@ export function Page() {
   const refresh = useRefresh();
 
   assertPresent(checkIn.notifications, "Check-in notifications must be defined");
+  assertPresent(checkIn.project?.reviewer, "project and project reviewer must be present in checkIn");
+
   useClearNotificationsOnLoad(checkIn.notifications);
 
   return (
@@ -40,8 +42,8 @@ export function Page() {
         <Paper.Body>
           <Options />
           <Title />
-          <StatusSection />
-          <DescriptionSection />
+          <StatusSection checkIn={checkIn} reviewer={checkIn.project.reviewer} />
+          <DescriptionSection checkIn={checkIn} />
           <AckCTA />
 
           <Spacer size={4} />
@@ -129,34 +131,6 @@ function Acknowledgement() {
   } else {
     return <span className="flex items-center gap-1">Not yet acknowledged</span>;
   }
-}
-
-function StatusSection() {
-  const { checkIn } = useLoadedData();
-
-  return (
-    <div className="my-8">
-      <div className="text-lg font-bold mx-auto">1. How's the project going?</div>
-
-      <div className="flex flex-col gap-2 mt-2 border border-stroke-base rounded-lg p-2">
-        <Status status={checkIn.status!} reviewer={checkIn.project!.reviewer!} />
-      </div>
-    </div>
-  );
-}
-
-function DescriptionSection() {
-  const { checkIn } = useLoadedData();
-
-  return (
-    <div className="my-8">
-      <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
-
-      <div className="mt-2 border border-stroke-base rounded p-4">
-        <RichContent jsonContent={checkIn.description!} className="text-lg" />
-      </div>
-    </div>
-  );
 }
 
 function Options() {

--- a/lib/operately_web/api/queries/get_projects.ex
+++ b/lib/operately_web/api/queries/get_projects.ex
@@ -19,6 +19,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjects do
     field :include_contributors, :boolean
     field :include_last_check_in, :boolean
     field :include_champion, :boolean
+    field :include_reviewer, :boolean
     field :include_goal, :boolean
     field :include_archived, :boolean
     field :include_privacy, :boolean

--- a/test/operately_web/api/queries/get_projects_test.exs
+++ b/test/operately_web/api/queries/get_projects_test.exs
@@ -131,6 +131,20 @@ defmodule OperatelyWeb.Api.Queries.GetProjectsTest do
       assert res.projects == serialize([project], level: :full)
     end
 
+    test "include_reviewer", ctx do
+      project_fixture(company_id: ctx.company.id, name: "Project 1", creator_id: ctx.person.id, reviewer_id: ctx.person.id, group_id: ctx.company.company_space_id)
+
+      assert {200, res} = query(ctx.conn, :get_projects, %{})
+
+      assert length(res.projects) == 1
+      refute hd(res.projects).reviewer
+
+      assert {200, res} = query(ctx.conn, :get_projects, %{include_reviewer: true})
+
+      assert length(res.projects) == 1
+      assert hd(res.projects).reviewer == serialize(ctx.person)
+    end
+
     test "include_space", ctx do
       space = group_fixture(ctx.person, company_id: ctx.company.id, name: "Space 1")
       project_fixture(company_id: ctx.company.id, name: "Project 1", creator_id: ctx.person.id, group_id: space.id)


### PR DESCRIPTION
I've added the project status to the Goals V2 page. When you click on it, a pop-up shows the latest check-in:

https://github.com/user-attachments/assets/e7f81cc8-042b-4493-9b05-d7f4ecbd154c

