### PR TITLE
feat: Display folder-renamed event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -544,6 +544,13 @@ export interface ActivityContentResourceHubFolderCreated {
   folder?: ResourceHubFolder | null;
 }
 
+export interface ActivityContentResourceHubFolderRenamed {
+  resourceHub?: ResourceHub | null;
+  folder?: ResourceHubFolder | null;
+  oldName?: string | null;
+  newName?: string | null;
+}
+
 export interface ActivityContentSpaceAdded {
   companyId?: string | null;
   spaceId?: string | null;
@@ -2627,6 +2634,15 @@ export interface RemoveProjectMilestoneResult {
   milestone?: Milestone | null;
 }
 
+export interface RenameResourceHubFolderInput {
+  folderId?: Id | null;
+  newName?: string | null;
+}
+
+export interface RenameResourceHubFolderResult {
+  success?: boolean | null;
+}
+
 export interface ReopenGoalInput {
   id?: string | null;
   message?: string | null;
@@ -3256,6 +3272,10 @@ export class ApiClient {
     return this.post("/remove_project_milestone", input);
   }
 
+  async renameResourceHubFolder(input: RenameResourceHubFolderInput): Promise<RenameResourceHubFolderResult> {
+    return this.post("/rename_resource_hub_folder", input);
+  }
+
   async reopenGoal(input: ReopenGoalInput): Promise<ReopenGoalResult> {
     return this.post("/reopen_goal", input);
   }
@@ -3716,6 +3736,11 @@ export async function removeProjectMilestone(
   input: RemoveProjectMilestoneInput,
 ): Promise<RemoveProjectMilestoneResult> {
   return defaultApiClient.removeProjectMilestone(input);
+}
+export async function renameResourceHubFolder(
+  input: RenameResourceHubFolderInput,
+): Promise<RenameResourceHubFolderResult> {
+  return defaultApiClient.renameResourceHubFolder(input);
 }
 export async function reopenGoal(input: ReopenGoalInput): Promise<ReopenGoalResult> {
   return defaultApiClient.reopenGoal(input);
@@ -4442,6 +4467,15 @@ export function useRemoveProjectMilestone(): UseMutationHookResult<
   );
 }
 
+export function useRenameResourceHubFolder(): UseMutationHookResult<
+  RenameResourceHubFolderInput,
+  RenameResourceHubFolderResult
+> {
+  return useMutation<RenameResourceHubFolderInput, RenameResourceHubFolderResult>((input) =>
+    defaultApiClient.renameResourceHubFolder(input),
+  );
+}
+
 export function useReopenGoal(): UseMutationHookResult<ReopenGoalInput, ReopenGoalResult> {
   return useMutation<ReopenGoalInput, ReopenGoalResult>((input) => defaultApiClient.reopenGoal(input));
 }
@@ -4761,6 +4795,8 @@ export default {
   useRemoveProjectContributor,
   removeProjectMilestone,
   useRemoveProjectMilestone,
+  renameResourceHubFolder,
+  useRenameResourceHubFolder,
   reopenGoal,
   useReopenGoal,
   restoreCompanyMember,

--- a/assets/js/features/activities/ResourceHubFolderRenamed/index.tsx
+++ b/assets/js/features/activities/ResourceHubFolderRenamed/index.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFolderRenamed } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubFolderRenamed: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    const folder = content(activity).folder;
+    assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderRenamed activity content");
+
+    return Paths.resourceHubFolderPath(folder.id);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const resourceHub = content(activity).resourceHub;
+    const folder = content(activity).folder;
+    assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderRenamed activity content");
+    assertPresent(resourceHub?.id, "resourceHub.id must be present in ResourceHubFolderRenamed activity content");
+
+    const path = Paths.resourceHubFolderPath(folder.id);
+    const link = <Link to={path}>{folder.name}</Link>;
+    const hubPath = Paths.resourceHubPath(resourceHub.id);
+    const hubLink = <Link to={hubPath}>{resourceHub.name}</Link>;
+
+    return feedTitle(activity, "renamed the", link, "folder in", hubLink);
+  },
+
+  FeedItemContent({ activity }: { activity: Activity; page: any }) {
+    return (
+      <>
+        <span className="line-through">{content(activity).oldName}</span> → {content(activity).newName}
+      </>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " renamed a folder: " + content(activity).folder!.name!;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFolderRenamed {
+  return activity.content as ActivityContentResourceHubFolderRenamed;
+}
+
+export default ResourceHubFolderRenamed;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -113,6 +113,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_file_deleted",
   "resource_hub_file_commented",
   "resource_hub_folder_created",
+  "resource_hub_folder_renamed",
   "space_added",
   "space_joining",
   "space_member_removed",
@@ -177,6 +178,7 @@ import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated
 import ResourceHubFileDeleted from "@/features/activities/ResourceHubFileDeleted";
 import ResourceHubFileCommented from "@/features/activities/ResourceHubFileCommented";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
+import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRenamed";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
 import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
@@ -237,6 +239,7 @@ function handler(activity: Activity) {
     .with("resource_hub_file_deleted", () => ResourceHubFileDeleted)
     .with("resource_hub_file_commented", () => ResourceHubFileCommented)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
+    .with("resource_hub_folder_renamed", () => ResourceHubFolderRenamed)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)
     .with("space_member_removed", () => SpaceMemberRemoved)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_folder_renamed.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_folder_renamed.ex
@@ -1,0 +1,14 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFolderRenamed do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    folder = Map.put(content["folder"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      folder: Serializer.serialize(folder, level: :essential),
+      old_name: Serializer.serialize(content["old_name"], level: :essential),
+      new_name: Serializer.serialize(content["new_name"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -425,6 +425,13 @@ defmodule OperatelyWeb.Api.Types do
     field :folder, :resource_hub_folder
   end
 
+  object :activity_content_resource_hub_folder_renamed do
+    field :resource_hub, :resource_hub
+    field :folder, :resource_hub_folder
+    field :old_name, :string
+    field :new_name, :string
+  end
+
   object :activity_content_resource_hub_file_created do
     field :file_id, :string
     field :file_name, :string


### PR DESCRIPTION
The `ResourceHubFolderRenamed` event is now displayed in the feed.