### PR TITLE
fix: Move action buttons to the right on Goals page

### DIFF
--- a/assets/js/features/goals/GoalTree/index.tsx
+++ b/assets/js/features/goals/GoalTree/index.tsx
@@ -74,12 +74,14 @@ function GoalHeader({ node }: { node: GoalNode }) {
       onMouseLeave={() => setHovered(false)}
       data-test-id={testId}
     >
-      <div className="flex items-center gap-1 relative">
-        <NodeExpandCollapseToggle node={node} />
-        <NodeIcon node={node} />
-        <NodeName node={node} />
-        <GoalProgressBar node={node} />
-        <ExpandGoalSuccessConditions node={node} />
+      <div className="flex justify-between">
+        <div className="flex items-center gap-1 relative">
+          <NodeExpandCollapseToggle node={node} />
+          <NodeIcon node={node} />
+          <NodeName node={node} />
+          <GoalProgressBar node={node} />
+          <ExpandGoalSuccessConditions node={node} />
+        </div>
         <GoalActions node={node} hovered={hovered} />
       </div>
 


### PR DESCRIPTION
I've moved the action buttons to the right as suggested in https://github.com/operately/operately/issues/1527. 

https://github.com/user-attachments/assets/c1acabbe-4e95-4fb4-8e70-3006d75586c4

