### PR TITLE
feat: Document notifications are cleared when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1053,6 +1053,7 @@ export interface ResourceHubDocument {
   comments?: Comment[] | null;
   potentialSubscribers?: Subscriber[] | null;
   subscriptionList?: SubscriptionList | null;
+  notifications?: Notification[] | null;
 }
 
 export interface ResourceHubFile {
@@ -1734,6 +1735,7 @@ export interface GetResourceHubDocumentInput {
   includePermissions?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
 }
 
 export interface GetResourceHubDocumentResult {

--- a/assets/js/pages/ResourceHubDocumentPage/loader.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/loader.tsx
@@ -16,6 +16,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includePermissions: true,
       includePotentialSubscribers: true,
       includeSubscriptionsList: true,
+      includeUnreadNotifications: true,
     }).then((res) => res.document!),
   };
 }

--- a/assets/js/pages/ResourceHubDocumentPage/page.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/page.tsx
@@ -16,11 +16,15 @@ import { assertPresent } from "@/utils/assertions";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useComments } from "@/features/CommentSection";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 import { useLoadedData } from "./loader";
 
 export function Page() {
   const { document } = useLoadedData();
+
+  assertPresent(document.notifications, "notifications must be present in document");
+  useClearNotificationsOnLoad(document.notifications);
 
   return (
     <Pages.Page title={document.name!}>

--- a/lib/operately/resource_hubs/document.ex
+++ b/lib/operately/resource_hubs/document.ex
@@ -19,6 +19,7 @@ defmodule Operately.ResourceHubs.Document do
     # populated with after load hooks
     field :potential_subscribers, :any, virtual: true
     field :permissions, :any, virtual: true
+    field :notifications, :any, virtual: true, default: []
 
     timestamps()
     soft_delete()
@@ -38,6 +39,24 @@ defmodule Operately.ResourceHubs.Document do
   #
   # After load hooks
   #
+
+  def load_unread_notifications(document = %__MODULE__{}, person) do
+    actions = [
+      "resource_hub_document_created",
+      "resource_hub_document_edited"
+    ]
+
+    notifications =
+      from(n in Operately.Notifications.Notification,
+        join: a in assoc(n, :activity),
+        where: a.action in ^actions and a.content["document_id"] == ^document.id,
+        where: n.person_id == ^person.id and not n.read,
+        select: n
+      )
+      |> Repo.all()
+
+    Map.put(document, :notifications, notifications)
+  end
 
   def load_potential_subscribers(document = %__MODULE__{}) do
     document = Repo.preload(document, [:access_context, resource_hub: [space: :members]])

--- a/lib/operately_web/api/queries/get_resource_hub_document.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_document.ex
@@ -13,6 +13,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
     field :include_permissions, :boolean
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
   end
 
   outputs do
@@ -38,7 +39,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
   def load(ctx, inputs) do
     Document.get(ctx.me, id: inputs.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs),
+      after_load: after_load(inputs, ctx.me),
     ])
   end
 
@@ -53,10 +54,17 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
     ])
   end
 
-  defp after_load(inputs) do
+  defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_permissions: &Document.set_permissions/1,
+      include_unread_notifications: load_unread_notifications(me),
       include_potential_subscribers: &Document.load_potential_subscribers/1,
     ])
+  end
+
+  defp load_unread_notifications(person) do
+    fn document ->
+      Document.load_unread_notifications(document, person)
+    end
   end
 end

--- a/lib/operately_web/api/serializers/resource_hub_document.ex
+++ b/lib/operately_web/api/serializers/resource_hub_document.ex
@@ -22,6 +22,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Document do
       permissions: OperatelyWeb.Api.Serializer.serialize(document.permissions),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(document.potential_subscribers),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(document.subscription_list),
+      notifications: OperatelyWeb.Api.Serializer.serialize(document.notifications),
     }
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -579,6 +579,7 @@ defmodule OperatelyWeb.Api.Types do
     field :comments, list_of(:comment)
     field :potential_subscribers, list_of(:subscriber)
     field :subscription_list, :subscription_list
+    field :notifications, list_of(:notification)
   end
 
   object :resource_hub_file do


### PR DESCRIPTION
When the document page loads, `ResourceHubDocumentCreated` and `ResourceHubDocumentEdited` unread notifications are automatically marked as read.