### PR TITLE
feat: Add CreateResourceHubFolder operation

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -981,6 +981,17 @@ export interface Reaction {
   person?: Person | null;
 }
 
+export interface ResourceHubFolder {
+  id?: string | null;
+  name?: string | null;
+  description?: string | null;
+  permissions?: ResourceHubPermissions | null;
+}
+
+export interface ResourceHubPermissions {
+  canCreateFolder?: boolean | null;
+}
+
 export interface ReviewAssignment {
   id?: string | null;
   name?: string | null;
@@ -1914,6 +1925,17 @@ export interface CreateProjectResult {
   project?: Project | null;
 }
 
+export interface CreateResourceHubFolderInput {
+  resourceHubId?: string | null;
+  folderId?: string | null;
+  name?: string | null;
+  description?: string | null;
+}
+
+export interface CreateResourceHubFolderResult {
+  folder?: ResourceHubFolder | null;
+}
+
 export interface CreateSpaceInput {
   name?: string | null;
   mission?: string | null;
@@ -2671,6 +2693,10 @@ export class ApiClient {
     return this.post("/create_project", input);
   }
 
+  async createResourceHubFolder(input: CreateResourceHubFolderInput): Promise<CreateResourceHubFolderResult> {
+    return this.post("/create_resource_hub_folder", input);
+  }
+
   async createSpace(input: CreateSpaceInput): Promise<CreateSpaceResult> {
     return this.post("/create_space", input);
   }
@@ -3085,6 +3111,11 @@ export async function createGoalDiscussion(input: CreateGoalDiscussionInput): Pr
 }
 export async function createProject(input: CreateProjectInput): Promise<CreateProjectResult> {
   return defaultApiClient.createProject(input);
+}
+export async function createResourceHubFolder(
+  input: CreateResourceHubFolderInput,
+): Promise<CreateResourceHubFolderResult> {
+  return defaultApiClient.createResourceHubFolder(input);
 }
 export async function createSpace(input: CreateSpaceInput): Promise<CreateSpaceResult> {
   return defaultApiClient.createSpace(input);
@@ -3581,6 +3612,15 @@ export function useCreateProject(): UseMutationHookResult<CreateProjectInput, Cr
   return useMutation<CreateProjectInput, CreateProjectResult>((input) => defaultApiClient.createProject(input));
 }
 
+export function useCreateResourceHubFolder(): UseMutationHookResult<
+  CreateResourceHubFolderInput,
+  CreateResourceHubFolderResult
+> {
+  return useMutation<CreateResourceHubFolderInput, CreateResourceHubFolderResult>((input) =>
+    defaultApiClient.createResourceHubFolder(input),
+  );
+}
+
 export function useCreateSpace(): UseMutationHookResult<CreateSpaceInput, CreateSpaceResult> {
   return useMutation<CreateSpaceInput, CreateSpaceResult>((input) => defaultApiClient.createSpace(input));
 }
@@ -4043,6 +4083,8 @@ export default {
   useCreateGoalDiscussion,
   createProject,
   useCreateProject,
+  createResourceHubFolder,
+  useCreateResourceHubFolder,
   createSpace,
   useCreateSpace,
   createTask,

--- a/lib/operately/activities/content/resource_hub_folder_created.ex
+++ b/lib/operately/activities/content/resource_hub_folder_created.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Activities.Content.ResourceHubFolderCreated do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    field :company_id, :string
+    field :space_id, :string
+    field :resource_hub_id, :string
+    field :folder_id, :string
+    field :resource_name, :string
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/lib/operately/activities/notifications/resource_hub_folder_created.ex
+++ b/lib/operately/activities/notifications/resource_hub_folder_created.ex
@@ -1,0 +1,6 @@
+defmodule Operately.Activities.Notifications.ResourceHubFolderCreated do
+  def dispatch(_activity) do
+    # Notification dispatcher for ResourceHubFolderCreatednot implemented yet
+    {:ok, []}
+  end
+end

--- a/lib/operately/operations/resource_hub_folder_creating.ex
+++ b/lib/operately/operations/resource_hub_folder_creating.ex
@@ -1,0 +1,37 @@
+defmodule Operately.Operations.ResourceHubFolderCreating do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Activities
+  alias Operately.ResourceHubs.{Folder, Node}
+
+  def run(author, hub, attrs) do
+    Multi.new()
+    |> Multi.insert(:node, Node.changeset(%{
+      resource_hub_id: hub.id,
+      folder_id: attrs.folder_id,
+      name: attrs.name,
+      type: :folder,
+    }))
+    |> Multi.insert(:folder, fn changes ->
+      Folder.changeset(%{
+        node_id: changes.node.id,
+        description: attrs.description,
+      })
+    end)
+    |> Multi.run(:folder_with_node, fn _, changes ->
+      folder = Map.put(changes.folder, :node, changes.node)
+      {:ok, folder}
+    end)
+    |> Activities.insert_sync(author.id, :resource_hub_folder_created, fn changes ->
+      %{
+        company_id: author.company_id,
+        space_id: hub.space_id,
+        resource_hub_id: hub.id,
+        folder_id: changes.folder.id,
+        resource_name: attrs.name,
+      }
+    end)
+    |> Repo.transaction()
+    |> Repo.extract_result(:folder_with_node)
+  end
+end

--- a/lib/operately/resource_hubs.ex
+++ b/lib/operately/resource_hubs.ex
@@ -2,11 +2,51 @@ defmodule Operately.ResourceHubs do
   import Ecto.Query, warn: false
 
   alias Operately.Repo
-  alias Operately.ResourceHubs.ResourceHub
+  alias Operately.ResourceHubs.{ResourceHub, Folder, Node}
 
   def create_resource_hub(attrs \\ %{}) do
     %ResourceHub{}
     |> ResourceHub.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def list_folders(resource_hub = %ResourceHub{}) do
+    from(f in Folder,
+      join: n in assoc(f, :node),
+      preload: [node: n],
+      where: n.resource_hub_id == ^resource_hub.id,
+      select: f
+    )
+    |> Repo.all()
+  end
+
+  def list_folders(folder = %Folder{}) do
+    from(f in Folder,
+      join: n in assoc(f, :node),
+      preload: [node: n],
+      where: n.folder_id == ^folder.id,
+      select: f
+    )
+    |> Repo.all()
+  end
+
+  #
+  # Folders
+  #
+
+  def create_folder(attrs \\ %{}) do
+    %Folder{}
+    |> Folder.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  #
+  # Nodes
+  #
+
+  def create_node(attrs \\ %{}) do
+    %Node{}
+    |> Node.changeset(attrs)
     |> Repo.insert()
   end
 end

--- a/lib/operately/resource_hubs/folder.ex
+++ b/lib/operately/resource_hubs/folder.ex
@@ -5,6 +5,8 @@ defmodule Operately.ResourceHubs.Folder do
     belongs_to :node, Operately.ResourceHubs.Node
 
     field :description, :map
+
+    timestamps()
   end
 
   def changeset(attrs) do

--- a/lib/operately/resource_hubs/permissions.ex
+++ b/lib/operately/resource_hubs/permissions.ex
@@ -1,0 +1,23 @@
+defmodule Operately.ResourceHubs.Permissions do
+  alias Operately.Access.Binding
+
+  defstruct [
+    :can_create_folder,
+  ]
+
+  def calculate(access_level) when is_integer(access_level) do
+    %__MODULE__{
+      can_create_folder: access_level >= Binding.edit_access(),
+    }
+  end
+
+  def check(access_level, permission) do
+    permissions = calculate(access_level)
+
+    case Map.get(permissions, permission) do
+      true -> {:ok, :allowed}
+      false -> {:error, :forbidden}
+      nil -> raise "Unknown permission: #{permission}"
+    end
+  end
+end

--- a/lib/operately_web/api.ex
+++ b/lib/operately_web/api.ex
@@ -49,6 +49,7 @@ defmodule OperatelyWeb.Api do
   query :search_potential_space_members, Q.SearchPotentialSpaceMembers
   query :search_project_contributor_candidates, Q.SearchProjectContributorCandidates
 
+  mutation :create_resource_hub_folder, M.CreateResourceHubFolder
   mutation :restore_company_member, M.RestoreCompanyMember
   mutation :add_company, M.AddCompany
   mutation :add_company_admins, M.AddCompanyAdmins

--- a/lib/operately_web/api/mutations/create_resource_hub_folder.ex
+++ b/lib/operately_web/api/mutations/create_resource_hub_folder.ex
@@ -1,0 +1,68 @@
+defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolder do
+  use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
+
+  alias Operately.ResourceHubs.{ResourceHub, Permissions}
+  alias Operately.Operations.ResourceHubFolderCreating
+
+  inputs do
+    field :resource_hub_id, :string
+    field :folder_id, :string
+    field :name, :string
+    field :description, :string
+  end
+
+  outputs do
+    field :folder, :folder
+  end
+
+  def call(conn, inputs) do
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:attrs, fn -> parse_inputs(inputs) end)
+    |> run(:hub, fn ctx -> find_resource(ctx) end)
+    |> run(:permissions, fn ctx -> authorize(ctx.hub) end)
+    |> run(:operation, fn ctx -> execute(ctx) end)
+    |> run(:serialized, fn ctx -> serialize(ctx) end)
+    |> respond()
+  end
+
+  defp respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :attrs, _} -> {:error, :bad_request}
+      {:error, :hub, _} -> {:error, :not_found}
+      {:error, :permissions, _} -> {:error, :forbidden}
+      {:error, :operation, _} -> {:error, :internal_server_error}
+      _ -> {:error, :internal_server_error}
+    end
+  end
+
+  defp parse_inputs(inputs) do
+    {:ok, resource_hub_id} = decode_id(inputs.resource_hub_id)
+    {:ok, folder_id} = decode_id(inputs[:folder_id], :allow_nil)
+
+    {:ok, Map.merge(inputs, %{
+      resource_hub_id: resource_hub_id,
+      folder_id: folder_id,
+      description: Jason.decode!(inputs.description),
+    })}
+  end
+
+  defp find_resource(ctx) do
+    ResourceHub.get(ctx.me, id: ctx.attrs.resource_hub_id)
+  end
+
+  defp authorize(hub) do
+    Permissions.check(hub.request_info.access_level, :can_create_folder)
+  end
+
+  defp execute(ctx) do
+    ResourceHubFolderCreating.run(ctx.me, ctx.hub, ctx.attrs)
+  end
+
+  defp serialize(ctx) do
+    {:ok, %{folder: Serializer.serialize(ctx.operation)}}
+  end
+end

