### PR TITLE
feat: Goals page is responsive

### DIFF
--- a/assets/js/components/ProgressBar/index.tsx
+++ b/assets/js/components/ProgressBar/index.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import classNames from "classnames";
 
-export function ProgressBar({ percentage, className }: { percentage: number; className?: string }) {
-  className = classNames("w-24 h-2.5 bg-surface-outline rounded relative", className || "");
+interface Props {
+  percentage: number;
+  className?: string;
+  width?: string;
+}
+
+export function ProgressBar({ percentage, className, width }: Props) {
+  className = classNames("h-2.5 bg-surface-outline rounded relative", className || "", width || "w-24");
 
   return (
     <div className={className}>

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -86,10 +86,14 @@ export function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
 }
 
 export function GoalActions({ hovered, node }: { hovered: boolean; node: GoalNode }) {
-  const containerClasses = classNames(
-    "ml-2 flex gap-2 items-center",
-    hovered ? "opacity-100 transition-opacity duration-300" : "opacity-0",
-  );
+  const size = useWindowSizeBreakpoints();
+
+  const containerClasses = classNames("ml-2 gap-2 items-center", {
+    "opacity-0": !hovered,
+    "opacity-100 transition-opacity duration-300": hovered,
+    hidden: size === "xs",
+    flex: size !== "xs",
+  });
   const newGoalPath = Paths.goalNewPath({ parentGoalId: node.goal.id! });
   const newProjectPath = Paths.newProjectPath();
 

--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 
 import * as Goals from "@/models/goals";
 import * as Timeframes from "@/utils/timeframes";
+import { useWindowSizeBreakpoints } from "@/components/Pages";
 
 import classNames from "classnames";
 import { match } from "ts-pattern";
@@ -22,12 +23,19 @@ import { useTreeContext } from "../treeContext";
 import { Status } from "./Status";
 
 export function GoalDetails({ node }: { node: GoalNode }) {
+  const size = useWindowSizeBreakpoints();
   const { density } = useTreeContext();
+
+  const layout = match(size)
+    .with("xs", () => "grid grid-cols-[auto,1fr] gap-y-0 mt-1")
+    .otherwise(() => "flex gap-y-2");
+
+  const className = classNames("gap-x-10 items-center", layout);
 
   return (
     <div className="pl-6 ml-[1px]">
       {density !== "compact" && (
-        <div className="flex gap-10 items-center">
+        <div className={className}>
           <GoalStatus goal={node.goal} />
           <GoalTimeframe goal={node.goal} />
           <ChampionAndSpace goal={node.goal} />
@@ -43,7 +51,17 @@ export function GoalDetails({ node }: { node: GoalNode }) {
 export function GoalProgressBar({ node }: { node: GoalNode }) {
   assertPresent(node.goal.progressPercentage, "progressPercentage must be present in goal");
 
-  return <ProgressBar percentage={node.goal.progressPercentage} className="ml-2" />;
+  const size = useWindowSizeBreakpoints();
+  const width = match(size)
+    .with("xs", () => "w-16")
+    .with("sm", () => "w-16")
+    .otherwise(() => undefined);
+
+  return (
+    <div style={{ height: "10px" }}>
+      <ProgressBar percentage={node.goal.progressPercentage} className="ml-2" width={width} />
+    </div>
+  );
 }
 
 export function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
@@ -51,16 +69,18 @@ export function ExpandGoalSuccessConditions({ node }: { node: GoalNode }) {
   const testId = createTestId("toggle-goal", node.goal.id!);
 
   return (
-    <div
-      onClick={() => toggleGoalExpanded(node.goal.id!)}
-      className="ml-2 h-[20px] w-[20px] rounded-full border-2 border-surface-outline flex items-center justify-center cursor-pointer"
-      data-test-id={testId}
-    >
-      {includesId(goalExpanded, node.goal.id) ? (
-        <IconMinus size={12} stroke={3} className="border-surface-outline shrink-0" />
-      ) : (
-        <IconPlus size={12} stroke={3} className="border-surface-outline shrink-0" />
-      )}
+    <div>
+      <div
+        onClick={() => toggleGoalExpanded(node.goal.id!)}
+        className="ml-2 h-[20px] w-[20px] rounded-full border-2 border-surface-outline flex items-center justify-center cursor-pointer"
+        data-test-id={testId}
+      >
+        {includesId(goalExpanded, node.goal.id) ? (
+          <IconMinus size={12} stroke={3} className="border-surface-outline shrink-0" />
+        ) : (
+          <IconPlus size={12} stroke={3} className="border-surface-outline shrink-0" />
+        )}
+      </div>
     </div>
   );
 }

--- a/assets/js/features/goals/GoalTree/components/NodeName.tsx
+++ b/assets/js/features/goals/GoalTree/components/NodeName.tsx
@@ -12,16 +12,13 @@ interface NodeNameProps {
 }
 
 export function NodeName({ node, target = "_self" }: NodeNameProps) {
-  const titleClass = classNames({
+  const titleClass = classNames("decoration-content-subtle hover:underline truncate", {
     "font-bold": node.depth === 0,
     "font-medium": node.depth > 0,
-    "hover:underline": true,
-    "decoration-content-subtle": true,
-    truncate: true,
   });
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 truncate">
       <DivLink to={node.linkTo()} className={titleClass} target={target}>
         {node.name}
       </DivLink>

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
+import { useWindowSizeBreakpoints } from "@/components/Pages";
 
+import classNames from "classnames";
+import { match } from "ts-pattern";
 import { splitByStatus } from "@/models/milestones";
 import { Project, sortContributorsByRole } from "@/models/projects";
 import { StatusSection } from "@/features/projectCheckIns/StatusSection";
@@ -21,11 +24,20 @@ import { useTreeContext } from "../treeContext";
 
 export function ProjectDetails({ node }: { node: ProjectNode }) {
   const { density } = useTreeContext();
+  const size = useWindowSizeBreakpoints();
 
   if (density === "compact") return <></>;
 
+  const layout = match(size)
+    .with("xl", () => "flex")
+    .with("lg", () => "flex")
+    .with("md", () => "grid grid-cols-[auto,auto,1fr]")
+    .otherwise(() => "grid grid-cols-[auto,1fr]");
+
+  const className = classNames("pl-6 mt-1 ml-[2px] gap-x-10 gap-y-2 items-center", layout);
+
   return (
-    <div className="pl-6 ml-[2px] flex gap-10 items-center">
+    <div className={className}>
       <ProjectStatus project={node.project} />
       <MilestoneCompletion project={node.project} />
       <NextMilestone project={node.project} />
@@ -71,9 +83,11 @@ function MilestoneCompletion({ project }: { project: Project }) {
 }
 
 function NextMilestone({ project }: { project: Project }) {
+  const size = useWindowSizeBreakpoints();
+
   if (!project.nextMilestone) return <></>;
 
-  const name = truncateString(project.nextMilestone.title!, 40);
+  const name = truncateString(project.nextMilestone.title!, size !== "xs" ? 30 : 20);
   const path = Paths.projectMilestonePath(project.nextMilestone.id!);
 
   return (
@@ -101,7 +115,13 @@ function SpaceName({ project }: { project: Project }) {
 function ContributorsList({ project }: { project: Project }) {
   assertPresent(project.contributors, "contributors must be present in project");
 
+  const size = useWindowSizeBreakpoints();
   const sortedContributors = sortContributorsByRole(project.contributors);
 
-  return <AvatarList people={sortedContributors.map((c) => c.person!)} size="tiny" linked maxElements={8} />;
+  const maxElements = match(size)
+    .with("xl", () => 8)
+    .with("lg", () => 6)
+    .otherwise(() => 4);
+
+  return <AvatarList people={sortedContributors.map((c) => c.person!)} size="tiny" linked maxElements={maxElements} />;
 }

--- a/assets/js/features/goals/GoalTree/index.tsx
+++ b/assets/js/features/goals/GoalTree/index.tsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
 import { createTestId } from "@/utils/testid";
 
+import { match } from "ts-pattern";
+import { useWindowSizeBreakpoints } from "@/components/Pages";
 import { useTreeContext, TreeContextProvider, TreeContextProviderProps } from "./treeContext";
 import { ExpandGoalSuccessConditions, GoalActions, GoalDetails, GoalProgressBar } from "./components/GoalDetails";
 import { ProjectDetails } from "./components/ProjectDetails";
@@ -27,7 +29,7 @@ function GoalTreeRoots() {
     <div>
       <Controls />
 
-      <div className="border-b border-stroke-base">
+      <div className="border-b border-stroke-base overflow-hidden">
         {context.tree.map((root) => (
           <NodeView key={root.id} node={root} />
         ))}
@@ -112,9 +114,18 @@ function NodeExpandCollapseToggle({ node }: { node: Node }) {
 }
 
 function HeaderContainer(props: { node: Node } & React.HTMLAttributes<HTMLDivElement>) {
+  const size = useWindowSizeBreakpoints();
+
+  const padding = match(size)
+    .with("xl", () => 45)
+    .with("lg", () => 40)
+    .with("md", () => 35)
+    .with("sm", () => 30)
+    .otherwise(() => 25);
+
   return (
     <div className="border-t border-stroke-base py-3" {...props}>
-      <div style={{ paddingLeft: props.node.depth * 45 }}>{props.children}</div>
+      <div style={{ paddingLeft: props.node.depth * padding }}>{props.children}</div>
     </div>
   );
 }

--- a/assets/js/pages/GoalsAndProjectsPage/page.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/page.tsx
@@ -8,14 +8,22 @@ import { GoalTree } from "@/features/goals/GoalTree";
 import { OptionsButton } from "@/components/Buttons";
 import { Paths } from "@/routes/paths";
 import { useLoadedData } from "./loader";
+import classNames from "classnames";
 
 export function Page() {
   const { goals, projects } = useLoadedData();
+  const size = Pages.useWindowSizeBreakpoints();
+
+  const noPadding = ["xs", "sm"].includes(size);
+  const bodyClassName = classNames({
+    "p-6": size === "sm",
+    "p-4": size === "xs",
+  });
 
   return (
     <Pages.Page title="Goals & Projects">
       <Paper.Root size="xlarge">
-        <Paper.Body>
+        <Paper.Body noPadding={noPadding} className={bodyClassName}>
           <Header />
           <GoalTree goals={goals} projects={projects} options={{}} />
         </Paper.Body>


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1530.

Regarding decreasing the font-size, it didn't seem to make a big difference and, in the resource details, the font is already pretty small.

Something that still doesn't look good in my opinion is the "add sub-goal" and "create project" buttons. I'm not really sure what to do with them when we run out of space. Is it an option to hide them when the screen is in the "xs" breakpoint?

https://github.com/user-attachments/assets/9cb07b66-fc08-4c7c-aecb-eaf223724411

