### PR TITLE
chore: Small tweaks in paddings

### DIFF
--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -25,7 +25,7 @@ export function GoalDetails({ node }: { node: GoalNode }) {
   const { density } = useTreeContext();
 
   return (
-    <div className="pl-[2px]">
+    <div className="pl-6 ml-[1px]">
       {density !== "compact" && (
         <div className="flex gap-10 items-center">
           <GoalStatus goal={node.goal} />

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -25,7 +25,7 @@ export function ProjectDetails({ node }: { node: ProjectNode }) {
   if (density === "compact") return <></>;
 
   return (
-    <div className="pl-[2px] flex gap-10 items-center">
+    <div className="pl-6 ml-[2px] flex gap-10 items-center">
       <ProjectStatus project={node.project} />
       <MilestoneCompletion project={node.project} />
       <NextMilestone project={node.project} />

--- a/assets/js/features/goals/GoalTree/index.tsx
+++ b/assets/js/features/goals/GoalTree/index.tsx
@@ -51,6 +51,7 @@ function ProjectHeader({ node }: { node: ProjectNode }) {
   return (
     <HeaderContainer node={node} data-test-id={testId}>
       <div className="flex items-center gap-1">
+        <NodeExpandCollapseToggle node={node} />
         <NodeIcon node={node} />
         <NodeName node={node} />
       </div>
@@ -96,16 +97,18 @@ function NodeChildren({ node }: { node: Node }) {
 function NodeExpandCollapseToggle({ node }: { node: Node }) {
   const { expanded, toggleExpanded } = useExpandable();
 
-  if (node.children.length === 0) {
-    return <IconChevronRight size={16} className="cursor-pointer text-content-subtle" />;
-  }
-
   const resourceId = "goal" in node ? (node as GoalNode).goal.id : (node as ProjectNode).project.id;
   const testId = createTestId("toggle-node", resourceId!);
   const handleClick = () => toggleExpanded(node.id);
   const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
 
-  return <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} data-test-id={testId} />;
+  return (
+    <div className="w-5">
+      {node.hasChildren && (
+        <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} data-test-id={testId} />
+      )}
+    </div>
+  );
 }
 
 function HeaderContainer(props: { node: Node } & React.HTMLAttributes<HTMLDivElement>) {

--- a/assets/js/features/goals/GoalTree/index.tsx
+++ b/assets/js/features/goals/GoalTree/index.tsx
@@ -96,27 +96,22 @@ function NodeChildren({ node }: { node: Node }) {
 function NodeExpandCollapseToggle({ node }: { node: Node }) {
   const { expanded, toggleExpanded } = useExpandable();
 
-  if (node.children.length === 0) return <></>;
+  if (node.children.length === 0) {
+    return <IconChevronRight size={16} className="cursor-pointer text-content-subtle" />;
+  }
 
   const resourceId = "goal" in node ? (node as GoalNode).goal.id : (node as ProjectNode).project.id;
   const testId = createTestId("toggle-node", resourceId!);
   const handleClick = () => toggleExpanded(node.id);
   const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
 
-  return (
-    <ChevronIcon
-      size={16}
-      className="absolute left-[-1.2rem] top-1 cursor-pointer"
-      onClick={handleClick}
-      data-test-id={testId}
-    />
-  );
+  return <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} data-test-id={testId} />;
 }
 
-function HeaderContainer(props) {
+function HeaderContainer(props: { node: Node } & React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div className="border-t border-stroke-base py-3" {...props}>
-      <div style={{ paddingLeft: props.node.depth * 30 }}>{props.children}</div>
+      <div style={{ paddingLeft: props.node.depth * 45 }}>{props.children}</div>
     </div>
   );
 }


### PR DESCRIPTION
Before this the chevrons were "flowing out" to the margins of the page. Small tweaks to keep everything inside.

Before:
![Screenshot 2024-11-08 at 12 44 28](https://github.com/user-attachments/assets/e0afd996-530a-4ebc-90bc-d9340c441b06)

After:
![Screenshot 2024-11-08 at 12 44 41](https://github.com/user-attachments/assets/4528fda6-c0fe-4c2f-8e99-525132cbf772)

