### PR TITLE
feat: Add MessagesBoard

### DIFF
--- a/lib/operately/data/change_042_populate_messages_board_id_field_in_messages.ex
+++ b/lib/operately/data/change_042_populate_messages_board_id_field_in_messages.ex
@@ -1,0 +1,29 @@
+defmodule Operately.Data.Change042PopulateMessagesBoardIdFieldInMessages do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  def run do
+    Repo.transaction(fn ->
+      from(s in Operately.Groups.Group, select: s.id)
+      |> Repo.all()
+      |> create_boards()
+    end)
+  end
+
+  defp create_boards(space_ids) when is_list(space_ids) do
+    Enum.each(space_ids, &(create_boards(&1)))
+  end
+
+  defp create_boards(space_id) do
+    {:ok, board_id} = Ecto.UUID.dump(Ecto.UUID.generate())
+    {:ok, space_id} = Ecto.UUID.dump(space_id)
+
+    {1, nil} = Repo.insert_all("messages_boards", [[id: board_id, space_id: space_id, name: "Messages Board", inserted_at: DateTime.utc_now(), updated_at: DateTime.utc_now()]])
+
+    from(m in "messages", where: m.space_id == ^space_id and is_nil(m.messages_board_id))
+    |> Repo.update_all(set: [
+      messages_board_id: board_id,
+    ])
+  end
+end

--- a/lib/operately/demo/discussions.ex
+++ b/lib/operately/demo/discussions.ex
@@ -14,8 +14,10 @@ defmodule Operately.Demo.Discussions do
   defp create_discussion(resources, data) do
     author = Resources.get(resources, data.author)
     space = Resources.get(resources, data.space)
