### PR TITLE
chore: Add retries to unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test.ee:
 	./devenv mix test ee/test/**/*_test.exs
 
 test.mix.unit: test.init
-	./devenv mix test $$(find test -name "*_test.exs" | grep -v "test/features")
+	./devenv mix tests_with_retries $$(find test -name "*_test.exs" | grep -v "test/features")
 
 test.mix.features: test.init
 	./devenv mix tests_with_retries $$(find test -name "*_test.exs" | grep "test/features" | ./scripts/split.rb $(INDEX) $(TOTAL))


### PR DESCRIPTION
Unit tests now also use the `tests_with_retries` task.