### PR TITLE
feat: "View options" button enabled on Goals V2 page

### DIFF
--- a/assets/js/components/Forms/CheckboxInput.tsx
+++ b/assets/js/components/Forms/CheckboxInput.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+import { useFieldValue } from "./FormContext";
+import { InputField } from "./FieldGroup";
+
+import classNames from "classnames";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface CheckboxInputProps {
+  field: string;
+  label?: string;
+  hidden?: boolean;
+  options: Option[];
+}
+
+export function CheckboxInput({ field, label, hidden, options }: CheckboxInputProps) {
+  return (
+    <InputField field={field} label={label} hidden={hidden}>
+      <div className="flex flex-col gap-2 mt-1">
+        {options.map((option: Option) => (
+          <Checkbox key={option.value} field={field} value={option.value} label={option.label} />
+        ))}
+      </div>
+    </InputField>
+  );
+}
+
+function Checkbox({ field, value, label }: { field: string; value: string; label: string }) {
+  const [checkedValues, setCheckedValues] = useFieldValue<string[]>(field);
+
+  const handleChange = () => {
+    if (checkedValues.includes(value)) {
+      setCheckedValues(checkedValues.filter((obj) => obj !== value));
+    } else {
+      setCheckedValues([...checkedValues, value]);
+    }
+  };
+
+  return (
+    <label className="flex items-start gap-2">
+      <input
+        data-test-id={field + "-" + value}
+        name={field}
+        type="checkbox"
+        className={checkboxClass}
+        style={CheckboxStyle}
+        value={value}
+        onChange={handleChange}
+        checked={checkedValues.includes(value)}
+      />
+
+      <div className="flex flex-col">
+        <div className="text-content-accent leading-none">{label}</div>
+      </div>
+    </label>
+  );
+}
+
+const checkboxClass = classNames(
+  "before:content[''] peer relative h-4 w-4 cursor-pointer appearance-none",
+  "border border-surface-outline transition-all",
+  "checked:text-blue-400",
+);
+
+const CheckboxStyle = {
+  boxShadow: "none",
+};

