### PR TITLE
feat: Display image preview in resource hub

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1107,6 +1107,8 @@ export interface ResourceHubFile {
   insertedAt?: string | null;
   permissions?: ResourceHubPermissions | null;
   reactions?: Reaction[] | null;
+  type?: string | null;
+  size?: number | null;
   blob?: Blob | null;
 }
 
@@ -2219,6 +2221,7 @@ export interface CreateResourceHubFileInput {
   resourceHubId?: Id | null;
   folderId?: Id | null;
   blobId?: string | null;
+  previewBlobId?: string | null;
   name?: string | null;
   description?: string | null;
   sendNotificationsToEveryone?: boolean | null;

--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 
 import * as Hub from "@/models/resourceHubs";
-import { IconFolder, IconFile, IconPhoto, IconFileTypePdf, IconMovie } from "@tabler/icons-react";
+import { findFileSize } from "@/models/blobs";
+
+import { IconFolder, IconFile, IconPhoto, IconFileTypePdf, IconMovie, IconMusic } from "@tabler/icons-react";
 import classNames from "classnames";
 import { Paths } from "@/routes/paths";
 import { DivLink } from "@/components/Link";
+import { ImageWithPlaceholder } from "@/components/Image";
 import { richContentToString } from "@/components/RichContent";
 import { truncateString } from "@/utils/strings";
 import { assertPresent } from "@/utils/assertions";
@@ -48,14 +51,13 @@ function NodeItem({ node, permissions, refetch, testid }: NodeItemProps) {
     "grid grid-cols-[1fr,20px]",
     "border-b border-stroke-base first:border-t last:border-b-0",
   );
-  const Icon = findIcon(node.type as NodeType, node);
   const path = findPath(node.type as NodeType, node);
   const subtitle = findSubtitle(node.type as NodeType, node);
 
   return (
     <div className={className} data-test-id={testid}>
-      <DivLink to={path} className="flex gap-4 py-4 cursor-pointer">
-        <Icon size={48} />
+      <DivLink to={path} className="flex gap-4 py-4 items-center cursor-pointer">
+        <FilePreview node={node} />
         <div>
           <div className="font-bold text-lg">{node.name}</div>
           <div>{subtitle}</div>
@@ -81,6 +83,28 @@ function NodeItem({ node, permissions, refetch, testid }: NodeItemProps) {
   );
 }
 
+function FilePreview({ node }: { node: Hub.ResourceHubNode }) {
+  const Icon = findIcon(node.type as NodeType, node);
+
+  if (node.file?.blob?.contentType?.includes("image")) {
+    return <Thumbnail file={node.file} />;
+  } else {
+    return <Icon size={48} color="#444" />;
+  }
+}
+
+function Thumbnail({ file }: { file: Hub.ResourceHubFile }) {
+  assertPresent(file.blob, "blob must be present in file");
+
+  const imgRatio = file.blob.height! / file.blob.width!;
+
+  return (
+    <div style={{ width: 48, height: 48 * imgRatio }}>
+      <ImageWithPlaceholder src={file.blob.url!} alt={file.name!} ratio={imgRatio} />
+    </div>
+  );
+}
+
 function findIcon(nodeType: NodeType, node: Hub.ResourceHubNode) {
   switch (nodeType) {
     case "document":
@@ -93,6 +117,7 @@ function findIcon(nodeType: NodeType, node: Hub.ResourceHubNode) {
       if (node.file.blob.contentType?.includes("image")) return IconPhoto;
       if (node.file.blob.contentType?.includes("pdf")) return IconFileTypePdf;
       if (node.file.blob.contentType?.includes("video")) return IconMovie;
+      if (node.file.blob.contentType?.includes("audio")) return IconMusic;
       return IconFile;
   }
 }
@@ -112,12 +137,19 @@ function findSubtitle(nodeType: NodeType, node: Hub.ResourceHubNode) {
   switch (nodeType) {
     case "document":
       assertPresent(node.document?.content, "content must be present in node.document");
+
       const content = richContentToString(JSON.parse(node.document.content));
       return truncateString(content, 60);
     case "folder":
       assertPresent(node.folder?.childrenCount, "childrenCount must be present in node.folder");
+
       return node.folder.childrenCount === 1 ? "1 item" : `${node.folder.childrenCount} items`;
     case "file":
-      return "";
+      assertPresent(node.file?.size, "size must be present in node.file");
+      assertPresent(node.file?.description, "description must be present in node.file");
+
+      const size = findFileSize(node.file.size);
+      const description = richContentToString(JSON.parse(node.file.description));
+      return size + (description ? ` - ${truncateString(description, 50)}` : "");
   }
 }

--- a/assets/js/models/blobs/index.tsx
+++ b/assets/js/models/blobs/index.tsx
@@ -2,15 +2,13 @@ import axios, { AxiosRequestConfig } from "axios";
 import csrftoken from "@/utils/csrf_token";
 
 import { createBlob } from "@/api";
+import { findImageDimensions } from "./utils";
 
 export { useDownloadFile } from "./useDownloadFile";
+export { resizeImage, findFileSize } from "./utils";
 
 type ProgressCallback = (number: number) => any;
 type UploadResult = { id: string; url: string };
-interface FileDimensions {
-  width: number;
-  height: number;
-}
 
 export async function uploadFile(file: File, progressCallback: ProgressCallback): Promise<UploadResult> {
   let blob;
@@ -71,20 +69,4 @@ async function multipartUpload(file: File, url: string, progressCallback: Progre
   formData.append("file", file);
 
   await client.put(url, formData, config);
-}
-
-function findImageDimensions(imgFile: File): Promise<FileDimensions> {
-  return new Promise((resolve, _) => {
-    const reader = new FileReader();
-
-    reader.onload = (readerEvent) => {
-      const image = new Image();
-      image.onload = () => {
-        resolve({ width: image.width, height: image.height });
-      };
-      image.src = readerEvent.target?.result as string;
-    };
-
-    reader.readAsDataURL(imgFile);
-  });
 }

--- a/assets/js/models/blobs/utils.tsx
+++ b/assets/js/models/blobs/utils.tsx
@@ -1,0 +1,85 @@
+interface FileDimensions {
+  width: number;
+  height: number;
+}
+
+export function findImageDimensions(imgFile: File): Promise<FileDimensions> {
+  return new Promise((resolve, _) => {
+    const reader = new FileReader();
+
+    reader.onload = (readerEvent) => {
+      const image = new Image();
+      image.onload = () => {
+        resolve({ width: image.width, height: image.height });
+      };
+      image.src = readerEvent.target?.result as string;
+    };
+
+    reader.readAsDataURL(imgFile);
+  });
+}
+
+export async function resizeImage(imgFile: File, { height, width }: Partial<FileDimensions>): Promise<File> {
+  const { width: originalWidth, height: originalHeight } = await findImageDimensions(imgFile);
+
+  if (!height && !width) {
+    throw new Error("Either targetHeight or targetWidth must be specified.");
+  } else if (width) {
+    height = Math.round((width / originalWidth) * originalHeight);
+  } else if (height) {
+    width = Math.round((height / originalHeight) * originalWidth);
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = (readerEvent) => {
+      const image = new Image();
+
+      image.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = width!;
+        canvas.height = height!;
+
+        const ctx = canvas.getContext("2d");
+        ctx?.drawImage(image, 0, 0, width!, height!);
+
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              const resizedFile = new File([blob], imgFile.name, { type: imgFile.type });
+              resolve(resizedFile);
+            } else {
+              reject(new Error("Canvas conversion to Blob failed"));
+            }
+          },
+          imgFile.type,
+          0.9,
+        );
+      };
+
+      image.onerror = (error) => {
+        reject(error);
+      };
+
+      image.src = readerEvent.target?.result as string;
+    };
+
+    reader.onerror = (error) => {
+      reject(error);
+    };
+
+    reader.readAsDataURL(imgFile);
+  });
+}
+
+export function findFileSize(size: number) {
+  const units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+  for (let unit of units) {
+    if (size < 1024) return `${Math.round(size)}${unit}`;
+    size /= 1024;
+  }
+
+  return "";
+}

