### PR TITLE
feat: Display resource hub item's icon and subtitle on space page

### DIFF
--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -1,20 +1,14 @@
 import React from "react";
 
 import * as Hub from "@/models/resourceHubs";
-import { findFileSize } from "@/models/blobs";
 
-import { IconFolder, IconFile, IconPhoto, IconFileTypePdf, IconMovie, IconMusic } from "@tabler/icons-react";
 import classNames from "classnames";
-import { Paths } from "@/routes/paths";
 import { DivLink } from "@/components/Link";
 import { ImageWithPlaceholder } from "@/components/Image";
-import { richContentToString } from "@/components/RichContent";
-import { truncateString } from "@/utils/strings";
 import { assertPresent } from "@/utils/assertions";
 import { createTestId } from "@/utils/testid";
 import { DocumentMenu, FileMenu, FolderMenu } from "./components";
-
-type NodeType = "document" | "folder" | "file";
+import { findIcon, findPath, findSubtitle, NodeType } from "./utils";
 
 interface Props {
   permissions: Hub.ResourceHubPermissions;
@@ -103,53 +97,4 @@ function Thumbnail({ file }: { file: Hub.ResourceHubFile }) {
       <ImageWithPlaceholder src={file.blob.url!} alt={file.name!} ratio={imgRatio} />
     </div>
   );
-}
-
-function findIcon(nodeType: NodeType, node: Hub.ResourceHubNode) {
-  switch (nodeType) {
-    case "document":
-      return IconFile;
-    case "folder":
-      return IconFolder;
-    case "file":
-      assertPresent(node.file?.blob, "file.blob must be present in node");
-
-      if (node.file.blob.contentType?.includes("image")) return IconPhoto;
-      if (node.file.blob.contentType?.includes("pdf")) return IconFileTypePdf;
-      if (node.file.blob.contentType?.includes("video")) return IconMovie;
-      if (node.file.blob.contentType?.includes("audio")) return IconMusic;
-      return IconFile;
-  }
-}
-
-function findPath(nodeType: NodeType, node: Hub.ResourceHubNode) {
-  switch (nodeType) {
-    case "document":
-      return Paths.resourceHubDocumentPath(node.document!.id!);
-    case "folder":
-      return Paths.resourceHubFolderPath(node.folder!.id!);
-    case "file":
-      return Paths.resourceHubFilePath(node.file!.id!);
-  }
-}
-
-function findSubtitle(nodeType: NodeType, node: Hub.ResourceHubNode) {
-  switch (nodeType) {
-    case "document":
-      assertPresent(node.document?.content, "content must be present in node.document");
-
-      const content = richContentToString(JSON.parse(node.document.content));
-      return truncateString(content, 60);
-    case "folder":
-      assertPresent(node.folder?.childrenCount, "childrenCount must be present in node.folder");
-
-      return node.folder.childrenCount === 1 ? "1 item" : `${node.folder.childrenCount} items`;
-    case "file":
-      assertPresent(node.file?.size, "size must be present in node.file");
-      assertPresent(node.file?.description, "description must be present in node.file");
-
-      const size = findFileSize(node.file.size);
-      const description = richContentToString(JSON.parse(node.file.description));
-      return size + (description ? ` - ${truncateString(description, 50)}` : "");
-  }
 }

--- a/assets/js/features/ResourceHub/index.tsx
+++ b/assets/js/features/ResourceHub/index.tsx
@@ -1,3 +1,4 @@
 export { NodesList } from "./NodesList";
 export { ZeroNodes } from "./ZeroNodes";
 export { AddFilesButtonAndForms } from "./AddNewFiles";
+export { findIcon, findSubtitle, NodeType } from "./utils";

