### PR TITLE
feat: Add Discussions to space tools

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -629,6 +629,7 @@ export interface Discussion {
   space?: Space | null;
   reactions?: Reaction[] | null;
   comments?: Comment[] | null;
+  commentsCount?: number | null;
   subscriptionList?: SubscriptionList | null;
   potentialSubscribers?: Subscriber[] | null;
   notifications?: Notification[] | null;
@@ -1318,6 +1319,8 @@ export interface GetDiscussionResult {
 
 export interface GetDiscussionsInput {
   spaceId?: string | null;
+  includeAuthor?: boolean | null;
+  includeCommentsCount?: boolean | null;
 }
 
 export interface GetDiscussionsResult {

--- a/assets/js/features/SpaceTools/Discussions.tsx
+++ b/assets/js/features/SpaceTools/Discussions.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import { Discussion } from "@/models/discussions";
+
+import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { DivLink } from "@/components/Link";
+import Avatar from "@/components/Avatar";
+
+import { Title, Container } from "./components";
+
+export function Discussions({ discussions }: { discussions: Discussion[] }) {
+  return (
+    <Container>
+      <Title title="Discussions" />
+      <DiscussionList discussions={discussions} />
+    </Container>
+  );
+}
+
+function DiscussionList({ discussions }: { discussions: Discussion[] }) {
+  return (
+    <div>
+      {discussions.map((discussion) => (
+        <DiscussionItem discussion={discussion} key={discussion.id} />
+      ))}
+    </div>
+  );
+}
+
+function DiscussionItem({ discussion }: { discussion: Discussion }) {
+  assertPresent(discussion.author, "author must be present in discussion");
+  assertPresent(discussion.commentsCount, "commentsCount must be present in discussion");
+
+  const path = Paths.discussionPath(discussion.id!);
+
+  return (
+    <DivLink to={path} className="flex items-center gap-2 py-3 px-2 border-b border-stroke-base last:border-b-0">
+      <Avatar person={discussion.author} size="normal" />
+      <div className="text-sm font-bold">{discussion.title}</div>
+      <CommnetsCount count={discussion.commentsCount} />
+    </DivLink>
+  );
+}
+
+function CommnetsCount({ count }: { count: number }) {
+  if (count < 1) return <></>;
+
+  return (
+    <div>
+      <div className="w-[20px] h-[20px] text-xs bg-blue-500 text-white-1 flex items-center justify-center rounded-full">
+        {count}
+      </div>
+    </div>
+  );
+}

--- a/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import { Container, Title } from "./components";
+
+export function GoalsAndProjects() {
+  return (
+    <Container>
+      <Title title="Goals & Projects" />
+    </Container>
+  );
+}

--- a/assets/js/features/SpaceTools/ToolsSection.tsx
+++ b/assets/js/features/SpaceTools/ToolsSection.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { Discussion } from "@/models/discussions";
+
+import { GoalsAndProjects } from "./GoalsAndProjects";
+import { Discussions } from "./Discussions";
+
+interface ToolsSectionPros {
+  discussions: Discussion[];
+}
+
+export function ToolsSection({ discussions }: ToolsSectionPros) {
+  return (
+    <div className="mt-6 py-6">
+      <div className="flex justify-center items-start flex-wrap gap-8">
+        <GoalsAndProjects />
+        <Discussions discussions={discussions} />
+      </div>
+    </div>
+  );
+}

--- a/assets/js/features/SpaceTools/components.tsx
+++ b/assets/js/features/SpaceTools/components.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export function Title({ title }: { title: string }) {
+  return <div className="font-bold text-lg text-center py-2 border-b border-stroke-base">{title}</div>;
+}
+
+export function Container({ children }) {
+  return <div className="min-h-[160px] w-[300px] border border-stroke-base">{children}</div>;
+}

--- a/assets/js/features/SpaceTools/index.tsx
+++ b/assets/js/features/SpaceTools/index.tsx
@@ -1,0 +1,1 @@
+export { ToolsSection } from "./ToolsSection";

--- a/assets/js/models/discussions/index.tsx
+++ b/assets/js/models/discussions/index.tsx
@@ -1,3 +1,3 @@
 export type { Discussion } from "@/api";
 
-export { getDiscussion, getDiscussions, usePostDiscussion, useEditDiscussion } from "@/api";
+export { getDiscussion, getDiscussions, useGetDiscussions, usePostDiscussion, useEditDiscussion } from "@/api";

--- a/assets/js/models/goals/index.tsx
+++ b/assets/js/models/goals/index.tsx
@@ -6,6 +6,7 @@ export type Target = api.Target;
 export {
   getGoal,
   getGoals,
+  useGetGoals,
   useCreateGoal,
   useEditGoal,
   useConnectGoalToProject,

--- a/assets/js/models/projects/index.tsx
+++ b/assets/js/models/projects/index.tsx
@@ -9,6 +9,7 @@ export type ProjectRetrospective = api.ProjectRetrospective;
 export {
   getProject,
   getProjects,
+  useGetProjects,
   getProjectRetrospective,
   useMoveProjectToSpace,
   useCreateProject,

--- a/assets/js/pages/SpaceDiscussionsPage/loader.tsx
+++ b/assets/js/pages/SpaceDiscussionsPage/loader.tsx
@@ -8,12 +8,14 @@ interface LoadedData {
 }
 
 export async function loader({ params }): Promise<LoadedData> {
-  const spacePromise = Spaces.getSpace({ id: params.id, includePermissions: true });
-  const discussionsPromise = Discussions.getDiscussions({ spaceId: params.id }).then((data) => data.discussions!);
+  const [space, discussions] = await Promise.all([
+    Spaces.getSpace({ id: params.id, includePermissions: true }),
+    Discussions.getDiscussions({ spaceId: params.id, includeAuthor: true }).then((data) => data.discussions!),
+  ]);
 
   return {
-    space: await spacePromise,
-    discussions: await discussionsPromise,
+    space,
+    discussions,
   };
 }
 

--- a/assets/js/pages/SpaceDiscussionsPage/page.tsx
+++ b/assets/js/pages/SpaceDiscussionsPage/page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as Time from "@/utils/time";
 
+import { Discussion } from "@/models/discussions";
 import Avatar from "@/components/Avatar";
 import FormattedTime from "@/components/FormattedTime";
 import { SpacePageNavigation } from "@/components/SpacePageNavigation";
@@ -11,6 +12,7 @@ import { Summary } from "@/components/RichContent";
 import { useLoadedData } from "./loader";
 import { PrimaryButton } from "@/components/Buttons";
 import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const { space } = useLoadedData();
@@ -58,8 +60,10 @@ function DiscussionList() {
   );
 }
 
-function DiscussionListItem({ discussion }) {
-  const path = Paths.discussionPath(discussion.id);
+function DiscussionListItem({ discussion }: { discussion: Discussion }) {
+  assertPresent(discussion.author, "author must be present in discussion");
+
+  const path = Paths.discussionPath(discussion.id!);
 
   return (
     <DivLink
@@ -78,7 +82,7 @@ function DiscussionListItem({ discussion }) {
           <div className="text-sm text-content-dimmed">{discussion.author.fullName}</div>
           <div className="text-sm text-content-dimmed">·</div>
           <div className="text-sm text-content-dimmed">
-            <FormattedTime time={discussion.insertedAt} format="long-date" />
+            <FormattedTime time={discussion.insertedAt!} format="long-date" />
           </div>
         </div>
       </div>

--- a/assets/knip.json
+++ b/assets/knip.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/knip@2/schema.json",
   "entry": ["js/app.tsx", "build.js", "codegen.ts"],
   "project": ["js/**/*.ts", "js/**/*.tsx"],
-  "ignore": ["js/gql/generated.tsx", "js/api/index.tsx"],
+  "ignore": ["js/gql/generated.tsx", "js/api/index.tsx", "js/features/SpaceTools/*.tsx"],
   "ignoreDependencies": ["@types/jest"],
 
   "rules": {

--- a/lib/operately_web/api/queries/get_discussions.ex
+++ b/lib/operately_web/api/queries/get_discussions.ex
@@ -2,10 +2,13 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
+  alias Operately.Messages.Message
   alias Operately.Access.Filters
 
   inputs do
     field :space_id, :string
+    field :include_author, :boolean
+    field :include_comments_count, :boolean
   end
 
   outputs do
@@ -16,7 +19,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
     |> run(:id, fn -> decode_id(inputs.space_id) end)
-    |> run(:messages, fn ctx -> load_messages(ctx.me, ctx.id) end)
+    |> run(:messages, fn ctx -> load_messages(ctx, inputs) end)
     |> run(:serialized, fn ctx -> {:ok, %{discussions: Serializer.serialize(ctx.messages, level: :essential)}} end)
     |> respond()
   end
@@ -30,16 +33,32 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
     end
   end
 
-  defp load_messages(person, space_id) do
+  defp load_messages(ctx, inputs) do
     messages =
-      from(m in Operately.Messages.Message,
-        where: m.space_id == ^space_id,
-        preload: :author,
+      from(m in Message,
+        where: m.space_id == ^ctx.id,
+        preload: ^preload(inputs),
         order_by: [desc: m.inserted_at]
       )
-      |> Filters.filter_by_view_access(person.id)
+      |> Filters.filter_by_view_access(ctx.me.id)
       |> Repo.all()
+      |> after_load(inputs)
 
     {:ok, messages}
+  end
+
+  defp preload(inputs) do
+    Inputs.parse_includes(inputs, [
+      include_author: :author,
+    ])
+  end
+
+  defp after_load(messages, inputs) do
+    Inputs.parse_includes(inputs, [
+      include_comments_count: &Message.load_comments_count/1,
+    ])
+    |> Enum.reduce(messages, fn hook, message ->
+      hook.(message)
+    end)
   end
 end

--- a/lib/operately_web/api/serializers/message.ex
+++ b/lib/operately_web/api/serializers/message.ex
@@ -7,6 +7,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(message.inserted_at),
       updated_at: OperatelyWeb.Api.Serializer.serialize(message.updated_at),
       author: OperatelyWeb.Api.Serializer.serialize(message.author),
+      comments_count: message.comments_count,
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -214,6 +214,7 @@ defmodule OperatelyWeb.Api.Types do
     field :space, :space
     field :reactions, list_of(:reaction)
     field :comments, list_of(:comment)
+    field :comments_count, :integer
     field :subscription_list, :subscription_list
     field :potential_subscribers, list_of(:subscriber)
     field :notifications, list_of(:notification)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Support.Factory do
-  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages, Goals}
+  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages, Goals, Comments}
 
   def setup(ctx) do
     ctx = add_account(ctx, :account)
@@ -48,4 +48,6 @@ defmodule Operately.Support.Factory do
   # messages
   defdelegate add_message(ctx, testid, space_name, opts \\ []), to: Messages
 
+  # comments
+  defdelegate add_comment(ctx, testid, parent_name, opts \\ []), to: Comments
 end

--- a/test/support/factory/comments.ex
+++ b/test/support/factory/comments.ex
@@ -1,0 +1,22 @@
+defmodule Operately.Support.Factory.Comments do
+  alias Operately.Support.RichText
+
+  def add_comment(ctx, testid, parent_name, opts \\ []) do
+    creator = Keyword.get(opts, :creator, ctx.creator)
+    entity_type = find_entity_type(ctx[parent_name])
+
+    {:ok, comment} = Operately.Operations.CommentAdding.run(creator, ctx[parent_name], entity_type, RichText.rich_text("Content"))
+
+    Map.put(ctx, testid, comment)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp find_entity_type(%Operately.Messages.Message{}), do: "message"
+  defp find_entity_type(%Operately.Projects.CheckIn{}), do: "project_check_in"
+  defp find_entity_type(%Operately.Goals.Update{}), do: "goal_update"
+  defp find_entity_type(%Operately.Comments.CommentThread{}), do: "comment_thread"
+  defp find_entity_type(%Operately.Projects.Retrospective{}), do: "project_retrospective"
+end


### PR DESCRIPTION
I've started adding the new ToolsSection to the Space page. As this is going to be too much code for a single PR, I decided to build it in the `features/SpaceTools/` directory and add the directory to the ignore list in the `knip.json` file. This way the linter won't complain. 

To see how the component looks, we just need to add it to the Space page:

```
<ToolsSection space={space} />
```

I started building it by the Discussions tool. Here is how it looks:

![tmp](https://github.com/user-attachments/assets/736f2017-9509-4bd8-b58c-0979476c94dc)

I'm marking this PR as a draft because I think we could improve some things before merging it:

1) I'm using `Paper.DimmedSection`, that's why the background is not white as in the wireframe. The reason why I'm using it is because it calculates the negative margins, which is necessary for adding a new section to the page. I didn't manage to find a section component in the codebase that has a white background. Do we have one? If not, I can create one that behaves similarly to `Paper.DimmedSection`, but with another background.

2) Currently, while the discussions are loading, I just hide the component. Do we have a spinner component? If not, I can also create one.

3) What do you think about the `surface-outline` background color in the comments count? Should I try another color?



@shiroyasha @markoa 
