### PR TITLE
feat: Creating space also creates default resource hub

### DIFF
--- a/lib/operately/groups/insert_group.ex
+++ b/lib/operately/groups/insert_group.ex
@@ -10,6 +10,7 @@ defmodule Operately.Groups.InsertGroup do
     |> insert_access_groups()
     |> insert_bindings(attrs)
     |> insert_default_messages_board()
+    |> insert_default_resource_hub()
   end
 
   defp insert_group(multi, attrs) do
@@ -42,16 +43,18 @@ defmodule Operately.Groups.InsertGroup do
 
   defp insert_bindings(multi, attrs) do
     multi
+    |> Multi.run(:company_admins_group, fn _, changes ->
+      {:ok, Access.get_group!(company_id: changes.group.company_id, tag: :full_access)}
+    end)
     |> Multi.insert(:space_full_access_binding, fn changes ->
-      group = Access.get_group!(company_id: changes.group.company_id, tag: :full_access)
-
-      Binding.changeset(%{group_id: group.id, context_id: changes.context.id, access_level: Binding.full_access()})
+      Binding.changeset(%{group_id: changes.company_admins_group.id, context_id: changes.context.id, access_level: Binding.full_access()})
+    end)
+    |> Multi.run(:company_members_group, fn _, changes ->
+      {:ok, Access.get_group!(company_id: changes.group.company_id, tag: :standard)}
     end)
     |> Multi.insert(:space_members_binding, fn changes ->
       access_level = Map.get(attrs, :company_permissions, Binding.no_access())
-      group = Access.get_group!(company_id: changes.group.company_id, tag: :standard)
-
-      Binding.changeset(%{group_id: group.id, context_id: changes.context.id, access_level: access_level})
+      Binding.changeset(%{group_id: changes.company_members_group.id, context_id: changes.context.id, access_level: access_level})
     end)
     |> Multi.run(:anonymous_binding, fn _, changes ->
       if attrs[:public_permissions] == Binding.view_access() do
@@ -70,6 +73,33 @@ defmodule Operately.Groups.InsertGroup do
         space_id: changes.group.id,
         name: "Messages Board",
       })
+    end)
+  end
+
+  defp insert_default_resource_hub(multi) do
+    multi
+    |> Multi.insert(:resource_hub, fn changes ->
+      Operately.ResourceHubs.ResourceHub.changeset(%{
+        space_id: changes.group.id,
+        name: "Resource Hub",
+      })
+    end)
+    |> Multi.insert(:hub_context, fn changes ->
+      Access.Context.changeset(%{
+        resource_hub_id: changes.resource_hub.id,
+      })
+    end)
+    |> Multi.insert(:company_admins_and_hub_binding, fn changes ->
+      Binding.changeset(%{group_id: changes.company_admins_group.id, context_id: changes.hub_context.id, access_level: Binding.full_access()})
+    end)
+    |> Multi.insert(:company_members_and_hub_binding, fn changes ->
+      Binding.changeset(%{group_id: changes.company_members_group.id, context_id: changes.hub_context.id, access_level: Binding.comment_access()})
+    end)
+    |> Multi.insert(:space_managers_and_hub_binding, fn changes ->
+      Binding.changeset(%{group_id: changes.space_managers_access_group.id, context_id: changes.hub_context.id, access_level: Binding.full_access()})
+    end)
+    |> Multi.insert(:space_members_and_hub_binding, fn changes ->
+      Binding.changeset(%{group_id: changes.space_members_access_group.id, context_id: changes.hub_context.id, access_level: Binding.edit_access()})
     end)
   end
 end

--- a/test/operately/access/bindings_test.exs
+++ b/test/operately/access/bindings_test.exs
@@ -27,7 +27,7 @@ defmodule Operately.AccessBindingsTest do
 
       bindings_list = Access.list_bindings()
 
-      assert 6 == length(bindings_list)
+      assert 10 == length(bindings_list)
       assert Enum.member?(bindings_list, binding)
     end
 

--- a/test/operately/data/change_041_create_one_resource_hub_for_each_existing_space_test.exs
+++ b/test/operately/data/change_041_create_one_resource_hub_for_each_existing_space_test.exs
@@ -16,10 +16,6 @@ defmodule Operately.Data.Change041CreateOneResourceHubForEachExistingSpaceTest d
       group_fixture(ctx.creator)
     end)
 
