### PR TITLE
chore: Fix menu on space page

### DIFF
--- a/assets/js/components/PaperContainer/PageOptions.tsx
+++ b/assets/js/components/PaperContainer/PageOptions.tsx
@@ -6,9 +6,7 @@ import { TestableElement } from "@/utils/testid";
 
 type RootProps = TestableElement & {
   children: React.ReactNode;
-
   position?: "top-right";
-  noBorder?: boolean;
 };
 
 const Context = React.createContext({
@@ -36,7 +34,7 @@ export function Root(props: RootProps) {
   return (
     <Context.Provider value={{ close: closeOptions }}>
       <div className={className}>
-        <Open onClick={openOptions} noBorder={props.noBorder} testId={props.testId} position={props.position} />
+        <Open onClick={openOptions} testId={props.testId} position={props.position} />
 
         {showOptions && <Dropdown closeOptions={closeOptions} children={props.children} />}
       </div>

--- a/assets/js/components/SpacePageNavigation/index.tsx
+++ b/assets/js/components/SpacePageNavigation/index.tsx
@@ -24,21 +24,19 @@ export function SpacePageSettings({ space }: { space: Spaces.Space }) {
   if (!space.permissions.canEdit) return null;
 
   return (
-    <div className="flex absolute right-5 top-4">
-      <PageOptions.Root noBorder testId="space-settings">
-        <PageOptions.Link
-          icon={Icons.IconEdit}
-          title="Edit name and purpose"
-          to={Paths.spaceEditPath(space.id!)}
-          testId="edit-name-and-purpose"
-        />
-        <PageOptions.Link
-          icon={Icons.IconPaint}
-          title="Change Appearance"
-          to={Paths.spaceAppearancePath(space.id!)}
-          testId="change-appearance"
-        />
-      </PageOptions.Root>
-    </div>
+    <PageOptions.Root testId="space-settings" position="top-right">
+      <PageOptions.Link
+        icon={Icons.IconEdit}
+        title="Edit name and purpose"
+        to={Paths.spaceEditPath(space.id!)}
+        testId="edit-name-and-purpose"
+      />
+      <PageOptions.Link
+        icon={Icons.IconPaint}
+        title="Change Appearance"
+        to={Paths.spaceAppearancePath(space.id!)}
+        testId="change-appearance"
+      />
+    </PageOptions.Root>
   );
 }


### PR DESCRIPTION
Adjusting the menu now that we no longer have a top bar. Wider circle, and the menu behaves like in other places like projects and goals.

Before:

https://github.com/user-attachments/assets/fdf0f8bc-7ebf-4293-aca2-307a02634fc7

After:


https://github.com/user-attachments/assets/f74800fd-bbd9-4a8e-9b88-b4b70db9834d


