### PR TITLE
fix: Commenting on "goal reopening" doesn't break notifications page

### DIFF
--- a/assets/js/features/activities/CommentAdded/index.tsx
+++ b/assets/js/features/activities/CommentAdded/index.tsx
@@ -8,6 +8,7 @@ import type {
   ActivityContentGoalClosing,
   ActivityContentGoalDiscussionCreation,
   ActivityContentGoalTimeframeEditing,
+  ActivityContentGoalReopening,
 } from "@/api";
 
 import { match } from "ts-pattern";
@@ -28,6 +29,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_timeframe_editing", () => Paths.goalActivityPath(commentedActivity.id!))
       .with("goal_closing", () => Paths.goalActivityPath(commentedActivity.id!))
       .with("goal_discussion_creation", () => Paths.goalActivityPath(commentedActivity.id!))
+      .with("goal_reopening", () => Paths.goalActivityPath(commentedActivity.id!))
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -85,6 +87,18 @@ const CommentAdded: ActivityHandler = {
           return feedTitle(activity, "commented on the", activityLink, "in the", goalLink(goal), "goal");
         }
       })
+      .with("goal_reopening", () => {
+        const c = commentedActivity.content as ActivityContentGoalReopening;
+        const goal = c.goal!;
+        const path = Paths.goalActivityPath(commentedActivity.id!);
+        const activityLink = <Link to={path}>goal reopening</Link>;
+
+        if (page === "goal") {
+          return feedTitle(activity, "commented on the", activityLink);
+        } else {
+          return feedTitle(activity, "commented on the", activityLink, "in the", goalLink(goal), "goal");
+        }
+      })
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -116,6 +130,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_timeframe_editing", () => "timeframe change")
       .with("goal_closing", () => "goal closing")
       .with("goal_discussion_creation", () => commentedActivity.commentThread!.title)
