### PR TITLE
fix: Goals tree contributors and avatars

### DIFF
--- a/assets/js/components/Avatar/index.tsx
+++ b/assets/js/components/Avatar/index.tsx
@@ -14,6 +14,10 @@ interface AvatarProps {
   size: AvatarSize;
 }
 
+interface AvatarLinkProps extends AvatarProps {
+  className?: string;
+}
+
 function calculateSize(size: AvatarSize): number {
   if (size.constructor.name === "Number") {
     return size as number;
@@ -165,9 +169,9 @@ export default function Avatar(props: AvatarProps): JSX.Element {
   }
 }
 
-export function AvatarLink(props: AvatarProps) {
+export function AvatarLink(props: AvatarLinkProps) {
   return (
-    <DivLink to={Paths.profilePath(props.person!.id!)}>
+    <DivLink to={Paths.profilePath(props.person!.id!)} className={props.className}>
       <Avatar {...props} />
     </DivLink>
   );

--- a/assets/js/components/AvatarList/index.tsx
+++ b/assets/js/components/AvatarList/index.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import * as People from "@/models/people";
 
+import { useNavigate } from "react-router-dom";
+import { Paths } from "@/routes/paths";
+
 import Avatar, { AvatarSize } from "@/components/Avatar";
 import classNames from "classnames";
 
@@ -9,6 +12,7 @@ interface Props {
   size: AvatarSize;
 
   stacked?: boolean;
+  linked?: boolean;
   maxElements?: number;
 
   showCutOff?: boolean;
@@ -21,20 +25,30 @@ const DEFAULT_VALUES = {
 };
 
 export default function AvatarList(props: Props) {
+  const navigate = useNavigate();
   props = { ...DEFAULT_VALUES, ...props };
 
   const className = classNames("flex items-center flex-wrap", {
     "-space-x-2": props.stacked,
     "gap-1": !props.stacked,
   });
+  const avatarClassName = classNames("border border-surface-base rounded-full flex items-center", {
+    "cursor-pointer": props.linked,
+  });
 
   const isCutOff = props.maxElements && props.people.length > props.maxElements;
   const people = isCutOff ? props.people.slice(0, props.maxElements) : props.people;
 
+  const handleRedirect = (id: string) => {
+    if (!props.linked) return;
+
+    navigate(Paths.profilePath(id));
+  };
+
   return (
     <div className={className}>
       {people!.map((a) => (
-        <div className="border border-surface-base rounded-full flex items-center" key={a.id}>
+        <div className={avatarClassName} key={a.id} onClick={() => handleRedirect(a.id!)}>
           <Avatar person={a} size={props.size} />
         </div>
       ))}

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -114,7 +114,7 @@ function ChampionAndSpace({ goal }: { goal: Goals.Goal }) {
 
   return (
     <div className="flex items-center gap-1">
-      <AvatarLink person={goal.champion} size="tiny" />
+      <AvatarLink person={goal.champion} size="tiny" className="mt-[6px]" />
       <DivLink to={path} className="text-xs text-content-dimmed hover:underline underline-offset-2">
         {goal.space.name}
       </DivLink>

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
-import { AvatarLink } from "@/components/Avatar";
 
 import { splitByStatus } from "@/models/milestones";
 import { Project, sortContributorsByRole } from "@/models/projects";
@@ -14,6 +13,7 @@ import { assertPresent } from "@/utils/assertions";
 import { truncateString } from "@/utils/strings";
 import { Paths } from "@/routes/paths";
 import { RetrospectiveContent } from "@/features/ProjectRetrospective";
+import AvatarList from "@/components/AvatarList";
 
 import { Status } from "./Status";
 import { ProjectNode } from "../tree";
@@ -102,19 +102,6 @@ function ContributorsList({ project }: { project: Project }) {
   assertPresent(project.contributors, "contributors must be present in project");
 
   const sortedContributors = sortContributorsByRole(project.contributors);
-  const hiddenContribsCount = sortedContributors.length - 8;
 
-  return (
-    <div className="flex items-center gap-1">
-      {sortedContributors.slice(0, 8).map((contributor) => (
-        <AvatarLink key={contributor!.id} person={contributor!.person!} size="tiny" />
-      ))}
-
-      {hiddenContribsCount > 0 && (
-        <div className="flex items-center justify-center text-[.6rem] w-5 h-5 bg-surface-dimmed text-content-dimmed font-bold rounded-full">
-          +{hiddenContribsCount}
-        </div>
-      )}
-    </div>
-  );
+  return <AvatarList people={sortedContributors.map((c) => c.person!)} size="tiny" linked maxElements={8} />;
 }

--- a/assets/js/pages/SpaceGoalsPage/loader.tsx
+++ b/assets/js/pages/SpaceGoalsPage/loader.tsx
@@ -31,6 +31,7 @@ export async function loader({ params }): Promise<LoadedData> {
     includeMilestones: true,
     includePrivacy: true,
     includeRetrospective: true,
+    includeContributors: true,
   }).then((data) => data.projects!);
 
   return {


### PR DESCRIPTION
The list of contributors was not being displayed on the SpaceGoalsPage goals tree because the contributors were not being loaded. 

In this PR, I've also: 

- aligned the Goal Champion avatar with the Goal Space
- replaced the custom avatar list by the new `AvatarList` component
- extended the `AvatarList` component and added the `linked` option. If it's true, clicking on the avatar will redirect the user to the person's profile