### PR TITLE
fix: Fix discussions navigation

### DIFF
--- a/assets/js/pages/DiscussionPage/page.tsx
+++ b/assets/js/pages/DiscussionPage/page.tsx
@@ -100,10 +100,12 @@ function Title({ discussion }) {
 function Navigation({ space }) {
   return (
     <Paper.Navigation>
-      <Paper.NavItem linkTo={Paths.spaceDiscussionsPath(space.id)}>
+      <Paper.NavItem linkTo={Paths.spacePath(space.id)}>
         {React.createElement(Icons[space.icon], { size: 16, className: space.color })}
         {space.name}
       </Paper.NavItem>
+      <Paper.NavSeparator />
+      <Paper.NavItem linkTo={Paths.spaceDiscussionsPath(space.id)}>Discussions</Paper.NavItem>
     </Paper.Navigation>
   );
 }


### PR DESCRIPTION
While fixing the projects navigation, I noticed that the discussions navigation has similar problems.

Before:
https://github.com/user-attachments/assets/91a2eec9-3f5c-43f3-a92c-b1c5ad18ef37

Now:
https://github.com/user-attachments/assets/9f81f2ce-47b4-4cf6-aa15-731b7d8f7935