### PR TITLE
fix: Display resource hub actions only if user has permissions

### DIFF
--- a/assets/js/components/Buttons/OptionsButton.tsx
+++ b/assets/js/components/Buttons/OptionsButton.tsx
@@ -6,6 +6,7 @@ import { IconChevronDown, IconProps } from "@tabler/icons-react";
 interface Option {
   label: string;
   action: () => void;
+  hidden?: boolean;
   icon?: React.ComponentType<IconProps>;
   testId?: string;
 }
@@ -18,6 +19,9 @@ interface Props {
 
 export function OptionsButton({ options, align = "center", testId }: Props) {
   const [open, setOpen] = React.useState(false);
+  const availableOptions = options.filter((option) => !option.hidden);
+
+  if (availableOptions.length < 1) return <></>;
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
@@ -38,7 +42,7 @@ export function OptionsButton({ options, align = "center", testId }: Props) {
           sideOffset={5}
         >
           <Popover.Arrow className="fill-surface-outline scale-150" />
-          {options.map((option, idx) => (
+          {availableOptions.map((option, idx) => (
             <div
               onClick={option.action}
               className="cursor-pointer px-4 py-2 flex items-center gap-1 border-b border-surface-outline hover:bg-surface-accent last:border-b-0"

--- a/assets/js/features/ResourceHub/AddFilesButton.tsx
+++ b/assets/js/features/ResourceHub/AddFilesButton.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 
 import { IconFile, IconFolder, IconUpload } from "@tabler/icons-react";
+import { ResourceHubPermissions } from "@/models/resourceHubs";
 import { OptionsButton } from "@/components/Buttons";
 
 import { useNewFileModalsContext } from "./contexts/NewFileModalsContext";
 
-export function AddFilesButton() {
+export function AddFilesButton({ permissions }: { permissions: ResourceHubPermissions }) {
   const { navigateToNewDocument, toggleShowAddFolder, showAddFilePopUp } = useNewFileModalsContext();
 
   return (
@@ -13,9 +14,27 @@ export function AddFilesButton() {
       <OptionsButton
         align="start"
         options={[
-          { icon: IconFile, label: "Write a new document", action: navigateToNewDocument, testId: "new-document" },
-          { icon: IconFolder, label: "Create a new folder", action: toggleShowAddFolder, testId: "new-folder" },
-          { icon: IconUpload, label: "Upload files", action: showAddFilePopUp, testId: "upload-files" },
+          {
+            icon: IconFile,
+            label: "Write a new document",
+            action: navigateToNewDocument,
+            testId: "new-document",
+            hidden: !permissions.canCreateDocument,
+          },
+          {
+            icon: IconFolder,
+            label: "Create a new folder",
+            action: toggleShowAddFolder,
+            testId: "new-folder",
+            hidden: !permissions.canCreateFolder,
+          },
+          {
+            icon: IconUpload,
+            label: "Upload files",
+            action: showAddFilePopUp,
+            testId: "upload-files",
+            hidden: !permissions.canCreateFile,
+          },
         ]}
         testId="add-options"
       />

--- a/assets/js/pages/ResourceHubFolderPage/page.tsx
+++ b/assets/js/pages/ResourceHubFolderPage/page.tsx
@@ -25,7 +25,11 @@ export function Page() {
             <PageNavigation />
 
             <Paper.Body minHeight="75vh">
-              <Paper.Header actions={<Hub.AddFilesButton />} title={folder.name!} layout="title-center-actions-left" />
+              <Paper.Header
+                actions={<Hub.AddFilesButton permissions={folder.permissions} />}
+                title={folder.name!}
+                layout="title-center-actions-left"
+              />
 
               <Hub.NodesList nodes={folder.nodes} permissions={folder.permissions} refetch={refresh} />
 

--- a/assets/js/pages/ResourceHubPage/page.tsx
+++ b/assets/js/pages/ResourceHubPage/page.tsx
@@ -24,7 +24,7 @@ export function Page() {
 
             <Paper.Body minHeight="75vh">
               <Paper.Header
-                actions={<Hub.AddFilesButton />}
+                actions={<Hub.AddFilesButton permissions={resourceHub.permissions} />}
                 title={resourceHub.name!}
                 layout="title-center-actions-left"
               />


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1717 and https://github.com/operately/operately/issues/1718.

The migration 043 gave comment access to space members, so it makes sense that @markoa is getting 403s. Now, the action buttons are displayed only to members who have permissions to perform those actions.