### PR TITLE
chore: Fix flaky tests that appears at the end of the month

### DIFF
--- a/test/support/features/project_timeline_steps.ex
+++ b/test/support/features/project_timeline_steps.ex
@@ -23,16 +23,13 @@ defmodule Operately.Support.Features.ProjectTimelineSteps do
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
     |> UI.click(testid: "manage-timeline")
     |> UI.click(testid: "edit-timeline")
-    |> UI.click(testid: "project-start")
-    |> UI.click(css: ".react-datepicker__day.react-datepicker__day--0#{attrs.started_at.day}")
-    |> UI.click(testid: "project-due")
-    |> UI.click(css: ".react-datepicker__day.react-datepicker__day--0#{attrs.deadline.day}")
+    |> UI.select_day_in_datepicker(testid: "project-start", date: attrs.started_at)
+    |> UI.select_day_in_datepicker(testid: "project-due", date: attrs.deadline)
     |> UI.foreach(attrs.milestones, fn milestone, ctx ->
       ctx
       |> UI.click(testid: "add-milestone")
       |> UI.fill(testid: "new-milestone-title", with: milestone.title)
-      |> UI.click(testid: "new-milestone-due")
-      |> UI.click(css: ".react-datepicker__day.react-datepicker__day--0#{milestone.due_day.day}")
+      |> UI.select_day_in_datepicker(testid: "new-milestone-due", date: milestone.due_day)
       |> UI.click(testid: "save-milestone-button")
     end)
     |> UI.click(testid: "save-changes")
@@ -82,16 +79,13 @@ defmodule Operately.Support.Features.ProjectTimelineSteps do
   end
 
   step :when_i_add_a_milestone, ctx do
-    current_day = Date.utc_today().day
-
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))
     |> UI.click(testid: "manage-timeline")
     |> UI.click(testid: "edit-timeline")
     |> UI.click(testid: "add-milestone")
     |> UI.fill(testid: "new-milestone-title", with: "Website Published")
-    |> UI.click(testid: "new-milestone-due")
-    |> UI.click(css: ".react-datepicker__day.react-datepicker__day--0#{current_day}")
+    |> UI.select_day_in_datepicker(testid: "new-milestone-due", date: Time.days_from_now(5))
     |> UI.click(testid: "save-milestone-button")
     |> UI.click(testid: "save-changes")
     |> UI.assert_has(testid: "project-timeline-page")

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -417,4 +417,36 @@ defmodule Operately.Support.Features.UI do
       cb.(item, ctx)
     end)
   end
+
+  def select_day_in_datepicker(ctx, testid: testid, date: date) do
+    is_current_month = date.month == Date.utc_today().month
+    is_last_month = date.month == Date.utc_today().month - 1
+    is_next_month = date.month == Date.utc_today().month + 1
+
+    day = if date.day < 10 do 
+      "00#{date.day}"
+    else
+      "0#{date.day}"
+    end
+
+    ctx
+    |> click(testid: testid)
+    |> then(fn ctx ->
+      cond do
+        is_current_month ->
+          ctx
+          |> click(css: ".react-datepicker__day.react-datepicker__day--#{day}")
+
+        is_last_month ->
+          ctx
+          |> click(css: ".react-datepicker__navigation.react-datepicker__navigation--prev")
+          |> click(css: ".react-datepicker__day.react-datepicker__day--#{day}")
+
+        is_next_month ->
+          ctx
+          |> click(css: ".react-datepicker__navigation.react-datepicker__navigation--next")
+          |> click(css: ".react-datepicker__day.react-datepicker__day--#{day}")
+      end
+    end)
+  end
 end


### PR DESCRIPTION
tldr: At the end of the month, two elements match the selector in the test:

![Screenshot 2024-10-29 at 14 30 40](https://github.com/user-attachments/assets/8d6b8cb6-5659-443c-9197-3fdfda3412d2)
