### PR TITLE
feat: Display document-commented event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -503,6 +503,11 @@ export interface ActivityContentProjectTimelineEdited {
   updatedMilestones?: Milestone[] | null;
 }
 
+export interface ActivityContentResourceHubDocumentCommented {
+  document?: ResourceHubDocument | null;
+  comment?: Comment | null;
+}
+
 export interface ActivityContentResourceHubDocumentCreated {
   resourceHub?: ResourceHub | null;
   document?: ResourceHubDocument | null;

--- a/assets/js/features/activities/ResourceHubDocumentCommented/index.tsx
+++ b/assets/js/features/activities/ResourceHubDocumentCommented/index.tsx
@@ -1,0 +1,74 @@
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubDocumentCommented } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+
+import { Paths } from "@/routes/paths";
+import { Summary } from "@/components/RichContent";
+import React from "react";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubDocumentCommented: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    return Paths.resourceHubDocumentPath(content(activity).document!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity; page: any }) {
+    const document = content(activity).document!;
+
+    const path = Paths.resourceHubDocumentPath(document.id!);
+    const activityLink = <Link to={path}>{document.name}</Link>;
+
+    return feedTitle(activity, "commented on", activityLink);
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const comment = content(activity).comment!;
+    const commentContent = JSON.parse(comment.content!)["message"];
+    return <Summary jsonContent={commentContent} characterCount={200} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " commented on: " + content(activity).document!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).document!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubDocumentCommented {
+  return activity.content as ActivityContentResourceHubDocumentCommented;
+}
+
+export default ResourceHubDocumentCommented;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -106,6 +106,7 @@ export const DISPLAYED_IN_FEED = [
   "project_timeline_edited",
   "project_retrospective_commented",
   "resource_hub_document_created",
+  "resource_hub_document_commented",
   "resource_hub_folder_created",
   "space_added",
   "space_joining",
@@ -164,6 +165,7 @@ import ProjectResuming from "@/features/activities/ProjectResuming";
 import ProjectRetrospectiveCommented from "@/features/activities/ProjectRetrospectiveCommented";
 import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import ResourceHubDocumentCreated from "@/features/activities/ResourceHubDocumentCreated";
+import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -218,6 +220,7 @@ function handler(activity: Activity) {
     .with("project_retrospective_commented", () => ProjectRetrospectiveCommented)
     .with("project_timeline_edited", () => ProjectTimelineEdited)
     .with("resource_hub_document_created", () => ResourceHubDocumentCreated)
+    .with("resource_hub_document_commented", () => ResourceHubDocumentCommented)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/lib/operately/activities/content/resource_hub_document_commented.ex
+++ b/lib/operately/activities/content/resource_hub_document_commented.ex
@@ -6,6 +6,7 @@ defmodule Operately.Activities.Content.ResourceHubDocumentCommented do
     belongs_to :space, Operately.Groups.Group
     belongs_to :resource_hub, Operately.ResourceHubs.ResourceHub
     belongs_to :document, Operately.ResourceHubs.Document
+    belongs_to :node, Operately.ResourceHubs.Node
     belongs_to :comment, Operately.Updates.Comment
   end
 

--- a/lib/operately/operations/comment_adding/activity.ex
+++ b/lib/operately/operations/comment_adding/activity.ex
@@ -55,6 +55,7 @@ defmodule Operately.Operations.CommentAdding.Activity do
         space_id: entity.resource_hub.space_id,
         resource_hub_id: entity.resource_hub.id,
         document_id: entity.id,
+        node_id: entity.node.id,
         comment_id: changes.comment.id,
       }
     end)

--- a/lib/operately_web/api/mutations/create_comment.ex
+++ b/lib/operately_web/api/mutations/create_comment.ex
@@ -59,7 +59,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateComment do
       :comment_thread -> Comments.get_thread_with_activity_and_access_level(id, person.id)
       :goal_update -> Update.get(person, id: id, opts: [preload: :goal])
       :message -> Message.get(person, id: id, opts: [preload: :space])
-      :resource_hub_document -> Document.get(person, id: id, opts: [preload: :resource_hub])
+      :resource_hub_document -> Document.get(person, id: id, opts: [preload: [:resource_hub, :node]])
     end
   end
 

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_document_commented.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_document_commented.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubDocumentCommented do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    document = Map.put(content["document"], :node, content["node"])
+
+    %{
+      document: Serializer.serialize(document, level: :essential),
+      comment: Serializer.serialize(content["comment"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -430,6 +430,11 @@ defmodule OperatelyWeb.Api.Types do
     field :document, :resource_hub_document
   end
 
+  object :activity_content_resource_hub_document_commented do
+    field :document, :resource_hub_document
+    field :comment, :comment
+  end
+
   object :activity_content_project_discussion_submitted do
     field :project_id, :string
     field :discussion_id, :string


### PR DESCRIPTION
The `ResourceHubDocumentCommented` event is now displayed in the feed.