### PR TITLE
fix: Goal-update-commented notification redirects to correct page

### DIFF
--- a/assets/js/features/activities/GoalCheckInCommented/index.tsx
+++ b/assets/js/features/activities/GoalCheckInCommented/index.tsx
@@ -17,7 +17,7 @@ const GoalUpdateCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalProgressUpdatePath(content(activity).goalId!);
+    return Paths.goalProgressUpdatePath(content(activity).update?.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/test/features/goal_progress_update_test.exs
+++ b/test/features/goal_progress_update_test.exs
@@ -50,6 +50,8 @@ defmodule Operately.Features.GoalProgressUpdateTest do
     |> Steps.update_progress(params)
     |> Steps.comment_on_progress_update_as_reviewer("Great job!")
     |> Steps.assert_progress_update_commented_in_feed("Great job!")
+    |> Steps.assert_progress_update_commented_in_notifications()
+    |> Steps.assert_progress_update_commented_notification_redirects_on_click()
     |> Steps.assert_comment_email_sent()
   end
 end

--- a/test/support/features/goal_progress_update_steps.ex
+++ b/test/support/features/goal_progress_update_steps.ex
@@ -196,6 +196,24 @@ defmodule Operately.Support.Features.GoalProgressUpdateSteps do
     |> FeedSteps.assert_goal_check_in_commented(author: ctx.champion, goal_name: ctx.goal.name, comment: comment)
   end
 
+  step :assert_progress_update_commented_in_notifications, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.reviewer,
+      action: "commented on the goal update"
+    })
+  end
+
+  step :assert_progress_update_commented_notification_redirects_on_click, ctx do
+    update = Operately.Goals.list_updates(ctx.goal) |> hd()
+
+    ctx
+    |> UI.click(testid: "notification-item-goal_check_in_commented")
+    |> UI.assert_page(Paths.goal_check_in_path(ctx.company, update))
+  end
+
   step :assert_comment_email_sent, ctx do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1673.