### PR TITLE
feat: Display file-deleted event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -529,6 +529,11 @@ export interface ActivityContentResourceHubFileCreated {
   resourceHub?: ResourceHub | null;
 }
 
+export interface ActivityContentResourceHubFileDeleted {
+  resourceHub?: ResourceHub | null;
+  file?: ResourceHubFile | null;
+}
+
 export interface ActivityContentResourceHubFolderCreated {
   resourceHub?: ResourceHub | null;
   folder?: ResourceHubFolder | null;

--- a/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFileDeleted } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubFileDeleted: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const resourceHub = content(activity).resourceHub!;
+    const file = content(activity).file!;
+
+    const path = Paths.resourceHubDocumentPath(resourceHub.id!);
+    const link = <Link to={path}>{resourceHub.name}</Link>;
+
+    return feedTitle(activity, "deleted", file.name!, "from", link);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " deleted a file: " + content(activity).file!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).resourceHub!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFileDeleted {
+  return activity.content as ActivityContentResourceHubFileDeleted;
+}
+
+export default ResourceHubFileDeleted;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -110,6 +110,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_document_commented",
   "resource_hub_document_deleted",
   "resource_hub_file_created",
+  "resource_hub_file_deleted",
   "resource_hub_folder_created",
   "space_added",
   "space_joining",
@@ -172,6 +173,7 @@ import ResourceHubDocumentEdited from "@/features/activities/ResourceHubDocument
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubDocumentDeleted from "@/features/activities/ResourceHubDocumentDeleted";
 import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated";
+import ResourceHubFileDeleted from "@/features/activities/ResourceHubFileDeleted";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -230,6 +232,7 @@ function handler(activity: Activity) {
     .with("resource_hub_document_commented", () => ResourceHubDocumentCommented)
     .with("resource_hub_document_deleted", () => ResourceHubDocumentDeleted)
     .with("resource_hub_file_created", () => ResourceHubFileCreated)
+    .with("resource_hub_file_deleted", () => ResourceHubFileDeleted)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_file_deleted.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_file_deleted.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFileDeleted do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    file = Map.put(content["file"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      file: Serializer.serialize(file, level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -431,6 +431,11 @@ defmodule OperatelyWeb.Api.Types do
     field :resource_hub, :resource_hub
   end
 
+  object :activity_content_resource_hub_file_deleted do
+    field :resource_hub, :resource_hub
+    field :file, :resource_hub_file
+  end
+
   object :activity_content_resource_hub_document_created do
     field :resource_hub, :resource_hub
     field :document, :resource_hub_document


### PR DESCRIPTION
The `ResourceHubFileDeleted` event is now displayed in the feed.