### PR TITLE
fix: Filtering nodes by reviewer on Goals V2 page wasn't woeking

### DIFF
--- a/assets/js/features/goals/GoalTree/tree/buildTree.tsx
+++ b/assets/js/features/goals/GoalTree/tree/buildTree.tsx
@@ -101,7 +101,8 @@ class TreeBuilder {
         (compareIds(n.champion?.id, this.options.personId!) || compareIds(n.reviewer?.id, this.options.reviewerId)) &&
         n.hasNoParentWith(
           (node) =>
-            compareIds(node.champion?.id, this.options.personId) || compareIds(n.reviewer?.id, this.options.reviewerId),
+            compareIds(node.champion?.id, this.options.personId) ||
+            compareIds(node.reviewer?.id, this.options.reviewerId),
         ),
     );
   }

--- a/assets/js/features/goals/GoalTree/tree/node.tsx
+++ b/assets/js/features/goals/GoalTree/tree/node.tsx
@@ -20,7 +20,7 @@ export abstract class Node {
   public showCompleted: boolean;
 
   public champion: People.Person;
-  public reviewer: People.Person;
+  public reviewer?: People.Person;
   public parent: Node | undefined;
   public children: Node[];
   public hasChildren: boolean;

--- a/test/features/goal_tree_test.exs
+++ b/test/features/goal_tree_test.exs
@@ -96,5 +96,16 @@ defmodule Operately.Features.GoalTreeTest do
       |> Steps.assert_project_visible(:project_alpha)
       |> Steps.assert_project_visible(:project_beta)
     end
+
+    feature "reviewed by", ctx do
+      ctx
+      |> Steps.given_project_and_goal_with_other_reviewer_exists()
+      |> Steps.visit_goals_v2_page()
+      |> Steps.assert_goal_visible(:goal_3)
+      |> Steps.assert_project_visible(:project_omega)
+      |> Steps.select_reviewed_by_me_filter()
+      |> Steps.refute_goal_visible(:goal_3)
+      |> Steps.refute_project_visible(:project_omega)
+    end
   end
 end

--- a/test/support/features/goal_tree_steps.ex
+++ b/test/support/features/goal_tree_steps.ex
@@ -15,6 +15,12 @@ defmodule Operately.Support.Features.GoalTreeSteps do
     |> then(fn ctx -> UI.login_as(ctx, ctx.creator) end)
   end
 
+  step :given_project_and_goal_with_other_reviewer_exists, ctx do
+    ctx
+    |> Factory.add_goal(:goal_3, :product, [reviewer: :john, name: "Goal Tres"])
+    |> Factory.add_project(:project_omega, :product, [reviewer: :john, name: "Project Omega"])
+  end
+
   step :given_project_is_paused, ctx, project do
     Operately.Operations.ProjectPausing.run(ctx.creator, project)
     ctx
@@ -133,6 +139,13 @@ defmodule Operately.Support.Features.GoalTreeSteps do
     ctx
     |> UI.click(testid: "view-options")
     |> UI.click(testid: "ownedBy-me")
+    |> UI.click(testid: "submit")
+  end
+
+  step :select_reviewed_by_me_filter, ctx do
+    ctx
+    |> UI.click(testid: "view-options")
+    |> UI.click(testid: "reviewedBy-me")
     |> UI.click(testid: "submit")
   end
 


### PR DESCRIPTION
Filtering nodes by reviewer wasn't always working because of a typo in `TreeBuilder.rootNodesForPerson`. 