### PR TITLE
fix: Clear rich text before adding new text in feature tests

### DIFF
--- a/test/features/project_tasks_test.exs
+++ b/test/features/project_tasks_test.exs
@@ -73,7 +73,7 @@ defmodule Operately.Features.ProjectTasksTest do
       test_id: "todo_0",
     }
     name = "new name"
-    description = " - new description"
+    description = "new description"
 
     ctx
     |> Steps.visit_milestone_page()
@@ -85,7 +85,7 @@ defmodule Operately.Features.ProjectTasksTest do
     |> UI.assert_text(name)
     |> UI.refute_text(description)
     |> Steps.edit_task_description(description)
-    |> UI.assert_text(attrs.description <> description)
+    |> UI.assert_text(description)
   end
 
   @tag login_as: :champion

--- a/test/support/features/discussions_steps.ex
+++ b/test/support/features/discussions_steps.ex
@@ -119,7 +119,6 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     ctx
     |> UI.click(testid: "options-button")
     |> UI.click(testid: "edit-discussion")
-    |> UI.fill(testid: "discussion-title", with: "")
     |> UI.fill(testid: "discussion-title", with: "This is an edited discussion")
     |> UI.fill_rich_text("This is the edited body of the discussion.")
     |> UI.click(testid: "save-changes")
@@ -259,7 +258,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   end
 
   step :edit_and_publish_draft, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "continue-editing")
     |> UI.assert_has(testid: "discussion-edit-page")
     |> UI.fill(testid: "discussion-title", with: "This is a draft discussion (edited)")
@@ -305,7 +304,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   step :archive_discussion, ctx do
     message = last_message(ctx)
 
-    ctx 
+    ctx
     |> UI.visit(Paths.message_path(ctx.company, message))
     |> UI.click(testid: "options-button")
     |> UI.click(testid: "archive-discussion")
@@ -314,7 +313,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   step :assert_discussion_is_archived, ctx do
     message = last_archived_message(ctx)
 
-    ctx 
+    ctx
     |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
     |> UI.refute_text(message.title)
   end
@@ -322,13 +321,13 @@ defmodule Operately.Support.Features.DiscussionsSteps do
   step :assert_discussion_feed_events, ctx do
     message = last_archived_message(ctx)
 
-    ctx 
+    ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.marketing_space))
     |> UI.assert_feed_item(ctx.creator, "deleted: #{message.title}")
   end
 
   step :assert_comment_is_listed_in_the_feed, ctx do
-    ctx 
+    ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.marketing_space))
     |> UI.assert_feed_item(ctx.reader, "commented on #{@title}")
     |> UI.visit(Paths.feed_path(ctx.company))
@@ -343,7 +342,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     import Ecto.Query
 
     message = Operately.Repo.one(
-      from m in Operately.Messages.Message, 
+      from m in Operately.Messages.Message,
       where: not is_nil(m.deleted_at),
       limit: 1
     )
@@ -351,7 +350,7 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     cond do
       message -> message
       attempts <= 0 -> raise "Could not find the last archived message"
-      true -> 
+      true ->
         :timer.sleep(300)
         last_archived_message(ctx, attempts - 1)
     end

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -177,18 +177,24 @@ defmodule Operately.Support.Features.UI do
   end
 
   def fill_rich_text(state, message) when is_binary(message) do
+    query = Query.css(".ProseMirror[contenteditable=true]")
+
     execute(state, fn session ->
       session
-      |> Browser.find(Query.css(".ProseMirror[contenteditable=true]"), fn element ->
+      |> Browser.clear(query)
+      |> Browser.find(query, fn element ->
         element |> Browser.send_keys(message)
       end)
     end)
   end
 
   def fill_rich_text(state, testid: id, with: message) when is_binary(message) do
+    query = Query.css("[data-test-id=\"#{id}\"] .ProseMirror[contenteditable=true]")
+
     execute(state, fn session ->
       session
-      |> Browser.find(Query.css("[data-test-id=\"#{id}\"] .ProseMirror[contenteditable=true]"), fn element ->
+      |> Browser.clear(query)
+      |> Browser.find(query, fn element ->
         element |> Browser.send_keys(message)
       end)
     end)


### PR DESCRIPTION
The function `UI.fill_rich_text` now clears any existing text before adding the new one. Hopefully, that will solve the problem with flaky tests where the content was sometimes appended to the existing text, but sometimes not.