### PR TITLE
feat: Display file-created event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -523,6 +523,12 @@ export interface ActivityContentResourceHubDocumentEdited {
   document?: ResourceHubDocument | null;
 }
 
+export interface ActivityContentResourceHubFileCreated {
+  fileId?: string | null;
+  fileName?: string | null;
+  resourceHub?: ResourceHub | null;
+}
+
 export interface ActivityContentResourceHubFolderCreated {
   resourceHub?: ResourceHub | null;
   folder?: ResourceHubFolder | null;

--- a/assets/js/features/activities/ResourceHubFileCreated/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileCreated/index.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFileCreated } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubFileCreated: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(_activity: Activity) {
+    return Paths.resourceHubFilePath(content(_activity).fileId!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity; page: any }) {
+    const path = Paths.resourceHubFilePath(content(activity).fileId!);
+    const link = <Link to={path}>{content(activity).fileName}</Link>;
+
+    return feedTitle(activity, "added a file:", link);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " added a file: " + content(activity).fileName;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFileCreated {
+  return activity.content as ActivityContentResourceHubFileCreated;
+}
+
+export default ResourceHubFileCreated;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -109,6 +109,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_document_edited",
   "resource_hub_document_commented",
   "resource_hub_document_deleted",
+  "resource_hub_file_created",
   "resource_hub_folder_created",
   "space_added",
   "space_joining",
@@ -170,6 +171,7 @@ import ResourceHubDocumentCreated from "@/features/activities/ResourceHubDocumen
 import ResourceHubDocumentEdited from "@/features/activities/ResourceHubDocumentEdited";
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubDocumentDeleted from "@/features/activities/ResourceHubDocumentDeleted";
+import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -227,6 +229,7 @@ function handler(activity: Activity) {
     .with("resource_hub_document_edited", () => ResourceHubDocumentEdited)
     .with("resource_hub_document_commented", () => ResourceHubDocumentCommented)
     .with("resource_hub_document_deleted", () => ResourceHubDocumentDeleted)
+    .with("resource_hub_file_created", () => ResourceHubFileCreated)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/assets/js/routes/paths.tsx
+++ b/assets/js/routes/paths.tsx
@@ -208,6 +208,10 @@ export class Paths {
     return createCompanyPath(["folders", folderId]);
   }
 
+  static resourceHubFilePath(fileId: string) {
+    return createCompanyPath(["files", fileId]);
+  }
+
   static resourceHubDocumentPath(documentId: string) {
     return createCompanyPath(["documents", documentId]);
   }

--- a/lib/operately/activities/preloader.ex
+++ b/lib/operately/activities/preloader.ex
@@ -23,6 +23,7 @@ defmodule Operately.Activities.Preloader do
     |> preload(Operately.Messages.Message)
     |> preload(Operately.ResourceHubs.ResourceHub)
     |> preload(Operately.ResourceHubs.Folder)
+    |> preload(Operately.ResourceHubs.File)
     |> preload(Operately.ResourceHubs.Document)
     |> preload(Operately.ResourceHubs.Node)
     |> preload_sub_activities()

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_file_created.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_file_created.ex
@@ -1,0 +1,11 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFileCreated do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      file_id: OperatelyWeb.Paths.file_id(content["file"]),
+      file_name: content["file_name"],
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -425,6 +425,12 @@ defmodule OperatelyWeb.Api.Types do
     field :folder, :resource_hub_folder
   end
 
+  object :activity_content_resource_hub_file_created do
+    field :file_id, :string
+    field :file_name, :string
+    field :resource_hub, :resource_hub
+  end
+
   object :activity_content_resource_hub_document_created do
     field :resource_hub, :resource_hub
     field :document, :resource_hub_document


### PR DESCRIPTION
The `ResourceHubFileCreated` event is now displayed in the feed.