### PR TITLE
feat: Handle zero state in space tools

### DIFF
--- a/assets/js/features/SpaceTools/Discussions.tsx
+++ b/assets/js/features/SpaceTools/Discussions.tsx
@@ -9,7 +9,7 @@ import { richContentToString } from "@/components/RichContent";
 import Avatar from "@/components/Avatar";
 import classNames from "classnames";
 
-import { Title, Container } from "./components";
+import { Title, Container, ZeroResourcesContainer } from "./components";
 
 interface DiscussionsProps {
   space: Space;
@@ -23,9 +23,13 @@ export function Discussions({ space, discussions, toolsCount }: DiscussionsProps
   return (
     <Container path={path} toolsCount={toolsCount}>
       <Title title="Discussions" />
-      <DiscussionList discussions={discussions} />
+      {discussions.length < 1 ? <ZeroDiscussions /> : <DiscussionList discussions={discussions} />}
     </Container>
   );
+}
+
+function ZeroDiscussions() {
+  return <ZeroResourcesContainer>Post announcements, pitch ideas, and start discussions.</ZeroResourcesContainer>;
 }
 
 function DiscussionList({ discussions }: { discussions: Discussion[] }) {

--- a/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -12,7 +12,7 @@ import { SmallStatusIndicator } from "@/components/status";
 import { assertPresent } from "@/utils/assertions";
 import { Paths } from "@/routes/paths";
 
-import { Container, Title } from "./components";
+import { Container, Title, ZeroResourcesContainer } from "./components";
 import { calculateStatus } from "./utils";
 
 interface GoalsAndProjectsProps {
@@ -39,13 +39,26 @@ export function GoalsAndProjects({ space, goals, projects, toolsCount }: GoalsAn
   return (
     <Container path={path} toolsCount={toolsCount}>
       <Title title="Goals & Projects" />
-      <Goals goals={slicedGoals} />
-      <Projects projects={projects} />
+
+      {goals.length < 1 && projects.length < 1 ? (
+        <ZeroGoalsAndProjects />
+      ) : (
+        <>
+          <Goals goals={slicedGoals} />
+          <Projects projects={projects} />
+        </>
+      )}
     </Container>
   );
 }
 
+function ZeroGoalsAndProjects() {
+  return <ZeroResourcesContainer>Add a new goal or project to begin tracking your progress!</ZeroResourcesContainer>;
+}
+
 function Goals({ goals }: { goals: Goal[] }) {
+  if (goals.length < 1) return <></>;
+
   return (
     <div className="flex flex-col gap-2 px-2 py-3">
       <Header goals={goals} type="goals" />
@@ -63,7 +76,10 @@ function GoalItem({ goal }: { goal: Goal }) {
   return (
     <div className="flex items-center gap-1 overflow-hidden">
       <GoalStatusIndicator goal={goal} />
-      <ProgressBar percentage={goal.progressPercentage} className="w-[50px] h-[9px]" />
+      {/* Extra div is necessary to ensure all bars have the same size */}
+      <div>
+        <ProgressBar percentage={goal.progressPercentage} className="w-[50px] h-[9px]" />
+      </div>
       <div className="truncate">{goal.name}</div>
     </div>
   );
@@ -76,6 +92,8 @@ function GoalStatusIndicator({ goal }: { goal: Goal }) {
 }
 
 function Projects({ projects }: { projects: Project[] }) {
+  if (projects.length < 1) return <></>;
+
   return (
     <div className="flex flex-col gap-2 px-2 py-3">
       <Header projects={projects} type="projects" />

--- a/assets/js/features/SpaceTools/components.tsx
+++ b/assets/js/features/SpaceTools/components.tsx
@@ -30,3 +30,7 @@ export function Container({ children, path, toolsCount }: ContainerProps) {
     </DivLink>
   );
 }
+
+export function ZeroResourcesContainer({ children }) {
+  return <div className="text-center text-base font-semibold py-4 px-2">{children}</div>;
+}

--- a/assets/js/pages/SpaceDiscussionsPage/page.tsx
+++ b/assets/js/pages/SpaceDiscussionsPage/page.tsx
@@ -15,7 +15,7 @@ import { Paths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
-  const { space } = useLoadedData();
+  const { space, discussions } = useLoadedData();
 
   return (
     <Pages.Page title={space.name!}>
@@ -28,10 +28,19 @@ export function Page() {
               New Discussion
             </PrimaryButton>
           </div>
-          <DiscussionList />
+
+          {discussions.length < 1 ? <ZeroDiscussions /> : <DiscussionList />}
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>
+  );
+}
+
+function ZeroDiscussions() {
+  return (
+    <div className="text-center text-base font-semibold mt-28">
+      Post announcements, pitch ideas, and start discussions.
+    </div>
   );
 }
 


### PR DESCRIPTION
When a user doesn't have any goals, projects or discussions, a short message explaining the tool is shown to them:

![tmp-1](https://github.com/user-attachments/assets/7633beff-9dbc-49dc-8195-b9e664c98b20)

I've added a similar message to the discussions page:

![tmp-2](https://github.com/user-attachments/assets/99f8e734-91a5-43bd-89eb-6c7125035b73)
