### PR TITLE
feat: Add compact view option to Goals tree

### DIFF
--- a/assets/js/features/goals/GoalTree/components/Controls-v2.tsx
+++ b/assets/js/features/goals/GoalTree/components/Controls-v2.tsx
@@ -43,6 +43,8 @@ function OptionsModal({ showOptions, toggleShowOptions }) {
     setShowCompleted,
     setChampionedBy,
     setReviewedBy,
+    density,
+    setDensity,
   } = useTreeContext();
 
   const filters = useMemo(() => {
@@ -60,6 +62,7 @@ function OptionsModal({ showOptions, toggleShowOptions }) {
       filters,
       ownedBy: "anyone",
       reviewedBy: "anyone",
+      density: density,
     },
     submit: () => {
       if (form.values.filters.includes("active")) setShowActive(true);
@@ -77,14 +80,16 @@ function OptionsModal({ showOptions, toggleShowOptions }) {
       if (form.values.reviewedBy === "me") setReviewedBy(me);
       else setReviewedBy(undefined);
 
+      if (form.values.density) setDensity(form.values.density);
+
       toggleShowOptions();
     },
   });
 
   return (
-    <Modal title="View options" isOpen={showOptions} hideModal={toggleShowOptions} size="lg">
+    <Modal title="View options" isOpen={showOptions} hideModal={toggleShowOptions} size="base">
       <Forms.Form form={form}>
-        <Forms.FieldGroup layout="grid" layoutOptions={{ gridTemplateColumns: "repeat(3, auto)" }}>
+        <Forms.FieldGroup layout="grid" layoutOptions={{ gridTemplateColumns: "repeat(2, auto)" }}>
           <Forms.CheckboxInput
             field="filters"
             label="Show goals and projects:"
@@ -108,6 +113,14 @@ function OptionsModal({ showOptions, toggleShowOptions }) {
             options={[
               { label: "Anyone", value: "anyone" },
               { label: "Me", value: "me" },
+            ]}
+          />
+          <Forms.RadioButtons
+            field="density"
+            label="Density:"
+            options={[
+              { label: "Default", value: "default" },
+              { label: "Compact", value: "compact" },
             ]}
           />
         </Forms.FieldGroup>

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -18,9 +18,14 @@ import { DescriptionSection, StatusSection, TargetsSection } from "@/features/go
 
 import { GoalNode, Node } from "../tree";
 import { useExpandable } from "../context/Expandable";
+import { useTreeContext } from "../treeContext";
 import { Status } from "./Status";
 
 export function GoalDetails({ node }: { node: GoalNode }) {
+  const { density } = useTreeContext();
+
+  if (density === "compact") return <></>;
+
   return (
     <div className="pl-[2px]">
       <div className="flex gap-10 items-center">

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -13,12 +13,17 @@ import { DivLink } from "@/components/Link";
 import { assertPresent } from "@/utils/assertions";
 import { truncateString } from "@/utils/strings";
 import { Paths } from "@/routes/paths";
+import { RetrospectiveContent } from "@/features/ProjectRetrospective";
 
 import { Status } from "./Status";
 import { ProjectNode } from "../tree";
-import { RetrospectiveContent } from "@/features/ProjectRetrospective";
+import { useTreeContext } from "../treeContext";
 
 export function ProjectDetails({ node }: { node: ProjectNode }) {
+  const { density } = useTreeContext();
+
+  if (density === "compact") return <></>;
+
   return (
     <div className="pl-[2px] flex gap-10 items-center">
       <ProjectStatus project={node.project} />

--- a/assets/js/features/goals/GoalTree/treeContext.tsx
+++ b/assets/js/features/goals/GoalTree/treeContext.tsx
@@ -7,6 +7,8 @@ import { useStateWithLocalStorage } from "@/hooks/useStateWithLocalStorage";
 import { Tree, buildTree, SortColumn, SortDirection, TreeOptions } from "./tree";
 import { ExpandableProvider } from "./context/Expandable";
 
+type DensityType = "default" | "compact";
+
 interface TreeContextValue {
   tree: Tree;
 
@@ -25,6 +27,8 @@ interface TreeContextValue {
   setShowCompleted: (show: boolean) => void;
   setChampionedBy: (person?: Person) => void;
   setReviewedBy: (person?: Person) => void;
+  density: DensityType;
+  setDensity: (density: DensityType) => void;
 }
 
 const TreeContext = React.createContext<TreeContextValue | null>(null);
@@ -49,6 +53,7 @@ export function TreeContextProvider(props: TreeContextProviderPropsWithChildren)
   const [showCompleted, setShowCompleted] = useStateWithLocalStorage<boolean>("showComepleted", false);
   const [championedBy, setChampionedBy] = React.useState<Person>();
   const [reviewedBy, setReviewedBy] = React.useState<Person>();
+  const [density, setDensity] = useStateWithLocalStorage<DensityType>("density", "default");
 
   const treeOptions = {
     ...props.options,
@@ -81,6 +86,8 @@ export function TreeContextProvider(props: TreeContextProviderPropsWithChildren)
     setShowCompleted,
     setChampionedBy,
     setReviewedBy,
+    density,
+    setDensity,
   };
 
   return (

--- a/test/features/goal_tree_test.exs
+++ b/test/features/goal_tree_test.exs
@@ -179,5 +179,17 @@ defmodule Operately.Features.GoalTreeTest do
       |> Steps.assert_goal_visible(:goal_2)
       |> Steps.assert_project_visible(:project_beta)
     end
+
+    feature "default and compact view", ctx do
+      ctx
+      |> Steps.visit_goal_tree_page()
+      |> Steps.assert_all_goals_and_projects_are_visible_by_default()
+      |> Steps.assert_resources_details_visible_by_default()
+      |> Steps.select_compact_density()
+      |> Steps.assert_resources_details_hidden()
+      |> Steps.visit_goal_page(ctx.goal_1)
+      |> Steps.visit_goal_tree_page()
+      |> Steps.assert_resources_details_hidden()
+    end
   end
 end

--- a/test/support/features/goal_tree_steps.ex
+++ b/test/support/features/goal_tree_steps.ex
@@ -161,6 +161,13 @@ defmodule Operately.Support.Features.GoalTreeSteps do
     |> UI.click(testid: "submit")
   end
 
+  step :select_compact_density, ctx do
+    ctx
+    |> UI.click(testid: "view-options")
+    |> UI.click(testid: "density-compact")
+    |> UI.click(testid: "submit")
+  end
+
   step :open_status_pop_up, ctx, attrs do
     testid = cond do
       Map.has_key?(attrs, :goal) -> UI.testid(["status", Paths.goal_id(attrs.goal)])
@@ -212,6 +219,16 @@ defmodule Operately.Support.Features.GoalTreeSteps do
     |> UI.assert_text(ctx[:project_beta].name)
     |> UI.assert_text(ctx[:goal_1].name)
     |> UI.assert_text(ctx[:goal_2].name)
+  end
+
+  step :assert_resources_details_visible_by_default, ctx do
+    ctx
+    |> UI.assert_has(Query.text("On Track", count: 4))
+  end
+
+  step :assert_resources_details_hidden, ctx do
+    ctx
+    |> UI.refute_text("On Track")
   end
 
   step :assert_subgoals_and_projects_are_visible, ctx do


### PR DESCRIPTION
The user can now choose between the default and compact Goals tree view:

https://github.com/user-attachments/assets/913097fa-ff3c-41bc-bcd1-e0385acce9d2

