### PR TITLE
fix: Items in move-file form don't overflow the container

### DIFF
--- a/assets/js/features/ResourceHub/components/MoveResources/FolderSelectField.tsx
+++ b/assets/js/features/ResourceHub/components/MoveResources/FolderSelectField.tsx
@@ -113,7 +113,7 @@ function OptionsList({ resource, currentLocation, selectFolder, loading }: Optio
   }, [currentLocation]);
 
   return (
-    <div className="h-[240px]">
+    <div className="h-[240px] overflow-scroll">
       {options?.map((node) => (
         <Option
           resource={resource}


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1737.

https://github.com/user-attachments/assets/87a1f32d-93bf-460e-8a56-460e71241e5a

