### PR TITLE
feat: Add project details to Goals V2 page

### DIFF
--- a/assets/js/features/ProjectListItem/StatusIndicator.tsx
+++ b/assets/js/features/ProjectListItem/StatusIndicator.tsx
@@ -4,11 +4,23 @@ import { SmallStatusIndicator } from "@/features/projectCheckIns/SmallStatusIndi
 import { Project } from "@/models/projects";
 
 type Size = "std" | "sm";
+interface StatusIndicatorProps {
+  project: Project;
+  size?: Size;
+  textClassName?: string;
+}
 
-export function StatusIndicator({ project, size = "std" }: { project: Project; size?: Size }) {
+export function StatusIndicator({ project, size = "std", textClassName }: StatusIndicatorProps) {
   if (project.status === "closed") return null;
-  if (project.status === "paused") return <SmallStatusIndicator status="paused" size={size} />;
-  if (project.isOutdated) return <SmallStatusIndicator status="outdated" size={size} />;
+  if (project.status === "paused")
+    return <SmallStatusIndicator status="paused" size={size} textClassName={textClassName} />;
+  if (project.isOutdated) return <SmallStatusIndicator status="outdated" size={size} textClassName={textClassName} />;
 
-  return <SmallStatusIndicator status={project.lastCheckIn?.status || "on_track"} size={size} />;
+  return (
+    <SmallStatusIndicator
+      status={project.lastCheckIn?.status || "on_track"}
+      size={size}
+      textClassName={textClassName}
+    />
+  );
 }

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+import { IconMinus, IconPlus } from "@tabler/icons-react";
+import { includesId } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { ProgressBar } from "@/components/ProgressBar";
+import { MiniPieChart } from "@/components/MiniPieChart";
+
+import { GoalNode } from "../tree";
+import { useExpandable } from "../context/Expandable";
+
+export function GoalDetails({ node }: { node: GoalNode }) {
+  return (
+    <div className="pl-[42px]">
+      <GoalSuccessConditions node={node} />
+    </div>
+  );
+}
+
+export function GoalProgressBar({ node }: { node: GoalNode }) {
+  assertPresent(node.goal.progressPercentage, "progressPercentage must be present in goal");
+
+  return <ProgressBar percentage={node.goal.progressPercentage} className="ml-2" />;
+}
+
+export function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
+  const { goalExpanded, toggleGoalExpanded } = useExpandable();
+
+  return (
+    <div
+      onClick={() => toggleGoalExpanded(node.goal.id!)}
+      className="ml-2 h-[20px] w-[20px] rounded-full border-2 border-surface-outline flex items-center justify-center cursor-pointer"
+    >
+      {includesId(goalExpanded, node.goal.id) ? (
+        <IconMinus size={12} stroke={3} className="border-surface-outline shrink-0" />
+      ) : (
+        <IconPlus size={12} stroke={3} className="border-surface-outline shrink-0" />
+      )}
+    </div>
+  );
+}
+
+function GoalSuccessConditions({ node }: { node: GoalNode }) {
+  const { goalExpanded } = useExpandable();
+  assertPresent(node.goal.targets, "targets must be present in goal");
+
+  if (!includesId(goalExpanded, node.goal.id)) return <></>;
+
+  return (
+    <div>
+      {node.goal.targets.map((t) => {
+        const total = t.to! - t.from!;
+        const completed = t.value! - t.from!;
+
+        return (
+          <div key={t.id} className="flex items-center gap-2 text-content-dimmed">
+            <MiniPieChart total={total} completed={completed} />
+            {t.name}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,22 +1,32 @@
 import React, { useState } from "react";
 
 import Modal from "@/components/Modal";
+import FormattedTime from "@/components/FormattedTime";
+import Avatar from "@/components/Avatar";
+
 import { IconArrowUpRight } from "@tabler/icons-react";
 import { splitByStatus } from "@/models/milestones";
-import { Project } from "@/models/projects";
+import { Project, sortContributorsByRole } from "@/models/projects";
 import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { StatusSection } from "@/features/projectCheckIns/StatusSection";
 import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
 import { MiniPieChart } from "@/components/MiniPieChart";
+import { MilestoneIcon } from "@/components/MilestoneIcon";
+import { DivLink } from "@/components/Link";
 import { assertPresent } from "@/utils/assertions";
+import { truncateString } from "@/utils/strings";
+import { Paths } from "@/routes/paths";
 
 import { ProjectNode } from "../tree";
 
 export default function ProjectDetails({ node }: { node: ProjectNode }) {
   return (
-    <div className="pl-[20px] flex gap-8 items-center">
+    <div className="pl-[20px] flex gap-10 items-center">
       <Status project={node.project} />
       <MilestoneCompletion project={node.project} />
+      <NextMilestone project={node.project} />
+      <SpaceName project={node.project} />
+      <ContributorsList project={node.project} />
     </div>
   );
 }
@@ -28,12 +38,16 @@ function Status({ project }: { project: Project }) {
     setShowCheckIn((prev) => !prev);
   };
 
+  if (!project.lastCheckIn) {
+    return <StatusIndicator project={project} size="sm" textClassName="text-content-dimmed" />;
+  }
+
   return (
     // The 14px padding-right in the container is the same
     // as the 14px offset in icon.
     <div className="pr-[14px]">
       <div onClick={toggleShowCheckIn} className="relative cursor-pointer">
-        <StatusIndicator project={project} size="sm" />
+        <StatusIndicator project={project} size="sm" textClassName="text-content-dimmed" />
         <IconArrowUpRight size={12} className="absolute top-0 right-[-14px]" />
       </div>
 
@@ -50,13 +64,12 @@ interface LatestProjectCheckInProps {
 
 function LatestProjectCheckIn({ project, showCheckIn, toggleShowCheckIn }: LatestProjectCheckInProps) {
   assertPresent(project.lastCheckIn, "lastCheckIn must be present in project");
-  assertPresent(project.reviewer, "reviewer must be present in project");
 
   return (
     <Modal title="" hideModal={toggleShowCheckIn} isOpen={showCheckIn} minHeight="300px">
       <div className="text-xl font-bold">{project.name}</div>
 
-      <StatusSection checkIn={project.lastCheckIn} reviewer={project.reviewer} />
+      <StatusSection checkIn={project.lastCheckIn} reviewer={project.reviewer || undefined} />
       <DescriptionSection checkIn={project.lastCheckIn} />
     </Modal>
   );
@@ -71,9 +84,57 @@ function MilestoneCompletion({ project }: { project: Project }) {
   if (totalCount === 0) return <></>;
 
   return (
-    <div className="flex items-center gap-2 shrink-0">
+    <div className="flex items-center gap-2 shrink-0 text-xs text-content-dimmed">
       <MiniPieChart completed={done.length} total={totalCount} />
       {done.length}/{totalCount} completed
+    </div>
+  );
+}
+
+function NextMilestone({ project }: { project: Project }) {
+  if (!project.nextMilestone) return <></>;
+
+  const name = truncateString(project.nextMilestone.title!, 40);
+
+  return (
+    <div className="flex items-center gap-2">
+      <MilestoneIcon milestone={project.nextMilestone} />
+      <div className="flex-1 truncate text-xs text-content-dimmed">
+        <FormattedTime time={project.nextMilestone.deadlineAt!} format="short-date" />: {name}
+      </div>
+    </div>
+  );
+}
+
+function SpaceName({ project }: { project: Project }) {
+  assertPresent(project.space, "space must be present in project");
+
+  const path = Paths.spacePath(project.space.id!);
+
+  return (
+    <DivLink to={path} className="text-xs text-content-dimmed">
+      {project.space.name}
+    </DivLink>
+  );
+}
+
+function ContributorsList({ project }: { project: Project }) {
+  assertPresent(project.contributors, "contributors must be present in project");
+
+  const sortedContributors = sortContributorsByRole(project.contributors);
+  const hiddenContribsCount = sortedContributors.length - 8;
+
+  return (
+    <div className="flex items-center gap-1">
+      {sortedContributors.slice(0, 8).map((contributor) => (
+        <Avatar key={contributor!.id} person={contributor!.person!} size="tiny" />
+      ))}
+
+      {hiddenContribsCount > 0 && (
+        <div className="flex items-center justify-center text-[.6rem] w-5 h-5 bg-surface-dimmed text-content-dimmed font-bold rounded-full">
+          +{hiddenContribsCount}
+        </div>
+      )}
     </div>
   );
 }

--- a/assets/js/features/goals/GoalTree/tree-v2.tsx
+++ b/assets/js/features/goals/GoalTree/tree-v2.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 
-import { IconChevronDown, IconChevronRight, IconMinus, IconPlus } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { GhostButton } from "@/components/Buttons";
-import { MiniPieChart } from "@/components/MiniPieChart";
-import { assertPresent } from "@/utils/assertions";
-import { includesId } from "@/routes/paths";
-import { ProgressBar } from "@/components/ProgressBar";
 
 import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
+import { ExpandGoalSuccessConditions, GoalDetails, GoalProgressBar } from "./components/GoalDetails";
 import { GoalNode, Node, ProjectNode } from "./tree";
 import { useExpandable } from "./context/Expandable";
 import { NodeIcon } from "./components/NodeIcon";
@@ -93,12 +90,6 @@ function NodeExpandCollapseToggle({ node }: { node: Node }) {
   return <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} />;
 }
 
-function GoalProgressBar({ node }: { node: GoalNode }) {
-  assertPresent(node.goal.progressPercentage, "progressPercentage must be present in goal");
-
-  return <ProgressBar percentage={node.goal.progressPercentage} className="ml-2" />;
-}
-
 function ResourceDetails({ node }: { node: Node }) {
   switch (node.type) {
     case "goal":
@@ -106,52 +97,4 @@ function ResourceDetails({ node }: { node: Node }) {
     case "project":
       return <ProjectDetails node={node as ProjectNode} />;
   }
-}
-
-function GoalDetails({ node }: { node: GoalNode }) {
-  return (
-    <div className="pl-[42px]">
-      <GoalSuccessConditions node={node} />
-    </div>
-  );
-}
-
-function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
-  const { goalExpanded, toggleGoalExpanded } = useExpandable();
-
-  return (
-    <div
-      onClick={() => toggleGoalExpanded(node.goal.id!)}
-      className="ml-2 h-[20px] w-[20px] rounded-full border-2 border-surface-outline flex items-center justify-center cursor-pointer"
-    >
-      {includesId(goalExpanded, node.goal.id) ? (
-        <IconMinus size={12} stroke={3} className="border-surface-outline shrink-0" />
-      ) : (
-        <IconPlus size={12} stroke={3} className="border-surface-outline shrink-0" />
-      )}
-    </div>
-  );
-}
-
-function GoalSuccessConditions({ node }: { node: GoalNode }) {
-  const { goalExpanded } = useExpandable();
-  assertPresent(node.goal.targets, "targets must be present in goal");
-
-  if (!includesId(goalExpanded, node.goal.id)) return <></>;
-
-  return (
-    <div>
-      {node.goal.targets.map((t) => {
-        const total = t.to! - t.from!;
-        const completed = t.value! - t.from!;
-
-        return (
-          <div key={t.id} className="flex items-center gap-2">
-            <MiniPieChart total={total} completed={completed} />
-            {t.name}
-          </div>
-        );
-      })}
-    </div>
-  );
 }

--- a/assets/js/features/projectCheckIns/SmallStatusIndicator.tsx
+++ b/assets/js/features/projectCheckIns/SmallStatusIndicator.tsx
@@ -7,22 +7,34 @@ import { match } from "ts-pattern";
 
 type Size = "std" | "sm";
 
-export function SmallStatusIndicator({ status, size }: { status: string; size?: Size }) {
+export function SmallStatusIndicator({
+  status,
+  size,
+  textClassName = "",
+}: {
+  status: string;
+  size?: Size;
+  textClassName?: string;
+}) {
   const color = COLORS[status];
   const title = TITLES[status];
 
   const bgColor = CIRCLE_BACKGROUND_COLORS[color];
   const contentSize = match(size)
-    .with("sm", () => "text-xm h-3 w-3")
+    .with("sm", () => "text-xs h-3 w-3")
     .otherwise(() => "text-sm h-4 w-4");
+  const textSize = match(size)
+    .with("sm", () => "text-xs")
+    .otherwise(() => "text-sm");
 
   const outerClasses = classNames("flex items-center gap-1.5");
   const innerClasses = classNames("py-1 rounded-full", contentSize, bgColor);
+  const textClasses = classNames(textSize, textClassName);
 
   return (
     <div className={outerClasses}>
       <div className={innerClasses} />
-      <div>{title}</div>
+      <div className={textClasses}>{title}</div>
     </div>
   );
 }

--- a/assets/js/features/projectCheckIns/StatusSection.tsx
+++ b/assets/js/features/projectCheckIns/StatusSection.tsx
@@ -4,7 +4,7 @@ import { ProjectCheckIn } from "@/models/projectCheckIns";
 import { Status } from "./Status";
 import { Person } from "@/models/people";
 
-export function StatusSection({ checkIn, reviewer }: { checkIn: ProjectCheckIn; reviewer: Person }) {
+export function StatusSection({ checkIn, reviewer }: { checkIn: ProjectCheckIn; reviewer?: Person }) {
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">1. How's the project going?</div>

--- a/assets/js/pages/GoalsAndProjectsPage/loader.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/loader.tsx
@@ -24,6 +24,7 @@ export async function loader(): Promise<LoaderResult> {
       includeMilestones: true,
       includePrivacy: true,
       includeReviewer: true,
+      includeContributors: true,
     }).then((data) => data.projects!),
   ]);
 


### PR DESCRIPTION
All project details are now displayed on the Goals V2 page.

![tmp](https://github.com/user-attachments/assets/82cab4c6-10ba-46f6-ad82-acbac97522e7)
