### PR TITLE
chore: Resource Hub and Space use the same access context

### DIFF
--- a/lib/operately/resource_hubs/resource_hub.ex
+++ b/lib/operately/resource_hubs/resource_hub.ex
@@ -4,7 +4,7 @@ defmodule Operately.ResourceHubs.ResourceHub do
 
   schema "resource_hubs" do
     belongs_to :space, Operately.Groups.Group
-    has_one :access_context, Operately.Access.Context, foreign_key: :resource_hub_id
+    has_one :access_context, through: [:space, :access_context]
     has_many :nodes, Operately.ResourceHubs.Node, foreign_key: :resource_hub_id
 
     field :name, :string

--- a/test/operately_web/api/mutations/add_reaction_test.exs
+++ b/test/operately_web/api/mutations/add_reaction_test.exs
@@ -124,8 +124,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
 
     tabletest @space_table do
       test "resource hub document - if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         doc = document_fixture(resource_hub.id, ctx.creator.id)
 
         assert {code, res} = mutation(ctx.conn, :add_reaction, %{
@@ -147,8 +147,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
 
     tabletest @space_table do
       test "resource hub file - if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         file = file_fixture(resource_hub, ctx.creator)
 
         assert {code, res} = mutation(ctx.conn, :add_reaction, %{
@@ -398,8 +398,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
 
     tabletest @space_table do
       test "resource hub document comment - if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         doc = document_fixture(resource_hub.id, ctx.creator.id) |> Repo.preload(resource_hub: :space)
         comment = create_comment(ctx, doc, "resource_hub_document")
 
@@ -423,8 +423,8 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
 
     tabletest @space_table do
       test "resource hub file comment - if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         file = file_fixture(resource_hub, ctx.creator) |> Repo.preload(:resource_hub)
         comment = create_comment(ctx, file, "resource_hub_file")
 
@@ -479,7 +479,7 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
     hd(Operately.Updates.list_reactions(id, type))
   end
 
-  def create_space(ctx) do
+  defp create_space(ctx) do
     group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
   end
 
@@ -581,22 +581,5 @@ defmodule OperatelyWeb.Api.Mutations.AddReactionTest do
       }
     )
     Operately.Updates.get_comment!(milestone_comment.comment_id)
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
-
-    if space_members_level != :no_access do
-      {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
-        id: ctx.person.id,
-        access_level: Binding.from_atom(space_members_level)
-      }])
-    end
-
-    resource_hub
   end
 end

