### PR TITLE
fix: "View Comment" button in email redirects you to the comment

### DIFF
--- a/assets/js/features/CommentSection/CommentSection.tsx
+++ b/assets/js/features/CommentSection/CommentSection.tsx
@@ -16,6 +16,7 @@ import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { compareIds } from "@/routes/paths";
 import { CommentParentType } from "@/models/comments";
+import { useScrollIntoViewOnLoad } from "./useScrollIntoViewOnLoad";
 
 interface CommentSectionProps {
   form: FormState;
@@ -162,6 +163,7 @@ function MilestoneReopened({ comment }) {
 function ViewComment({ comment, onEdit, commentParentType }) {
   const me = useMe()!;
   const commentRef = useClearNotificationOnIntersection(comment.notification);
+  useScrollIntoViewOnLoad(comment.id);
 
   const entity = { id: comment.id, type: "comment", parentType: commentParentType };
   const addReactionForm = useReactionsForm(entity, comment.reactions);
@@ -173,6 +175,7 @@ function ViewComment({ comment, onEdit, commentParentType }) {
     <div
       className="flex items-start justify-between gap-3 py-3 not-first:border-t border-stroke-base text-content-accent relative"
       data-test-id={testId}
+      id={comment.id}
       ref={commentRef}
     >
       <div className="shrink-0">

--- a/assets/js/features/CommentSection/useScrollIntoViewOnLoad.tsx
+++ b/assets/js/features/CommentSection/useScrollIntoViewOnLoad.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export function useScrollIntoViewOnLoad(id: string) {
+  const location = useLocation();
+
+  useEffect(() => {
+    const hash = location.hash.slice(1);
+
+    if (hash === id) {
+      setTimeout(() => {
+        document.getElementById(hash)?.scrollIntoView({ behavior: "smooth" });
+      }, 500);
+    }
+  }, [location]);
+}

--- a/lib/operately_email/emails/comment_added_email.ex
+++ b/lib/operately_email/emails/comment_added_email.ex
@@ -10,7 +10,7 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
 
     where = get_where(activity)
     action = get_action(activity)
-    link = get_link(company, activity)
+    link = get_link(company, activity, comment)
 
     company
     |> new()
@@ -56,20 +56,20 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
     end
   end
 
-  def get_link(company, activity) do
+  def get_link(company, activity, comment) do
     comment_thread = Operately.Comments.get_thread!(activity.content["comment_thread_id"])
     activity = Operately.Activities.get_activity!(comment_thread.parent_id)
     activity = Repo.preload(activity, :comment_thread)
 
     cond do
       activity.action == "goal_timeframe_editing" ->
-        Paths.goal_activity_path(company, activity) |> Paths.to_url()
+        Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
 
       activity.action == "goal_closing" ->
-        Paths.goal_activity_path(company, activity) |> Paths.to_url()
+        Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
 
       activity.action == "goal_discussion_creation" ->
-        Paths.goal_activity_path(company, activity) |> Paths.to_url()
+        Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
 
       true ->
         raise "Unsupported action"

--- a/lib/operately_email/emails/discussion_comment_submitted_email.ex
+++ b/lib/operately_email/emails/discussion_comment_submitted_email.ex
@@ -24,7 +24,7 @@ defmodule OperatelyEmail.Emails.DiscussionCommentSubmittedEmail do
     |> assign(:title, title)
     |> assign(:comment, comment)
     |> assign(:space, space)
-    |> assign(:cta_url, Paths.message_path(company, message) |> Paths.to_url())
+    |> assign(:cta_url, Paths.message_path(company, message, comment) |> Paths.to_url())
     |> render("discussion_comment_submitted")
   end
 end

--- a/lib/operately_email/emails/goal_check_in_commented_email.ex
+++ b/lib/operately_email/emails/goal_check_in_commented_email.ex
@@ -22,7 +22,7 @@ defmodule OperatelyEmail.Emails.GoalCheckInCommentedEmail do
     |> assign(:goal, goal)
     |> assign(:update, update)
     |> assign(:comment, comment)
-    |> assign(:link, Paths.goal_check_in_path(company, update) |> Paths.to_url())
+    |> assign(:link, Paths.goal_check_in_path(company, update, comment) |> Paths.to_url())
     |> render("goal_check_in_commented")
   end
 end

--- a/lib/operately_email/emails/project_check_in_commented_email.ex
+++ b/lib/operately_email/emails/project_check_in_commented_email.ex
@@ -8,7 +8,7 @@ defmodule OperatelyEmail.Emails.ProjectCheckInCommentedEmail do
     project = Projects.get_project!(activity.content["project_id"])
     comment = Updates.get_comment!(activity.content["comment_id"])
     company = Repo.preload(project, :company).company
-    link = OperatelyWeb.Paths.project_check_in_path(company, check_in) |> OperatelyWeb.Paths.to_url()
+    link = OperatelyWeb.Paths.project_check_in_path(company, check_in, comment) |> OperatelyWeb.Paths.to_url()
 
     company
     |> new()

--- a/lib/operately_email/emails/project_retrospective_commented_email.ex
+++ b/lib/operately_email/emails/project_retrospective_commented_email.ex
@@ -22,7 +22,7 @@ defmodule OperatelyEmail.Emails.ProjectRetrospectiveCommentedEmail do
     |> assign(:project, project)
     |> assign(:comment, comment)
     |> assign(:cta_text, "View Retrospective")
-    |> assign(:cta_url, Paths.project_retrospective_path(company, project) |> Paths.to_url())
+    |> assign(:cta_url, Paths.project_retrospective_path(company, project, comment) |> Paths.to_url())
     |> render("project_retrospective_commented")
   end
 end

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -5,6 +5,7 @@ defmodule OperatelyWeb.Paths do
   alias Operately.Companies.Company
   alias Operately.People.Person
   alias Operately.Projects.Milestone
+  alias Operately.Updates.Comment
 
   def account_path(company = %Company{}) do
     create_path([company_id(company), "account"])
@@ -26,12 +27,24 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company), "goal-updates", goal_update_id(update)])
   end
 
+  def goal_check_in_path(company = %Company{}, update, comment = %Comment{}) do
+    update_with_comment = goal_update_id(update) <> "#" <> comment_id(comment)
+
+    create_path([company_id(company), "goal-updates", update_with_comment])
+  end
+
   def goal_check_in_new_path(company = %Company{}, goal = %Goal{}) do
     create_path([company_id(company), "goals", goal_id(goal), "progress-updates", "new"])
   end
 
   def goal_activity_path(company = %Company{}, activity) do
     create_path([company_id(company), "goal-activities", activity_id(activity)])
+  end
+
+  def goal_activity_path(company = %Company{}, activity, comment = %Comment{}) do
+    activity_with_comment = activity_id(activity) <> "#" <> comment_id(comment)
+
+    create_path([company_id(company), "goal-activities", activity_with_comment])
   end
 
   def goal_discussions_path(company = %Company{}, goal = %Goal{}) do
@@ -74,6 +87,12 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company), "discussions", message_id(message)])
   end
 
