### PR TITLE
feat: ListResourceHubContent query can list folder content

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -989,6 +989,12 @@ export interface ResourceHubFolder {
   permissions?: ResourceHubPermissions | null;
 }
 
+export interface ResourceHubNode {
+  id?: string | null;
+  name?: string | null;
+  type?: string | null;
+}
+
 export interface ResourceHubPermissions {
   canCreateFolder?: boolean | null;
 }
@@ -1641,6 +1647,15 @@ export interface GetUnreadNotificationCountInput {}
 
 export interface GetUnreadNotificationCountResult {
   unread?: number | null;
+}
+
+export interface ListResourceHubContentInput {
+  resourceHubId?: string | null;
+  parentFolderId?: string | null;
+}
+
+export interface ListResourceHubContentResult {
+  nodes?: ResourceHubNode[] | null;
 }
 
 export interface SearchPeopleInput {
@@ -2575,6 +2590,10 @@ export class ApiClient {
     return this.get("/get_unread_notification_count", input);
   }
 
+  async listResourceHubContent(input: ListResourceHubContentInput): Promise<ListResourceHubContentResult> {
+    return this.get("/list_resource_hub_content", input);
+  }
+
   async searchPeople(input: SearchPeopleInput): Promise<SearchPeopleResult> {
     return this.get("/search_people", input);
   }
@@ -3018,6 +3037,11 @@ export async function getUnreadNotificationCount(
 ): Promise<GetUnreadNotificationCountResult> {
   return defaultApiClient.getUnreadNotificationCount(input);
 }
+export async function listResourceHubContent(
+  input: ListResourceHubContentInput,
+): Promise<ListResourceHubContentResult> {
+  return defaultApiClient.listResourceHubContent(input);
+}
 export async function searchPeople(input: SearchPeopleInput): Promise<SearchPeopleResult> {
   return defaultApiClient.searchPeople(input);
 }
@@ -3446,6 +3470,12 @@ export function useGetUnreadNotificationCount(
   input: GetUnreadNotificationCountInput,
 ): UseQueryHookResult<GetUnreadNotificationCountResult> {
   return useQuery<GetUnreadNotificationCountResult>(() => defaultApiClient.getUnreadNotificationCount(input));
+}
+
+export function useListResourceHubContent(
+  input: ListResourceHubContentInput,
+): UseQueryHookResult<ListResourceHubContentResult> {
+  return useQuery<ListResourceHubContentResult>(() => defaultApiClient.listResourceHubContent(input));
 }
 
 export function useSearchPeople(input: SearchPeopleInput): UseQueryHookResult<SearchPeopleResult> {
@@ -4029,6 +4059,8 @@ export default {
   useGetTasks,
   getUnreadNotificationCount,
   useGetUnreadNotificationCount,
+  listResourceHubContent,
+  useListResourceHubContent,
   searchPeople,
   useSearchPeople,
   searchPotentialSpaceMembers,

--- a/lib/operately_web/api/queries/list_resource_hub_content.ex
+++ b/lib/operately_web/api/queries/list_resource_hub_content.ex
@@ -7,16 +7,17 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContent do
 
   inputs do
     field :resource_hub_id, :string
+    field :parent_folder_id, :string
   end
 
   outputs do
-    field :nodes, list_of(:task)
+    field :nodes, list_of(:resource_hub_node )
   end
 
   def call(conn, inputs) do
     Action.new()
     |> run(:me, fn -> find_me(conn) end)
-    |> run(:id, fn -> decode_id(inputs.resource_hub_id) end)
+    |> run(:attrs, fn -> parse_inputs(inputs) end)
     |> run(:nodes, fn ctx -> load_nodes(ctx) end)
     |> run(:serialized, fn ctx -> serialize(ctx) end)
     |> respond()
@@ -25,7 +26,7 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContent do
   defp respond(result) do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
-      {:error, :id, _} -> {:error, :bad_request}
+      {:error, :attrs, _} -> {:error, :bad_request}
       {:error, :nodes, _} -> {:error, :not_found}
       _ -> {:error, :internal_server_error}
     end
@@ -33,7 +34,7 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContent do
 
   defp load_nodes(ctx) do
     nodes =
-      from(n in Node, where: n.resource_hub_id == ^ctx.id)
+      query(ctx.attrs)
       |> Filters.filter_by_view_access(ctx.me.id, join_parent: :resource_hub)
       |> Repo.all()
 
@@ -42,5 +43,22 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContent do
 
   defp serialize(ctx) do
     {:ok, %{nodes: Serializer.serialize(ctx.nodes)}}
+  end
+
+  defp query(%{parent_folder_id: id}) do
+    from(n in Node, where: n.parent_folder_id == ^id)
+  end
+  defp query(%{resource_hub_id: id}) do
+    from(n in Node, where: n.resource_hub_id == ^id)
+  end
+
+  defp parse_inputs(inputs) do
+    if Map.has_key?(inputs, :parent_folder_id) do
+      {:ok, id} = decode_id(inputs.parent_folder_id)
+      {:ok, %{parent_folder_id: id}}
+    else
+      {:ok, id} = decode_id(inputs.resource_hub_id)
+      {:ok, %{resource_hub_id: id}}
+    end
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -493,6 +493,12 @@ defmodule OperatelyWeb.Api.Types do
     field :permissions, :resource_hub_permissions
   end
 
+  object :resource_hub_node do
+    field :id, :string
+    field :name, :string
+    field :type, :string
+  end
+
   object :project_permissions do
     field :can_view, :boolean
     field :can_create_milestone, :boolean

--- a/test/operately_web/api/queries/list_resource_hub_content_test.exs
+++ b/test/operately_web/api/queries/list_resource_hub_content_test.exs
@@ -92,6 +92,30 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContentTest do
         assert Enum.find(res.nodes, &(&1.id == Paths.node_id(node)))
       end)
     end
+
+    test "list all files within folder", ctx do
+      ctx =
+        ctx
+        |> Factory.add_folder(:folder6, :hub1, :folder1)
+        |> Factory.add_folder(:folder7, :hub1, :folder1)
+        |> Factory.add_folder(:folder8, :hub1, :folder2)
+
+      assert {200, res} = query(ctx.conn, :list_resource_hub_content, %{parent_folder_id: Paths.folder_id(ctx.folder1)})
+      assert length(res.nodes) == 2
+
+      [ctx.folder6, ctx.folder7]
+      |> Enum.each(fn folder ->
+        node = Repo.preload(folder, :node).node
+
+        assert Enum.find(res.nodes, &(&1.id == Paths.node_id(node)))
+      end)
+
+      assert {200, res} = query(ctx.conn, :list_resource_hub_content, %{parent_folder_id: Paths.folder_id(ctx.folder2)})
+      assert length(res.nodes) == 1
+
+      node8 = Repo.preload(ctx.folder8, :node).node
+      assert hd(res.nodes).id == Paths.node_id(node8)
+    end
   end
 
   #

--- a/test/support/factory/resource_hubs.ex
+++ b/test/support/factory/resource_hubs.ex
@@ -12,7 +12,7 @@ defmodule Operately.Support.Factory.ResourceHubs do
     hub = Map.fetch!(ctx, hub_name)
     folder = folder_name && Map.fetch!(ctx, folder_name)
 
-    folder = Operately.ResourceHubsFixtures.folder_fixture(hub.id, %{folder_id: folder && folder.id})
+    folder = Operately.ResourceHubsFixtures.folder_fixture(hub.id, %{parent_folder_id: folder && folder.id})
 
     Map.put(ctx, testid, folder)
   end

--- a/test/support/fixtures/resource_hubs_fixtures.ex
+++ b/test/support/fixtures/resource_hubs_fixtures.ex
@@ -18,7 +18,7 @@ defmodule Operately.ResourceHubsFixtures do
   def folder_fixture(hub_id, attrs \\ %{}) do
     {:ok, node} = Operately.ResourceHubs.create_node(%{
       resource_hub_id: hub_id,
-      folder_id: attrs[:folder_id] && attrs.folder_id,
+      parent_folder_id: attrs[:parent_folder_id] && attrs.parent_folder_id,
       name: attrs[:name] || "some name",
       type: :folder,
     })


### PR DESCRIPTION
The query `ListResourceHubContent` can be used to list the contents of both a Resource Hub root and a folder.