--- a/lib/operately/operations/resource_hub_file_creating.ex
+++ b/lib/operately/operations/resource_hub_file_creating.ex
@@ -20,6 +20,7 @@ defmodule Operately.Operations.ResourceHubFileCreating do
         node_id: changes.node.id,
         author_id: author.id,
         blob_id: attrs.blob_id,
+        preview_blob_id: attrs[:preview_blob_id],
         description: attrs.content,
         subscription_list_id: changes.subscription_list.id,
       })
@@ -32,6 +33,14 @@ defmodule Operately.Operations.ResourceHubFileCreating do
     |> Multi.run(:blob, fn _, _ ->
       blob = Operately.Blobs.get_blob!(attrs.blob_id)
       Operately.Blobs.update_blob(blob, %{status: :uploaded})
+    end)
+    |> Multi.run(:preview_blob, fn _, _ ->
+      if attrs[:preview_blob_id] do
+        blob = Operately.Blobs.get_blob!(attrs.preview_blob_id)
+        Operately.Blobs.update_blob(blob, %{status: :uploaded})
+      else
+        {:ok, nil}
+      end
     end)
     |> Activities.insert_sync(author.id, :resource_hub_file_created, fn changes ->
       %{

--- a/lib/operately/resource_hubs/file.ex
+++ b/lib/operately/resource_hubs/file.ex
@@ -8,6 +8,7 @@ defmodule Operately.ResourceHubs.File do
     belongs_to :node, Operately.ResourceHubs.Node, foreign_key: :node_id
     belongs_to :author, Operately.People.Person, foreign_key: :author_id
     belongs_to :blob, Operately.Blobs.Blob, foreign_key: :blob_id
+    belongs_to :preview_blob, Operately.Blobs.Blob, foreign_key: :preview_blob_id
     belongs_to :subscription_list, Notifications.SubscriptionList, foreign_key: :subscription_list_id
 
     has_one :resource_hub, through: [:node, :resource_hub]
@@ -32,7 +33,7 @@ defmodule Operately.ResourceHubs.File do
 
   def changeset(file, attrs) do
     file
-    |> cast(attrs, [:node_id, :author_id, :blob_id, :description, :subscription_list_id])
+    |> cast(attrs, [:node_id, :author_id, :blob_id, :preview_blob_id, :description, :subscription_list_id])
     |> validate_required([:node_id, :author_id, :blob_id, :subscription_list_id])
   end
 

--- a/lib/operately_web/api/mutations/create_resource_hub_file.ex
+++ b/lib/operately_web/api/mutations/create_resource_hub_file.ex
@@ -9,6 +9,7 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFile do
     field :resource_hub_id, :id
     field :folder_id, :id
     field :blob_id, :string
+    field :preview_blob_id, :string
     field :name, :string
     field :description, :string
     field :send_notifications_to_everyone, :boolean

--- a/lib/operately_web/api/queries/get_resource_hub.ex
+++ b/lib/operately_web/api/queries/get_resource_hub.ex
@@ -42,7 +42,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
   end
 
   defp preload(inputs) do
-    q = from(n in Node, where: is_nil(n.parent_folder_id), preload: [folder: :node, document: :node, file: [:node, :blob]])
+    q = from(n in Node, where: is_nil(n.parent_folder_id), preload: [folder: :node, document: :node, file: [:node, :preview_blob, :blob]])
 
     Inputs.parse_includes(inputs, [
       include_space: :space,

--- a/lib/operately_web/api/queries/get_resource_hub_folder.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_folder.ex
@@ -43,7 +43,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolder do
 
   def preload(inputs) do
     Inputs.parse_includes(inputs, [
-      include_nodes: [child_nodes: [folder: :node, document: :node, file: [:node, :blob]]],
+      include_nodes: [child_nodes: [folder: :node, document: :node, file: [:node, :preview_blob, :blob]]],
       include_resource_hub: [node: :resource_hub],
       always_include: :node,
     ])

--- a/lib/operately_web/api/serializers/resource_hub_file.ex
+++ b/lib/operately_web/api/serializers/resource_hub_file.ex
@@ -6,7 +6,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.File do
       description: Jason.encode!(file.description),
       type: Ecto.assoc_loaded?(file.blob) && file.blob.content_type,
       size: Ecto.assoc_loaded?(file.blob) && file.blob.size,
-      blob: OperatelyWeb.Api.Serializer.serialize(file.blob),
+      blob: OperatelyWeb.Api.Serializer.serialize(file.preview_blob || file.blob),
     }
   end
 
@@ -23,6 +23,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.File do
       reactions: OperatelyWeb.Api.Serializer.serialize(file.reactions),
       inserted_at: OperatelyWeb.Api.Serializer.serialize(file.inserted_at),
       permissions: OperatelyWeb.Api.Serializer.serialize(file.permissions),
+      type: Ecto.assoc_loaded?(file.blob) && file.blob.content_type,
+      size: Ecto.assoc_loaded?(file.blob) && file.blob.size,
       blob: OperatelyWeb.Api.Serializer.serialize(file.blob),
     }
   end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -638,6 +638,8 @@ defmodule OperatelyWeb.Api.Types do
     field :inserted_at, :string
     field :permissions, :resource_hub_permissions
     field :reactions, list_of(:reaction)
+    field :type, :string
+    field :size, :integer
     field :blob, :blob
   end
 

--- a/priv/repo/migrations/20241209142058_add_preview_blob_relationship_between_files_and_blobs.exs
+++ b/priv/repo/migrations/20241209142058_add_preview_blob_relationship_between_files_and_blobs.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddPreviewBlobRelationshipBetweenFilesAndBlobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_files) do
+      add :preview_blob_id, references(:blobs, on_delete: :nothing, type: :binary_id)
+    end
+
+    create index(:resource_files, [:preview_blob_id])
+  end
+end


### PR DESCRIPTION
When an image is uploaded, a very small version of it is now also uploaded as the file's `preview blob`. Then, in the Resource Hub items list, this small image is used to show a preview of the image in the list.