--- a/lib/operately_web/api/mutations/create_resource_hub_folder.ex
+++ b/lib/operately_web/api/mutations/create_resource_hub_folder.ex
@@ -13,7 +13,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolder do
   end
 
   outputs do
-    field :folder, :folder
+    field :folder, :resource_hub_folder
   end
 
   def call(conn, inputs) do

--- a/lib/operately_web/api/serializers/resource_hub_folder.ex
+++ b/lib/operately_web/api/serializers/resource_hub_folder.ex
@@ -1,0 +1,18 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Folder do
+  def serialize(folder, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.folder_id(folder),
+      name: folder.node.name,
+      description: folder.description && Jason.encode!(folder.description),
+    }
+  end
+
+  def serialize(folder, level: :full) do
+    %{
+      id: OperatelyWeb.Paths.folder_id(folder),
+      name: folder.node.name,
+      description: folder.description && Jason.encode!(folder.description),
+      privacy: OperatelyWeb.Api.Serializer.serialize(folder.privacy),
+    }
+  end
+end

--- a/lib/operately_web/api/serializers/resource_hub_folder.ex
+++ b/lib/operately_web/api/serializers/resource_hub_folder.ex
@@ -12,7 +12,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Folder do
       id: OperatelyWeb.Paths.folder_id(folder),
       name: folder.node.name,
       description: folder.description && Jason.encode!(folder.description),
