### PR TITLE
chore: Move closed_at from retrospective to project

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1513,6 +1513,7 @@ export interface GetProjectRetrospectiveInput {
   projectId?: string | null;
   includeAuthor?: boolean | null;
   includeProject?: boolean | null;
+  includeClosedAt?: boolean | null;
   includePermissions?: boolean | null;
   includeReactions?: boolean | null;
   includeSubscriptionsList?: boolean | null;

--- a/assets/js/features/ProjectListItem/index.tsx
+++ b/assets/js/features/ProjectListItem/index.tsx
@@ -59,7 +59,7 @@ function ProjectStatusLine({ project }: { project: Projects.Project }) {
       <div className="mt-2 text-sm font-medium">
         {project.retrospective && (
           <>
-            Closed on <FormattedTime time={project.retrospective.closedAt!} format="short-date" /> &middot;{" "}
+            Closed on <FormattedTime time={project.closedAt!} format="short-date" /> &middot;{" "}
           </>
         )}
         <Link to={Paths.projectRetrospectivePath(project.id!)}>Read the retrospective</Link>

--- a/assets/js/pages/ProjectPage/Banner.tsx
+++ b/assets/js/pages/ProjectPage/Banner.tsx
@@ -21,7 +21,7 @@ function ProjectClosedBanner({ project }: { project: Projects.Project }) {
 
   return (
     <Paper.Banner testId="project-closed-banner">
-      This project was closed on <FormattedTime time={project.retrospective?.closedAt!} format="long-date" />. View the{" "}
+      This project was closed on <FormattedTime time={project.closedAt!} format="long-date" />. View the{" "}
       <Link to={retroPath} testId="project-retrospective-link" className="font-bold ml-1">
         retrospective
       </Link>

--- a/assets/js/pages/ProjectRetrospectivePage/loader.tsx
+++ b/assets/js/pages/ProjectRetrospectivePage/loader.tsx
@@ -11,6 +11,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       projectId: params.projectID,
       includeAuthor: true,
       includeProject: true,
+      includeClosedAt: true,
       includePermissions: true,
       includeReactions: true,
       includePotentialSubscribers: true,

--- a/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -69,6 +69,8 @@ function Options() {
 function Header() {
   const { retrospective } = useLoadedData();
 
+  assertPresent(retrospective.closedAt, "closedAt must be present in retrospective");
+
   return (
     <>
       <div className="text-center text-content-accent text-3xl font-extrabold">Project Retrospective</div>
@@ -76,7 +78,7 @@ function Header() {
       <div className="flex items-center gap-1.5 font-medium justify-center mt-2">
         {retrospective.author && <AvatarWithName person={retrospective.author!} size={20} />}
         {retrospective.author && <span>&middot;</span>}
-        <FormattedTime time={retrospective.closedAt!} format="long-date" />
+        <FormattedTime time={retrospective.closedAt} format="long-date" />
       </div>
     </>
   );

--- a/lib/operately/operations/project_closed.ex
+++ b/lib/operately/operations/project_closed.ex
@@ -14,17 +14,14 @@ defmodule Operately.Operations.ProjectClosed do
         author_id: author.id,
         project_id: project.id,
         content: attrs.retrospective,
-        closed_at: DateTime.utc_now(),
         subscription_list_id: changes.subscription_list.id,
       })
     end)
     |> SubscriptionList.update(:retrospective)
-    |> Multi.update(:project, fn changes ->
-      Project.changeset(project,%{
-        status: "closed",
-        closed_at: changes.retrospective.closed_at,
-      })
-    end)
+    |> Multi.update(:project, Project.changeset(project,%{
+      status: "closed",
+      closed_at: DateTime.utc_now(),
+    }))
     |> Activities.insert_sync(author.id, :project_closed, fn changes -> %{
       company_id: project.company_id,
       space_id: project.group_id,

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -76,6 +76,7 @@ defmodule Operately.Projects.Project do
       :private,
       :deleted_at,
       :status,
+      :closed_at,
       :last_check_in_id,
       :last_check_in_status,
       :next_update_scheduled_at,

--- a/lib/operately/projects/retrospective.ex
+++ b/lib/operately/projects/retrospective.ex
@@ -13,7 +13,6 @@ defmodule Operately.Projects.Retrospective do
     has_many :reactions, Operately.Updates.Reaction, where: [entity_type: :project_retrospective], foreign_key: :entity_id
 
     field :content, :map
-    field :closed_at, :utc_datetime
 
     # populated with after load hooks
     field :permissions, :any, virtual: true
@@ -31,8 +30,8 @@ defmodule Operately.Projects.Retrospective do
 
   def changeset(retrospective, attrs) do
     retrospective
-    |> cast(attrs, [:author_id, :project_id, :subscription_list_id, :content, :closed_at])
-    |> validate_required([:author_id, :project_id, :subscription_list_id, :content, :closed_at])
+    |> cast(attrs, [:author_id, :project_id, :subscription_list_id, :content])
+    |> validate_required([:author_id, :project_id, :subscription_list_id, :content])
   end
 
   #

--- a/lib/operately_web/api/queries/get_project_retrospective.ex
+++ b/lib/operately_web/api/queries/get_project_retrospective.ex
@@ -8,6 +8,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
     field :project_id, :string
     field :include_author, :boolean
     field :include_project, :boolean
+    field :include_closed_at, :boolean
     field :include_permissions, :boolean
     field :include_reactions, :boolean
     field :include_subscriptions_list, :boolean
@@ -50,6 +51,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
     Inputs.parse_includes(inputs, [
       include_author: [:author],
       include_project: [:project],
+      include_closed_at: [:project],
       include_reactions: [reactions: :person],
       include_subscriptions_list: :subscription_list,
     ])

--- a/lib/operately_web/api/serializers/project_retrospective.ex
+++ b/lib/operately_web/api/serializers/project_retrospective.ex
@@ -5,7 +5,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Retrospective do
       author: OperatelyWeb.Api.Serializer.serialize(retrospective.author),
       project: OperatelyWeb.Api.Serializer.serialize(retrospective.project),
       content: Jason.encode!(retrospective.content),
-      closed_at: OperatelyWeb.Api.Serializer.serialize(retrospective.closed_at),
+      closed_at: Ecto.assoc_loaded?(retrospective.project) && OperatelyWeb.Api.Serializer.serialize(retrospective.project.closed_at),
       permissions: OperatelyWeb.Api.Serializer.serialize(retrospective.permissions),
       reactions: OperatelyWeb.Api.Serializer.serialize(retrospective.reactions),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(retrospective.subscription_list),

--- a/priv/repo/migrations/20241024114823_add_closed_at_to_existing_closed_projects.exs
+++ b/priv/repo/migrations/20241024114823_add_closed_at_to_existing_closed_projects.exs
@@ -1,0 +1,26 @@
+defmodule Operately.Repo.Migrations.AddClosedAtToExistingClosedProjects do
+  use Ecto.Migration
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.{Repo, Projects}
+  alias Operately.Projects.Project
+
+  def up do
+    from(c in "project_retrospectives", select: [:id, :project_id, :closed_at])
+    |> Repo.all(with_deleted: true)
+    |> Enum.each(fn retro ->
+      {:ok, project_id} = Ecto.UUID.cast(retro.project_id)
+
+      project = from(p in Project, where: p.id == ^project_id) |> Repo.one(with_deleted: true)
+
+      if project.status == "closed" and project.closed_at == nil do
+        {:ok, _} = Projects.update_project(project, %{closed_at: retro.closed_at})
+      end
+    end)
+  end
+
+  def down do
+
+  end
+end


### PR DESCRIPTION
I've updated the `Operately.Operations.ProjectClosed` operation so that `closed_at` is now saved with the project, not the retrospective. 

I've also added a migration which updates the `closed_at` value in existing closed projects. Since this field used to be part of projects and it was never deleted, the migration didn't have to change the projects schema, only the values.

This should be enough to solve https://github.com/operately/operately/issues/1404.