+    board = Operately.Messages.get_messages_board(space_id: space.id)
 
     {:ok, discussion} = DiscussionPosting.run(author, space, %{
+      messages_board_id: board.id,
       title: data.title,
       content: from_markdown(data.content),
       post_as_draft: false,
@@ -55,7 +57,7 @@ defmodule Operately.Demo.Discussions do
   end
 
   defp parse_bullet_list(block) do
-    items = 
+    items =
       block
       |> String.split("\n", trim: true)
       |> Enum.map(&parse_bullet_item/1)

--- a/lib/operately/groups/insert_group.ex
+++ b/lib/operately/groups/insert_group.ex
@@ -6,10 +6,10 @@ defmodule Operately.Groups.InsertGroup do
   def insert(multi, attrs) do
     multi
     |> insert_group(attrs)
-    |> insert_group_context()
-    |> insert_members_access_group()
-    |> insert_managers_access_group()
+    |> insert_context()
+    |> insert_access_groups()
     |> insert_bindings(attrs)
+    |> insert_default_messages_board()
   end
 
   defp insert_group(multi, attrs) do
@@ -21,7 +21,7 @@ defmodule Operately.Groups.InsertGroup do
     end)
   end
 
-  defp insert_group_context(multi) do
+  defp insert_context(multi) do
     multi
     |> Multi.insert(:context, fn changes ->
       Access.Context.changeset(%{
@@ -30,15 +30,11 @@ defmodule Operately.Groups.InsertGroup do
     end)
   end
 
-  defp insert_members_access_group(multi) do
+  defp insert_access_groups(multi) do
     multi
     |> Multi.insert(:space_members_access_group, fn %{group: group} ->
       Access.Group.changeset(%{group_id: group.id, tag: :standard})
     end)
-  end
-
-  defp insert_managers_access_group(multi) do
-    multi
     |> Multi.insert(:space_managers_access_group, fn %{group: group} ->
       Access.Group.changeset(%{group_id: group.id, tag: :full_access})
     end)
@@ -64,6 +60,16 @@ defmodule Operately.Groups.InsertGroup do
       else
         {:ok, nil}
       end
+    end)
+  end
+
+  defp insert_default_messages_board(multi) do
+    multi
+    |> Multi.insert(:messages_board, fn changes ->
+      Operately.Messages.MessagesBoard.changeset(%{
+        space_id: changes.group.id,
+        name: "Messages Board",
+      })
     end)
   end
 end

--- a/lib/operately/messages.ex
+++ b/lib/operately/messages.ex
@@ -5,7 +5,7 @@ defmodule Operately.Messages do
   alias Operately.Messages.Message
 
   def list_messages(space_id) do
-    from(m in Message, where: m.space_id == ^space_id)
+    from(m in Message, join: s in assoc(m, :space), where: s.id == ^space_id)
     |> Repo.all()
   end
 
@@ -19,5 +19,16 @@ defmodule Operately.Messages do
     message
     |> Message.changeset(attrs)
     |> Repo.update()
+  end
+
+  alias Operately.Messages.MessagesBoard
+
+  def get_messages_board(attrs) when is_list(attrs), do: Repo.get_by(MessagesBoard, attrs)
+  def get_messages_board!(attrs) when is_list(attrs), do: Repo.get_by!(MessagesBoard, attrs)
+
+  def create_messages_board(attrs) do
+    %MessagesBoard{}
+    |> MessagesBoard.changeset(attrs)
+    |> Repo.insert()
   end
 end

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -5,11 +5,12 @@ defmodule Operately.Messages.Message do
   alias Operately.Notifications
 
   schema "messages" do
-    belongs_to :space, Operately.Groups.Group
-    belongs_to :author, Operately.People.Person
+    belongs_to :author, Operately.People.Person, foreign_key: :author_id
+    belongs_to :messages_board, Operately.Messages.MessagesBoard, foreign_key: :messages_board_id
     belongs_to :subscription_list, Notifications.SubscriptionList, foreign_key: :subscription_list_id
 
-    has_one :access_context, through: [:space, :access_context]
+    has_one :space, through: [:messages_board, :space]
+    has_one :access_context, through: [:messages_board, :space, :access_context]
     has_many :reactions, Operately.Updates.Reaction, where: [entity_type: :message], foreign_key: :entity_id
     has_many :comments, Operately.Updates.Comment, where: [entity_type: :message], foreign_key: :entity_id
 
@@ -34,8 +35,8 @@ defmodule Operately.Messages.Message do
 
   def changeset(update, attrs) do
     update
-    |> cast(attrs, [:space_id, :author_id, :title, :body, :subscription_list_id, :state])
-    |> validate_required([:space_id, :author_id, :title, :body, :subscription_list_id, :state])
+    |> cast(attrs, [:messages_board_id, :author_id, :title, :body, :subscription_list_id, :state])
+    |> validate_required([:messages_board_id, :author_id, :title, :body, :subscription_list_id, :state])
   end
 
   #

--- a/lib/operately/messages/messages_board.ex
+++ b/lib/operately/messages/messages_board.ex
@@ -1,0 +1,24 @@
+defmodule Operately.Messages.MessagesBoard do
+  use Operately.Schema
+
+  schema "messages_boards" do
+    belongs_to :space, Operately.Groups.Group, foreign_key: :space_id
+
+    field :name, :string
+    field :description, :map
+
+    has_many :messages, Operately.Messages.Message, foreign_key: :messages_board_id
+
+    timestamps()
+  end
+
+  def changeset(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(update, attrs) do
+    update
+    |> cast(attrs, [:space_id, :name, :description])
+    |> validate_required([:space_id, :name])
+  end
+end

--- a/lib/operately/operations/comment_adding/activity.ex
+++ b/lib/operately/operations/comment_adding/activity.ex
@@ -5,7 +5,7 @@ defmodule Operately.Operations.CommentAdding.Activity do
     Activities.insert_sync(multi, creator.id, action, fn changes ->
       %{
         company_id: creator.company_id,
-        space_id: entity.space_id,
+        space_id: entity.space.id,
         discussion_id: entity.id,
         comment_id: changes.comment.id
       }

--- a/lib/operately/operations/discussion_editing.ex
+++ b/lib/operately/operations/discussion_editing.ex
@@ -16,7 +16,7 @@ defmodule Operately.Operations.DiscussionEditing do
     |> Operately.Operations.Notifications.Subscription.update_mentioned_people(attrs.body)
     |> Activities.insert_sync(creator.id, :discussion_editing, fn _ -> %{
       company_id: creator.company_id,
-      space_id: message.space_id,
+      space_id: message.space.id,
       discussion_id: message.id,
     } end)
     |> Repo.transaction()

--- a/lib/operately/operations/discussion_posting.ex
+++ b/lib/operately/operations/discussion_posting.ex
@@ -11,7 +11,7 @@ defmodule Operately.Operations.DiscussionPosting do
     |> Multi.insert(:message, fn changes ->
       Operately.Messages.Message.changeset(%{
         author_id: creator.id,
-        space_id: space.id,
+        messages_board_id: attrs.messages_board_id,
         title: attrs.title,
         body: attrs.content,
         state: state(attrs),

--- a/lib/operately/operations/discussion_publishing.ex
+++ b/lib/operately/operations/discussion_publishing.ex
@@ -9,7 +9,7 @@ defmodule Operately.Operations.DiscussionPublishing do
     |> Multi.update(:message, Message.changeset(discussion, %{state: :published}))
     |> Activities.insert_sync(creator.id, :discussion_posting, fn _changes -> %{
       company_id: creator.company_id,
-      space_id: discussion.space_id,
+      space_id: discussion.space.id,
       discussion_id: discussion.id,
       title: discussion.title,
     } end)

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -56,7 +56,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
       :project_retrospective -> Retrospective.get(person, id: id, opts: [preload: :project])
       :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person.id)
       :goal_update -> Update.get(person, id: id, opts: [preload: :goal])
-      :message -> Message.get(person, id: id)
+      :message -> Message.get(person, id: id, opts: [preload: :space])
     end
   end
 

--- a/lib/operately_web/api/mutations/edit_discussion.ex
+++ b/lib/operately_web/api/mutations/edit_discussion.ex
@@ -20,7 +20,7 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussion do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
     |> run(:attrs, fn -> parse_inputs(inputs) end)
-    |> run(:message, fn ctx -> Message.get(ctx.me, id: ctx.attrs.id) end)
+    |> run(:message, fn ctx -> Message.get(ctx.me, id: ctx.attrs.id, opts: [preload: :space]) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.message.request_info.access_level, :can_edit_discussions) end)
     |> run(:operation, fn ctx -> DiscussionEditing.run(ctx.me, ctx.message, ctx.attrs) end)
     |> run(:serialized, fn ctx -> {:ok, %{discussion: Serializer.serialize(ctx.operation, level: :essential)}} end)

--- a/lib/operately_web/api/mutations/post_discussion.ex
+++ b/lib/operately_web/api/mutations/post_discussion.ex
@@ -43,7 +43,10 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussion do
   end
 
   defp parse_inputs(inputs) do
+    board_id = fetch_board_id(inputs.space_id)
+
     {:ok, %{
+      messages_board_id: board_id,
       space_id: inputs.space_id,
       title: inputs.title,
       content: Jason.decode!(inputs.body),
@@ -52,5 +55,12 @@ defmodule OperatelyWeb.Api.Mutations.PostDiscussion do
       subscription_parent_type: :message,
       subscriber_ids: inputs[:subscriber_ids] || []
     }}
+  end
+
+  # This is a temporary function.
+  # Once the Space Tools and Messages Boards are fully implemented,
+  # the messages_board_id will come from the frontend
+  defp fetch_board_id(space_id) do
+    from(b in Operately.Messages.MessagesBoard, where: b.space_id == ^space_id, select: b.id) |> Repo.one!()
   end
 end

--- a/lib/operately_web/api/mutations/publish_discussions.ex
+++ b/lib/operately_web/api/mutations/publish_discussions.ex
@@ -16,7 +16,7 @@ defmodule OperatelyWeb.Api.Mutations.PublishDiscussion do
   def call(conn, inputs) do
     with(
       {:ok, me} <- find_me(conn),
-      {:ok, discussion} <- Message.get(me, id: inputs.id),
+      {:ok, discussion} <- Message.get(me, id: inputs.id, opts: [preload: :space]),
       {:ok, :allowed} <- authorize(me, discussion),
       {:ok, discussion} <- publish(me, discussion)
     ) do

--- a/lib/operately_web/api/queries/get_discussions.ex
+++ b/lib/operately_web/api/queries/get_discussions.ex
@@ -33,7 +33,8 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
 
   defp load_messages(me, inputs) do
     from(m in Message,
-      where: m.space_id == ^inputs.space_id and m.state != :draft,
+      join: b in assoc(m, :messages_board),
+      where: b.space_id == ^inputs.space_id and m.state != :draft,
       preload: ^preload(inputs),
       order_by: [desc: m.inserted_at]
     )
@@ -44,7 +45,8 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussions do
 
   defp load_my_drafts(me, inputs) do
     from(m in Message,
-      where: m.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state == :draft,
+      join: b in assoc(m, :messages_board),
+      where: b.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state == :draft,
       preload: ^preload(inputs),
       order_by: [desc: m.inserted_at]
     )

--- a/priv/repo/migrations/20241113112605_create_messages_boards_schema_and_add_relationship_to_messages.exs
+++ b/priv/repo/migrations/20241113112605_create_messages_boards_schema_and_add_relationship_to_messages.exs
@@ -1,0 +1,22 @@
+defmodule Operately.Repo.Migrations.CreateMessagesBoardsSchemaAndAddRelationshipToMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages_boards, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :space_id, references(:groups, on_delete: :nothing, type: :binary_id), null: true
+
+      add :name, :string
+      add :description, :map
+
+      timestamps()
+    end
+
+    alter table(:messages) do
+      add :messages_board_id, references(:messages_boards, on_delete: :nothing, type: :binary_id), null: true
+    end
+
+    create index(:messages_boards, [:space_id])
+    create index(:messages, [:messages_board_id])
+  end
+end

--- a/priv/repo/migrations/20241113125136_populate_messages_board_id_field_in_messages.exs
+++ b/priv/repo/migrations/20241113125136_populate_messages_board_id_field_in_messages.exs
@@ -1,0 +1,7 @@
+defmodule Operately.Repo.Migrations.PopulateMessagesBoardIdFieldInMessages do
+  use Ecto.Migration
+
+  def change do
+    Operately.Data.Change042PopulateMessagesBoardIdFieldInMessages.run()
+  end
+end

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -74,5 +74,4 @@ defmodule Operately.Features.DiscussionsTest do
     |> Steps.submit_discussion()
     |> Steps.assert_discussion_is_posted_with_attachment()
   end
-
 end

--- a/test/operately/data/change_029_create_subscriptions_list_for_messages_test.exs
+++ b/test/operately/data/change_029_create_subscriptions_list_for_messages_test.exs
@@ -13,13 +13,14 @@ defmodule Operately.Data.Change029CreateSubscriptionsListForMessagesTest do
     |> Factory.add_space_member(:mike, :space)
     |> Factory.add_space_member(:bob, :space)
     |> Factory.add_space_member(:jane, :space)
+    |> Factory.add_messages_board(:messages_board, :space)
   end
 
   test "creates subscriptions list for existing messages", ctx do
     people = [ctx.creator, ctx.mike, ctx.bob, ctx.jane]
 
     messages = Enum.map(1..3, fn _ ->
-      message_fixture(ctx.creator.id, ctx.space.id)
+      message_fixture(ctx.creator.id, ctx.messages_board.id)
     end)
 
     Enum.each(messages, fn m ->

--- a/test/operately/operations/comment_adding_test.exs
+++ b/test/operately/operations/comment_adding_test.exs
@@ -245,10 +245,14 @@ defmodule Operately.Operations.CommentAddingTest do
       |> Factory.add_space_member(:mike, :space)
       |> Factory.add_space_member(:bob, :space)
       |> Factory.add_space_member(:jane, :space)
+      |> Factory.add_messages_board(:messages_board, :space)
     end
 
     test "Commenting on message notifies everyone", ctx do
-      ctx = Factory.add_message(ctx, :message, :space, send_to_everyone: true)
+      ctx =
+        ctx
+        |> Factory.add_message(:message, :messages_board, send_to_everyone: true)
+        |> Factory.preload(:message, :space)
 
       {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
         CommentAdding.run(ctx.creator, ctx.message, "message", RichText.rich_text("Some comment"))
@@ -271,10 +275,13 @@ defmodule Operately.Operations.CommentAddingTest do
     end
 
     test "Commenting on message notifies selected people", ctx do
-      ctx = Factory.add_message(ctx, :message, :space, [
-        person_ids: [ctx.mike.id, ctx.jane.id],
-        send_to_everyone: false,
-      ])
+      ctx =
+        ctx
+        |> Factory.add_message(:message, :messages_board, [
+          person_ids: [ctx.mike.id, ctx.jane.id],
+          send_to_everyone: false,
+        ])
+        |> Factory.preload(:message, :space)
 
       {:ok, comment} = Oban.Testing.with_testing_mode(:manual, fn ->
         CommentAdding.run(ctx.creator, ctx.message, "message", RichText.rich_text("Some comment"))
@@ -297,7 +304,10 @@ defmodule Operately.Operations.CommentAddingTest do
     end
 
     test "Mentioned person is notified", ctx do
-      ctx = Factory.add_message(ctx, :message, :space, send_to_everyone: false)
+      ctx =
+        ctx
+        |> Factory.add_message(:message, :messages_board, send_to_everyone: false)
+        |> Factory.preload(:message, :space)
 
       # Without permissions
       person = person_fixture_with_account(%{company_id: ctx.company.id})

--- a/test/operately/operations/discussion_posting_test.exs
+++ b/test/operately/operations/discussion_posting_test.exs
@@ -13,12 +13,13 @@ defmodule Operately.Operations.DiscussionPostingTest do
     |> Factory.add_space_member(:mike, :space)
     |> Factory.add_space_member(:bob, :space)
     |> Factory.add_space_member(:jane, :space)
+    |> Factory.add_messages_board(:messages_board, :space)
   end
 
   test "Creating message sends notifications to everyone", ctx do
     {:ok, message} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
-        space_id: ctx.space.id,
+        messages_board_id: ctx.messages_board.id,
         title: "Title",
         content: RichText.rich_text("Content"),
         post_as_draft: false,
@@ -47,7 +48,7 @@ defmodule Operately.Operations.DiscussionPostingTest do
   test "Creating message sends notifications to selected people", ctx do
     {:ok, message} = Oban.Testing.with_testing_mode(:manual, fn ->
       Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
-        space_id: ctx.space.id,
+        messages_board_id: ctx.messages_board.id,
         title: "Title",
         content: RichText.rich_text("Content"),
         post_as_draft: false,
@@ -79,7 +80,7 @@ defmodule Operately.Operations.DiscussionPostingTest do
     content = RichText.rich_text(mentioned_people: [person]) |> Jason.decode!()
 
     {:ok, message} = Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
-      space_id: ctx.space.id,
+      messages_board_id: ctx.messages_board.id,
       title: "Title",
       content: content,
       post_as_draft: false,
@@ -100,7 +101,7 @@ defmodule Operately.Operations.DiscussionPostingTest do
     ])
 
     {:ok, message} = Operately.Operations.DiscussionPosting.run(ctx.creator, ctx.space, %{
-      space_id: ctx.space.id,
+      messages_board_id: ctx.messages_board.id,
       title: "Title",
       content: content,
       post_as_draft: false,

--- a/test/operately/operations/group_creation_test.exs
+++ b/test/operately/operations/group_creation_test.exs
@@ -121,4 +121,10 @@ defmodule Operately.Operations.GroupCreationTest do
     assert activity.content["company_id"] == ctx.company.id
     assert activity.content["name"] == group.name
   end
+
+  test "GroupCreation operation creates default messages group", ctx do
+    {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, @group_attrs)
+
+    assert Operately.Messages.get_messages_board(space_id: group.id)
+  end
 end

--- a/test/operately_web/api/mutations/add_reaction_test.exs
+++ b/test/operately_web/api/mutations/add_reaction_test.exs
@@ -172,7 +172,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
     tabletest @space_table do
       test "if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        message = message_fixture(ctx.creator.id, space.id)
+        board = messages_board_fixture(space.id)
+        message = message_fixture(ctx.creator.id, board.id)
 
         assert {code, res} = mutation(ctx.conn, :add_reaction, %{
           entity_id: Paths.message_id(message),
@@ -325,7 +326,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
     tabletest @space_table do
       test "message comment - if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        message = message_fixture(ctx.creator.id, space.id)
+        board = messages_board_fixture(space.id)
+        message = message_fixture(ctx.creator.id, board.id) |> Repo.preload(:space)
         comment = create_comment(ctx, message, "message")
 
         assert {code, res} = mutation(ctx.conn, :add_reaction, %{
@@ -354,7 +356,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
       |> Factory.setup()
       |> Factory.add_company_owner(:owner)
       |> Factory.add_space(:product_space)
-      |> Factory.add_message(:hello_message, :product_space)
+      |> Factory.add_messages_board(:messages_board, :product_space)
+      |> Factory.add_message(:hello_message, :messages_board)
       |> Factory.log_in_person(:owner)
     end
 

--- a/test/operately_web/api/mutations/create_comment_test.exs
+++ b/test/operately_web/api/mutations/create_comment_test.exs
@@ -166,7 +166,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateCommentTest do
     tabletest @space_table do
       test "if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        message = message_fixture(ctx.creator.id, space.id)
+        board = messages_board_fixture(space.id)
+        message = message_fixture(ctx.creator.id, board.id)
 
         assert {code, res} = mutation(ctx.conn, :create_comment, %{
           entity_id: Paths.message_id(message),

--- a/test/operately_web/api/mutations/edit_comment_test.exs
+++ b/test/operately_web/api/mutations/edit_comment_test.exs
@@ -153,7 +153,8 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
     tabletest @space_table do
       test "if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
         space = create_space(ctx, @test.company, @test.space)
-        message = message_fixture(ctx.creator.id, space.id)
+        board = messages_board_fixture(space.id)
+        message = message_fixture(ctx.creator.id, board.id) |> Repo.preload(:space)
         comment = create_comment(ctx, message, "message")
 
         assert {code, res} = mutation(ctx.conn, :edit_comment, %{
@@ -244,7 +245,9 @@ defmodule OperatelyWeb.Api.Mutations.EditCommentTest do
       |> Factory.add_goal(:goal, :space)
       |> Factory.add_goal_update(:update, :goal, :creator)
       |> Factory.preload(:update, :goal)
-      |> Factory.add_message(:message, :space)
+      |> Factory.add_messages_board(:messages_board, :space)
+      |> Factory.add_message(:message, :messages_board)
+      |> Factory.preload(:message, :space)
     end
 
     tabletest @table do

--- a/test/operately_web/api/mutations/edit_discussion_test.exs
+++ b/test/operately_web/api/mutations/edit_discussion_test.exs
@@ -27,14 +27,14 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
 
     test "company member can see only their company", ctx do
       other_ctx = register_and_log_in_account(ctx)
-      message = message_fixture(ctx.creator_id, ctx.company.company_space_id)
+      message = create_message(ctx.creator_id, ctx.company.company_space_id)
 
       assert {404, res} = request(other_ctx.conn, message)
       assert res.message == "The requested resource was not found"
     end
 
     test "company members without edit access can't edit discussion", ctx do
-      message = message_fixture(ctx.creator_id, ctx.company.company_space_id)
+      message = create_message(ctx.creator_id, ctx.company.company_space_id)
 
       assert {403, res} = request(ctx.conn, message)
       assert res.message == "You don't have permission to perform this action"
@@ -42,14 +42,14 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
 
     test "company members with edit access can edit discussion", ctx do
       give_person_edit_access(ctx)
-      message = message_fixture(ctx.creator_id, ctx.company.company_space_id)
+      message = create_message(ctx.creator_id, ctx.company.company_space_id)
 
       assert {200, _} = request(ctx.conn, message)
       assert_discussion_edited(message)
     end
 
     test "company owners can edit discussion", ctx do
-      message = message_fixture(ctx.creator_id, ctx.company.company_space_id)
+      message = create_message(ctx.creator_id, ctx.company.company_space_id)
 
       # Not owner
       assert {403, _} = request(ctx.conn, message)
@@ -72,14 +72,14 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
     end
 
     test "company member without view access can't see space", ctx do
-      message = message_fixture(ctx.creator_id, ctx.space_id)
+      message = create_message(ctx.creator_id, ctx.space_id)
 
       assert {404, res} = request(ctx.conn, message)
       assert res.message == "The requested resource was not found"
     end
 
     test "space member without edit access can't edit discussion", ctx do
-      message = message_fixture(ctx.creator_id, ctx.space_id)
+      message = create_message(ctx.creator_id, ctx.space_id)
       add_person_to_space(ctx, Binding.comment_access())
 
       assert {403, res} = request(ctx.conn, message)
@@ -87,7 +87,7 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
     end
 
     test "space members with edit access can edit discussion", ctx do
-      message = message_fixture(ctx.creator_id, ctx.space_id)
+      message = create_message(ctx.creator_id, ctx.space_id)
       add_person_to_space(ctx, Binding.edit_access())
 
       assert {200, _} = request(ctx.conn, message)
@@ -95,7 +95,7 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
     end
 
     test "company owner can edit discussion", ctx do
-      message = message_fixture(ctx.creator_id, ctx.space_id)
+      message = create_message(ctx.creator_id, ctx.space_id)
 
       # Not owner
       assert {404, _} = request(ctx.conn, message)
@@ -117,14 +117,14 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
     end
 
     test "edits discussion", ctx do
-      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
+      message = create_message(ctx.person.id, ctx.company.company_space_id)
 
       assert {200, _} = request(ctx.conn, message)
       assert_discussion_edited(message)
     end
 
     test "mentioned people are added to subscriptions list", ctx do
-      message = message_fixture(ctx.person.id, ctx.company.company_space_id)
+      message = create_message(ctx.person.id, ctx.company.company_space_id)
 
       {:ok, list} = SubscriptionList.get(:system, parent_id: message.id, opts: [
         preload: :subscriptions
@@ -184,5 +184,10 @@ defmodule OperatelyWeb.Api.Mutations.EditDiscussionTest do
       id: ctx.person.id,
       access_level: access_level,
     }])
+  end
+
+  defp create_message(person_id, space_id) do
+      board = messages_board_fixture(space_id)
+      message_fixture(person_id, board.id)
   end
 end

--- a/test/operately_web/api/queries/get_comments_test.exs
+++ b/test/operately_web/api/queries/get_comments_test.exs
@@ -258,7 +258,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     end
 
     test "company space - company members have access", ctx do
-      message = message_fixture(ctx.creator.id, ctx.company.company_space_id)
+      message = create_message(ctx.creator.id, ctx.company.company_space_id)
       comments = Enum.map(1..3, fn _ ->
         add_comment(ctx, message, "message")
       end)
@@ -272,7 +272,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
 
     test "company members have no access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
-      message = message_fixture(ctx.creator.id, space.id)
+      message = create_message(ctx.creator.id, space.id)
       Enum.each(1..3, fn _ ->
         add_comment(ctx, message, "message")
       end)
@@ -286,7 +286,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
 
     test "company members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.view_access())
-      message = message_fixture(ctx.creator.id, space.id)
+      message = create_message(ctx.creator.id, space.id)
       comments = Enum.map(1..3, fn _ ->
         add_comment(ctx, message, "message")
       end)
@@ -300,7 +300,7 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
 
     test "space members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
-      message = message_fixture(ctx.creator.id, space.id)
+      message = create_message(ctx.creator.id, space.id)
       comments = Enum.map(1..3, fn _ ->
         add_comment(ctx, message, "message")
       end)
@@ -505,5 +505,12 @@ defmodule OperatelyWeb.Api.Queries.GetCommentsTest do
     {:ok, comment} = Operately.Operations.CommentAdding.run(ctx.person, entity, entity_type, RichText.rich_text(content))
     Repo.preload(comment, :author)
     |> serialize(level: :full)
+  end
+
+  defp create_message(creator_id, space_id) do
+    board = messages_board_fixture(space_id)
+
+    message_fixture(creator_id, board.id)
+    |> Repo.preload(:space)
   end
 end

--- a/test/operately_web/api/queries/get_discussions_test.exs
+++ b/test/operately_web/api/queries/get_discussions_test.exs
@@ -23,7 +23,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
 
     test "company space - company members have access", ctx do
       messages = Enum.map(1..3, fn _ ->
-        message_fixture(ctx.creator.id, ctx.company.company_space_id)
+        create_message(ctx.creator.id, ctx.company.company_space_id)
       end)
       space = Operately.Groups.get_group!(ctx.company.company_space_id)
 
@@ -34,7 +34,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
     test "company members have no access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
       Enum.each(1..3, fn _ ->
-        message_fixture(ctx.creator.id, space.id)
+        create_message(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
@@ -44,7 +44,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
     test "company members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.view_access())
       messages = Enum.map(1..3, fn _ ->
-        message_fixture(ctx.creator.id, space.id)
+        create_message(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
@@ -54,7 +54,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
     test "space members have access", ctx do
       space = create_space(ctx, company_permissions: Binding.no_access())
       messages = Enum.map(1..3, fn _ ->
-        message_fixture(ctx.creator.id, space.id)
+        create_message(ctx.creator.id, space.id)
       end)
 
       assert {200, res} = query(ctx.conn, :get_discussions, %{space_id: Paths.space_id(space)})
@@ -73,7 +73,9 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
       ctx
       |> Factory.setup()
       |> Factory.add_space(:space)
-      |> Factory.add_message(:message, :space)
+      |> Factory.add_messages_board(:messages_board, :space)
+      |> Factory.add_message(:message, :messages_board)
+      |> Factory.preload(:message, :space)
       |> Factory.add_comment(:comment1, :message)
       |> Factory.add_comment(:comment2, :message)
       |> Factory.log_in_person(:creator)
@@ -133,5 +135,10 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussionsTest do
       id: ctx.person.id,
       access_level: Binding.view_access(),
     }])
+  end
+
+  defp create_message(creator_id, space_id) do
+    board = messages_board_fixture(space_id)
+    message_fixture(creator_id, board.id)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -48,7 +48,8 @@ defmodule Operately.Support.Factory do
   defdelegate edit_project_space_members_access(ctx, project_name, access_level), to: Projects
 
   # messages
-  defdelegate add_message(ctx, testid, space_name, opts \\ []), to: Messages
+  defdelegate add_message(ctx, testid, board_name, opts \\ []), to: Messages
+  defdelegate add_messages_board(ctx, testid, space_name, opts \\ []), to: Messages
 
   # comments
   defdelegate add_comment(ctx, testid, parent_name, opts \\ []), to: Comments

--- a/test/support/factory/messages.ex
+++ b/test/support/factory/messages.ex
@@ -1,11 +1,17 @@
 defmodule Operately.Support.Factory.Messages do
-  def add_message(ctx, testid, space_name, opts \\ []) do
+  def add_messages_board(ctx, testid, space_name, opts \\ []) do
+    board = Operately.MessagesFixtures.messages_board_fixture(ctx[space_name].id, opts)
+
+    Map.put(ctx, testid, board)
+  end
+
+  def add_message(ctx, testid, board_name, opts \\ []) do
     creator = Keyword.get(opts, :creator, ctx.creator)
-    space = Map.fetch!(ctx, space_name)
+    board = Map.fetch!(ctx, board_name)
 
     message = Operately.MessagesFixtures.message_fixture(
-      creator.id, 
-      space.id, 
+      creator.id,
+      board.id,
       opts
     )
 

--- a/test/support/features/discussions_steps.ex
+++ b/test/support/features/discussions_steps.ex
@@ -158,7 +158,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   end
 
   step :assert_draft_is_not_listed_on_space_page, ctx do
-    ctx 
+    ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.marketing_space))
     |> UI.click(testid: "messages-tool")
     |> UI.assert_has(testid: "discussions-page")
@@ -166,13 +166,13 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   end
 
   step :click_on_continue_editing, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "continue-editing")
     |> UI.assert_has(testid: "discussion-edit-page")
   end
 
   step :modify_the_draft_discussion_and_save, ctx do
-    ctx 
+    ctx
     |> UI.fill(testid: "discussion-title", with: "This is a draft discussion (edited)")
     |> UI.fill_rich_text("This is the body of the discussion. (edited)")
     |> UI.click(testid: "save-changes")
@@ -189,7 +189,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   end
 
   step :publish_draft, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "publish-now")
     |> UI.assert_has(testid: "discussion-page")
   end
@@ -224,7 +224,9 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   end
 
   step :given_a_draft_discussion_exists, ctx do
-    ctx |> Factory.add_message(:draft_discussion, :marketing_space, [
+    ctx
+    |> Factory.add_messages_board(:messages_board, :marketing_space)
+    |> Factory.add_message(:draft_discussion, :messages_board, [
       state: :draft,
       creator: ctx.author
     ])

--- a/test/support/fixtures/messages_fixtures.ex
+++ b/test/support/fixtures/messages_fixtures.ex
@@ -1,12 +1,25 @@
 defmodule Operately.MessagesFixtures do
-  def message_fixture(author_id, space_id, attrs \\ []) do
+  def messages_board_fixture(space_id, attrs \\ []) do
+    {:ok, board} =
+      attrs
+      |> Enum.into(%{
+        space_id: space_id,
+        name: "Messages Board",
+        description: Operately.Support.RichText.rich_text("Some description"),
+      })
+      |> Operately.Messages.create_messages_board()
+
+    board
+  end
+
+  def message_fixture(author_id, messages_board_id, attrs \\ []) do
     subscription_list = Operately.NotificationsFixtures.subscriptions_list_fixture(attrs)
 
     {:ok, message} =
       attrs
       |> Enum.into(%{
         author_id: author_id,
-        space_id: space_id,
+        messages_board_id: messages_board_id,
         title: "Some message",
         body: Operately.Support.RichText.rich_text("Some content"),
         subscription_list_id: subscription_list.id,


### PR DESCRIPTION
I've added the `Operately.Messages.MessagesBoard` schema.

Originally, I wanted to finish the Resource Hubs before working on the other Space Tools, but then I realized that I would have to add a query to fetch the resource hubs to the frontend. 

If I wrote a `ListResourceHubs` query now, it would be a waste of time, since in the near future I would replace it by a `ListSpaceTools` query. 

So, I decided to add the `MessagesBoard` and `GoalsAndProjectsGroup` schemas now. Then, I will add the `ListSpaceTools` query which will fetch all the existing tools in a Space. 

It will be a lot of work now, but later, the backend will be mostly ready for handling the Space Tools.