### PR TITLE
chore: Adjust font sizes and borders

### DIFF
--- a/assets/js/features/SpaceTools/components.tsx
+++ b/assets/js/features/SpaceTools/components.tsx
@@ -4,7 +4,7 @@ import classNames from "classnames";
 import { DivLink } from "@/components/Link";
 
 export function Title({ title }: { title: string }) {
-  return <div className="font-bold text-lg text-center py-2 border-b border-stroke-base">{title}</div>;
+  return <div className="font-bold text-base text-center py-2 border-b border-stroke-base">{title}</div>;
 }
 
 interface ContainerProps {
@@ -22,7 +22,7 @@ export function Container({ children, path, toolsCount, testId }: ContainerProps
     "h-[380px] max-w-[340px] overflow-hidden",
     `w-full md:w-[calc(50%-1rem)] ${large}`,
     "border border-stroke-base",
-    "hover:shadow transition-shadow duration-300",
+    "rounded-lg shadow transition-shadow duration-300 hover:border-surface-outline",
   );
 
   return (


### PR DESCRIPTION
A bit smaller text for the title, a bit more accented shadows.

Before:
![Screenshot 2024-11-06 at 23 42 45](https://github.com/user-attachments/assets/86ec9c1e-3052-4960-b901-9611929071b8)


After:

![Screenshot 2024-11-06 at 23 42 16](https://github.com/user-attachments/assets/7650c369-7db6-4dfa-8666-4db11ffb8cff)

Originally, I also wanted to change the aspect ratio to be more wide than tall, but after fiddling around, I started to like the more-tall-then-wide. It resembles a "paper" and when you click on it you "expand" the paper.