--- a/test/operately_web/api/mutations/create_resource_hub_document_test.exs
+++ b/test/operately_web/api/mutations/create_resource_hub_document_test.exs
@@ -40,8 +40,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubDocumentTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
 
         assert {code, res} = mutation(ctx.conn, :create_resource_hub_document, %{
           resource_hub_id: Paths.resource_hub_id(resource_hub),
@@ -190,16 +190,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubDocumentTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -208,6 +200,6 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubDocumentTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/create_resource_hub_file_test.exs
+++ b/test/operately_web/api/mutations/create_resource_hub_file_test.exs
@@ -40,8 +40,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFileTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         blob = blob_fixture(%{author_id: ctx.creator.id, company_id: ctx.company.id})
 
         assert {code, res} = mutation(ctx.conn, :create_resource_hub_file, %{
@@ -102,16 +102,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFileTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -120,6 +112,6 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFileTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/create_resource_hub_folder_test.exs
+++ b/test/operately_web/api/mutations/create_resource_hub_folder_test.exs
@@ -38,8 +38,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolderTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
 
         assert {code, res} = mutation(ctx.conn, :create_resource_hub_folder, %{
           resource_hub_id: Paths.resource_hub_id(resource_hub),
@@ -103,16 +103,8 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolderTest do
     end
   end
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -121,6 +113,6 @@ defmodule OperatelyWeb.Api.Mutations.CreateResourceHubFolderTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/delete_resource_hub_document_test.exs
+++ b/test/operately_web/api/mutations/delete_resource_hub_document_test.exs
@@ -38,8 +38,8 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubDocumentTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         document = document_fixture(resource_hub.id, ctx.creator.id)
 
         assert {code, res} = mutation(ctx.conn, :delete_resource_hub_document, %{
@@ -87,16 +87,8 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubDocumentTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -105,6 +97,6 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubDocumentTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/delete_resource_hub_folder_test.exs
+++ b/test/operately_web/api/mutations/delete_resource_hub_folder_test.exs
@@ -38,8 +38,8 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubFolderTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         folder = folder_fixture(resource_hub.id)
 
         assert {code, res} = mutation(ctx.conn, :delete_resource_hub_folder, %{
@@ -86,16 +86,8 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubFolderTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -104,6 +96,6 @@ defmodule OperatelyWeb.Api.Mutations.DeleteResourceHubFolderTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/edit_parent_folder_in_resource_hub_test.exs
+++ b/test/operately_web/api/mutations/edit_parent_folder_in_resource_hub_test.exs
@@ -37,8 +37,8 @@ defmodule OperatelyWeb.Api.Mutations.EditParentFolderInResourceHubTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         folder = folder_fixture(resource_hub.id)
         document = document_fixture(resource_hub.id, ctx.creator.id)
 
@@ -129,16 +129,8 @@ defmodule OperatelyWeb.Api.Mutations.EditParentFolderInResourceHubTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -147,6 +139,6 @@ defmodule OperatelyWeb.Api.Mutations.EditParentFolderInResourceHubTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/edit_resource_hub_document_test.exs
+++ b/test/operately_web/api/mutations/edit_resource_hub_document_test.exs
@@ -39,8 +39,8 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocumentTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         document = document_fixture(resource_hub.id, ctx.creator.id)
 
         assert {code, res} = mutation(ctx.conn, :edit_resource_hub_document, %{
@@ -98,16 +98,8 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocumentTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -116,6 +108,6 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocumentTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/mutations/rename_resource_hub_folder_test.exs
+++ b/test/operately_web/api/mutations/rename_resource_hub_folder_test.exs
@@ -37,8 +37,8 @@ defmodule OperatelyWeb.Api.Mutations.RenameResourceHubFolderTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         folder = folder_fixture(resource_hub.id)
 
         assert {code, res} = mutation(ctx.conn, :rename_resource_hub_folder, %{
@@ -91,16 +91,8 @@ defmodule OperatelyWeb.Api.Mutations.RenameResourceHubFolderTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -109,6 +101,6 @@ defmodule OperatelyWeb.Api.Mutations.RenameResourceHubFolderTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/queries/get_resource_hub_document_test.exs
+++ b/test/operately_web/api/queries/get_resource_hub_document_test.exs
@@ -37,8 +37,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocumentTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         doc = document_fixture(resource_hub.id, ctx.creator.id)
 
         assert {code, res} = query(ctx.conn, :get_resource_hub_document, %{id: Paths.document_id(doc)})
@@ -116,16 +116,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocumentTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -134,6 +126,6 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocumentTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/queries/get_resource_hub_file_test.exs
+++ b/test/operately_web/api/queries/get_resource_hub_file_test.exs
@@ -38,8 +38,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFileTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         file = file_fixture(resource_hub, ctx.creator)
 
         assert {code, res} = query(ctx.conn, :get_resource_hub_file, %{id: Paths.file_id(file)})
@@ -122,16 +122,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFileTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -140,6 +132,6 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFileTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/queries/get_resource_hub_folder_test.exs
+++ b/test/operately_web/api/queries/get_resource_hub_folder_test.exs
@@ -37,8 +37,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolderTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         folder = folder_fixture(resource_hub.id)
         document_fixture(resource_hub.id, ctx.creator.id, %{parent_folder_id: folder.id})
         document_fixture(resource_hub.id, ctx.creator.id, %{parent_folder_id: folder.id})
@@ -163,16 +163,8 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolderTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -181,6 +173,6 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolderTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end

--- a/test/operately_web/api/queries/get_resource_hub_test.exs
+++ b/test/operately_web/api/queries/get_resource_hub_test.exs
@@ -37,8 +37,8 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContentTest do
 
     tabletest @table do
       test "if caller has levels company=#{@test.company} and space=#{@test.space}, then expect code=#{@test.expected}", ctx do
-        space = create_space(ctx)
-        resource_hub = create_resource_hub(ctx, space, @test.company, @test.space)
+        space = create_space(ctx, @test.company, @test.space)
+        resource_hub = resource_hub_fixture(ctx.creator, space)
         folder_fixture(resource_hub.id)
 
         assert {code, res} = query(ctx.conn, :get_resource_hub, %{id: Paths.resource_hub_id(resource_hub), include_nodes: true})
@@ -109,16 +109,8 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContentTest do
   # Helpers
   #
 
-  def create_space(ctx) do
-    group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
-  end
-
-  def create_resource_hub(ctx, space, company_members_level, space_members_level) do
-    resource_hub = resource_hub_fixture(ctx.creator, space, %{
-      anonymous_access_level: Binding.no_access(),
-      company_access_level: Binding.from_atom(company_members_level),
-      space_access_level: Binding.from_atom(space_members_level),
-    })
+  defp create_space(ctx, company_members_level, space_members_level) do
+    space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.from_atom(company_members_level)})
 
     if space_members_level != :no_access do
       {:ok, _} = Operately.Groups.add_members(ctx.creator, space.id, [%{
@@ -127,6 +119,6 @@ defmodule OperatelyWeb.Api.Queries.ListResourceHubContentTest do
       }])
     end
 
-    resource_hub
+    space
   end
 end


### PR DESCRIPTION
Access to Resource Hubs was based on the Resource Hub's access context. Now, it will be based on the Space's access context. 