### PR TITLE
feat: Add ImageWithPlaceholder component

### DIFF
--- a/assets/js/components/Image/ImageWithPlaceholder.tsx
+++ b/assets/js/components/Image/ImageWithPlaceholder.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+
+interface Props {
+  src: string;
+  alt?: string;
+  ratio: number;
+}
+
+export function ImageWithPlaceholder({ src, alt, ratio }: Props) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: "100%",
+        paddingBottom: `${ratio * 100}%`,
+        overflow: "hidden",
+      }}
+    >
+      {!loaded && (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background: "linear-gradient(90deg, #f5f5f5 25%, #e0e0e0 50%, #f5f5f5 75%)",
+            backgroundSize: "200% 100%",
+            animation: "loading 3.5s infinite",
+          }}
+        />
+      )}
+      <img
+        src={src}
+        alt={alt}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+          opacity: loaded ? 1 : 0,
+          transition: "opacity 500ms ease-in-out",
+        }}
+        onLoad={() => setLoaded(true)}
+      />
+      <style>
+        {`
+          @keyframes loading {
+            0% {
+              background-position: -200% 0;
+            }
+            100% {
+              background-position: 200% 0;
+            }
+          }
+        `}
+      </style>
+    </div>
+  );
+}

--- a/assets/js/components/Image/index.tsx
+++ b/assets/js/components/Image/index.tsx
@@ -1,0 +1,1 @@
+export { ImageWithPlaceholder } from "./ImageWithPlaceholder";

--- a/assets/js/pages/ResourceHubFilePage/Content.tsx
+++ b/assets/js/pages/ResourceHubFilePage/Content.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { assertPresent } from "@/utils/assertions";
+import { ImageWithPlaceholder } from "@/components/Image";
 import { useLoadedData } from "./loader";
 
 export function Content() {
@@ -16,9 +17,7 @@ function Image() {
   const { file } = useLoadedData();
   assertPresent(file.blob, "blob must be present in file");
 
-  return (
-    <div>
-      <img alt={file.name!} src={file.blob.url!} />
-    </div>
-  );
+  const imgRatio = file.blob.height! / file.blob.width!;
+
+  return <ImageWithPlaceholder src={file.blob.url!} alt={file.name!} ratio={imgRatio} />;
 }

--- a/lib/operately_web/api/serializers/resource_hub_file.ex
+++ b/lib/operately_web/api/serializers/resource_hub_file.ex
@@ -6,6 +6,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.File do
       description: Jason.encode!(file.description),
       type: Ecto.assoc_loaded?(file.blob) && file.blob.content_type,
       size: Ecto.assoc_loaded?(file.blob) && file.blob.size,
+      blob: OperatelyWeb.Api.Serializer.serialize(file.blob),
     }
   end
 


### PR DESCRIPTION
I've added an image component which shows a placeholder while the image is loading. Without this component, loading the file page was very chaotic:

https://github.com/user-attachments/assets/5be534a7-80a0-4cab-8b02-bca7c804ee6f

Now everything stays in the same place:

https://github.com/user-attachments/assets/9856f777-e29b-4330-be56-7134aae2b31c

