### PR TITLE
feat: Space Tools visible on space v2 page

### DIFF
--- a/assets/js/pages/SpaceTemporaryV2Page/index.tsx
+++ b/assets/js/pages/SpaceTemporaryV2Page/index.tsx
@@ -1,0 +1,2 @@
+export { Page } from "./page";
+export { loader } from "./loader";

--- a/assets/js/pages/SpaceTemporaryV2Page/loader.tsx
+++ b/assets/js/pages/SpaceTemporaryV2Page/loader.tsx
@@ -1,0 +1,56 @@
+import * as Pages from "@/components/Pages";
+import * as Spaces from "@/models/spaces";
+import * as Companies from "@/models/companies";
+import * as Discussions from "@/models/discussions";
+import * as Goals from "@/models/goals";
+import * as Projects from "@/models/projects";
+
+interface LoadedData {
+  company: Companies.Company;
+  space: Spaces.Space;
+  discussions: Discussions.Discussion[];
+  goals: Goals.Goal[];
+  projects: Projects.Project[];
+  loadedAt: Date;
+}
+
+export async function loader({ params }): Promise<LoadedData> {
+  const [company, space, discussions, goals, projects] = await Promise.all([
+    Companies.getCompany({ id: params.companyId }).then((d) => d.company!),
+    Spaces.getSpace({
+      id: params.id,
+      includeMembers: true,
+      includeAccessLevels: true,
+      includeUnreadNotifications: true,
+      includePermissions: true,
+    }),
+    Discussions.getDiscussions({
+      spaceId: params.id,
+      includeAuthor: true,
+      includeCommentsCount: true,
+    }).then((data) => data.discussions!),
+    Goals.getGoals({ spaceId: params.id }).then((data) => data.goals!),
+    Projects.getProjects({
+      spaceId: params.id,
+      includeLastCheckIn: true,
+      includeMilestones: true,
+    }).then((data) => data.projects!),
+  ]);
+
+  return {
+    company,
+    space,
+    discussions,
+    goals,
+    projects,
+    loadedAt: new Date(),
+  };
+}
+
+export function useLoadedData(): LoadedData {
+  return Pages.useLoadedData() as LoadedData;
+}
+
+export function useRefresh() {
+  return Pages.useRefresh();
+}

--- a/assets/js/pages/SpaceTemporaryV2Page/page.tsx
+++ b/assets/js/pages/SpaceTemporaryV2Page/page.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Icons from "@tabler/icons-react";
+import * as Spaces from "@/models/spaces";
+
+import MemberList from "../SpacePage/MemberList";
+
+import { useLoadedData, useRefresh } from "./loader";
+import { SpacePageNavigation } from "@/components/SpacePageNavigation";
+import { Feed, useItemsQuery } from "@/features/Feed";
+import { PrimaryButton } from "@/components/Buttons";
+
+import { useJoinSpace } from "@/models/spaces";
+import { PrivacyIndicator } from "@/features/spaces/PrivacyIndicator";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
+import { ToolsSection } from "@/features/SpaceTools";
+
+export function Page() {
+  const { space, discussions, goals, projects } = useLoadedData();
+
+  assertPresent(space.notifications, "notifications must be present in space");
+  useClearNotificationsOnLoad(space.notifications);
+
+  return (
+    <Pages.Page title={space.name!} testId="space-page">
+      <Paper.Root size="large">
+        <Paper.Body>
+          <SpacePageNavigation space={space} activeTab="overview" />
+          <SpaceHeader space={space} />
+          <SpaceMembers space={space} />
+          <JoinButton space={space} />
+          <ToolsSection space={space} discussions={discussions} goals={goals} projects={projects} />
+          <SpaceFooter space={space} />
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
+  );
+}
+
+function SpaceHeader({ space }: { space: Spaces.Space }) {
+  return (
+    <div className="mt-12">
+      <SpaceIcon space={space} />
+      <SpaceName space={space} />
+      <SpaceMission space={space} />
+    </div>
+  );
+}
+
+function SpaceIcon({ space }: { space: Spaces.Space }) {
+  return (
+    <div className="font-medium flex items-center gap-2 justify-center mb-2">
+      {React.createElement(Icons[space.icon!], { size: 48, className: space.color, strokeWidth: 1 })}
+    </div>
+  );
+}
+
+function SpaceName({ space }: { space: Spaces.Space }) {
+  return (
+    <div className="flex items-center gap-2 justify-center">
+      <PrivacyIndicator space={space} size={30} />
+      <div className="font-bold text-4xl text-center">{space.name}</div>
+    </div>
+  );
+}
+
+function SpaceMission({ space }: { space: Spaces.Space }) {
+  return (
+    <div className="text-center mt-1">
+      <div className="">{space.mission}</div>
+    </div>
+  );
+}
+
+function SpaceMembers({ space }: { space: Spaces.Space }) {
+  return (
+    <div className="font-medium flex items-center gap-2 w-full justify-center mt-2" data-test-id="space-members">
+      <MemberList space={space!} />
+    </div>
+  );
+}
+
+function SpaceFooter({ space }: { space: Spaces.Space }) {
+  return (
+    <Paper.DimmedSection>
+      <div className="uppercase text-xs font-semibold mb-2">Activity</div>
+      <SpaceActivity space={space} />
+    </Paper.DimmedSection>
+  );
+}
+
+function SpaceActivity({ space }: { space: Spaces.Space }) {
+  const { data, loading, error } = useItemsQuery("space", space.id!);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error</div>;
+
+  return <Feed items={data!.activities!} testId="space-feed" page="space" />;
+}
+
+function JoinButton({ space }) {
+  const refresh = useRefresh();
+  const [join] = useJoinSpace();
+
+  if (space.isMember) return null;
+
+  const handleClick = async () => {
+    await join({ spaceId: space.id });
+    refresh();
+  };
+
+  return (
+    <div className="flex justify-center mb-8 mt-6">
+      <PrimaryButton size="sm" onClick={handleClick} testId="join-space-button">
+        Join this Space
+      </PrimaryButton>
+    </div>
+  );
+}

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -86,6 +86,7 @@ import * as SpaceGoalsPage from "./SpaceGoalsPage";
 import * as SpaceListPage from "./SpaceListPage";
 import * as SpacePage from "./SpacePage";
 import * as SpaceProjectsPage from "./SpaceProjectsPage";
