### PR TITLE
feat: Show latest update/check-in on hover

### DIFF
--- a/assets/js/components/Buttons/OptionsButton.tsx
+++ b/assets/js/components/Buttons/OptionsButton.tsx
@@ -37,11 +37,12 @@ export function OptionsButton({ options, align = "center", testId }: Props) {
           sideOffset={5}
         >
           <Popover.Arrow className="fill-surface-outline scale-150" />
-          {options.map((option) => (
+          {options.map((option, idx) => (
             <div
               onClick={option.action}
               className="cursor-pointer px-4 py-2 border-b border-surface-outline hover:bg-surface-accent last:border-b-0"
               data-test-id={option.testId}
+              key={idx}
             >
               {option.label}
             </div>

--- a/assets/js/components/status/Status.tsx
+++ b/assets/js/components/status/Status.tsx
@@ -24,7 +24,9 @@ export function Status({ status, reviewer, selectable, onSelected, testId }: Sta
 
   return (
     <div className={className} onClick={onSelected} data-test-id={testId}>
-      <Circle color={color} />
+      <div>
+        <Circle color={color} />
+      </div>
 
       <div>
         <p className="font-bold">{title}</p>

--- a/assets/js/features/goals/GoalCheckIn/DescriptionSection.tsx
+++ b/assets/js/features/goals/GoalCheckIn/DescriptionSection.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 
 import { Update } from "@/models/goalCheckIns";
-import RichContent from "@/components/RichContent";
+import RichContent, { shortenContent } from "@/components/RichContent";
 
-export function DescriptionSection({ update }: { update: Update }) {
+export function DescriptionSection({ update, limit }: { update: Update; limit?: number }) {
+  const message = limit ? shortenContent(update.message!, limit, { suffix: "..." }) : update.message!;
+
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">2. What's new since the last update?</div>
 
       <div className="mt-2 border border-stroke-base rounded p-4">
-        <RichContent jsonContent={update.message!} className="text-lg" />
+        <RichContent jsonContent={message} />
       </div>
     </div>
   );

--- a/assets/js/features/goals/GoalCheckIn/TargetsSection.tsx
+++ b/assets/js/features/goals/GoalCheckIn/TargetsSection.tsx
@@ -14,7 +14,7 @@ export function TargetsSection({ update }: { update: Update }) {
       <div className="flex flex-col gap-2 mt-2 border border-stroke-base rounded-lg p-4">
         {targets.map((target) => (
           <div key={target.id} className="flex justify-between items-center gap-2">
-            <div className="font-medium truncate">{target.name}</div>
+            <div className="truncate">{target.name}</div>
             <div className="h-px bg-stroke-base flex-1" />
             <TargetChange target={target} />
             <TargetProgress value={target.value} start={target.from} end={target.to} />

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -1,31 +1,32 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo } from "react";
 
 import * as Goals from "@/models/goals";
 import * as Timeframes from "@/utils/timeframes";
 
 import classNames from "classnames";
 import { match } from "ts-pattern";
-import { IconArrowUpRight, IconCalendar, IconMinus, IconPlus } from "@tabler/icons-react";
+import { IconCalendar, IconMinus, IconPlus } from "@tabler/icons-react";
 import { includesId, Paths } from "@/routes/paths";
 import { createTestId } from "@/utils/testid";
 import { assertPresent } from "@/utils/assertions";
-import Modal from "@/components/Modal";
 import { ProgressBar } from "@/components/ProgressBar";
 import { MiniPieChart } from "@/components/MiniPieChart";
 import { SecondaryButton } from "@/components/Buttons";
 import { DivLink } from "@/components/Link";
 import Avatar from "@/components/Avatar";
-import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { DescriptionSection, StatusSection, TargetsSection } from "@/features/goals/GoalCheckIn";
 
 import { GoalNode, Node } from "../tree";
 import { useExpandable } from "../context/Expandable";
+import { Status } from "./Status";
 
 export function GoalDetails({ node }: { node: GoalNode }) {
+  const className = classNames(node.hasChildren ? "ml-[38px]" : "ml-[18px]", "mt-1");
+
   return (
-    <div className="pl-[42px]">
+    <div className={className}>
       <div className="flex gap-10 items-center">
-        <Status goal={node.goal} />
+        <GoalStatus goal={node.goal} />
         <GoalTimeframe goal={node.goal} />
         <ChampionAndSpace goal={node.goal} />
         <GoalChildrenCount node={node} />
@@ -81,47 +82,13 @@ export function GoalActions({ hovered, node }: { hovered: boolean; node: GoalNod
   );
 }
 
-function Status({ goal }: { goal: Goals.Goal }) {
-  const [showCheckIn, setShowCheckIn] = useState(false);
-  const testId = createTestId("status", goal.id!);
-
-  const toggleShowCheckIn = () => {
-    setShowCheckIn((prev) => !prev);
-  };
-
-  if (!goal.lastCheckIn) {
-    return <StatusIndicator project={goal} size="sm" textClassName="text-content-dimmed" />;
-  }
-
+function GoalStatus({ goal }: { goal: Goals.Goal }) {
   return (
-    // The 14px padding-right in the container is the same
-    // as the 14px offset in icon.
-    <div className="pr-[14px]">
-      <div onClick={toggleShowCheckIn} className="relative cursor-pointer" data-test-id={testId}>
-        <StatusIndicator project={goal} size="sm" textClassName="text-content-dimmed" />
-        <IconArrowUpRight size={12} className="absolute top-0 right-[-14px]" />
-      </div>
-
-      <LatestGoalUpdate goal={goal} showCheckIn={showCheckIn} toggleShowCheckIn={toggleShowCheckIn} />
-    </div>
-  );
-}
-
-interface LatestGoalUpdateProps {
-  goal: Goals.Goal;
-  showCheckIn: boolean;
-  toggleShowCheckIn: () => void;
-}
-
-function LatestGoalUpdate({ goal, showCheckIn, toggleShowCheckIn }: LatestGoalUpdateProps) {
-  assertPresent(goal.lastCheckIn, "lastCheckIn must be present in goal");
-
-  return (
-    <Modal title={goal.name!} hideModal={toggleShowCheckIn} isOpen={showCheckIn}>
-      <StatusSection update={goal.lastCheckIn} reviewer={goal.reviewer || undefined} />
-      <DescriptionSection update={goal.lastCheckIn} />
-      <TargetsSection update={goal.lastCheckIn} />
-    </Modal>
+    <Status resource={goal}>
+      <StatusSection update={goal.lastCheckIn!} reviewer={goal.reviewer || undefined} />
+      <DescriptionSection update={goal.lastCheckIn!} limit={120} />
+      <TargetsSection update={goal.lastCheckIn!} />
+    </Status>
   );
 }
 

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,13 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 
-import Modal from "@/components/Modal";
 import FormattedTime from "@/components/FormattedTime";
 import Avatar from "@/components/Avatar";
 
-import { IconArrowUpRight } from "@tabler/icons-react";
 import { splitByStatus } from "@/models/milestones";
 import { Project, sortContributorsByRole } from "@/models/projects";
-import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { StatusSection } from "@/features/projectCheckIns/StatusSection";
 import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
 import { MiniPieChart } from "@/components/MiniPieChart";
@@ -15,15 +12,15 @@ import { MilestoneIcon } from "@/components/MilestoneIcon";
 import { DivLink } from "@/components/Link";
 import { assertPresent } from "@/utils/assertions";
 import { truncateString } from "@/utils/strings";
-import { createTestId } from "@/utils/testid";
 import { Paths } from "@/routes/paths";
 
+import { Status } from "./Status";
 import { ProjectNode } from "../tree";
 
 export function ProjectDetails({ node }: { node: ProjectNode }) {
   return (
     <div className="pl-[20px] flex gap-10 items-center">
-      <Status project={node.project} />
+      <ProjectStatus project={node.project} />
       <MilestoneCompletion project={node.project} />
       <NextMilestone project={node.project} />
       <SpaceName project={node.project} />
@@ -32,46 +29,12 @@ export function ProjectDetails({ node }: { node: ProjectNode }) {
   );
 }
 
-function Status({ project }: { project: Project }) {
-  const [showCheckIn, setShowCheckIn] = useState(false);
-  const testId = createTestId("status", project.id!);
-
-  const toggleShowCheckIn = () => {
-    setShowCheckIn((prev) => !prev);
-  };
-
-  if (!project.lastCheckIn) {
-    return <StatusIndicator project={project} size="sm" textClassName="text-content-dimmed" />;
-  }
-
+function ProjectStatus({ project }: { project: Project }) {
   return (
-    // The 14px padding-right in the container is the same
-    // as the 14px offset in icon.
-    <div className="pr-[14px]">
-      <div onClick={toggleShowCheckIn} className="relative cursor-pointer" data-test-id={testId}>
-        <StatusIndicator project={project} size="sm" textClassName="text-content-dimmed" />
-        <IconArrowUpRight size={12} className="absolute top-0 right-[-14px]" />
-      </div>
-
-      <LatestProjectCheckIn project={project} showCheckIn={showCheckIn} toggleShowCheckIn={toggleShowCheckIn} />
-    </div>
-  );
-}
-
-interface LatestProjectCheckInProps {
-  project: Project;
-  showCheckIn: boolean;
-  toggleShowCheckIn: () => void;
-}
-
-function LatestProjectCheckIn({ project, showCheckIn, toggleShowCheckIn }: LatestProjectCheckInProps) {
-  assertPresent(project.lastCheckIn, "lastCheckIn must be present in project");
-
-  return (
-    <Modal title={project.name!} hideModal={toggleShowCheckIn} isOpen={showCheckIn}>
-      <StatusSection checkIn={project.lastCheckIn} reviewer={project.reviewer || undefined} />
-      <DescriptionSection checkIn={project.lastCheckIn} />
-    </Modal>
+    <Status resource={project}>
+      <StatusSection checkIn={project.lastCheckIn!} reviewer={project.reviewer || undefined} />
+      <DescriptionSection checkIn={project.lastCheckIn!} limit={120} />
+    </Status>
   );
 }
 

--- a/assets/js/features/goals/GoalTree/components/Status.tsx
+++ b/assets/js/features/goals/GoalTree/components/Status.tsx
@@ -1,0 +1,99 @@
+import React, { ReactNode, useRef, useState } from "react";
+
+import * as Popover from "@radix-ui/react-popover";
+
+import { Goal } from "@/models/goals";
+import { Project } from "@/models/projects";
+import { createTestId } from "@/utils/testid";
+import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
+import { IconArrowUpRight } from "@tabler/icons-react";
+
+export function Status({ resource, children }: { resource: Goal | Project; children: ReactNode }) {
+  const [clicked, setClicked] = useState(false);
+  const [hoveringTrigger, setHoveringTrigger] = useState(false);
+  const [hoveringContent, setHoveringContent] = useState(false);
+
+  const showTimeoutRef = useRef<NodeJS.Timeout>();
+  const hideTimeoutRef = useRef<NodeJS.Timeout>();
+  const testId = createTestId("status", resource.id!);
+  const open = clicked || hoveringTrigger || hoveringContent;
+
+  const handleClick = () => {
+    if (open) {
+      setClicked(false);
+      setHoveringTrigger(false);
+      setHoveringContent(false);
+    } else {
+      setClicked(true);
+    }
+  };
+
+  const handleMouseEnter = () => {
+    clearTimeout(hideTimeoutRef.current);
+    showTimeoutRef.current = setTimeout(() => {
+      setHoveringTrigger(true);
+    }, 1000);
+  };
+
+  const handleMouseLeave = () => {
+    clearTimeout(showTimeoutRef.current);
+    hideTimeoutRef.current = setTimeout(() => {
+      setHoveringTrigger(false);
+    }, 1000);
+  };
+
+  if (!resource.lastCheckIn) {
+    return <StatusIndicator project={resource} size="sm" textClassName="text-content-dimmed" />;
+  }
+
+  return (
+    <Popover.Root open={open} onOpenChange={handleClick}>
+      <Popover.Trigger asChild onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+        <div
+          className="flex items-end gap-[2px] cursor-pointer hover:underline underline-offset-4"
+          data-test-id={testId}
+        >
+          <StatusIndicator project={resource} size="sm" textClassName="text-content-dimmed" />
+          <IconArrowUpRight size={12} className="mb-1" />
+        </div>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <LatestCheckIn setHoveringContent={setHoveringContent} children={children} />
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+
+interface LatestCheckInProps {
+  setHoveringContent: React.Dispatch<React.SetStateAction<boolean>>;
+  children: ReactNode;
+}
+
+function LatestCheckIn({ setHoveringContent, children }: LatestCheckInProps) {
+  const hideTimeoutRef = useRef<NodeJS.Timeout>();
+
+  const handleMouseEnter = () => {
+    clearTimeout(hideTimeoutRef.current);
+    setHoveringContent(true);
+  };
+
+  const handleMouseLeave = () => {
+    hideTimeoutRef.current = setTimeout(() => {
+      setHoveringContent(false);
+    }, 1000);
+  };
+
+  return (
+    <Popover.Content
+      className="px-8 w-[500px] bg-surface-base rounded-lg border border-surface-outline z-[100] shadow-xl overflow-hidden"
+      align="start"
+      sideOffset={8}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Popover.Arrow className="fill-surface-outline scale-150" />
+      {children}
+    </Popover.Content>
+  );
+}

--- a/assets/js/features/projectCheckIns/DescriptionSection.tsx
+++ b/assets/js/features/projectCheckIns/DescriptionSection.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 
-import RichContent from "@/components/RichContent";
+import RichContent, { shortenContent } from "@/components/RichContent";
 import { ProjectCheckIn } from "@/models/projectCheckIns";
 
-export function DescriptionSection({ checkIn }: { checkIn: ProjectCheckIn }) {
+export function DescriptionSection({ checkIn, limit }: { checkIn: ProjectCheckIn; limit?: number }) {
+  const message = limit ? shortenContent(checkIn.description!, limit, { suffix: "..." }) : checkIn.description!;
+
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
 
       <div className="mt-2 border border-stroke-base rounded p-4">
-        <RichContent jsonContent={checkIn.description!} className="text-lg" />
+        <RichContent jsonContent={message} />
       </div>
     </div>
   );


### PR DESCRIPTION
The latest update/check-in is now displayed both when the user hovers over and clicks on the status. 

- When the user clicks on it, the popup is displayed until the user clicks outside of it. 
- When the user hovers over it for longer than a second, the popup is displayed until the user hovers outside of it for longer than a second.

https://github.com/user-attachments/assets/ce008b95-257e-4d77-9b6d-ec90b75bfdd8

Using `radix-ui/react-popover`, we got a nice popup that behaves nicely most of the time. However, it sometimes does some weird things, such as scrolling the window a little or changing the cursor from pointer to default. I spend some time trying to understand why it would sometimes behave like this, but couldn't find the reason. 

If it turns out that this behavior is not acceptable, I can spend some more time trying to fix. If there is no fix it, I can just build a popup from scratch. 