### PR TITLE
fix: On Goals page, don't show icon when Goal has no children

### DIFF
--- a/assets/js/features/goals/GoalTree/index.tsx
+++ b/assets/js/features/goals/GoalTree/index.tsx
@@ -108,7 +108,7 @@ function NodeExpandCollapseToggle({ node }: { node: Node }) {
 
   return (
     <div className="w-5">
-      {node.hasChildren && (
+      {node.children.length > 0 && (
         <ChevronIcon size={16} className="cursor-pointer" onClick={handleClick} data-test-id={testId} />
       )}
     </div>


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1559.

https://github.com/user-attachments/assets/a3440950-8be8-4b6d-918e-65f7d5d96566