-      privacy: OperatelyWeb.Api.Serializer.serialize(folder.privacy),
+      permissions: OperatelyWeb.Api.Serializer.serialize(folder.permissions),
     }
   end
 end

--- a/lib/operately_web/api/serializers/resource_hub_permissions.ex
+++ b/lib/operately_web/api/serializers/resource_hub_permissions.ex
@@ -1,0 +1,7 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Permissions do
+  def serialize(permissions, level: :essential) do
+    %{
+      can_create_folder: permissions.can_create_folder,
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -481,6 +481,17 @@ defmodule OperatelyWeb.Api.Types do
     field :contributor, :person
   end
 
+  object :resource_hub_permissions do
+    field :can_create_folder, :boolean
+  end
+
+  object :resource_hub_folder do
+    field :id, :string
+    field :name, :string
+    field :description, :string
+    field :permissions, :resource_hub_permissions
+  end
+
   object :project_permissions do
     field :can_view, :boolean
     field :can_create_milestone, :boolean

--- a/lib/operately_web/paths.ex
+++ b/lib/operately_web/paths.ex
@@ -247,6 +247,15 @@ defmodule OperatelyWeb.Paths do
     Operately.ShortUuid.encode!(comment.id)
   end
 
+  def resource_hub_id(resource_hub) do
+    id = Operately.ShortUuid.encode!(resource_hub.id)
+    OperatelyWeb.Api.Helpers.id_with_comments(resource_hub.name, id)
+  end
+
+  def folder_id(folder) do
+    Operately.ShortUuid.encode!(folder.id)
+  end
+
   #
   # Path Construction Helpers
   #

--- a/priv/repo/migrations/20241111124913_add_timestamps_to_resource_nodes_and_folders.exs
+++ b/priv/repo/migrations/20241111124913_add_timestamps_to_resource_nodes_and_folders.exs
@@ -1,0 +1,13 @@
+defmodule Operately.Repo.Migrations.AddTimestampsToResourceNodesAndFolders do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_nodes) do
+      timestamps()
+    end
+
+    alter table(:resource_folders) do
+      timestamps()
+    end
+  end
+end

