### PR TITLE
feat: Display goals and projects space tools

### DIFF
--- a/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -2,10 +2,17 @@ import React from "react";
 
 import { Goal } from "@/models/goals";
 import { Project } from "@/models/projects";
+import { splitByStatus } from "@/models/milestones";
+
+import { PieChart } from "@/components/PieChart";
+import { ProgressBar } from "@/components/ProgressBar";
+import { MiniPieChart } from "@/components/MiniPieChart";
+import { assertPresent } from "@/utils/assertions";
+import { DivLink } from "@/components/Link";
+import { Paths } from "@/routes/paths";
 
 import { Container, Title } from "./components";
 import { calculateGoalsStatus, calculateProjectsStatus } from "./utils";
-import { PieChart } from "@/components/PieChart";
 
 interface GoalsAndProjectsProps {
   goals: Goal[];
@@ -16,11 +23,68 @@ export function GoalsAndProjects({ goals, projects }: GoalsAndProjectsProps) {
   return (
     <Container>
       <Title title="Goals & Projects" />
+      <Goals goals={goals} />
+      <Projects projects={projects} />
+    </Container>
+  );
+}
 
+function Goals({ goals }: { goals: Goal[] }) {
+  return (
+    <div className="flex flex-col gap-2 px-2 py-3">
       <Header goals={goals} type="goals" />
 
+      {goals.map((goal) => (
+        <GoalItem goal={goal} key={goal.id} />
+      ))}
+    </div>
+  );
+}
+
+function GoalItem({ goal }: { goal: Goal }) {
+  assertPresent(goal.progressPercentage, "progressPercentage");
+
+  const path = Paths.goalPath(goal.id!);
+
+  return (
+    <DivLink to={path} className="flex items-center gap-1 overflow-hidden">
+      <div>
+        <div className="w-[14px] h-[14px] bg-red-500 rounded-full" />
+      </div>
+      <div>
+        <ProgressBar percentage={goal.progressPercentage} className="w-[50px]" />
+      </div>
+      <div className="truncate">{goal.name}</div>
+    </DivLink>
+  );
+}
+
+function Projects({ projects }: { projects: Project[] }) {
+  return (
+    <div className="flex flex-col gap-2 px-2 py-3">
       <Header projects={projects} type="projects" />
-    </Container>
+
+      {projects.map((project) => (
+        <ProjectItem project={project} key={project.id} />
+      ))}
+    </div>
+  );
+}
+
+function ProjectItem({ project }: { project: Project }) {
+  assertPresent(project.milestones, "milestones must be present in project");
+
+  const path = Paths.projectPath(project.id!);
+  const total = project.milestones.length;
+  const { done } = splitByStatus(project.milestones);
+
+  return (
+    <DivLink to={path} className="flex items-center gap-1 overflow-hidden">
+      <div>
+        <MiniPieChart completed={done.length} total={total} />
+      </div>
+      <div className="truncate">{project.name}</div>
+    </DivLink>
   );
 }
 
@@ -50,7 +114,7 @@ function Header(props: GoalsHeader | ProjectsHeader) {
   }, []);
 
   return (
-    <div className="font-bold flex items-center gap-2 py-3 px-2">
+    <div className="font-bold flex items-center gap-2">
       <PieChart
         total={status.total}
         slices={[

--- a/assets/js/features/SpaceTools/components.tsx
+++ b/assets/js/features/SpaceTools/components.tsx
@@ -5,5 +5,5 @@ export function Title({ title }: { title: string }) {
 }
 
 export function Container({ children }) {
-  return <div className="min-h-[160px] w-[300px] border border-stroke-base">{children}</div>;
+  return <div className="min-h-[160px] w-[320px] border border-stroke-base">{children}</div>;
 }


### PR DESCRIPTION
Now, a list of current goals and projects is displayed in the Goals & Projects tool:

![tmp](https://github.com/user-attachments/assets/3f9e84aa-655a-4317-a689-24d7bb89b92f)