--- a/assets/js/components/Forms/FieldGroup/Grid.tsx
+++ b/assets/js/components/Forms/FieldGroup/Grid.tsx
@@ -7,6 +7,7 @@ import { InputFieldProps } from "../FieldGroup";
 
 export interface Options {
   columns: number;
+  gridTemplateColumns?: string;
 }
 
 const DEFAULT_OPTIONS: Options = {
@@ -21,7 +22,7 @@ export function Container({ children }: { children: React.ReactNode }) {
   const options = useLayoutOptions<Options>();
 
   const style = {
-    gridTemplateColumns: `repeat(${options.columns}, 1fr)`,
+    gridTemplateColumns: options.gridTemplateColumns || `repeat(${options.columns}, 1fr)`,
   };
 
   return (

--- a/assets/js/components/Forms/index.tsx
+++ b/assets/js/components/Forms/index.tsx
@@ -10,6 +10,7 @@ import { SelectPerson } from "./SelectPerson";
 import { RichTextArea } from "./RichTextArea";
 import { PasswordInput } from "./PasswordInput";
 import { MultiPeopleSelectField } from "./MultiPeopleSelectField";
+import { CheckboxInput } from "./CheckboxInput";
 
 import { useForm } from "./useForm";
 import { useFieldError, useFieldValue } from "./FormContext";
@@ -31,4 +32,5 @@ export default {
   SelectPerson,
   PasswordInput,
   MultiPeopleSelectField,
+  CheckboxInput,
 };

--- a/assets/js/features/goals/GoalTree/components/Controls-v2.tsx
+++ b/assets/js/features/goals/GoalTree/components/Controls-v2.tsx
@@ -1,0 +1,119 @@
+import React, { useMemo, useState } from "react";
+
+import Forms from "@/components/Forms";
+import Modal from "@/components/Modal";
+
+import { useMe } from "@/contexts/CurrentUserContext";
+import { GhostButton } from "@/components/Buttons";
+
+import { useExpandable } from "../context/Expandable";
+import { useTreeContext } from "../treeContext";
+
+export function Controls() {
+  const { expanded, expandAll, collapseAll } = useExpandable();
+  const isExpanded = Object.keys(expanded).length > 0;
+  const [showOptions, setShowOptions] = useState(false);
+
+  const toggleShowOptions = () => setShowOptions((prev) => !prev);
+
+  return (
+    <>
+      <div className="flex mb-4 items-center gap-2">
+        <GhostButton onClick={isExpanded ? collapseAll : expandAll} size="sm">
+          {isExpanded ? "Collapse All" : "Expand all"}
+        </GhostButton>
+        <GhostButton onClick={toggleShowOptions} size="sm">
+          View options
+        </GhostButton>
+      </div>
+
+      <OptionsModal showOptions={showOptions} toggleShowOptions={toggleShowOptions} />
+    </>
+  );
+}
+
+function OptionsModal({ showOptions, toggleShowOptions }) {
+  const me = useMe()!;
+  const {
+    showActive,
+    setShowActive,
+    showPaused,
+    setShowPaused,
+    showCompleted,
+    setShowCompleted,
+    setChampionedBy,
+    setReviewedBy,
+  } = useTreeContext();
+
+  const filters = useMemo(() => {
+    const result: string[] = [];
+
+    if (showActive) result.push("active");
+    if (showPaused) result.push("paused");
+    if (showCompleted) result.push("completed");
+
+    return result;
+  }, [showActive, showPaused, showCompleted]);
+
+  const form = Forms.useForm({
+    fields: {
+      filters,
+      ownedBy: "anyone",
+      reviewedBy: "anyone",
+    },
+    submit: () => {
+      if (form.values.filters.includes("active")) setShowActive(true);
+      else setShowActive(false);
+
+      if (form.values.filters.includes("paused")) setShowPaused(true);
+      else setShowPaused(false);
+
+      if (form.values.filters.includes("completed")) setShowCompleted(true);
+      else setShowCompleted(false);
+
+      if (form.values.ownedBy === "me") setChampionedBy(me);
+      else setChampionedBy(undefined);
+
+      if (form.values.reviewedBy === "me") setReviewedBy(me);
+      else setReviewedBy(undefined);
+
+      toggleShowOptions();
+    },
+  });
+
+  return (
+    <Modal title="View options" isOpen={showOptions} hideModal={toggleShowOptions} minHeight="200px" width="700px">
+      <Forms.Form form={form}>
+        <Forms.FieldGroup layout="grid" layoutOptions={{ gridTemplateColumns: "repeat(3, auto)" }}>
+          <Forms.CheckboxInput
+            field="filters"
+            label="Show goals and projects:"
+            options={[
+              { label: "Active", value: "active" },
+              { label: "Paused", value: "paused" },
+              { label: "Completed", value: "completed" },
+            ]}
+          />
+          <Forms.RadioButtons
+            field="ownedBy"
+            label="Owned by:"
+            options={[
+              { label: "Anyone", value: "anyone" },
+              { label: "Me", value: "me" },
+            ]}
+          />
+          <Forms.RadioButtons
+            field="reviewedBy"
+            label="Reviewed by:"
+            options={[
+              { label: "Anyone", value: "anyone" },
+              { label: "Me", value: "me" },
+            ]}
+          />
+        </Forms.FieldGroup>
+
+        <Forms.Submit />
+      </Forms.Form>
+    </Modal>
+  );
+}

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -19,7 +19,7 @@ import { Paths } from "@/routes/paths";
 
 import { ProjectNode } from "../tree";
 
-export default function ProjectDetails({ node }: { node: ProjectNode }) {
+export function ProjectDetails({ node }: { node: ProjectNode }) {
   return (
     <div className="pl-[20px] flex gap-10 items-center">
       <Status project={node.project} />

--- a/assets/js/features/goals/GoalTree/tree-v2.tsx
+++ b/assets/js/features/goals/GoalTree/tree-v2.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 
 import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
-import { GhostButton } from "@/components/Buttons";
 
 import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
 import { ExpandGoalSuccessConditions, GoalActions, GoalDetails, GoalProgressBar } from "./components/GoalDetails";
+import { ProjectDetails } from "./components/ProjectDetails";
 import { GoalNode, Node, ProjectNode } from "./tree";
 import { useExpandable } from "./context/Expandable";
 import { NodeIcon } from "./components/NodeIcon";
 import { NodeName } from "./components/NodeName";
-import ProjectDetails from "./components/ProjectDetails";
+import { Controls } from "./components/Controls-v2";
 
 export function GoalTree(props: TreeContextProviderProps) {
   return (
@@ -31,20 +31,6 @@ function GoalTreeRoots() {
           <NodeView key={root.id} node={root} />
         ))}
       </div>
-    </div>
-  );
-}
-
-function Controls() {
-  const { expanded, expandAll, collapseAll } = useExpandable();
-  const isExpanded = Object.keys(expanded).length > 0;
-
-  return (
-    <div className="flex mb-4 items-center gap-2">
-      <GhostButton onClick={isExpanded ? collapseAll : expandAll} size="sm">
-        {isExpanded ? "Collapse All" : "Expand all"}
-      </GhostButton>
-      <GhostButton size="sm">View options</GhostButton>
     </div>
   );
 }
@@ -101,7 +87,7 @@ function NodeChildren({ node }: { node: Node }) {
 function NodeExpandCollapseToggle({ node }: { node: Node }) {
   const { expanded, toggleExpanded } = useExpandable();
 
-  if (!node.hasChildren) return <></>;
+  if (node.children.length === 0) return <></>;
 
   const handleClick = () => toggleExpanded(node.id);
   const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;

--- a/assets/js/features/goals/GoalTree/tree/goalNode.tsx
+++ b/assets/js/features/goals/GoalTree/tree/goalNode.tsx
@@ -22,6 +22,7 @@ export class GoalNode extends Node {
     this.type = "goal";
     this.name = goal.name!;
     this.champion = goal.champion!;
+    this.reviewer = goal.reviewer!;
     this.isClosed = goal.isClosed!;
     this.progress = this.goal.progressPercentage!;
     this.lastCheckInDate = Time.parseDate(goal.lastCheckIn?.insertedAt);

--- a/assets/js/features/goals/GoalTree/tree/node.tsx
+++ b/assets/js/features/goals/GoalTree/tree/node.tsx
@@ -20,6 +20,7 @@ export abstract class Node {
   public showCompleted: boolean;
 
   public champion: People.Person;
+  public reviewer: People.Person;
   public parent: Node | undefined;
   public children: Node[];
   public hasChildren: boolean;

--- a/assets/js/features/goals/GoalTree/tree/projectNode.tsx
+++ b/assets/js/features/goals/GoalTree/tree/projectNode.tsx
@@ -19,6 +19,7 @@ export class ProjectNode extends Node {
     this.name = project.name!;
 
     this.champion = project.champion!;
+    this.reviewer = project.reviewer!;
     this.space = project.space as Spaces.Space;
     this.isClosed = project.status === "closed";
     this.progress = this.calculateProgress();

--- a/assets/js/features/goals/GoalTree/treeContext.tsx
+++ b/assets/js/features/goals/GoalTree/treeContext.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
+import { Person } from "@/models/people";
 
 import { Tree, buildTree, SortColumn, SortDirection, TreeOptions } from "./tree";
 import { ExpandableProvider } from "./context/Expandable";
@@ -15,8 +16,14 @@ interface TreeContextValue {
 
   hideSpaceColumn?: boolean;
 
+  showActive: boolean;
+  setShowActive: (show: boolean) => void;
+  showPaused: boolean;
+  setShowPaused: (show: boolean) => void;
   showCompleted: boolean;
   setShowCompleted: (show: boolean) => void;
+  setChampionedBy: (person?: Person) => void;
+  setReviewedBy: (person?: Person) => void;
 }
 
 const TreeContext = React.createContext<TreeContextValue | null>(null);
@@ -36,12 +43,20 @@ interface TreeContextProviderPropsWithChildren extends TreeContextProviderProps 
 export function TreeContextProvider(props: TreeContextProviderPropsWithChildren) {
   const [sortColumn, setSortColumn] = React.useState<SortColumn>("name");
   const [sortDirection, setSortDirection] = React.useState<SortDirection>("asc");
+  const [showActive, setShowActive] = React.useState<boolean>(true);
+  const [showPaused, setShowPaused] = React.useState<boolean>(false);
   const [showCompleted, setShowCompleted] = React.useState<boolean>(false);
+  const [championedBy, setChampionedBy] = React.useState<Person>();
+  const [reviewedBy, setReviewedBy] = React.useState<Person>();
 
   const treeOptions = {
     ...props.options,
+    personId: props.options.personId || championedBy?.id!,
+    reviewerId: reviewedBy?.id!,
     sortColumn,
     sortDirection,
+    showActive,
+    showPaused,
     showCompleted,
   };
 
@@ -57,8 +72,14 @@ export function TreeContextProvider(props: TreeContextProviderPropsWithChildren)
     setSortDirection,
     sortDirection,
     hideSpaceColumn: props.hideSpaceColumn,
+    showActive,
+    setShowActive,
+    showPaused,
+    setShowPaused,
     showCompleted,
     setShowCompleted,
+    setChampionedBy,
+    setReviewedBy,
   };
 
   return (


### PR DESCRIPTION
Now, we have several ways of filtering the Goals Tree on the new Goals page:

https://github.com/user-attachments/assets/8c3a0de8-7c35-48f6-84bd-22446b2c481c

