### PR TITLE
fix: Limit height of status popup on Goals page

### DIFF
--- a/assets/js/features/goals/GoalTree/components/Status.tsx
+++ b/assets/js/features/goals/GoalTree/components/Status.tsx
@@ -97,7 +97,7 @@ function LatestCheckIn({ setHoveringContent, children }: LatestCheckInProps) {
 
   return (
     <Popover.Content
-      className="px-8 w-[500px] bg-surface-base rounded-lg border border-surface-outline z-[100] shadow-xl overflow-hidden"
+      className="px-8 w-[500px] max-h-[400px] bg-surface-base rounded-lg border border-surface-outline z-[100] shadow-xl overflow-y-scroll"
       align="start"
       sideOffset={8}
       onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
When the Goals Tree is collapsed and there is no scroll on the page, if a status popup was too long, it would be outside of the viewport and there was no way to see it:
https://github.com/user-attachments/assets/494cd4e8-6e6b-491f-a0be-8317aceacf6b

I've limited the height of the popup so that is always stays within the viewport:
https://github.com/user-attachments/assets/48a9df4e-dda7-4f03-9cdd-9d3d614639cd

