### PR TITLE
chore: Inject an api type definition for the generated activity content

### DIFF
--- a/lib/mix/tasks/operately.gen.operation.ex
+++ b/lib/mix/tasks/operately.gen.operation.ex
@@ -15,6 +15,7 @@ defmodule Mix.Tasks.Operately.Gen.Operation do
     IO.puts("")
     IO.puts(" * Operation:            #{ctx.operation_file_path}")
     IO.puts(" * API Mutation:         #{ctx.api_mutation_file_path}")
+    IO.puts(" * API Types:            #{ctx.api_types_file_path}")
     IO.puts(" * Activity Schema:      #{ctx.activity_schema_file_path}")
     IO.puts(" * Notification Handler: #{ctx.notification_handler_file_path}")
     IO.puts(" * Email Handler:        #{ctx.email_handler_file_path}")
@@ -42,6 +43,7 @@ defmodule Mix.Tasks.Operately.Gen.Operation do
   def generate_files(ctx) do
     Mix.Tasks.Operation.GenOperationModule.gen(ctx)
     Mix.Tasks.Operation.GenApiMutation.gen(ctx)
+    Mix.Tasks.Operation.GenApiTypes.gen(ctx)
     Mix.Tasks.Operation.GenActivitySchema.gen(ctx)
     Mix.Tasks.Operation.GenNotificationHandler.gen(ctx)
     Mix.Tasks.Operation.GenEmailHandler.gen(ctx)
@@ -71,6 +73,7 @@ defmodule Mix.Tasks.Operately.Gen.Operation do
       serializer_file_path: "lib/operately_web/api/serializers/activity_content/#{resource}_#{action_gerund}.ex",
       operation_file_path: "lib/operately/operations/#{resource}_#{action_gerund}.ex",
       api_mutation_file_path: "lib/operately_web/api/mutations/#{action}_#{resource}.ex",
+      api_types_file_path: "lib/operately_web/api/types.ex",
       activity_schema_file_path: "lib/operately/activities/content/#{resource}_#{action_gerund}.ex",
       notification_handler_file_path: "lib/operately/activities/notifications/#{resource}_#{action_gerund}.ex",
       email_handler_file_path: "lib/operately_email/emails/#{resource}_#{action_gerund}_email.ex",

--- a/lib/mix/tasks/operation/gen_api_types.ex
+++ b/lib/mix/tasks/operation/gen_api_types.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Operation.GenApiTypes do
+
+  def gen(ctx) do
+    Mix.Operately.inject_into_file(
+      ctx.api_types_file_path, 
+      content(ctx), 
+      find_insertion_point(ctx))
+  end
+
+  defp content(ctx) do
+    fields = 
+      ctx.activity_fields 
+      |> Enum.map(fn {name, type} -> "field :#{name}, :#{type}" end)
+      |> Enum.join("\n")
+
+    [
+      "  object :activity_content_#{ctx.resource}_#{ctx.action_gerund} do",
+      "    #{Mix.Operately.indent(fields, 4)}",
+      "  end",
+      "",
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp find_insertion_point(ctx) do
+    ctx.api_types_file_path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.find_index(fn line -> String.contains?(line, "object :activity_content") end)
+  end
+
+end

--- a/test/mix/tasks/operately.gen.operation_test.exs
+++ b/test/mix/tasks/operately.gen.operation_test.exs
@@ -10,7 +10,10 @@ defmodule Mix.Tasks.Operately.Gen.Operation.Task do
       {
         Mix.Operately,
         [:passthrough],
-        [generate_file: fn _path, generator -> IO.puts(generator.("")) end]
+        [
+          generate_file: fn _path, generator -> IO.puts(generator.("")) end,
+          inject_into_file: fn path, content, line -> display_inject_context(path, content, line) end
+        ]
       },
       {
         IO,
@@ -24,8 +27,33 @@ defmodule Mix.Tasks.Operately.Gen.Operation.Task do
     end
   end
 
-  def gets("Enter resource name: (e.g project_milestone): "), do: "project\n"
-  def gets("Enter action name: (e.g create): "), do: "edit\n"
-  def gets(">  "), do: "company_id:string space_id:string name:string\n"
-  def gets("Continue? (y/n): "), do: "y\n"
+  defp gets("Enter resource name: (e.g project_milestone): "), do: "project\n"
+  defp gets("Enter action name: (e.g create): "), do: "edit\n"
+  defp gets(">  "), do: "company_id:string space_id:string name:string\n"
+  defp gets("Continue? (y/n): "), do: "y\n"
+
+  # A mock function. Instead of injecting into the file, we display the context
+  # in which the injection would be made. A couple of lines before and after
+  # the line where the injection would be made.
+  defp display_inject_context(path, content, line) do
+    file_content = File.read!(path) |> String.split("\n")
+
+    IO.puts("")
+    IO.puts("Injecting into #{path}")
+    IO.puts("=====================================")
+    IO.puts(Enum.at(file_content, line - 4))
+    IO.puts(Enum.at(file_content, line - 3))
+    IO.puts(Enum.at(file_content, line - 2))
+    IO.puts(Enum.at(file_content, line - 1))
+
+    IO.puts(content)
+
+    IO.puts(Enum.at(file_content, line))
+    IO.puts(Enum.at(file_content, line + 1))
+    IO.puts(Enum.at(file_content, line + 2))
+    IO.puts(Enum.at(file_content, line + 3))
+    IO.puts(Enum.at(file_content, line + 4))
+    IO.puts("=====================================")
+    IO.puts("")
+  end
 end


### PR DESCRIPTION
I was adding the company_owners_adding operation and struggled to get this right. If it is not defined in the API types, that means that it is not defined in Typescript as well, so you need to hunt it down.

---

After injection, this is what I see in tests:

![Screenshot 2024-10-30 at 17 04 23](https://github.com/user-attachments/assets/3d416154-38f2-447a-a310-400e7a4635f1)

Tagging @Rockyy174 to keep you in the loop how this works, I don't want to this to end up like "magic" code. Let me know if you have any questions or feedback how this works. 
