### PR TITLE
feat: Display file-edited event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -539,6 +539,11 @@ export interface ActivityContentResourceHubFileDeleted {
   file?: ResourceHubFile | null;
 }
 
+export interface ActivityContentResourceHubFileEdited {
+  resourceHub?: ResourceHub | null;
+  file?: ResourceHubFile | null;
+}
+
 export interface ActivityContentResourceHubFolderCreated {
   resourceHub?: ResourceHub | null;
   folder?: ResourceHubFolder | null;

--- a/assets/js/features/activities/ResourceHubFileEdited/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileEdited/index.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFileEdited } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+import { Summary } from "@/components/RichContent";
+
+const ResourceHubFileEdited: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    const file = content(activity).file!;
+    return Paths.resourceHubFilePath(file.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const file = content(activity).file!;
+
+    const path = Paths.resourceHubFilePath(file.id!);
+    const link = <Link to={path}>{file.name}</Link>;
+
+    return feedTitle(activity, "edited a file:", link);
+  },
+
+  FeedItemContent({ activity }: { activity: Activity; page: any }) {
+    return <Summary jsonContent={content(activity).file!.description!} characterCount={160} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " edited a file: " + content(activity).file!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).resourceHub!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFileEdited {
+  return activity.content as ActivityContentResourceHubFileEdited;
+}
+
+export default ResourceHubFileEdited;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -110,6 +110,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_document_commented",
   "resource_hub_document_deleted",
   "resource_hub_file_created",
+  "resource_hub_file_edited",
   "resource_hub_file_deleted",
   "resource_hub_file_commented",
   "resource_hub_folder_created",
@@ -176,6 +177,7 @@ import ResourceHubDocumentEdited from "@/features/activities/ResourceHubDocument
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubDocumentDeleted from "@/features/activities/ResourceHubDocumentDeleted";
 import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated";
+import ResourceHubFileEdited from "@/features/activities/ResourceHubFileEdited";
 import ResourceHubFileDeleted from "@/features/activities/ResourceHubFileDeleted";
 import ResourceHubFileCommented from "@/features/activities/ResourceHubFileCommented";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
@@ -239,6 +241,7 @@ function handler(activity: Activity) {
     .with("resource_hub_document_deleted", () => ResourceHubDocumentDeleted)
     .with("resource_hub_file_created", () => ResourceHubFileCreated)
     .with("resource_hub_file_deleted", () => ResourceHubFileDeleted)
+    .with("resource_hub_file_edited", () => ResourceHubFileEdited)
     .with("resource_hub_file_commented", () => ResourceHubFileCommented)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("resource_hub_folder_deleted", () => ResourceHubFolderDeleted)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_file_edited.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_file_edited.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFileEdited do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    file = Map.put(content["file"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      file: Serializer.serialize(file, level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -448,6 +448,11 @@ defmodule OperatelyWeb.Api.Types do
     field :file, :resource_hub_file
   end
 
+  object :activity_content_resource_hub_file_edited do
+    field :resource_hub, :resource_hub
+    field :file, :resource_hub_file
+  end
+
   object :activity_content_resource_hub_file_commented do
     field :file, :resource_hub_file
     field :comment, :comment


### PR DESCRIPTION
The `ResourceHubFileEdited` event is now displayed in the feed.