### PR TITLE
feat: Add subtitle to resource hubs items

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1076,6 +1076,7 @@ export interface ResourceHubFolder {
   nodes?: ResourceHubNode[] | null;
   permissions?: ResourceHubPermissions | null;
   pathToFolder?: ResourceHubFolder[] | null;
+  childrenCount?: number | null;
 }
 
 export interface ResourceHubNode {
@@ -1719,6 +1720,7 @@ export interface GetResourceHubInput {
   includeNodes?: boolean | null;
   includePotentialSubscribers?: boolean | null;
   includePermissions?: boolean | null;
+  includeChildrenCount?: boolean | null;
 }
 
 export interface GetResourceHubResult {
@@ -1746,6 +1748,7 @@ export interface GetResourceHubFolderInput {
   includeResourceHub?: boolean | null;
   includePathToFolder?: boolean | null;
   includePermissions?: boolean | null;
+  includeChildrenCount?: boolean | null;
 }
 
 export interface GetResourceHubFolderResult {

--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -6,6 +6,9 @@ import classNames from "classnames";
 import { Paths } from "@/routes/paths";
 import { DivLink } from "@/components/Link";
 import { Menu, MenuLinkItem, MenuActionItem } from "@/components/Menu";
+import { richContentToString } from "@/components/RichContent";
+import { truncateString } from "@/utils/strings";
+import { assertPresent } from "@/utils/assertions";
 
 type NodeType = "document" | "folder" | "file";
 
@@ -43,6 +46,7 @@ function NodeItem({ node, permissions, refetch }: NodeItemProps) {
   );
   const Icon = findIcon(node.type as NodeType, node);
   const path = findPath(node.type as NodeType, node);
+  const subtitle = findSubtitle(node.type as NodeType, node);
 
   return (
     <div className={className}>
@@ -50,7 +54,7 @@ function NodeItem({ node, permissions, refetch }: NodeItemProps) {
         <Icon size={48} />
         <div>
           <div className="font-bold text-lg">{node.name}</div>
-          <div>3 items</div>
+          <div>{subtitle}</div>
         </div>
       </DivLink>
 
@@ -112,6 +116,19 @@ function findPath(nodeType: NodeType, node: Hub.ResourceHubNode) {
       return Paths.resourceHubDocumentPath(node.document!.id!);
     case "folder":
       return Paths.resourceHubFolderPath(node.folder!.id!);
+    case "file":
+      return "";
+  }
+}
+
+function findSubtitle(nodeType: NodeType, node: Hub.ResourceHubNode) {
+  switch (nodeType) {
+    case "document":
+      const content = richContentToString(JSON.parse(node.document?.content!));
+      return truncateString(content, 60);
+    case "folder":
+      assertPresent(node.folder?.childrenCount, "childrenCount must be present in node.folder");
+      return node.folder.childrenCount === 1 ? "1 item" : `${node.folder.childrenCount} items`;
     case "file":
       return "";
   }

--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -124,7 +124,8 @@ function findPath(nodeType: NodeType, node: Hub.ResourceHubNode) {
 function findSubtitle(nodeType: NodeType, node: Hub.ResourceHubNode) {
   switch (nodeType) {
     case "document":
-      const content = richContentToString(JSON.parse(node.document?.content!));
+      assertPresent(node.document?.content, "content must be present in node.document");
+      const content = richContentToString(JSON.parse(node.document.content));
       return truncateString(content, 60);
     case "folder":
       assertPresent(node.folder?.childrenCount, "childrenCount must be present in node.folder");

--- a/assets/js/pages/ResourceHubFolderPage/loader.tsx
+++ b/assets/js/pages/ResourceHubFolderPage/loader.tsx
@@ -13,6 +13,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeResourceHub: true,
       includePathToFolder: true,
       includePermissions: true,
+      includeChildrenCount: true,
     }).then((res) => res.folder!),
   };
 }

--- a/assets/js/pages/ResourceHubPage/loader.tsx
+++ b/assets/js/pages/ResourceHubPage/loader.tsx
@@ -13,6 +13,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeSpace: true,
       includeNodes: true,
       includePermissions: true,
+      includeChildrenCount: true,
     }).then((res) => res.resourceHub!),
   };
 }

--- a/lib/operately/resource_hubs/folder.ex
+++ b/lib/operately/resource_hubs/folder.ex
@@ -11,7 +11,7 @@ defmodule Operately.ResourceHubs.Folder do
     # populated with after load hooks
     field :permissions, :any, virtual: true
     field :path_to_folder, :any, virtual: true
-    field :children_count, :any, virtual: true
+    field :children_count, :integer, virtual: true
 
     timestamps()
     request_info()

--- a/lib/operately/resource_hubs/resource_hub.ex
+++ b/lib/operately/resource_hubs/resource_hub.ex
@@ -40,6 +40,11 @@ defmodule Operately.ResourceHubs.ResourceHub do
     Map.put(resource_hub, :potential_subscribers, subscribers)
   end
 
+  def set_children_count(resource_hub = %__MODULE__{}) do
+    nodes = Operately.ResourceHubs.Folder.find_children_count(resource_hub.nodes)
+    Map.put(resource_hub, :nodes, nodes)
+  end
+
   def set_permissions(resource_hub = %__MODULE__{}) do
     perms = Operately.ResourceHubs.Permissions.calculate(resource_hub.request_info.access_level)
     Map.put(resource_hub, :permissions, perms)

--- a/lib/operately_web/api/queries/get_resource_hub.ex
+++ b/lib/operately_web/api/queries/get_resource_hub.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
     field :include_nodes, :boolean
     field :include_potential_subscribers, :boolean
     field :include_permissions, :boolean
+    field :include_children_count, :boolean
   end
 
   outputs do
@@ -52,6 +53,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
   defp after_load(inputs) do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &ResourceHub.load_potential_subscribers/1,
+      include_children_count: &ResourceHub.set_children_count/1,
       include_permissions: &ResourceHub.set_permissions/1,
     ])
   end

--- a/lib/operately_web/api/queries/get_resource_hub_folder.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_folder.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolder do
     field :include_resource_hub, :boolean
     field :include_path_to_folder, :boolean
     field :include_permissions, :boolean
+    field :include_children_count, :boolean
   end
 
   outputs do
@@ -50,6 +51,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolder do
   def after_load(inputs) do
     Inputs.parse_includes(inputs, [
       include_path_to_folder: &Folder.find_path_to_folder/1,
+      include_children_count: &Folder.set_children_count/1,
       include_permissions: &Folder.set_permissions/1,
     ])
   end

--- a/lib/operately_web/api/serializers/resource_hub_folder.ex
+++ b/lib/operately_web/api/serializers/resource_hub_folder.ex
@@ -3,6 +3,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Folder do
     %{
       id: OperatelyWeb.Paths.folder_id(folder),
       name: folder.node.name,
+      children_count: folder.children_count,
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -563,6 +563,7 @@ defmodule OperatelyWeb.Api.Types do
     field :nodes, list_of(:resource_hub_node)
     field :permissions, :resource_hub_permissions
     field :path_to_folder, list_of(:resource_hub_folder)
+    field :children_count, :integer
   end
 
   object :resource_hub_document do


### PR DESCRIPTION
Now, a preview of a document's content and a folder's children count is displayed in the Resource Hub items list:

https://github.com/user-attachments/assets/09d904a1-1760-4d78-a413-f630824757f6