+  def message_path(company = %Company{}, message, comment = %Comment{}) do
+    message_with_comment = message_id(message) <> "#" <> comment_id(comment)
+
+    create_path([company_id(company), "discussions", message_with_comment])
+  end
+
   def project_path(company = %Company{}, project = %Project{}) do
     create_path([company_id(company), "projects", project_id(project)])
   end
@@ -82,12 +101,24 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company), "project-check-ins", project_check_in_id(check_in)])
   end
 
+  def project_check_in_path(company = %Company{}, check_in, comment = %Comment{}) do
+    check_in_with_comment = project_check_in_id(check_in) <> "#" <> comment_id(comment)
+
+    create_path([company_id(company), "project-check-ins", check_in_with_comment])
+  end
+
   def project_check_in_new_path(company = %Company{}, project = %Project{}) do
     create_path([company_id(company), "projects", project_id(project), "check-ins", "new"])
   end
 
   def project_retrospective_path(company = %Company{}, project = %Project{}) do
     create_path([company_id(company), "projects", project_id(project), "retrospective"])
+  end
+
+  def project_retrospective_path(company = %Company{}, project = %Project{}, comment = %Comment{}) do
+    retrospective_with_comment = "retrospective#" <> comment_id(comment)
+
+    create_path([company_id(company), "projects", project_id(project), retrospective_with_comment])
   end
 
   def project_milestone_path(company = %Company{}, milestone = %Milestone{}) do


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1376. I've added the same functionality to all comments, not only discussion comments.

I thought this issue could be fixed by simply appending `#id` to the URL, but it turned out that, since the comments are not loaded instantly with the page, some extra code was needed.

Also, we should expect this functionality not to work 100% as expected when there is layout shift on the page. 

I noticed this issue when I added some very long comments. The little moment that the long comments would take to load was enough to make the browser scroll to the wrong position on the page. I've added a 500ms delay which solved the problem for long comments and didn't affect the user experience (imo). Nevertheless, I expect we will still have this problem with images.

The problem with images cannot be solved with a delay because there is no way to know how long it will take them to load. So, if we find this problem too annoying, we could tackle the root of the problem and fix the layout shift with images, which should be enough to fix the problem I've described above.

https://github.com/user-attachments/assets/19053a4c-0565-46a6-9d7b-cbbabb099403

