### PR TITLE
feat: Space tools are responsive + hovering on them shows shadow

### DIFF
--- a/assets/js/features/SpaceTools/Discussions.tsx
+++ b/assets/js/features/SpaceTools/Discussions.tsx
@@ -10,11 +10,17 @@ import Avatar from "@/components/Avatar";
 
 import { Title, Container } from "./components";
 
-export function Discussions({ space, discussions }: { space: Space; discussions: Discussion[] }) {
+interface DiscussionsProps {
+  space: Space;
+  discussions: Discussion[];
+  toolsCount: number;
+}
+
+export function Discussions({ space, discussions, toolsCount }: DiscussionsProps) {
   const path = Paths.discussionsPath(space.id!);
 
   return (
-    <Container path={path}>
+    <Container path={path} toolsCount={toolsCount}>
       <Title title="Discussions" />
       <DiscussionList discussions={discussions} />
     </Container>

--- a/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -18,9 +18,10 @@ interface GoalsAndProjectsProps {
   space: Space;
   goals: Goal[];
   projects: Project[];
+  toolsCount: number;
 }
 
-export function GoalsAndProjects({ space, goals, projects }: GoalsAndProjectsProps) {
+export function GoalsAndProjects({ space, goals, projects, toolsCount }: GoalsAndProjectsProps) {
   const path = Paths.spaceGoalsPath(space.id!);
 
   // Limiting the number of goals to ensure that the component
@@ -35,7 +36,7 @@ export function GoalsAndProjects({ space, goals, projects }: GoalsAndProjectsPro
   }, []);
 
   return (
-    <Container path={path}>
+    <Container path={path} toolsCount={toolsCount}>
       <Title title="Goals & Projects" />
       <Goals goals={slicedGoals} />
       <Projects projects={projects} />

--- a/assets/js/features/SpaceTools/ToolsSection.tsx
+++ b/assets/js/features/SpaceTools/ToolsSection.tsx
@@ -19,8 +19,8 @@ export function ToolsSection({ space, discussions, goals, projects }: ToolsSecti
   return (
     <div className="mt-6 py-6">
       <div className="flex justify-center items-start flex-wrap gap-8">
-        <GoalsAndProjects space={space} goals={goals} projects={projects} />
-        <Discussions space={space} discussions={discussions} />
+        <GoalsAndProjects space={space} goals={goals} projects={projects} toolsCount={2} />
+        <Discussions space={space} discussions={discussions} toolsCount={2} />
       </div>
     </div>
   );

--- a/assets/js/features/SpaceTools/components.tsx
+++ b/assets/js/features/SpaceTools/components.tsx
@@ -1,13 +1,31 @@
 import React from "react";
+
+import classNames from "classnames";
 import { DivLink } from "@/components/Link";
 
 export function Title({ title }: { title: string }) {
   return <div className="font-bold text-lg text-center py-2 border-b border-stroke-base">{title}</div>;
 }
 
-export function Container({ children, path }: { children: NonNullable<React.ReactNode>; path: string }) {
+interface ContainerProps {
+  path: string;
+  toolsCount: number;
+  children: NonNullable<React.ReactNode>;
+}
+
+export function Container({ children, path, toolsCount }: ContainerProps) {
+  const large = toolsCount > 2 ? "lg:w-[calc(33%-1.33rem)]" : "lg:w-[340px]";
+
+  const className = classNames(
+    "text-sm",
+    "h-[380px] max-w-[340px] overflow-hidden",
+    `w-full md:w-[calc(50%-1rem)] ${large}`,
+    "border border-stroke-base",
+    "hover:shadow transition-shadow duration-300",
+  );
+
   return (
-    <DivLink to={path} className="text-sm h-[380px] w-[285px] overflow-hidden border border-stroke-base">
+    <DivLink to={path} className={className}>
       {children}
     </DivLink>
   );


### PR DESCRIPTION
When we hover over a tool, a subtle shadow appears:

https://github.com/user-attachments/assets/5199f1c4-db17-4f0d-81ea-0f29508c225f

Also, space tools are now responsive. 

2 tools:
https://github.com/user-attachments/assets/053f7c87-c6c0-48f0-ac68-ebc63013e7c5

5 tools: 
https://github.com/user-attachments/assets/d78f1155-694a-41f2-abd8-bd1dfbdb4fc9


