### PR TITLE
fix: Sub-folders are not listed in the resource hub root

### DIFF
--- a/lib/operately_web/api/queries/get_resource_hub.ex
+++ b/lib/operately_web/api/queries/get_resource_hub.ex
@@ -2,7 +2,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  alias Operately.ResourceHubs.ResourceHub
+  alias Operately.ResourceHubs.{ResourceHub, Node}
 
   inputs do
     field :id, :id
@@ -38,9 +38,11 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
   end
 
   def preload(inputs) do
+    q = from(n in Node, where: is_nil(n.parent_folder_id), preload: [folder: :node, document: :node])
+
     Inputs.parse_includes(inputs, [
       include_space: :space,
-      include_nodes: [nodes: [[folder: :node], [document: :node]]],
+      include_nodes: [nodes: q],
     ])
   end
 end


### PR DESCRIPTION
Display only folders and documents that don't have a parent folder in the Resource Hub root.