### PR TITLE
chore: Improve resource hub zero-state copy

### DIFF
--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -8,7 +8,7 @@ import { ImageWithPlaceholder } from "@/components/Image";
 import { assertPresent } from "@/utils/assertions";
 import { createTestId } from "@/utils/testid";
 import { findIcon, findPath, findSubtitle, NodeType, sortNodesWithFoldersFirst } from "./utils";
-import { DocumentMenu, FileMenu, FolderMenu, ZeroNodes } from "./components";
+import { DocumentMenu, FileMenu, FolderMenu, FolderZeroNodes, HubZeroNodes } from "./components";
 import { NodesProps, NodesProvider } from "./contexts/NodesContext";
 
 export function NodesList(props: NodesProps) {
@@ -17,7 +17,10 @@ export function NodesList(props: NodesProps) {
   assertPresent(resource.nodes, `nodes must be present in ${props.type}`);
   const nodes = useMemo(() => sortNodesWithFoldersFirst(resource.nodes!), [resource.nodes]);
 
-  if (nodes.length < 1) return <ZeroNodes />;
+  if (resource.nodes.length < 1) {
+    if (props.type === "resource_hub") return <HubZeroNodes />;
+    else return <FolderZeroNodes />;
+  }
 
   return (
     <NodesProvider {...props}>

--- a/assets/js/features/ResourceHub/components/ZeroNodes.tsx
+++ b/assets/js/features/ResourceHub/components/ZeroNodes.tsx
@@ -1,13 +1,27 @@
 import React from "react";
 import { IconFile } from "@tabler/icons-react";
 
-export function ZeroNodes() {
+export function HubZeroNodes() {
   return (
     <div className="border border-dashed border-stroke-base p-4 w-[500px] mx-auto mt-12 flex gap-4">
       <IconFile size={48} className="text-gray-600" />
       <div>
-        <div className="font-bold">Nothing here just yet.</div>A place to share rich text documents, images, videos, and
-        other files.
+        <div className="font-bold">Ready for your first document</div>
+        <br />
+        <div>Your team's central hub for sharing documents, images, videos, and files. Click 'Add' to get started.</div>
+      </div>
+    </div>
+  );
+}
+
+export function FolderZeroNodes() {
+  return (
+    <div className="border border-dashed border-stroke-base p-4 w-[500px] mx-auto mt-12 flex gap-4">
+      <IconFile size={48} className="text-gray-600" />
+      <div>
+        <div className="font-bold">Ready for your first document</div>
+        <br />
+        <div>This folder is empty. Click 'Add' to upload your first file.</div>
       </div>
     </div>
   );

--- a/assets/js/features/ResourceHub/components/index.tsx
+++ b/assets/js/features/ResourceHub/components/index.tsx
@@ -1,4 +1,4 @@
 export { DocumentMenu } from "./DocumentMenu";
 export { FileMenu } from "./FileMenu";
 export { FolderMenu } from "./FolderMenu";
-export { ZeroNodes } from "./ZeroNodes";
+export { FolderZeroNodes, HubZeroNodes } from "./ZeroNodes";

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -6,7 +6,7 @@ defmodule Features.Features.ResourceHubTest do
   setup ctx, do: Steps.setup(ctx)
 
   describe "folders" do
-    test "resource hub zero state", ctx do
+    feature "resource hub zero state", ctx do
       ctx
       |> Steps.visit_space_page()
       |> Steps.assert_zero_state_on_space_page()
@@ -14,7 +14,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_zero_state()
     end
 
-    test "create folders at the root of resource hub", ctx do
+    feature "create folders at the root of resource hub", ctx do
       folder1 = "First Folder"
       folder2 = "Second Folder"
 
@@ -26,7 +26,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_folder_created(%{name: folder2, index: 1})
     end
 
-    test "create nested folders", ctx do
+    feature "create nested folders", ctx do
       folder1 = "First Folder"
       folder2 = "Second Folder"
       folder3 = "Third Folder"
@@ -50,7 +50,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_items_count(%{index: 0, items_count: "1 item"})
     end
 
-    test "folder navigation works", ctx do
+    feature "folder navigation works", ctx do
       ctx
       |> Steps.given_nested_folders_exist()
       |> Steps.visit_folder_page(:five)
@@ -63,7 +63,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_navigation_links(["Resource hub"])
     end
 
-    test "folder created feed event", ctx do
+    feature "folder created feed event", ctx do
       folder = "Documents"
 
       ctx
@@ -76,7 +76,7 @@ defmodule Features.Features.ResourceHubTest do
   end
 
   describe "documents" do
-    test "create document", ctx do
+    feature "create document", ctx do
       doc = %{
         name: "My First Document",
         content: "This is the document's content",
@@ -92,7 +92,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_document_created_email_sent(doc.name)
     end
 
-    test "edit document", ctx do
+    feature "edit document", ctx do
       default_doc = %{
         name: "some name",
         content: "Content",
@@ -114,7 +114,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_document_edited_email_sent(new_doc.name)
     end
 
-    test "delete document", ctx do
+    feature "delete document", ctx do
       doc = %{
         name: "My First Document",
         content: "This is the document's content",

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -110,8 +110,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   step :assert_zero_state, ctx do
     ctx
     |> UI.assert_text("Documents & Files")
-    |> UI.assert_text("Nothing here just yet.")
-    |> UI.assert_text("A place to share rich text documents, images, videos, and other files")
+    |> UI.assert_text("Ready for your first document")
+    |> UI.assert_text("Your team's central hub for sharing documents, images, videos, and files. Click 'Add' to get started.")
   end
 
   step :assert_zero_state_on_space_page, ctx do


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1732.

This is how the page looks like now:

![tmp](https://github.com/user-attachments/assets/2ed7fd75-6e6d-49f6-8541-458b6411b85b)

