### PR TITLE
feat: Display document-edited event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -513,6 +513,11 @@ export interface ActivityContentResourceHubDocumentCreated {
   document?: ResourceHubDocument | null;
 }
 
+export interface ActivityContentResourceHubDocumentEdited {
+  resourceHub?: ResourceHub | null;
+  document?: ResourceHubDocument | null;
+}
+
 export interface ActivityContentResourceHubFolderCreated {
   resourceHub?: ResourceHub | null;
   folder?: ResourceHubFolder | null;
@@ -2158,6 +2163,14 @@ export interface CreateTaskResult {
   task?: Task | null;
 }
 
+export interface DeleteResourceHubDocumentInput {
+  documentId?: Id | null;
+}
+
+export interface DeleteResourceHubDocumentResult {
+  document?: Document | null;
+}
+
 export interface DisconnectGoalFromProjectInput {
   projectId?: string | null;
   goalId?: string | null;
@@ -2963,6 +2976,10 @@ export class ApiClient {
     return this.post("/create_task", input);
   }
 
+  async deleteResourceHubDocument(input: DeleteResourceHubDocumentInput): Promise<DeleteResourceHubDocumentResult> {
+    return this.post("/delete_resource_hub_document", input);
+  }
+
   async disconnectGoalFromProject(input: DisconnectGoalFromProjectInput): Promise<DisconnectGoalFromProjectResult> {
     return this.post("/disconnect_goal_from_project", input);
   }
@@ -3419,6 +3436,11 @@ export async function createSpace(input: CreateSpaceInput): Promise<CreateSpaceR
 }
 export async function createTask(input: CreateTaskInput): Promise<CreateTaskResult> {
   return defaultApiClient.createTask(input);
+}
+export async function deleteResourceHubDocument(
+  input: DeleteResourceHubDocumentInput,
+): Promise<DeleteResourceHubDocumentResult> {
+  return defaultApiClient.deleteResourceHubDocument(input);
 }
 export async function disconnectGoalFromProject(
   input: DisconnectGoalFromProjectInput,
@@ -3986,6 +4008,15 @@ export function useCreateTask(): UseMutationHookResult<CreateTaskInput, CreateTa
   return useMutation<CreateTaskInput, CreateTaskResult>((input) => defaultApiClient.createTask(input));
 }
 
+export function useDeleteResourceHubDocument(): UseMutationHookResult<
+  DeleteResourceHubDocumentInput,
+  DeleteResourceHubDocumentResult
+> {
+  return useMutation<DeleteResourceHubDocumentInput, DeleteResourceHubDocumentResult>((input) =>
+    defaultApiClient.deleteResourceHubDocument(input),
+  );
+}
+
 export function useDisconnectGoalFromProject(): UseMutationHookResult<
   DisconnectGoalFromProjectInput,
   DisconnectGoalFromProjectResult
@@ -4479,6 +4510,8 @@ export default {
   useCreateSpace,
   createTask,
   useCreateTask,
+  deleteResourceHubDocument,
+  useDeleteResourceHubDocument,
   disconnectGoalFromProject,
   useDisconnectGoalFromProject,
   editComment,

--- a/assets/js/features/activities/ResourceHubDocumentEdited/index.tsx
+++ b/assets/js/features/activities/ResourceHubDocumentEdited/index.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubDocumentEdited } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { feedTitle } from "../feedItemLinks";
+import { Link } from "@/components/Link";
+
+const ResourceHubDocumentEdited: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubDocumentPath(content(activity).document!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const document = content(activity).document!;
+
+    const path = Paths.resourceHubDocumentPath(document.id!);
+    const activityLink = <Link to={path}>{document.name}</Link>;
+
+    return feedTitle(activity, "edited", activityLink);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " edited the document";
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).resourceHub!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubDocumentEdited {
+  return activity.content as ActivityContentResourceHubDocumentEdited;
+}
+
+export default ResourceHubDocumentEdited;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -106,6 +106,7 @@ export const DISPLAYED_IN_FEED = [
   "project_timeline_edited",
   "project_retrospective_commented",
   "resource_hub_document_created",
+  "resource_hub_document_edited",
   "resource_hub_document_commented",
   "resource_hub_folder_created",
   "space_added",
@@ -165,6 +166,7 @@ import ProjectResuming from "@/features/activities/ProjectResuming";
 import ProjectRetrospectiveCommented from "@/features/activities/ProjectRetrospectiveCommented";
 import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import ResourceHubDocumentCreated from "@/features/activities/ResourceHubDocumentCreated";
+import ResourceHubDocumentEdited from "@/features/activities/ResourceHubDocumentEdited";
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
@@ -220,6 +222,7 @@ function handler(activity: Activity) {
     .with("project_retrospective_commented", () => ProjectRetrospectiveCommented)
     .with("project_timeline_edited", () => ProjectTimelineEdited)
     .with("resource_hub_document_created", () => ResourceHubDocumentCreated)
+    .with("resource_hub_document_edited", () => ResourceHubDocumentEdited)
     .with("resource_hub_document_commented", () => ResourceHubDocumentCommented)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_document_edited.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_document_edited.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubDocumentEdited do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    document = Map.put(content["document"], :node, content["node"])
+
+    %{
+      document: Serializer.serialize(document, level: :essential),
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential)
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -430,6 +430,11 @@ defmodule OperatelyWeb.Api.Types do
     field :document, :resource_hub_document
   end
 
+  object :activity_content_resource_hub_document_edited do
+    field :resource_hub, :resource_hub
+    field :document, :resource_hub_document
+  end
+
   object :activity_content_resource_hub_document_commented do
     field :document, :resource_hub_document
     field :comment, :comment


### PR DESCRIPTION
The `ResourceHubDocumentEdited` event is now displayed in the feed.