### PR TITLE
chore: Stabilize contributor ordering in the API

### DIFF
--- a/lib/operately_web/api/serializers/project.ex
+++ b/lib/operately_web/api/serializers/project.ex
@@ -29,7 +29,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       reviewer: OperatelyWeb.Api.Serializer.serialize(project.reviewer),
       goal: OperatelyWeb.Api.Serializer.serialize(project.goal),
       milestones: OperatelyWeb.Api.Serializer.serialize(project.milestones),
-      contributors: OperatelyWeb.Api.Serializer.serialize(exclude_suspended(project)),
+      contributors: OperatelyWeb.Api.Serializer.serialize(sort_contribs(exclude_suspended(project))),
       last_check_in: OperatelyWeb.Api.Serializer.serialize(project.last_check_in),
       next_milestone: OperatelyWeb.Api.Serializer.serialize(project.next_milestone),
       permissions: OperatelyWeb.Api.Serializer.serialize(project.permissions),
@@ -45,5 +45,20 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       %Ecto.Association.NotLoaded{} -> []
       contributors -> Enum.filter(contributors, &(not is_nil(&1.person)))
     end
+  end
+
+  @roles_ordering [champion: 0, reviewer: 1, contributor: 2]
+
+  defp sort_contribs(contribs) do
+    Enum.sort(contribs, fn contrib1, contrib2 ->
+      order1 = Keyword.get(@roles_ordering, contrib1.role, 100)
+      order2 = Keyword.get(@roles_ordering, contrib2.role, 100)
+
+      if order1 == order2 do
+        contrib1.person.full_name < contrib2.person.full_name
+      else
+        order1 < order2
+      end
+    end)
   end
 end


### PR DESCRIPTION
This was the cause of some flaky tests, like this one: https://operately.semaphoreci.com/workflows/77f95d40-c31b-40a5-8248-00ffe01383ea/summary?pipeline_id=777dbb7d-bec6-47dc-9acd-76ab1aed83b8&report_id=31c127ba-6edc-33b1-9f53-fc4a54e74c82&test_id=c46e1b96-ec05-3e5a-9913-4b006ca8e450.