+import * as SpaceTemporaryV2Page from "./SpaceTemporaryV2Page";
 import * as TaskPage from "./TaskPage";
 
 //
@@ -507,6 +508,11 @@ export default {
     name: "SpaceProjectsPage",
     loader: SpaceProjectsPage.loader,
     Page: SpaceProjectsPage.Page,
+  },
+  SpaceTemporaryV2Page: {
+    name: "SpaceTemporaryV2Page",
+    loader: SpaceTemporaryV2Page.loader,
+    Page: SpaceTemporaryV2Page.Page,
   },
   TaskPage: {
     name: "TaskPage",

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -74,6 +74,7 @@ export function createAppRoutes() {
 
         pageRoute("spaces/new", pages.SpaceAddPage),
         pageRoute("spaces/:id", pages.SpacePage),
+        pageRoute("spaces/:id/v2", pages.SpaceTemporaryV2Page),
         pageRoute("spaces/:id/edit", pages.SpaceEditPage),
         pageRoute("spaces/:id/appearance", pages.SpaceAppearancePage),
         pageRoute("spaces/:id/projects/new", pages.ProjectAddPage),

--- a/assets/knip.json
+++ b/assets/knip.json
@@ -2,13 +2,7 @@
   "$schema": "https://unpkg.com/knip@2/schema.json",
   "entry": ["js/app.tsx", "build.js", "codegen.ts"],
   "project": ["js/**/*.ts", "js/**/*.tsx"],
-  "ignore": [
-    "js/gql/generated.tsx",
-    "js/api/index.tsx",
-    "js/features/SpaceTools/*.tsx",
-    "js/components/RichContent/contentOps.tsx",
-    "js/components/PieChart/index.tsx"
-  ],
+  "ignore": ["js/gql/generated.tsx", "js/api/index.tsx"],
   "ignoreDependencies": ["@types/jest"],
 
   "rules": {


### PR DESCRIPTION
This is a copy of the space page where we can see and use the new Space Tools before it's deployed to the main space page. 

To access this page, we have to add `/v2` at the end of the space page URL. 
For example:

`http://localhost:4000/my-company-0bgq/spaces/my-space-EJ1vzAGsxzIF1NWUbKNjkg` -> `http://localhost:4000/my-company-0bgq/spaces/my-space-EJ1vzAGsxzIF1NWUbKNjkg/v2`
