### PR TITLE
fix: Discussions tool doesn't squeeze title and comments count

### DIFF
--- a/assets/js/features/SpaceTools/Discussions.tsx
+++ b/assets/js/features/SpaceTools/Discussions.tsx
@@ -7,6 +7,7 @@ import { Paths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { richContentToString } from "@/components/RichContent";
 import Avatar from "@/components/Avatar";
+import classNames from "classnames";
 
 import { Title, Container } from "./components";
 
@@ -41,8 +42,16 @@ function DiscussionItem({ discussion }: { discussion: Discussion }) {
   assertPresent(discussion.author, "author must be present in discussion");
   assertPresent(discussion.commentsCount, "commentsCount must be present in discussion");
 
+  const className = classNames(
+    // 2rem is the size of <Avatar size="normal" />
+    discussion.commentsCount > 0 ? "grid-cols-[2rem_1fr_20px]" : "grid-cols-[2rem_1fr]",
+    "grid items-center gap-2",
+    "py-3 px-2",
+    "border-b border-stroke-base last:border-b-0",
+  );
+
   return (
-    <div className="flex items-center gap-2 py-3 px-2 border-b border-stroke-base last:border-b-0">
+    <div className={className}>
       <Avatar person={discussion.author} size="normal" />
       <DiscussionTitle title={discussion.title!} body={discussion.body!} />
       <CommnetsCount count={discussion.commentsCount} />


### PR DESCRIPTION
In the discussions tool, when the title was too short, the comments count was displayed right next to it. In order to fix it, I had to replace flexbox by grid.

Before:
![before](https://github.com/user-attachments/assets/f5964f51-a123-4ae5-a481-2f87dcd75586)

After:
![after](https://github.com/user-attachments/assets/cfcffbe9-1434-4af4-bdcb-dd9b91a116db)
