### PR TITLE
fix: Create bindings between existing resource hubs and groups

### DIFF
--- a/lib/operately/data/change_043_create_access_bindings_between_resource_hubs_and_people.ex
+++ b/lib/operately/data/change_043_create_access_bindings_between_resource_hubs_and_people.ex
@@ -1,0 +1,45 @@
+defmodule Operately.Data.Change043CreateAccessBindingsBetweenResourceHubsAndPeople do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Access
+  alias Operately.Access.Binding
+
+  def run do
+    Repo.transaction(fn ->
+      from(h in Operately.ResourceHubs.ResourceHub, preload: :space, select: h)
+      |> Repo.all()
+      |> create_bindings()
+    end)
+  end
+
+  defp create_bindings(hubs) when is_list(hubs) do
+    Enum.each(hubs, &(create_bindings(&1)))
+  end
+
+  defp create_bindings(hub) do
+    context = Access.get_context!(resource_hub_id: hub.id)
+
+    company_full = Access.get_group!(company_id: hub.space.company_id, tag: :full_access)
+    space_full = Access.get_group!(group_id: hub.space.id, tag: :full_access)
+    company_standard = Access.get_group!(company_id: hub.space.company_id, tag: :standard)
+    space_standard =Access.get_group!(group_id: hub.space.id, tag: :standard)
+
+    create_binding(context, company_full, Binding.full_access())
+    create_binding(context, space_full, Binding.full_access())
+    create_binding(context, company_standard, Binding.comment_access())
+    create_binding(context, space_standard, Binding.comment_access())
+  end
+
+  defp create_binding(context, group, access_level) do
+    case Access.get_binding(context_id: context.id, group_id: group.id) do
+      nil ->
+        {:ok, _} = Access.create_binding(%{
+          group_id: group.id,
+          context_id: context.id,
+          access_level: access_level,
+        })
+      _ -> :ok
+    end
+  end
+end

--- a/priv/repo/migrations/20241115093941_create_access_bindings_between_resource_hubs_and_company_members.exs
+++ b/priv/repo/migrations/20241115093941_create_access_bindings_between_resource_hubs_and_company_members.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.CreateAccessBindingsBetweenResourceHubsAndCompanyMembers do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change043CreateAccessBindingsBetweenResourceHubsAndPeople.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/data/change_043_create_access_bindings_between_resource_hubs_and_people_test.exs
+++ b/test/operately/data/change_043_create_access_bindings_between_resource_hubs_and_people_test.exs
@@ -1,0 +1,68 @@
+defmodule Operately.Data.Change043CreateAccessBindingsBetweenResourceHubsAndPeopleTest do
+  use Operately.DataCase
+
+  import Operately.GroupsFixtures
+
+  alias Operately.Access
+  alias Operately.ResourceHubs.ResourceHub
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> setup_resource_hubs()
+  end
+
+  test "creates bindings to exising resource hubs contexts", ctx do
+    company_full = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
+    company_standard = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+
+    Enum.each(ctx.hubs, fn hub ->
+      context = Access.get_context!(resource_hub_id: hub.id)
+      space_full = Access.get_group!(group_id: hub.space_id, tag: :full_access)
+      space_standard =Access.get_group!(group_id: hub.space_id, tag: :standard)
+
+      refute Access.get_binding(context_id: context.id, group_id: company_full.id)
+      refute Access.get_binding(context_id: context.id, group_id: company_standard.id)
+      refute Access.get_binding(context_id: context.id, group_id: space_full.id)
+      refute Access.get_binding(context_id: context.id, group_id: space_standard.id)
+    end)
+
+    Operately.Data.Change043CreateAccessBindingsBetweenResourceHubsAndPeople.run()
+
+    Enum.each(ctx.hubs, fn hub ->
+      context = Access.get_context!(resource_hub_id: hub.id)
+      space_full = Access.get_group!(group_id: hub.space_id, tag: :full_access)
+      space_standard =Access.get_group!(group_id: hub.space_id, tag: :standard)
+
+      assert Access.get_binding(context_id: context.id, group_id: company_full.id)
+      assert Access.get_binding(context_id: context.id, group_id: company_standard.id)
+      assert Access.get_binding(context_id: context.id, group_id: space_full.id)
+      assert Access.get_binding(context_id: context.id, group_id: space_standard.id)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp setup_resource_hubs(ctx) do
+    spaces = Enum.map(1..3, fn _ ->
+      group_fixture(ctx.creator)
+    end)
+
+    hubs = Enum.map(spaces, fn s ->
+      {:ok, hub} = ResourceHub.changeset(%{
+        space_id: s.id,
+        name: "Resource Hub",
+      })
+      |> Repo.insert()
+
+      {:ok, _} = Access.create_context(%{resource_hub_id: hub.id})
+
+      hub
+    end)
+
+    ctx
+    |> Map.put(:hubs, hubs)
+  end
+end


### PR DESCRIPTION
It turned out that the bindings between the resource hubs and access groups were not created in the previous migrations. I'm fixing that in this PR.