### PR TITLE
fix: Adding reactions to goal updates and enforcing rules with enum types

### DIFF
--- a/assets/js/features/CommentSection/CommentSection.tsx
+++ b/assets/js/features/CommentSection/CommentSection.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as TipTapEditor from "@/components/Editor";
+import * as Reactions from "@/models/reactions";
 
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
@@ -174,7 +175,7 @@ function ViewComment({ comment, onEdit, commentParentType, canComment }) {
   const commentRef = useClearNotificationOnIntersection(comment.notification);
   useScrollIntoViewOnLoad(comment.id);
 
-  const entity = { id: comment.id, type: "comment", parentType: commentParentType };
+  const entity = Reactions.entity(comment.id, "comment", commentParentType);
   const addReactionForm = useReactionsForm(entity, comment.reactions);
 
   const testId = "comment-" + comment.id;

--- a/assets/js/features/Reactions/index.tsx
+++ b/assets/js/features/Reactions/index.tsx
@@ -14,19 +14,13 @@ interface ReactionsFormState {
   submit: (type: string) => void;
 }
 
-interface Entity {
-  id: string;
-  type: string;
-  parentType?: string;
-}
-
 interface ReactionListItem {
   id: string;
   person: Pick<api.Person, "id" | "fullName" | "avatarUrl">;
   emoji: string;
 }
 
-export function useReactionsForm(entity: Entity, initial: api.Reaction[] | Reactions.Reaction[]): ReactionsFormState {
+export function useReactionsForm(entity: Reactions.Entity, initial: Reactions.Reaction[]): ReactionsFormState {
   const me = useMe()!;
   const [add] = Reactions.useAddReaction();
 

--- a/assets/js/features/goals/GoalCheckIn/index.tsx
+++ b/assets/js/features/goals/GoalCheckIn/index.tsx
@@ -1,4 +1,7 @@
-import React from "react";
+import * as React from "react";
+import * as Icons from "@tabler/icons-react";
+import * as Goals from "@/models/goals";
+import * as Reactions from "@/models/reactions";
 
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
@@ -7,9 +10,6 @@ import RichContent from "@/components/RichContent";
 import { SecondaryButton } from "@/components/Buttons";
 import { Paths } from "@/routes/paths";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
-
-import * as Icons from "@tabler/icons-react";
-import * as Goals from "@/models/goals";
 
 import plurarize from "@/utils/plurarize";
 import { DivLink } from "@/components/Link";
@@ -70,7 +70,7 @@ function LastMessageReactions({ goal }: { goal: Goals.Goal }) {
 
   const update = goal.lastCheckIn!;
   const reactions = update.reactions!.map((r: any) => r!);
-  const entity = { id: update.id!, type: "update" };
+  const entity = Reactions.entity(update.id!, "goal_update");
 
   const addReactionForm = useReactionsForm(entity, reactions);
 

--- a/assets/js/models/reactions/index.tsx
+++ b/assets/js/models/reactions/index.tsx
@@ -1,4 +1,24 @@
 import * as api from "@/api";
 
 export type Reaction = api.Reaction;
+
 export { useAddReaction } from "@/api";
+
+type EntityType =
+  | "project_check_in"
+  | "project_retrospective"
+  | "comment_thread"
+  | "goal_update"
+  | "message"
+  | "comment";
+
+// Which entity the reactions are for
+export type Entity = {
+  id: string;
+  type: EntityType;
+  parentType?: string;
+};
+
+export function entity(id: string, type: EntityType, parentType?: string): Entity {
+  return { id, type, parentType };
+}

--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -6,6 +6,7 @@ import * as Icons from "@tabler/icons-react";
 import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Reactions from "@/models/reactions";
 
 import Avatar from "@/components/Avatar";
 import RichContent from "@/components/RichContent";
@@ -44,7 +45,7 @@ export function Page() {
             <RichContent jsonContent={discussion.body!} className="text-md sm:text-lg" />
 
             <Spacer size={2} />
-            <Reactions />
+            <DiscussionReactions />
 
             <Spacer size={4} />
 
@@ -66,10 +67,10 @@ export function Page() {
   );
 }
 
-function Reactions() {
+function DiscussionReactions() {
   const { discussion } = useLoadedData();
   const reactions = discussion.reactions!.map((r) => r!);
-  const entity = { id: discussion.id!, type: "message" };
+  const entity = Reactions.entity(discussion.id!, "message");
   const addReactionForm = useReactionsForm(entity, reactions);
 
   assertPresent(discussion.permissions?.canCommentOnDiscussions, "permissions must be present in discussion");

--- a/assets/js/pages/GoalActivityPage/index.tsx
+++ b/assets/js/pages/GoalActivityPage/index.tsx
@@ -3,6 +3,7 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as Goals from "@/models/goals";
 import * as Activities from "@/models/activities";
+import * as Reactions from "@/models/reactions";
 
 import { GoalSubpageNavigation } from "@/features/goals/GoalSubpageNavigation";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
@@ -47,7 +48,7 @@ export function Page() {
             <ActivityHandler.PageContent activity={activity} />
           </div>
 
-          <Reactions />
+          <ActivityReactions />
           <Comments goal={goal} />
         </Paper.Body>
       </Paper.Root>
@@ -72,7 +73,7 @@ function Title({ activity }: { activity: Activities.Activity }) {
   );
 }
 
-function Reactions() {
+function ActivityReactions() {
   const { activity } = Pages.useLoadedData<LoaderResult>();
 
   assertPresent(
@@ -82,7 +83,7 @@ function Reactions() {
   assertPresent(activity.permissions?.canCommentOnThread, "permissions must be present in activity");
 
   const reactions = activity.commentThread.reactions.map((r) => r!);
-  const entity = { id: activity.commentThread.id!, type: "comment_thread" };
+  const entity = Reactions.entity(activity.commentThread.id!, "comment_thread");
   const addReactionForm = useReactionsForm(entity, reactions);
 
   return <ReactionList size={24} form={addReactionForm} canAddReaction={activity.permissions.canCommentOnThread} />;

--- a/assets/js/pages/GoalProgressUpdatePage/page.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/page.tsx
@@ -3,6 +3,7 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Reactions from "@/models/reactions";
 
 import { useLoadedData, useRefresh } from "./loader";
 import FormattedTime from "@/components/FormattedTime";
@@ -56,7 +57,7 @@ export function Page() {
           <Targets />
 
           <Spacer size={4} />
-          <Reactions />
+          <GoalUpdateReactions />
 
           <AckCTA />
           <Comments />
@@ -76,10 +77,10 @@ export function Page() {
   );
 }
 
-function Reactions() {
+function GoalUpdateReactions() {
   const { update } = useLoadedData();
   const reactions = update.reactions!.map((r: any) => r!);
-  const entity = { id: update.id!, type: "goal_update" };
+  const entity = Reactions.entity(update.id!, "goal_update");
   const addReactionForm = useReactionsForm(entity, reactions);
 
   assertPresent(update.goal?.permissions?.canCommentOnUpdate, "permissions must be present in update");

--- a/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -3,7 +3,7 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import * as api from "@/api";
+import * as Reactions from "@/models/reactions";
 
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
@@ -47,7 +47,7 @@ export function Page() {
           <AckCTA />
 
           <Spacer size={4} />
-          <Reactions />
+          <CheckInReactions />
 
           <div className="border-t border-stroke-base mt-8" />
           <Comments />
@@ -84,10 +84,10 @@ function Comments() {
   );
 }
 
-function Reactions() {
+function CheckInReactions() {
   const { checkIn } = useLoadedData();
-  const reactions = checkIn.reactions!.map((r) => r!) as api.Reaction[];
-  const entity = { id: checkIn.id!, type: "project_check_in" };
+  const reactions = checkIn.reactions!.map((r) => r!);
+  const entity = Reactions.entity(checkIn.id!, "project_check_in");
   const form = useReactionsForm(entity, reactions);
 
   assertPresent(checkIn.project?.permissions?.canCommentOnCheckIn, "permissions must be present in project checkIn");

--- a/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Reactions from "@/models/reactions";
 
 import { Paths } from "@/routes/paths";
 import { IconEdit } from "@tabler/icons-react";
@@ -36,7 +37,7 @@ export function Page() {
           <Content />
 
           <Spacer size={2} />
-          <Reactions />
+          <RetroReactions />
 
           <Spacer size={4} />
           <Comments />
@@ -99,10 +100,10 @@ function Content() {
   );
 }
 
-function Reactions() {
+function RetroReactions() {
   const { retrospective } = useLoadedData();
   const reactions = retrospective.reactions!.map((r) => r!);
-  const entity = { id: retrospective.id!, type: "project_retrospective" };
+  const entity = Reactions.entity(retrospective.id!, "project_retrospective");
   const addReactionForm = useReactionsForm(entity, reactions);
 
   assertPresent(retrospective.permissions?.canCommentOnRetrospective, "permissions must be present in retrospective");


### PR DESCRIPTION
fixes: https://github.com/operately/operately/issues/1394

Previously the parent was declared as "string" so when we changed the name from "goal_update" -> "update" the linter didn't scream. Now, the type is an enum of strings.