### PR TITLE
feat: Display file-commented event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -523,6 +523,11 @@ export interface ActivityContentResourceHubDocumentEdited {
   document?: ResourceHubDocument | null;
 }
 
+export interface ActivityContentResourceHubFileCommented {
+  file?: ResourceHubFile | null;
+  comment?: Comment | null;
+}
+
 export interface ActivityContentResourceHubFileCreated {
   fileId?: string | null;
   fileName?: string | null;

--- a/assets/js/features/activities/ResourceHubFileCommented/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileCommented/index.tsx
@@ -1,0 +1,74 @@
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFileCommented } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+
+import { Paths } from "@/routes/paths";
+import { Summary } from "@/components/RichContent";
+import React from "react";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubFileCommented: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    return Paths.resourceHubFilePath(content(activity).file!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity; page: any }) {
+    const file = content(activity).file!;
+
+    const path = Paths.resourceHubFilePath(file.id!);
+    const activityLink = <Link to={path}>{file.name}</Link>;
+
+    return feedTitle(activity, "commented on", activityLink);
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const comment = content(activity).comment!;
+    const commentContent = JSON.parse(comment.content!)["message"];
+    return <Summary jsonContent={commentContent} characterCount={200} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " commented on: " + content(activity).file!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).file!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFileCommented {
+  return activity.content as ActivityContentResourceHubFileCommented;
+}
+
+export default ResourceHubFileCommented;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -111,6 +111,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_document_deleted",
   "resource_hub_file_created",
   "resource_hub_file_deleted",
+  "resource_hub_file_commented",
   "resource_hub_folder_created",
   "space_added",
   "space_joining",
@@ -174,6 +175,7 @@ import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocum
 import ResourceHubDocumentDeleted from "@/features/activities/ResourceHubDocumentDeleted";
 import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated";
 import ResourceHubFileDeleted from "@/features/activities/ResourceHubFileDeleted";
+import ResourceHubFileCommented from "@/features/activities/ResourceHubFileCommented";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -233,6 +235,7 @@ function handler(activity: Activity) {
     .with("resource_hub_document_deleted", () => ResourceHubDocumentDeleted)
     .with("resource_hub_file_created", () => ResourceHubFileCreated)
     .with("resource_hub_file_deleted", () => ResourceHubFileDeleted)
+    .with("resource_hub_file_commented", () => ResourceHubFileCommented)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_file_commented.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_file_commented.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFileCommented do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    file = Map.put(content["file"], :node, content["node"])
+
+    %{
+      file: Serializer.serialize(file, level: :essential),
+      comment: Serializer.serialize(content["comment"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -436,6 +436,11 @@ defmodule OperatelyWeb.Api.Types do
     field :file, :resource_hub_file
   end
 
+  object :activity_content_resource_hub_file_commented do
+    field :file, :resource_hub_file
+    field :comment, :comment
+  end
+
   object :activity_content_resource_hub_document_created do
     field :resource_hub, :resource_hub
     field :document, :resource_hub_document


### PR DESCRIPTION
The `ResourceHubFileCommented` event is now displayed in the feed.