### PR TITLE
feat: Show people avatars when they are mentioned

### DIFF
--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -98,13 +98,13 @@ function initials(fullName: string): string {
 
 function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
   const baseClass = classnames(
-    "flex items-center justify-center",
     "text-white-1",
     "bg-gray-500",
     "rounded-full",
     "shrink-0",
     "tracking-wider",
     "font-semibold",
+    "block",
   );
 
   const sizeClass = SizeClasses({ size });
@@ -115,7 +115,7 @@ function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
 
   return (
     <div title={person!.fullName!} className={className} style={style}>
-      {initials(person!.fullName!)}
+      <div className="flex items-center justify-center h-full">{initials(person!.fullName!)}</div>
     </div>
   );
 }
@@ -133,27 +133,20 @@ function BackupAvatar({ person, size }: AvatarProps): JSX.Element {
 function ImageAvatar({ person, size }: AvatarProps): JSX.Element {
   if (!person) return <></>;
 
-  const baseClass = "rounded-full overflow-hidden bg-white shrink-0 border border-stroke-base";
+  const baseClass = "rounded-full overflow-hidden bg-white shrink-0 border border-stroke-base inline-block";
   const sizeClass = SizeClasses({ size });
   const className = `${baseClass} ${sizeClass}`;
 
   const style = typeof size === "number" ? { width: `${size}px`, height: "100%" } : {};
 
-  const image = React.useMemo(
-    () => (
+  return (
+    <div title={person.fullName!} className={className} style={style}>
       <img
         src={person.avatarUrl!}
         alt={person.fullName!}
         referrerPolicy="no-referrer"
-        style={{ height: "100%", width: "100%" }}
+        style={{ height: "100%", width: "100%", display: "block" }}
       />
-    ),
-    [person.avatarUrl, person.fullName],
-  );
-
-  return (
-    <div title={person.fullName!} className={className} style={style}>
-      {image}
     </div>
   );
 }


### PR DESCRIPTION
The core idea of using the `TipTap.NodeViewWrapper` for loading avatars async works. Things left tbd:

- [ ] Figure out how to properly align images and backup avatars
- [ ] Add caching for this api
- [ ] Refactor/Extract the code to not be a dumpster of mishmash ideas

![Screenshot 2024-11-04 at 18 08 24](https://github.com/user-attachments/assets/439fd5d0-6e48-4688-8d41-de98b2740c30)
