### PR TITLE
feat: Show update status on goal update page

### DIFF
--- a/assets/js/pages/GoalProgressUpdatePage/page.tsx
+++ b/assets/js/pages/GoalProgressUpdatePage/page.tsx
@@ -15,12 +15,12 @@ import { AckCTA } from "./AckCTA";
 
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import Avatar from "@/components/Avatar";
-import RichContent from "@/components/RichContent";
 import { CommentSection, useForGoalCheckIn } from "@/features/CommentSection";
 import { Paths, compareIds } from "@/routes/paths";
 import { useMe } from "@/contexts/CurrentUserContext";
 import { assertPresent } from "@/utils/assertions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { DescriptionSection, StatusSection, TargetsSection } from "@/features/goals/GoalCheckIn";
 
 export function Page() {
   const me = useMe()!;
@@ -51,10 +51,10 @@ export function Page() {
           </div>
 
           <Spacer size={4} />
-          <RichContent jsonContent={update.message!} className="text-lg" />
-          <Spacer size={4} />
 
-          <Targets />
+          <StatusSection update={update} />
+          <DescriptionSection update={update} />
+          <TargetsSection update={update} />
 
           <Spacer size={4} />
           <GoalUpdateReactions />
@@ -152,58 +152,4 @@ function Options() {
       />
     </PageOptions.Root>
   );
-}
-
-function Targets() {
-  const { update } = useLoadedData();
-  const targets = update
-    .goalTargetUpdates!.map((t) => t!)
-    .slice()
-    .sort((a, b) => a.index! - b.index!);
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="text-content-accent text-xs font-medium uppercase">Success Conditions</div>
-      <div className="flex flex-col gap-2">
-        {targets.map((target) => (
-          <div key={target.id} className="flex justify-between items-center gap-2">
-            <div className="font-medium truncate">{target.name}</div>
-            <div className="h-px bg-stroke-base flex-1" />
-            <TargetChange target={target} />
-            <TargetProgress value={target.value} start={target.from} end={target.to} />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TargetProgress({ value, start, end }) {
-  const total = end - start;
-  const progress = (value - start) / total;
-  const width = 100 * progress;
-
-  return (
-    <div className="text-xs font-medium bg-gray-500 rounded px-1.5 py-0.5 text-white-1 relative w-[60px] text-right truncate">
-      <div className="absolute top-0 left-0 bottom-0 bg-accent-1 rounded" style={{ width: `${width}%` }} />
-
-      <div className="relative">
-        {value} / {end}
-      </div>
-    </div>
-  );
-}
-
-function TargetChange({ target }) {
-  const newProgress = target.value - target.from;
-  const oldProgress = target.previousValue - target.from;
-  const diff = newProgress - oldProgress;
-
-  if (newProgress > oldProgress) {
-    return <div className="text-green-600 font-bold shrink-0 text-sm">+ {Math.abs(diff)}</div>;
-  } else if (newProgress < oldProgress) {
-    return <div className="text-content-error font-bold shrink-0 test-sm">- {Math.abs(diff)}</div>;
-  } else {
-    return <div className="flex items-center gap-1 text-content-dimmed font-medium shrink-0 text-xs">No Change</div>;
-  }
 }

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -72,9 +72,10 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     |> UI.sleep(500)
   end
 
-  step :assert_progress_updated, ctx, %{message: message, target_values: target_values} do
+  step :assert_progress_updated, ctx, %{status: status, message: message, target_values: target_values} do
     ctx
     |> UI.assert_text("Progress Update from")
+    |> UI.assert_text(format_status(status))
     |> UI.assert_text(message)
     |> UI.assert_text("First response time")
     |> UI.assert_text("Increase feedback score to 90%")
@@ -170,6 +171,7 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
   step :assert_progress_update_edited, ctx, params do
     ctx
     |> UI.assert_text("Progress Update from")
+    |> UI.assert_text(format_status(params.status))
     |> UI.assert_text(params.message)
   end
 
@@ -202,5 +204,13 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
       author: ctx.reviewer,
       action: "commented on the progress update"
     })
+  end
+
+  defp format_status(status) do
+    status
+    |> String.replace("_", " ")
+    |> String.split()
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join(" ")
   end
 end


### PR DESCRIPTION
The update status is now displayed on the goal update page:

![tmp](https://github.com/user-attachments/assets/9bebc57d-4c3e-4458-aae3-4b12e0b9af49)