--- a/test/operately_web/api/mutations/create_resource_hub_folder_test.exs
+++ b/test/operately_web/api/mutations/create_resource_hub_folder_test.exs
@@ -1,0 +1,63 @@
+defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolderTest do
+  use OperatelyWeb.TurboCase
+
+  alias Operately.Support.RichText
+  alias Operately.ResourceHubs
+
+  setup ctx do
+    ctx |> Factory.setup()
+  end
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, :create_resource_hub_folder, %{})
+    end
+  end
+
+  describe "permissions" do
+
+  end
+
+  describe "functionality" do
+    setup ctx do
+      ctx
+      |> Factory.add_space(:space)
+      |> Factory.add_space_member(:person, :space)
+      |> Factory.log_in_person(:person)
+      |> Factory.add_resource_hub(:hub, :space, :edit_access)
+    end
+
+    test "creates folder within hub", ctx do
+      assert ResourceHubs.list_folders(ctx.hub) == []
+
+      assert {200, res} = mutation(ctx.conn, :create_resource_hub_folder, %{
+        resource_hub_id: Paths.resource_hub_id(ctx.hub),
+        name: "My folder",
+        description: RichText.rich_text("description", :as_string)
+      })
+
+      folders = ResourceHubs.list_folders(ctx.hub)
+
+      assert length(folders) == 1
+      assert res.folder == Serializer.serialize(hd(folders))
+    end
+
+    test "creates folder within folder", ctx do
+      ctx = Factory.add_folder(ctx, :folder, :hub)
+
+      assert ResourceHubs.list_folders(ctx.folder) == []
+
+      assert {200, res} = mutation(ctx.conn, :create_resource_hub_folder, %{
+        resource_hub_id: Paths.resource_hub_id(ctx.hub),
+        folder_id: Paths.folder_id(ctx.folder),
+        name: "My folder",
+        description: RichText.rich_text("description", :as_string)
+      })
+
+      folders = ResourceHubs.list_folders(ctx.folder)
+
+      assert length(folders) == 1
+      assert res.folder == Serializer.serialize(hd(folders))
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Support.Factory do
-  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages, Goals, Comments}
+  alias Operately.Support.Factory.{Projects, Spaces, Companies, Accounts, Messages, Goals, Comments, ResourceHubs}
 
   def setup(ctx) do
     ctx = add_account(ctx, :account)
