### PR TITLE
feat: Display document-deleted event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -513,6 +513,11 @@ export interface ActivityContentResourceHubDocumentCreated {
   document?: ResourceHubDocument | null;
 }
 
+export interface ActivityContentResourceHubDocumentDeleted {
+  resourceHub?: ResourceHub | null;
+  document?: ResourceHubDocument | null;
+}
+
 export interface ActivityContentResourceHubDocumentEdited {
   resourceHub?: ResourceHub | null;
   document?: ResourceHubDocument | null;

--- a/assets/js/features/activities/ResourceHubDocumentDeleted/index.tsx
+++ b/assets/js/features/activities/ResourceHubDocumentDeleted/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubDocumentDeleted } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubDocumentDeleted: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const resourceHub = content(activity).resourceHub!;
+    const document = content(activity).document!;
+
+    const path = Paths.resourceHubDocumentPath(resourceHub.id!);
+    const link = <Link to={path}>{resourceHub.name}</Link>;
+
+    return feedTitle(activity, "deleted", document.name!, "from", link);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " deleted a document: " + content(activity).document!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).resourceHub!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubDocumentDeleted {
+  return activity.content as ActivityContentResourceHubDocumentDeleted;
+}
+
+export default ResourceHubDocumentDeleted;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -108,6 +108,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_document_created",
   "resource_hub_document_edited",
   "resource_hub_document_commented",
+  "resource_hub_document_deleted",
   "resource_hub_folder_created",
   "space_added",
   "space_joining",
@@ -168,6 +169,7 @@ import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import ResourceHubDocumentCreated from "@/features/activities/ResourceHubDocumentCreated";
 import ResourceHubDocumentEdited from "@/features/activities/ResourceHubDocumentEdited";
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
+import ResourceHubDocumentDeleted from "@/features/activities/ResourceHubDocumentDeleted";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -224,6 +226,7 @@ function handler(activity: Activity) {
     .with("resource_hub_document_created", () => ResourceHubDocumentCreated)
     .with("resource_hub_document_edited", () => ResourceHubDocumentEdited)
     .with("resource_hub_document_commented", () => ResourceHubDocumentCommented)
+    .with("resource_hub_document_deleted", () => ResourceHubDocumentDeleted)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_document_deleted.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_document_deleted.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubDocumentDeleted do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    document = Map.put(content["document"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      document: Serializer.serialize(document, level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -435,6 +435,11 @@ defmodule OperatelyWeb.Api.Types do
     field :document, :resource_hub_document
   end
 
+  object :activity_content_resource_hub_document_deleted do
+    field :resource_hub, :resource_hub
+    field :document, :resource_hub_document
+  end
+
   object :activity_content_resource_hub_document_commented do
     field :document, :resource_hub_document
     field :comment, :comment


### PR DESCRIPTION
The `ResourceHubDocumentDeleted` event is now displayed in the feed.