+      .with("goal_reopening", () => "goal reopening")
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -137,6 +152,10 @@ const CommentAdded: ActivityHandler = {
       })
       .with("goal_discussion_creation", () => {
         const c = commentedActivity.content as ActivityContentGoalDiscussionCreation;
+        return c.goal!.name!;
+      })
+      .with("goal_reopening", () => {
+        const c = commentedActivity.content as ActivityContentGoalReopening;
         return c.goal!.name!;
       })
       .otherwise(() => {

--- a/lib/operately_email/emails/comment_added_email.ex
+++ b/lib/operately_email/emails/comment_added_email.ex
@@ -51,6 +51,9 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
 
         "commented on: #{parent_comment_thread.title}"
 
+      activity.action == "goal_reopening" ->
+        "commented on goal reopening"
+
       true ->
         raise "Unsupported action: #{activity.action}"
     end
@@ -69,6 +72,9 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
         Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
 
       activity.action == "goal_discussion_creation" ->
+        Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
+
+      activity.action == "goal_reopening" ->
         Paths.goal_activity_path(company, activity, comment) |> Paths.to_url()
 
       true ->

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -359,7 +359,7 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
   def serialize_goal(nil), do: nil
   def serialize_goal(goal) do
     %{
-      id: goal.id,
+      id: Paths.goal_id(goal),
       name: goal.name,
       my_role: goal.my_role,
     }

--- a/test/features/goals_test.exs
+++ b/test/features/goals_test.exs
@@ -102,6 +102,18 @@ defmodule Operately.Features.GoalTest do
   end
 
   @tag login_as: :champion
+  feature "commenting on goal reopening", ctx do
+    ctx
+    |> Steps.visit_page()
+    |> Steps.close_goal(%{success: "yes", retrospective: "We did it!"})
+    |> Steps.reopen_goal(%{message: "It was too early to close it. Reopening."})
+    |> Steps.comment_on_the_goal_reopened()
+    |> Steps.assert_comment_on_the_goal_reopening_feed_posted()
+    |> Steps.assert_comment_on_the_goal_reopening_email_sent()
+    |> Steps.assert_comment_on_the_goal_reopening_notification_sent()
+  end
+
+  @tag login_as: :champion
   feature "editing the goal's timeframe", ctx do
     ctx
     |> Steps.visit_page()
@@ -122,5 +134,4 @@ defmodule Operately.Features.GoalTest do
     |> Steps.assert_comment_on_the_timeframe_change_email_sent()
     |> Steps.assert_comment_on_the_timeframe_change_notification_sent()
   end
-
 end

--- a/test/operately_web/api/queries/get_activities_test.exs
+++ b/test/operately_web/api/queries/get_activities_test.exs
@@ -53,7 +53,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
       assert {200, %{ activities: activities } = _res} = query(ctx.conn, :get_activities, ctx.attrs)
 
       assert length(activities) == 1
-      assert goal.id == hd(activities).content.goal.id
+      assert Paths.goal_id(goal) == hd(activities).content.goal.id
     end
 
     test "space members have no access", ctx do
@@ -80,7 +80,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
       assert {200, %{ activities: activities } = _res} = query(ctx.conn, :get_activities, ctx.attrs)
 
       assert length(activities) == 1
-      assert goal.id == hd(activities).content.goal.id
+      assert Paths.goal_id(goal) == hd(activities).content.goal.id
     end
 
     test "reviewers have access", ctx do
@@ -97,7 +97,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
       assert {200, %{ activities: activities } = _res} = query(conn, :get_activities, ctx.attrs)
 
       assert length(activities) == 1
-      assert goal.id == hd(activities).content.goal.id
+      assert Paths.goal_id(goal) == hd(activities).content.goal.id
     end
 
     test "champions have access", ctx do
@@ -114,7 +114,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivitiesTest do
       assert {200, %{ activities: activities } = _res} = query(conn, :get_activities, ctx.attrs)
 
       assert length(activities) == 1
-      assert goal.id == hd(activities).content.goal.id
+      assert Paths.goal_id(goal) == hd(activities).content.goal.id
     end
   end
 

--- a/test/operately_web/api/queries/get_activity_test.exs
+++ b/test/operately_web/api/queries/get_activity_test.exs
@@ -126,7 +126,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
 
       assert res.activity.author == Serializer.serialize(ctx.creator)
       assert res.activity.action == "goal_closing"
-      assert res.activity.content.goal.id == ctx.goal.id
+      assert res.activity.content.goal.id == Paths.goal_id(ctx.goal)
       assert res.activity.comment_thread.message == RichText.rich_text("content", :as_string)
     end
 
@@ -166,6 +166,6 @@ defmodule OperatelyWeb.Api.Queries.GetActivityTest do
 
     assert res.activity.id == Paths.activity_id(activity)
     assert res.activity.action == "goal_created"
-    assert res.activity.content.goal.id == goal.id
+    assert res.activity.content.goal.id == Paths.goal_id(goal)
   end
 end

--- a/test/support/features/goal_steps.ex
+++ b/test/support/features/goal_steps.ex
@@ -365,6 +365,43 @@ defmodule Operately.Support.Features.GoalSteps do
     |> UI.assert_page(Paths.goal_path(ctx.company, ctx.goal))
   end
 
+  step :comment_on_the_goal_reopened, ctx do
+    ctx
+    |> UI.login_as(ctx.reviewer)
+    |> NotificationsSteps.visit_notifications_page()
+    |> UI.click(testid: "notification-item-goal_reopening")
+    |> UI.click(testid: "add-comment")
+    |> UI.fill_rich_text("I think we did a great job!")
+    |> UI.click(testid: "post-comment")
+  end
+
+  step :assert_comment_on_the_goal_reopening_feed_posted, ctx do
+    ctx
+    |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    |> FeedSteps.assert_feed_item_exists(%{
+      author: ctx.reviewer,
+      title: "commented on the goal reopening",
+      subtitle: "I think we did a great job!"
+    })
+  end
+
+  step :assert_comment_on_the_goal_reopening_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.goal.name,
+      to: ctx.champion,
+      author: ctx.reviewer,
+      action: "commented on goal reopening"
+    })
+  end
+
+  step :assert_comment_on_the_goal_reopening_notification_sent, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.assert_activity_notification(%{author: ctx.reviewer, action: "commented on goal reopening"})
+  end
+
   step :assert_goal_closed, ctx, %{success: success} do
     goal = Operately.Goals.get_goal!(ctx.goal.id)
 


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1473.