### PR TITLE
feat: Remove space navigation

### DIFF
--- a/assets/js/components/SpacePageNavigation/index.tsx
+++ b/assets/js/components/SpacePageNavigation/index.tsx
@@ -15,9 +15,10 @@ import { assertPresent } from "@/utils/assertions";
 interface SpacePageNavigationProps {
   space: Spaces.Space;
   activeTab: "overview" | "discussions" | "goals" | "projects";
+  hideWhenOnOverview?: boolean;
 }
 
-export function SpacePageNavigation({ space, activeTab }: SpacePageNavigationProps) {
+export function SpacePageNavigation({ space, activeTab, hideWhenOnOverview }: SpacePageNavigationProps) {
   const { negTop, negHor } = Paper.usePaperSizeHelpers();
 
   const overviewPath = Paths.spacePath(space.id!);
@@ -30,6 +31,14 @@ export function SpacePageNavigation({ space, activeTab }: SpacePageNavigationPro
     negHor,
     negTop,
   );
+
+  if (hideWhenOnOverview && activeTab === "overview") {
+    return (
+      <div className="flex absolute right-3 top-2">
+        <Settings space={space} />
+      </div>
+    );
+  }
 
   return (
     <div className={wrapperClassName}>

--- a/assets/js/pages/SpaceTemporaryV2Page/page.tsx
+++ b/assets/js/pages/SpaceTemporaryV2Page/page.tsx
@@ -28,7 +28,7 @@ export function Page() {
     <Pages.Page title={space.name!} testId="space-page">
       <Paper.Root size="large">
         <Paper.Body>
-          <SpacePageNavigation space={space} activeTab="overview" />
+          <SpacePageNavigation space={space} activeTab="overview" hideWhenOnOverview={true} />
           <SpaceHeader space={space} />
           <SpaceMembers space={space} />
           <JoinButton space={space} />


### PR DESCRIPTION
Last time @shiroyasha and I talked about the Space Tools, it was decided that we would remove the space navigation, since we won't need it after we add the tools.

However, once I started working on it, I realized that, if we remove the navigation, when the user is on the Goals or Discussions page, they won't be able to navigate to other pages.

So, unless I'm missing something, the navigation should be removed only on the Space home page. So, I've implemented it this way, but it feels a bit weird to me when the navigation appears and disappears:

https://github.com/user-attachments/assets/f09d5574-1c36-456a-ab64-b5879b560252


Is this how it's supposed to look like? Or do you have any idea on how to improve it?
