### PR TITLE
feat: Folders can be deleted

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1146,6 +1146,7 @@ export interface ResourceHubPermissions {
   canCreateFile?: boolean | null;
   canDeleteDocument?: boolean | null;
   canDeleteFile?: boolean | null;
+  canDeleteFolder?: boolean | null;
   canEditDocument?: boolean | null;
   canRenameFolder?: boolean | null;
   canView?: boolean | null;

--- a/assets/js/features/ResourceHub/components/FolderMenu.tsx
+++ b/assets/js/features/ResourceHub/components/FolderMenu.tsx
@@ -16,7 +16,7 @@ interface FolderMenuProps {
 export function FolderMenu({ permissions, folder, refetch }: FolderMenuProps) {
   const [showRenameForm, setShowRenameForm] = useState(false);
 
-  const relevantPermissions = [permissions.canRenameFolder];
+  const relevantPermissions = [permissions.canRenameFolder, permissions.canDeleteFolder];
   const menuId = createTestId("folder-menu", folder.id!);
 
   if (!relevantPermissions.some(Boolean)) return <></>;
@@ -27,6 +27,7 @@ export function FolderMenu({ permissions, folder, refetch }: FolderMenuProps) {
         {permissions.canRenameFolder && (
           <RenameFolderMenuItem folder={folder} showForm={() => setShowRenameForm(true)} />
         )}
+        {permissions.canDeleteFolder && <DeleteFolderMenuItem folder={folder} refetch={refetch} />}
       </Menu>
 
       <RenameFolderModal
@@ -36,6 +37,21 @@ export function FolderMenu({ permissions, folder, refetch }: FolderMenuProps) {
         toggleForm={() => setShowRenameForm(!showRenameForm)}
       />
     </>
+  );
+}
+
+function DeleteFolderMenuItem({ folder, refetch }: { folder: Hub.ResourceHubFolder; refetch: () => void }) {
+  const [remove] = Hub.useDeleteResourceHubFolder();
+  const handleDelete = async () => {
+    await remove({ folderId: folder.id });
+    refetch();
+  };
+  const deleteId = createTestId("delete", folder.id!);
+
+  return (
+    <MenuActionItem onClick={handleDelete} testId={deleteId} danger>
+      Delete folder
+    </MenuActionItem>
   );
 }
 

--- a/assets/js/models/resourceHubs/index.tsx
+++ b/assets/js/models/resourceHubs/index.tsx
@@ -16,5 +16,6 @@ export {
   useEditResourceHubDocument,
   useDeleteResourceHubDocument,
   useDeleteResourceHubFile,
+  useDeleteResourceHubFolder,
   useRenameResourceHubFolder,
 } from "@/api";

--- a/assets/js/pages/ResourceHubDocumentPage/Options.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/Options.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import { useDeleteResourceHubDocument } from "@/models/resourceHubs";
+import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+
+import { useLoadedData } from "./loader";
+import { IconEdit, IconTrash } from "@tabler/icons-react";
+
+export function Options() {
+  const { document } = useLoadedData();
+  assertPresent(document.permissions, "permissions must be present in document");
+
+  return (
+    <PageOptions.Root testId="document-options-button" position="top-right">
+      {document.permissions.canEditDocument && (
+        <PageOptions.Link
+          icon={IconEdit}
+          title="Edit document"
+          to={Paths.resourceHubEditDocumentPath(document.id!)}
+          testId="edit-document-link"
+        />
+      )}
+      {document.permissions.canDeleteDocument && <DeleteAction />}
+    </PageOptions.Root>
+  );
+}
+
+function DeleteAction() {
+  const { document } = useLoadedData();
+  const [remove] = useDeleteResourceHubDocument();
+  const navigate = useNavigate();
+
+  const handleDelete = async () => {
+    remove({ documentId: document.id }).then(() => {
+      assertPresent(document.resourceHub, "resourceHub must be present in document");
+      navigate(Paths.resourceHubPath(document.resourceHub.id!));
+    });
+  };
+
+  return <PageOptions.Action icon={IconTrash} title="Delete" onClick={handleDelete} testId="delete-document-link" />;
+}

--- a/assets/js/pages/ResourceHubDocumentPage/page.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/page.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import * as Reactions from "@/models/reactions";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import { IconEdit } from "@tabler/icons-react";
 
 import FormattedTime from "@/components/FormattedTime";
 import RichContent from "@/components/RichContent";
@@ -19,6 +17,7 @@ import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 import { useLoadedData } from "./loader";
+import { Options } from "./Options";
 
 export function Page() {
   const { document } = useLoadedData();
@@ -90,25 +89,6 @@ function Body() {
       <Spacer size={4} />
       <RichContent jsonContent={document.content!} className="text-md sm:text-lg" />
     </>
-  );
-}
-
-function Options() {
-  const { document } = useLoadedData();
-
-  assertPresent(document.permissions, "permissions must be present in document");
-
-  return (
-    <PageOptions.Root testId="document-options-button" position="top-right">
-      {document.permissions.canEditDocument && (
-        <PageOptions.Link
-          icon={IconEdit}
-          title="Edit document"
-          to={Paths.resourceHubEditDocumentPath(document.id!)}
-          testId="edit-document-link"
-        />
-      )}
-    </PageOptions.Root>
   );
 }
 

--- a/lib/operately_web/api/serializers/resource_hub_permissions.ex
+++ b/lib/operately_web/api/serializers/resource_hub_permissions.ex
@@ -8,6 +8,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Permissions d
       can_create_file: permissions.can_create_file,
       can_delete_document: permissions.can_delete_document,
       can_delete_file: permissions.can_delete_file,
+      can_delete_folder: permissions.can_delete_folder,
       can_edit_document: permissions.can_edit_document,
       can_rename_folder: permissions.can_rename_folder,
       can_view: permissions.can_view,

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -597,6 +597,7 @@ defmodule OperatelyWeb.Api.Types do
     field :can_create_file, :boolean
     field :can_delete_document, :boolean
     field :can_delete_file, :boolean
+    field :can_delete_folder, :boolean
     field :can_edit_document, :boolean
     field :can_rename_folder, :boolean
     field :can_view, :boolean


### PR DESCRIPTION
I've added the option to delete folders from the resource hub page.

I've also added the option to delete a document from the document page. Previously, we could delete them only from the resource hub page.