-    Enum.each(spaces, fn s ->
-      assert {:error, :not_found} = ResourceHub.get(:system, space_id: s.id)
-    end)
-
     Operately.Data.Change041CreateOneResourceHubForEachExistingSpace.run()
 
     Enum.each(spaces, fn s ->

--- a/test/operately/operations/group_creation_test.exs
+++ b/test/operately/operations/group_creation_test.exs
@@ -127,4 +127,22 @@ defmodule Operately.Operations.GroupCreationTest do
 
     assert Operately.Messages.get_messages_board(space_id: group.id)
   end
+
+  test "GroupCreation operation creates default resource hub", ctx do
+    {:ok, group} = Operately.Operations.GroupCreation.run(ctx.creator, @group_attrs)
+
+    hubs = Operately.ResourceHubs.list_resource_hubs(group)
+    assert length(hubs) == 1
+
+    context = Access.get_context(resource_hub_id: hd(hubs).id)
+    company_full = Access.get_group!(company_id: ctx.company.id, tag: :full_access)
+    space_full = Access.get_group!(group_id: group.id, tag: :full_access)
+    company_standard = Access.get_group!(company_id: ctx.company.id, tag: :standard)
+    space_standard = Access.get_group!(group_id: group.id, tag: :standard)
+
+    assert Access.get_binding(group_id: company_full.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: space_full.id, context_id: context.id, access_level: Binding.full_access())
+    assert Access.get_binding(group_id: company_standard.id, context_id: context.id, access_level: Binding.comment_access())
+    assert Access.get_binding(group_id: space_standard.id, context_id: context.id, access_level: Binding.edit_access())
+  end
 end

--- a/test/operately/operations/resource_hub_creating_test.exs
+++ b/test/operately/operations/resource_hub_creating_test.exs
@@ -21,11 +21,14 @@ defmodule Operately.Operations.ResourceHubCreatingTest do
   }
 
   test "ResourceHubCreating operation creates resource hub", ctx do
-    assert ResourceHubs.list_resource_hubs(ctx.space) == []
+    assert length(ResourceHubs.list_resource_hubs(ctx.space)) == 1
 
     {:ok, resource_hub} = Operately.Operations.ResourceHubCreating.run(ctx.creator, ctx.space, @attrs)
 
-    assert ResourceHubs.list_resource_hubs(ctx.space) == [resource_hub]
+    hubs = ResourceHubs.list_resource_hubs(ctx.space)
+
+    assert length(hubs) == 2
+    assert Enum.find(hubs, &(&1 == resource_hub))
   end
 
   test "ResourceHubCreating operation creates context", ctx do

--- a/test/operately_web/api/mutations/create_resource_hub_test.exs
+++ b/test/operately_web/api/mutations/create_resource_hub_test.exs
@@ -61,13 +61,12 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubTest do
         case @test.expected do
           200 ->
             hubs = ResourceHubs.list_resource_hubs(space)
-            assert length(hubs) == 1
-            assert res == %{resource_hub: Serializer.serialize(hd(hubs))}
+            assert length(hubs) == 2
           403 ->
-            assert ResourceHubs.list_resource_hubs(space) == []
+            assert length(ResourceHubs.list_resource_hubs(space)) == 1
             assert res.message == "You don't have permission to perform this action"
           404 ->
-            assert ResourceHubs.list_resource_hubs(space) == []
+            assert length(ResourceHubs.list_resource_hubs(space)) == 1
             assert res.message == "The requested resource was not found"
         end
       end
@@ -82,7 +81,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubTest do
     end
 
     test "creates resource hub", ctx do
-      assert ResourceHubs.list_resource_hubs(ctx.space) == []
+      assert length(ResourceHubs.list_resource_hubs(ctx.space)) == 1
 
       assert {200, res} = mutation(ctx.conn, :create_resource_hub, %{
         space_id: Paths.space_id(ctx.space),
@@ -95,8 +94,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubTest do
 
       hubs = ResourceHubs.list_resource_hubs(ctx.space)
 
-      assert length(hubs) == 1
-      assert res.resource_hub == Serializer.serialize(hd(hubs))
+      assert length(hubs) == 2
+      assert Enum.find(hubs, &(Serializer.serialize(&1) == res.resource_hub))
     end
   end
 

--- a/test/operately_web/api/queries/list_space_tools_test.exs
+++ b/test/operately_web/api/queries/list_space_tools_test.exs
@@ -67,9 +67,9 @@ defmodule OperatelyWeb.Api.Queries.ListSpaceToolsTest do
 
         case @test.expected do
           :forbidden ->
-            assert length(res.tools.resource_hubs) == 0
+            assert length(res.tools.resource_hubs) == 1
           :allowed ->
-            assert length(res.tools.resource_hubs) == 2
+            assert length(res.tools.resource_hubs) == 3
         end
       end
     end
@@ -188,7 +188,7 @@ defmodule OperatelyWeb.Api.Queries.ListSpaceToolsTest do
     test "list resource hubs", ctx do
       assert {200, res} = query(ctx.conn, :list_space_tools, %{space_id: Paths.space_id(ctx.space)})
 
-      assert length(res.tools.resource_hubs) == 2
+      assert length(res.tools.resource_hubs) == 3
 
       hub1 = Enum.find(res.tools.resource_hubs, &(&1.id == Paths.resource_hub_id(ctx.hub1)))
       assert length(hub1.nodes) == 2


### PR DESCRIPTION
When a Space is created, a Resource Hub is also created for it. This will be necessary until we have a way to manually create Resource Hubs.