### PR TITLE
feat: Goal update feed item shows status

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -195,13 +195,14 @@ export interface ActivityContentGoalArchived {
 }
 
 export interface ActivityContentGoalCheckIn {
+  goalId?: string | null;
   goal?: Goal | null;
-  update?: Update | null;
+  update?: GoalProgressUpdate | null;
 }
 
 export interface ActivityContentGoalCheckInAcknowledgement {
   goal?: Goal | null;
-  update?: Update | null;
+  update?: GoalProgressUpdate | null;
 }
 
 export interface ActivityContentGoalCheckInCommented {
@@ -1055,22 +1056,6 @@ export interface Update {
   commentsCount?: number | null;
 }
 
-export interface UpdateContentGoalCheckIn {
-  message?: string | null;
-  targets?: UpdateContentGoalCheckInTarget[] | null;
-}
-
-export interface UpdateContentGoalCheckInTarget {
-  id?: string | null;
-  name?: string | null;
-  value?: number | null;
-  unit?: string | null;
-  previousValue?: number | null;
-  index?: number | null;
-  from?: number | null;
-  to?: number | null;
-}
-
 export interface UpdateContentMessage {
   message?: string | null;
 }
@@ -1235,7 +1220,6 @@ export type UpdateContent =
   | UpdateContentProjectMilestoneDeadlineChanged
   | UpdateContentProjectMilestoneDeleted
   | UpdateContentStatusUpdate
-  | UpdateContentGoalCheckIn
   | UpdateContentReview
   | UpdateContentProjectDiscussion
   | UpdateContentMessage;

--- a/assets/js/features/activities/GoalCheckIn/index.tsx
+++ b/assets/js/features/activities/GoalCheckIn/index.tsx
@@ -11,6 +11,7 @@ import { ActivityHandler } from "../interfaces";
 
 import { Link } from "@/components/Link";
 import { feedTitle, goalLink } from "../feedItemLinks";
+import { SmallStatusIndicator } from "@/components/status";
 
 const GoalCheckIn: ActivityHandler = {
   pagePath(activity: Activity): string {
@@ -39,10 +40,13 @@ const GoalCheckIn: ActivityHandler = {
   },
 
   FeedItemContent({ activity }: { activity: Activity; page: string }) {
+    const update = content(activity).update!;
+
     return (
       <div className="flex flex-col">
-        <RichContent jsonContent={content(activity).update!.message!} />
-        <ConditionChanges update={content(activity).update!} />
+        <RichContent jsonContent={update.message!} />
+        <ConditionChanges update={update} />
+        <SmallStatusIndicator status={update.status!} />
       </div>
     );
   },

--- a/assets/js/pages/GoalPage/index.tsx
+++ b/assets/js/pages/GoalPage/index.tsx
@@ -73,5 +73,5 @@ function GoalFeedItems({ goal }) {
   if (error) return <div>Error: {error.message}</div>;
   if (!data) return null;
 
-  return <Feed items={data!.activities!} page="goal" />;
+  return <Feed items={data!.activities!} page="goal" testId="goal-feed" />;
 }

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -113,20 +113,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_content("goal_check_in", content) do
-    %{
-      goal: serialize_goal(content["goal"]),
-      update: serialize_goal_check_in_update(content["update"])
-    }
-  end
-
-  def serialize_content("goal_check_in_acknowledgement", content) do
-    %{
-      goal: serialize_goal(content["goal"]),
-      update: serialize_goal_check_in_update(content["update"])
-    }
-  end
-
   def serialize_content("goal_check_in_edit", _content) do
     %{}
   end
@@ -418,20 +404,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(check_in.inserted_at),
       status: check_in.status,
       description: check_in.description
-    }
-  end
-
-  def serialize_goal_check_in_update(update) do
-    %{
-      id: OperatelyWeb.Paths.goal_update_id(update),
-      message: Jason.encode!(update.message),
-      message_type: "status_update",
-      inserted_at: OperatelyWeb.Api.Serializer.serialize(update.inserted_at),
-      comments_count: Operately.Updates.count_comments(update.id, :goal_update),
-      content: %{
-        "__typename" => "UpdateContentGoalCheckIn",
-        targets: Enum.map(update.targets, &(Map.from_struct(&1)))
-      }
     }
   end
 

--- a/lib/operately_web/api/serializers/activity_content/goal_check_in.ex
+++ b/lib/operately_web/api/serializers/activity_content/goal_check_in.ex
@@ -1,12 +1,11 @@
-defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalCheckInCommented do
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalCheckIn do
   alias OperatelyWeb.Api.Serializer
 
   def serialize(content, level: :essential) do
     %{
       goal_id: OperatelyWeb.Paths.goal_id(content["goal"]),
       goal: Serializer.serialize(content["goal"], level: :essential),
-      update: Serializer.serialize(content["goal_check_in"], level: :essential),
-      comment: Serializer.serialize(content["comment"]),
+      update: Serializer.serialize(content["update"], level: :essential),
     }
   end
 end

--- a/lib/operately_web/api/serializers/activity_content/goal_check_in_acknowledgement.ex
+++ b/lib/operately_web/api/serializers/activity_content/goal_check_in_acknowledgement.ex
@@ -1,12 +1,11 @@
-defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalCheckInCommented do
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalCheckInAcknowledgement do
   alias OperatelyWeb.Api.Serializer
 
   def serialize(content, level: :essential) do
     %{
       goal_id: OperatelyWeb.Paths.goal_id(content["goal"]),
       goal: Serializer.serialize(content["goal"], level: :essential),
-      update: Serializer.serialize(content["goal_check_in"], level: :essential),
-      comment: Serializer.serialize(content["comment"]),
+      update: Serializer.serialize(content["update"], level: :essential),
     }
   end
 end

--- a/lib/operately_web/api/serializers/goal_update.ex
+++ b/lib/operately_web/api/serializers/goal_update.ex
@@ -1,4 +1,14 @@
 defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update  do
+  def serialize(update, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.goal_update_id(update),
+      status: Atom.to_string(update.status),
+      message: Jason.encode!(update.message),
+      inserted_at: OperatelyWeb.Api.Serializer.serialize(update.inserted_at),
+      goal_target_updates: parse_targets(update.targets),
+    }
+  end
+
   def serialize(update, level: :full) do
     %{
       id: OperatelyWeb.Paths.goal_update_id(update),

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -83,7 +83,6 @@ defmodule OperatelyWeb.Api.Types do
     :update_content_project_milestone_deadline_changed,
     :update_content_project_milestone_deleted,
     :update_content_status_update,
-    :update_content_goal_check_in,
     :update_content_review,
     :update_content_project_discussion,
     :update_content_message
@@ -397,8 +396,9 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :activity_content_goal_check_in do
+    field :goal_id, :string
     field :goal, :goal
-    field :update, :update
+    field :update, :goal_progress_update
   end
 
   object :activity_content_discussion_posting do
@@ -627,7 +627,7 @@ defmodule OperatelyWeb.Api.Types do
 
   object :activity_content_goal_check_in_acknowledgement do
     field :goal, :goal
-    field :update, :update
+    field :update, :goal_progress_update
   end
 
   object :activity_content_project_archived do
@@ -854,11 +854,6 @@ defmodule OperatelyWeb.Api.Types do
     field :assignments, list_of(:assignment)
   end
 
-  object :update_content_goal_check_in do
-    field :message, :string
-    field :targets, list_of(:update_content_goal_check_in_target)
-  end
-
   object :company do
     field :id, :string
     field :name, :string
@@ -993,17 +988,6 @@ defmodule OperatelyWeb.Api.Types do
   object :activity_content_project_created do
     field :project_id, :string
     field :project, :project
-  end
-
-  object :update_content_goal_check_in_target do
-    field :id, :string
-    field :name, :string
-    field :value, :float
-    field :unit, :string
-    field :previous_value, :float
-    field :index, :integer
-    field :from, :float
-    field :to, :float
   end
 
   object :project_check_in do

--- a/test/features/goal_progress_update_test.exs
+++ b/test/features/goal_progress_update_test.exs
@@ -12,7 +12,7 @@ defmodule Operately.Features.GoalProgressUpdateTest do
     |> Steps.visit_page()
     |> Steps.update_progress(params)
     |> Steps.assert_progress_updated(params)
-    |> Steps.assert_progress_update_in_feed(params)
+    |> Steps.assert_progress_update_in_feed()
     |> Steps.assert_progress_update_in_notifications()
   end
 

--- a/test/support/features/feed_steps.ex
+++ b/test/support/features/feed_steps.ex
@@ -18,12 +18,22 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "edited the #{name} goal", "")
   end
 
-  def assert_goal_checked_in(ctx, author: author, message: message) do
-    ctx |> assert_feed_item_exists(author, "updated the progress", message)
+  def assert_goal_checked_in(ctx, author: author, texts: texts) do
+    UI.find(ctx, UI.query(testid: "goal-feed"), fn ctx ->
+      assert_feed_item_exists(ctx, author, "updated the progress", "")
+
+      Enum.reduce(texts, ctx, fn text, ctx ->
+        UI.assert_text(ctx, text)
+      end)
+    end)
   end
 
-  def assert_goal_checked_in(ctx, author: author, goal_name: goal_name, message: message) do
-    ctx |> assert_feed_item_exists(author, "updated the progress in the #{goal_name}", message)
+  def assert_goal_checked_in(ctx, author: author, goal_name: goal_name, texts: texts) do
+    ctx |> assert_feed_item_exists(author, "updated the progress in the #{goal_name}", "")
+
+    Enum.reduce(texts, ctx, fn text, ctx ->
+      UI.assert_text(ctx, text)
+    end)
   end
 
   def assert_goal_check_in_acknowledgement(ctx, author: author) do

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -82,14 +82,16 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     |> UI.assert_text("#{Enum.at(target_values, 0)} / 15")
   end
 
-  step :assert_progress_update_in_feed, ctx, attrs do
+  step :assert_progress_update_in_feed, ctx do
+    feed_texts = ["Checking-in on my goal", "First response time", "Increase feedback score to 90%", "On Track"]
+
     ctx
     |> visit_page()
-    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, message: attrs.message)
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, texts: feed_texts)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
-    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, message: attrs.message)
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, texts: feed_texts)
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, message: attrs.message)
+    |> FeedSteps.assert_goal_checked_in(author: ctx.champion, goal_name: ctx.goal.name, texts: feed_texts)
   end
 
   step :assert_progress_update_email_sent_to_reviewer, ctx do


### PR DESCRIPTION
Similarly to project check-in status, now a goal update status is also displayed in the feed:

![tmp](https://github.com/user-attachments/assets/aeefc164-333a-407e-a359-46b7176681e8)

While working on this, I realized that the changes in the targets were not being displayed in the feed. The reason why we didn't catch this before is because the activity content was referencing some old types, so TS wouldn't throw any error. 

I've updated the types and extended the feed tests, so this bug shouldn't appear again.