### PR TITLE
chore: Reduce top padding for space title

### DIFF
--- a/assets/js/pages/SpacePage/page.tsx
+++ b/assets/js/pages/SpacePage/page.tsx
@@ -42,7 +42,7 @@ export function Page() {
 
 function SpaceHeader({ space }: { space: Spaces.Space }) {
   return (
-    <div className="mt-12">
+    <div className="mt-2">
       <SpaceIcon space={space} />
       <SpaceName space={space} />
       <SpaceMission space={space} />


### PR DESCRIPTION
Now that we don't have the top navigation we can reduce the top margin to take up less space on smaller screens.

Before:
![Screenshot 2024-11-06 at 23 16 07](https://github.com/user-attachments/assets/f915464c-92d8-44c3-b58a-edf9b85947af)


After:

![Screenshot 2024-11-06 at 23 15 21](https://github.com/user-attachments/assets/14744db1-8b56-4f6f-a283-0a6cc1c31062)
