### PR TITLE
feat: Add project progress chart to Goals V2 page

### DIFF
--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,19 +1,22 @@
 import React, { useState } from "react";
 
 import Modal from "@/components/Modal";
-import { assertPresent } from "@/utils/assertions";
 import { IconArrowUpRight } from "@tabler/icons-react";
-import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
+import { splitByStatus } from "@/models/milestones";
 import { Project } from "@/models/projects";
+import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { StatusSection } from "@/features/projectCheckIns/StatusSection";
 import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
+import { MiniPieChart } from "@/components/MiniPieChart";
+import { assertPresent } from "@/utils/assertions";
 
 import { ProjectNode } from "../tree";
 
 export default function ProjectDetails({ node }: { node: ProjectNode }) {
   return (
-    <div className="pl-[20px] flex">
+    <div className="pl-[20px] flex gap-8 items-center">
       <Status project={node.project} />
+      <MilestoneCompletion project={node.project} />
     </div>
   );
 }
@@ -26,7 +29,9 @@ function Status({ project }: { project: Project }) {
   };
 
   return (
-    <div>
+    // The 14px padding-right in the container is the same
+    // as the 14px offset in icon.
+    <div className="pr-[14px]">
       <div onClick={toggleShowCheckIn} className="relative cursor-pointer">
         <StatusIndicator project={project} size="sm" />
         <IconArrowUpRight size={12} className="absolute top-0 right-[-14px]" />
@@ -54,5 +59,21 @@ function LatestProjectCheckIn({ project, showCheckIn, toggleShowCheckIn }: Lates
       <StatusSection checkIn={project.lastCheckIn} reviewer={project.reviewer} />
       <DescriptionSection checkIn={project.lastCheckIn} />
     </Modal>
+  );
+}
+
+function MilestoneCompletion({ project }: { project: Project }) {
+  assertPresent(project.milestones, "milestones must be present in project");
+
+  let { pending, done } = splitByStatus(project.milestones);
+  const totalCount = pending.length + done.length;
+
+  if (totalCount === 0) return <></>;
+
+  return (
+    <div className="flex items-center gap-2 shrink-0">
+      <MiniPieChart completed={done.length} total={totalCount} />
+      {done.length}/{totalCount} completed
+    </div>
   );
 }


### PR DESCRIPTION
I've added a pie chart to show the project progress in the Goals V2 page:

![tmp](https://github.com/user-attachments/assets/9eb2eb2c-c1e6-4521-9046-52ea8e65a832)