@@ -51,4 +51,8 @@ defmodule Operately.Support.Factory do
 
   # comments
   defdelegate add_comment(ctx, testid, parent_name, opts \\ []), to: Comments
+
+  # resource hubs
+  defdelegate add_resource_hub(ctx, testid, space_name, space_access_level \\ :no_access), to: ResourceHubs
+  defdelegate add_folder(ctx, testid, hub_name, folder_name \\ nil), to: ResourceHubs
 end

--- a/test/support/factory/resource_hubs.ex
+++ b/test/support/factory/resource_hubs.ex
@@ -1,0 +1,18 @@
+defmodule Operately.Support.Factory.ResourceHubs do
+  def add_resource_hub(ctx, testid, space_name, space_access_level \\ :no_access) do
+    space = Map.fetch!(ctx, space_name)
+
+    hub = Operately.ResourceHubsFixtures.resource_hub_fixture(space.id, %{space_access_level: space_access_level})
+
+    Map.put(ctx, testid, hub)
+  end
+
+  def add_folder(ctx, testid, hub_name, folder_name \\ nil) do
+    hub = Map.fetch!(ctx, hub_name)
+    folder = folder_name && Map.fetch!(ctx, folder_name)
+
+    folder = Operately.ResourceHubsFixtures.folder_fixture(hub.id, %{folder_id: folder && folder.id})
+
+    Map.put(ctx, testid, folder)
+  end
+end

--- a/test/support/fixtures/resource_hubs_fixtures.ex
+++ b/test/support/fixtures/resource_hubs_fixtures.ex
@@ -1,0 +1,40 @@
+defmodule Operately.ResourceHubsFixtures do
+  alias Operately.Support.RichText
+
+  def resource_hub_fixture(space_id, attrs \\ %{}) do
+    {:ok, hub} =
+      attrs
+      |> Enum.into(%{
+        space_id: space_id,
+        name: "Resource hub",
+        description: RichText.rich_text("This is a rosource hub")
+      })
+      |> Operately.ResourceHubs.create_resource_hub()
+
+    context = Operately.AccessFixtures.context_fixture(%{resource_hub_id: hub.id})
+    space_group = Operately.Access.get_group(group_id: space_id, tag: :standard)
+    Operately.AccessFixtures.binding_fixture(%{
+      group_id: space_group.id,
+      context_id: context.id,
+      access_level:  Operately.Access.Binding.from_atom(attrs[:space_access_level] || :no_access),
+    })
+
+    hub
+  end
+
+  def folder_fixture(hub_id, attrs \\ %{}) do
+    {:ok, node} = Operately.ResourceHubs.create_node(%{
+      resource_hub_id: hub_id,
+      folder_id: attrs[:folder_id] && attrs.folder_id,
+      name: attrs[:name] || "some name",
+      type: :folder,
+    })
+
+    {:ok, folder} = Operately.ResourceHubs.create_folder(%{
+      node_id: node.id,
+      description: attrs[:description] || RichText.rich_text("This is a rosource hub"),
+    })
+
+    folder
+  end
+end


### PR DESCRIPTION
I've added an operation for creating folders in the resource hub.

There are two things still missing:

1) I haven't tested the permissions because we don't have a way to create a resource hub with all the necessary bindings yet, which makes it very hard to set up tests. So, I decided to add these tests after I add an operation for creating resource hubs.

2) I haven't added the "resource_hub_folder_created" event to the feed, because we don't have a way to trigger this operation from the UI yet. After we have a way of triggering this operation in the UI, I will add this event to the feed and write some feature tests for it.

As this PR is already getting too big, I will handle these 2 details in upcoming PRs. I made sure to add these 2 todos as tasks in our project, so we won't forget about them.