--- a/assets/js/features/ResourceHub/utils.tsx
+++ b/assets/js/features/ResourceHub/utils.tsx
@@ -1,0 +1,60 @@
+import { IconFile, IconFileTypePdf, IconFolder, IconMovie, IconMusic, IconPhoto } from "@tabler/icons-react";
+
+import { ResourceHubNode } from "@/models/resourceHubs";
+import { findFileSize } from "@/models/blobs";
+
+import { richContentToString } from "@/components/RichContent";
+import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { truncateString } from "@/utils/strings";
+
+export type NodeType = "document" | "folder" | "file";
+
+export function findIcon(nodeType: NodeType, node: ResourceHubNode) {
+  switch (nodeType) {
+    case "document":
+      return IconFile;
+    case "folder":
+      return IconFolder;
+    case "file":
+      assertPresent(node.file?.blob, "file.blob must be present in node");
+
+      if (node.file.blob.contentType?.includes("image")) return IconPhoto;
+      if (node.file.blob.contentType?.includes("pdf")) return IconFileTypePdf;
+      if (node.file.blob.contentType?.includes("video")) return IconMovie;
+      if (node.file.blob.contentType?.includes("audio")) return IconMusic;
+      return IconFile;
+  }
+}
+
+export function findPath(nodeType: NodeType, node: ResourceHubNode) {
+  switch (nodeType) {
+    case "document":
+      return Paths.resourceHubDocumentPath(node.document!.id!);
+    case "folder":
+      return Paths.resourceHubFolderPath(node.folder!.id!);
+    case "file":
+      return Paths.resourceHubFilePath(node.file!.id!);
+  }
+}
+
+export function findSubtitle(nodeType: NodeType, node: ResourceHubNode) {
+  switch (nodeType) {
+    case "document":
+      assertPresent(node.document?.content, "content must be present in node.document");
+
+      const content = richContentToString(JSON.parse(node.document.content));
+      return truncateString(content, 60);
+    case "folder":
+      assertPresent(node.folder?.childrenCount, "childrenCount must be present in node.folder");
+
+      return node.folder.childrenCount === 1 ? "1 item" : `${node.folder.childrenCount} items`;
+    case "file":
+      assertPresent(node.file?.size, "size must be present in node.file");
+      assertPresent(node.file?.description, "description must be present in node.file");
+
+      const size = findFileSize(node.file.size);
+      const description = richContentToString(JSON.parse(node.file.description));
+      return size + (description ? ` - ${truncateString(description, 50)}` : "");
+  }
+}

--- a/assets/js/features/SpaceTools/ResourceHub.tsx
+++ b/assets/js/features/SpaceTools/ResourceHub.tsx
@@ -6,8 +6,8 @@ import { Paths } from "@/routes/paths";
 import { Container, Title, ZeroResourcesContainer } from "./components";
 import { assertPresent } from "@/utils/assertions";
 import classNames from "classnames";
-import { IconFolder } from "@tabler/icons-react";
 import { createTestId } from "@/utils/testid";
+import { findIcon, findSubtitle, NodeType } from "@/features/ResourceHub";
 
 interface ResourceHubProps {
   resourceHub: ResourceHub;
@@ -50,15 +50,17 @@ function NodesList({ nodes }: { nodes: ResourceHubNode[] }) {
 
 function NodeItem({ node }: { node: ResourceHubNode }) {
   const className = classNames("flex gap-2 p-2", "border-b border-stroke-base last:border-b-0");
+  const Icon = findIcon(node.type as NodeType, node);
+  const subtitle = findSubtitle(node.type as NodeType, node);
 
   return (
     <div key={node.id} className={className}>
       <div>
-        <IconFolder size={32} />
+        <Icon size={32} />
       </div>
       <div className="overflow-hidden">
         <div className="font-bold truncate">{node.name}</div>
-        <div className="truncate">3 items</div>
+        <div className="truncate">{subtitle}</div>
       </div>
     </div>
   );

--- a/lib/operately/resource_hubs/resource_hub.ex
+++ b/lib/operately/resource_hubs/resource_hub.ex
@@ -40,6 +40,10 @@ defmodule Operately.ResourceHubs.ResourceHub do
     Map.put(resource_hub, :potential_subscribers, subscribers)
   end
 
+  def set_children_count(resource_hubs) when is_list(resource_hubs) do
+    Enum.map(resource_hubs, &set_children_count/1)
+  end
+
   def set_children_count(resource_hub = %__MODULE__{}) do
     nodes = Operately.ResourceHubs.Folder.find_children_count(resource_hub.nodes)
     Map.put(resource_hub, :nodes, nodes)


### PR DESCRIPTION
On the Space page, the Resource Hub tool shows the appropriate icon and subtitle depending on the resource type.

![tmp](https://github.com/user-attachments/assets/a56e308f-fdca-4ad5-8eb1-55cc56287b65)
