### PR TITLE
feat: Add status field to goal update forms

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -707,6 +707,7 @@ export interface GoalPermissions {
 
 export interface GoalProgressUpdate {
   id?: string | null;
+  status?: string | null;
   message?: string | null;
   insertedAt?: string | null;
   author?: Person | null;
@@ -1971,6 +1972,7 @@ export interface EditGoalDiscussionResult {}
 
 export interface EditGoalProgressUpdateInput {
   id?: string | null;
+  status?: string | null;
   content?: string | null;
   newTargetValues?: string | null;
 }
@@ -2153,6 +2155,7 @@ export interface PostDiscussionResult {
 }
 
 export interface PostGoalProgressUpdateInput {
+  status?: string | null;
   content?: string | null;
   goalId?: string | null;
   newTargetValues?: string | null;

--- a/assets/js/components/status/Status.tsx
+++ b/assets/js/components/status/Status.tsx
@@ -75,6 +75,8 @@ function StatusDescription({ status, reviewer }: { status: StatusOptions; review
           <span className="capitalize">{reviewerMention}</span>’s involvement is necessary.
         </>
       );
+    case "pending":
+      return <>Work on this goal hasn't started yet.</>;
 
     default:
       throw new Error(`Unknown status: ${status}`);

--- a/assets/js/components/status/constants.tsx
+++ b/assets/js/components/status/constants.tsx
@@ -4,6 +4,7 @@ export const COLORS = {
   issue: "red",
   paused: "gray",
   outdated: "gray",
+  pending: "gray",
 };
 
 export const TITLES = {
@@ -12,6 +13,7 @@ export const TITLES = {
   issue: "Issue",
   paused: "Paused",
   outdated: "Outdated",
+  pending: "Pending",
 };
 
 export const CIRCLE_BORDER_COLORS = {

--- a/assets/js/components/status/index.tsx
+++ b/assets/js/components/status/index.tsx
@@ -1,5 +1,5 @@
 export { SmallStatusIndicator } from "./SmallStatusIndicator";
 export { Status, Placeholder } from "./Status";
 
-export type StatusOptions = "on_track" | "caution" | "issue";
-export type ColorOptions = "green" | "yellow" | "red";
+export type StatusOptions = "on_track" | "caution" | "issue" | "pending";
+export type ColorOptions = "green" | "yellow" | "red" | "gray";

--- a/assets/js/features/goals/GoalCheckInForm/Form.tsx
+++ b/assets/js/features/goals/GoalCheckInForm/Form.tsx
@@ -34,6 +34,7 @@ export function Form(props: CreateProps | EditProps) {
       <Header />
 
       <Forms.FieldGroup>
+        <Status />
         <TargetInputs />
         <Description goal={goal} />
       </Forms.FieldGroup>
@@ -51,12 +52,24 @@ function Header() {
   return <div className="text-3xl font-bold mb-8">Update Progress</div>;
 }
 
+function Status() {
+  return (
+    <div className="mt-8 mb-4">
+      <Forms.SelectStatus
+        label="1. How's the goal going?"
+        field="status"
+        options={["on_track", "caution", "issue", "pending"]}
+      />
+    </div>
+  );
+}
+
 function TargetInputs() {
   const [targets] = Forms.useFieldValue<Target[]>("targets");
 
   return (
     <div>
-      <div className="font-bold mb-1">Success Conditions</div>
+      <div className="font-bold mb-1">2. Success Conditions</div>
 
       <div className="flex flex-col gap-4">
         {targets.map((target, index) => {
@@ -87,7 +100,7 @@ function Description({ goal }: { goal: Goal }) {
   return (
     <div className="mt-4">
       <Forms.RichTextArea
-        label="Describe your progress and any learnings"
+        label="3. Describe your progress and any learnings"
         field="description"
         mentionSearchScope={mentionSearchScope}
         placeholder="Write your update here..."

--- a/assets/js/features/goals/GoalCheckInForm/useForm.tsx
+++ b/assets/js/features/goals/GoalCheckInForm/useForm.tsx
@@ -20,10 +20,14 @@ export function useForm(props: CreateProps | EditProps, subscriptionsState: Subs
 
   const form = Forms.useForm({
     fields: {
+      status: mode === "create" ? "" : props.update.status,
       targets: parseTargets(goal.targets),
       description: mode === "edit" && JSON.parse(props.update.message!),
     },
     validate: (addError) => {
+      if (!form.values.status) {
+        addError("status", "Status is required");
+      }
       if (!form.values.description) {
         addError("description", "Description is required");
       }
@@ -39,6 +43,7 @@ export function useForm(props: CreateProps | EditProps, subscriptionsState: Subs
       if (mode === "create") {
         const res = await post({
           goalId: goal.id,
+          status: form.values.status,
           content: JSON.stringify(form.values.description),
           newTargetValues: JSON.stringify(form.values.targets.map((t) => ({ id: t.id, value: parseInt(t.value!) }))),
           sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
@@ -49,6 +54,7 @@ export function useForm(props: CreateProps | EditProps, subscriptionsState: Subs
       } else {
         const res = await edit({
           id: props.update.id,
+          status: form.values.status,
           content: JSON.stringify(form.values.description),
           newTargetValues: JSON.stringify(form.values.targets.map((t) => ({ id: t.id, value: parseInt(t.value!) }))),
         });

--- a/lib/operately/demo/goals.ex
+++ b/lib/operately/demo/goals.ex
@@ -62,6 +62,7 @@ defmodule Operately.Demo.Goals do
     end)
 
     {:ok, _} = Operately.Operations.GoalCheckIn.run(goal.champion, goal, %{
+      status: "on_track",
       content: Operately.Demo.RichText.from_string(data.content),
       target_values: target_values,
       subscription_parent_type: :goal_update,
@@ -81,7 +82,7 @@ defmodule Operately.Demo.Goals do
   defp create_timeframe(:current_quarter) do
     {year, month, _day} = Date.to_erl(Date.utc_today())
 
-    {start_month, end_month} = 
+    {start_month, end_month} =
       case month do
         1 -> {1, 3}
         2 -> {1, 3}

--- a/lib/operately/goals/update.ex
+++ b/lib/operately/goals/update.ex
@@ -37,7 +37,7 @@ defmodule Operately.Goals.Update do
     check_in
     |> cast(attrs, [:goal_id, :author_id, :message, :status, :acknowledged_at, :acknowledged_by_id, :subscription_list_id])
     |> cast_embed(:targets)
-    |> validate_required([:goal_id, :author_id, :message, :subscription_list_id])
+    |> validate_required([:goal_id, :author_id, :message, :status, :subscription_list_id])
   end
 
   #

--- a/lib/operately/operations/goal_check_in.ex
+++ b/lib/operately/operations/goal_check_in.ex
@@ -15,6 +15,7 @@ defmodule Operately.Operations.GoalCheckIn do
       Update.changeset(%{
         goal_id: goal.id,
         author_id: author.id,
+        status: attrs.status,
         message: attrs.content,
         targets: encoded_new_target_values,
         subscription_list_id: changes.subscription_list.id,

--- a/lib/operately/operations/goal_check_in_edit.ex
+++ b/lib/operately/operations/goal_check_in_edit.ex
@@ -9,6 +9,7 @@ defmodule Operately.Operations.GoalCheckInEdit do
     encoded_new_target_values = encode_new_target_values(attrs.new_target_values, update)
 
     changeset = Update.changeset(update, %{
+      status: attrs.status,
       message: attrs.content,
       targets: encoded_new_target_values,
     })

--- a/lib/operately_web/api/mutations/edit_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/edit_goal_progress_update.ex
@@ -7,6 +7,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdate do
 
   inputs do
     field :id, :string
+    field :status, :string
     field :content, :string
     field :new_target_values, :string
   end
@@ -41,6 +42,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdate do
 
   defp parse_inputs(inputs) do
     {:ok, %{
+      status: inputs.status,
       content: Jason.decode!(inputs.content),
       new_target_values: Jason.decode!(inputs.new_target_values),
     }}

--- a/lib/operately_web/api/mutations/post_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/post_goal_progress_update.ex
@@ -7,6 +7,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
   alias Operately.Operations.GoalCheckIn
 
   inputs do
+    field :status, :string
     field :content, :string
     field :goal_id, :string
     field :new_target_values, :string
@@ -48,6 +49,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
       goal_id: goal_id,
       target_values: Jason.decode!(inputs.new_target_values),
       content: Jason.decode!(inputs.content),
+      status: inputs.status,
       send_to_everyone: inputs[:send_notifications_to_everyone] || false,
       subscription_parent_type: :goal_update,
       subscriber_ids: subscriber_ids || []

--- a/lib/operately_web/api/serializers/goal_update.ex
+++ b/lib/operately_web/api/serializers/goal_update.ex
@@ -3,6 +3,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update  do
     %{
       id: OperatelyWeb.Paths.goal_update_id(update),
       goal: OperatelyWeb.Api.Serializer.serialize(update.goal),
+      status: Atom.to_string(update.status),
       message: Jason.encode!(update.message),
       inserted_at: OperatelyWeb.Api.Serializer.serialize(update.inserted_at),
       author: OperatelyWeb.Api.Serializer.serialize(update.author),

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1098,6 +1098,7 @@ defmodule OperatelyWeb.Api.Types do
 
   object :goal_progress_update do
     field :id, :string
+    field :status, :string
     field :message, :string
     field :inserted_at, :datetime
     field :author, :person

--- a/test/features/goal_progress_update_test.exs
+++ b/test/features/goal_progress_update_test.exs
@@ -6,7 +6,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
 
   @tag login_as: :champion
   feature "check-in on a goal", ctx do
-    params = %{message: "Checking-in on my goal", target_values: [20, 80]}
+    params = %{status: "on_track", message: "Checking-in on my goal", target_values: [20, 80]}
 
     ctx
     |> Steps.visit_page()
@@ -18,7 +18,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
 
   @tag login_as: :champion
   feature "acknowledge a progress update", ctx do
-    params = %{message: "Checking-in on my goal", target_values: [20, 80]}
+    params = %{status: "caution", message: "Checking-in on my goal", target_values: [20, 80]}
 
     ctx
     |> Steps.visit_page()
@@ -31,8 +31,8 @@ defmodule Operately.Features.GoalProgressUpdateTest do
 
   @tag login_as: :champion
   feature "edit a submitted progress update", ctx do
-    params = %{message: "Checking-in on my goal", target_values: [20, 80]}
-    edit_params = %{message: "This is an edited check-in.", target_values: [30, 70]}
+    params = %{status: "issue", message: "Checking-in on my goal", target_values: [20, 80]}
+    edit_params = %{status: "on_track", message: "This is an edited check-in.", target_values: [30, 70]}
 
     ctx
     |> Steps.visit_page()
@@ -43,7 +43,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
 
   @tag login_as: :champion
   feature "commenting on a progress update", ctx do
-    params = %{message: "Checking-in on my goal", target_values: [20, 80]}
+    params = %{status: "pending", message: "Checking-in on my goal", target_values: [20, 80]}
 
     ctx
     |> Steps.visit_page()

--- a/test/operately/data/change_028_create_subscriptions_list_for_goal_updates_test.exs
+++ b/test/operately/data/change_028_create_subscriptions_list_for_goal_updates_test.exs
@@ -43,6 +43,7 @@ defmodule Operately.Data.Change028CreateSubscriptionsListForGoalUpdatesTest do
           author_id: author.id,
           subscription_list_id: subscriptions_list.id,
           message: Operately.Support.RichText.rich_text("message"),
+          status: "on_track",
         }),
         {:ok, _} <- Notifications.update_subscription_list(subscriptions_list, %{parent_id: update.id}) do
       update

--- a/test/operately/data/change_037_add_space_to_goal_update_activities_test.exs
+++ b/test/operately/data/change_037_add_space_to_goal_update_activities_test.exs
@@ -23,6 +23,7 @@ defmodule Operately.Data.Change037AddSpaceToGoalUpdateActivitiesTest do
       updates = Enum.map(1..3, fn _ ->
         {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.creator, ctx.goal, %{
           goal_id: ctx.goal.id,
+          status: "on_track",
           target_values: [],
           content: RichText.rich_text("content"),
           send_to_everyone: false,

--- a/test/operately/operations/comment_adding_test.exs
+++ b/test/operately/operations/comment_adding_test.exs
@@ -138,6 +138,7 @@ defmodule Operately.Operations.CommentAddingTest do
 
     test "Commenting on update notifies everyone", ctx do
       {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal,%{
+        status: "on_track",
         goal_id: ctx.goal.id,
         target_values: [],
         content: RichText.rich_text("Some content"),
@@ -170,6 +171,7 @@ defmodule Operately.Operations.CommentAddingTest do
     test "Commenting on update notifies selected people", ctx do
       {:ok, update} = GoalCheckIn.run(ctx.creator, ctx.goal,%{
         goal_id: ctx.goal.id,
+        status: "on_track",
         target_values: [],
         content: RichText.rich_text("Some content"),
         send_to_everyone: false,
@@ -200,6 +202,7 @@ defmodule Operately.Operations.CommentAddingTest do
     test "Mentioned person is notified", ctx do
       {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal,%{
         goal_id: ctx.goal.id,
+        status: "on_track",
         target_values: [],
         content: RichText.rich_text("Some content"),
         send_to_everyone: false,

--- a/test/operately/operations/goal_check_in_test.exs
+++ b/test/operately/operations/goal_check_in_test.exs
@@ -34,6 +34,7 @@ defmodule Operately.Operations.GoalCheckInTest do
     {:ok, update} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
         goal_id: ctx.goal.id,
+        status: "on_track",
         target_values: [],
         content: RichText.rich_text("Some content"),
         send_to_everyone: true,
@@ -65,6 +66,7 @@ defmodule Operately.Operations.GoalCheckInTest do
     {:ok, update} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
         goal_id: ctx.goal.id,
+        status: "caution",
         target_values: [],
         content: RichText.rich_text("Some content"),
         send_to_everyone: false,
@@ -92,6 +94,7 @@ defmodule Operately.Operations.GoalCheckInTest do
 
     {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
       goal_id: ctx.goal.id,
+      status: "issue",
       target_values: [],
       content: content,
       send_to_everyone: true,
@@ -112,6 +115,7 @@ defmodule Operately.Operations.GoalCheckInTest do
 
     {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
       goal_id: ctx.goal.id,
+      status: "issue",
       target_values: [],
       content: content,
       send_to_everyone: true,

--- a/test/operately_web/api/mutations/edit_goal_progress_update_test.exs
+++ b/test/operately_web/api/mutations/edit_goal_progress_update_test.exs
@@ -84,6 +84,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdateTest do
 
       assert {200, _} = mutation(ctx.conn, :edit_goal_progress_update, %{
         id: Paths.goal_update_id(update),
+        status: "issue",
         content: RichText.rich_text("content", :as_string),
         new_target_values: Jason.encode!([]),
       })
@@ -97,6 +98,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdateTest do
 
       assert {200, _} = mutation(ctx.conn, :edit_goal_progress_update, %{
         id: Paths.goal_update_id(update),
+        status: "issue",
         content: RichText.rich_text(mentioned_people: [ctx.company_creator]),
         new_target_values: Jason.encode!([]),
       })
@@ -117,6 +119,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdateTest do
 
     mutation(conn, :edit_goal_progress_update, %{
       id: Paths.goal_update_id(update),
+      status: "on_track",
       content: RichText.rich_text("Edited content", :as_string),
       new_target_values: targets,
     })

--- a/test/operately_web/api/mutations/post_goal_progress_update_test.exs
+++ b/test/operately_web/api/mutations/post_goal_progress_update_test.exs
@@ -45,6 +45,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
 
         assert {code, res} = mutation(ctx.conn, :post_goal_progress_update, %{
           goal_id: Paths.goal_id(goal),
+          status: "on_track",
           content: RichText.rich_text("Content", :as_string),
           new_target_values: new_target_values(goal),
         })
@@ -73,6 +74,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
 
       assert {200, res} = mutation(ctx.conn, :post_goal_progress_update, %{
         goal_id: Paths.goal_id(ctx.goal),
+        status: "caution",
         content: RichText.rich_text("Content", :as_string),
         new_target_values: new_target_values(ctx.goal),
       })
@@ -98,6 +100,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
     test "creates subscription list for goal update", ctx do
       assert {200, res} = mutation(ctx.conn, :post_goal_progress_update, %{
         goal_id: Paths.goal_id(ctx.goal),
+        status: "issue",
         content: RichText.rich_text("Content", :as_string),
         new_target_values: new_target_values(ctx.goal),
         send_notifications_to_everyone: true,
@@ -125,6 +128,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
 
       assert {200, res} = mutation(ctx.conn, :post_goal_progress_update, %{
         goal_id: Paths.goal_id(ctx.goal),
+        status: "pending",
         content: content,
         new_target_values: new_target_values(ctx.goal),
         send_notifications_to_everyone: false,
@@ -146,6 +150,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
 
       assert {200, res} = mutation(ctx.conn, :post_goal_progress_update, %{
         goal_id: Paths.goal_id(ctx.goal),
+        status: "caution",
         content: content,
         new_target_values: new_target_values(ctx.goal),
         send_notifications_to_everyone: true,

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -63,6 +63,8 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     ctx
     |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
     |> UI.click(testid: "update-progress-button")
+    |> UI.click(testid: "status-dropdown")
+    |> UI.click(testid: "status-dropdown-#{params.status}")
     |> UI.fill_rich_text(params.message)
     |> UI.fill(testid: "target-first-response-time", with: to_string(Enum.at(params.target_values, 0)))
     |> UI.fill(testid: "target-increase-feedback-score-to-90-", with: to_string(Enum.at(params.target_values, 1)))
@@ -157,6 +159,8 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     ctx
     |> UI.click(testid: "options-button")
     |> UI.click(testid: "edit-update")
+    |> UI.click(testid: "status-dropdown")
+    |> UI.click(testid: "status-dropdown-#{params.status}")
     |> UI.fill_rich_text(params.message)
     |> UI.click(testid: "submit")
   end

--- a/test/support/features/review_steps.ex
+++ b/test/support/features/review_steps.ex
@@ -107,6 +107,8 @@ defmodule Operately.Support.Features.ReviewSteps do
 
     ctx
     |> UI.click(testid: test_id)
+    |> UI.click(testid: "status-dropdown")
+    |> UI.click(testid: "status-dropdown-on_track")
     |> UI.fill_rich_text("Going well")
     |> UI.click(testid: "submit")
     |> UI.assert_text("Progress Update from")

--- a/test/support/features/subscriptions_steps.ex
+++ b/test/support/features/subscriptions_steps.ex
@@ -61,6 +61,8 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
 
   step :fill_out_goal_update_form, ctx do
     ctx
+    |> UI.click(testid: "status-dropdown")
+    |> UI.click(testid: "status-dropdown-on_track")
     |> UI.fill_rich_text("Some content")
   end
 

--- a/test/support/fixtures/goals_fixtures.ex
+++ b/test/support/fixtures/goals_fixtures.ex
@@ -56,6 +56,7 @@ defmodule Operately.GoalsFixtures do
   def goal_update_fixture(author, goal, attrs \\ []) do
     attrs = Enum.into(attrs, %{
       goal_id: goal.id,
+      status: "on_track",
       target_values: [],
       content: Operately.Support.RichText.rich_text("content"),
       send_to_everyone: false,


### PR DESCRIPTION
I've added the "status" field to forms used to edit and create goal update. Now, all new goal updates will have a status.