### PR TITLE
chore: Rename existing Resource Hubs to "Documents & Files"

### DIFF
--- a/lib/operately/data/change_044_rename_resource_hubs.ex
+++ b/lib/operately/data/change_044_rename_resource_hubs.ex
@@ -1,0 +1,12 @@
+defmodule Operately.Data.Change044RenameResourceHubs do
+  alias Operately.Repo
+  alias Operately.ResourceHubs.ResourceHub
+
+  def run do
+    Repo.transaction(fn ->
+      {_, nil} = Repo.update_all(ResourceHub, set: [
+        name: "Documents & Files",
+      ])
+    end)
+  end
+end

--- a/lib/operately/groups/insert_group.ex
+++ b/lib/operately/groups/insert_group.ex
@@ -81,7 +81,7 @@ defmodule Operately.Groups.InsertGroup do
     |> Multi.insert(:resource_hub, fn changes ->
       Operately.ResourceHubs.ResourceHub.changeset(%{
         space_id: changes.group.id,
-        name: "Resource Hub",
+        name: "Documents & Files",
       })
     end)
     |> Multi.insert(:hub_context, fn changes ->

--- a/priv/repo/migrations/20241219153512_rename_existing_resource_hubs_to_documents_and_files.exs
+++ b/priv/repo/migrations/20241219153512_rename_existing_resource_hubs_to_documents_and_files.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.RenameExistingResourceHubsToDocumentsAndFiles do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change044RenameResourceHubs.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -46,7 +46,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_folder_created(%{name: folder4, index: 1})
       |> Steps.navigate_back(folder1)
       |> Steps.assert_items_count(%{index: 0, items_count: "2 items"})
-      |> Steps.navigate_back("Resource Hub")
+      |> Steps.navigate_back("Documents & Files")
       |> Steps.assert_items_count(%{index: 0, items_count: "1 item"})
     end
 
@@ -124,7 +124,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_document(doc)
       |> Steps.assert_document_content(doc)
-      |> Steps.navigate_back("Resource Hub")
+      |> Steps.navigate_back("Documents & Files")
       |> Steps.delete_document(doc.name)
       |> Steps.assert_document_deleted(doc.name)
       |> Steps.assert_document_deleted_on_space_feed(doc.name)

--- a/test/operately/data/change_044_rename_resource_hubs_test.exs
+++ b/test/operately/data/change_044_rename_resource_hubs_test.exs
@@ -1,0 +1,33 @@
+defmodule Operately.Data.Change044RenameResourceHubsTest do
+  use Operately.DataCase
+
+  import Operately.ResourceHubsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space1)
+    |> Factory.add_space(:space2)
+  end
+
+  test "renames existing resource hubs to Documents & Files", ctx do
+    hubs1 = Enum.map(1..3, fn _ ->
+      resource_hub_fixture(ctx.creator, ctx.space1, name: "Some name")
+    end)
+    hubs2 = Enum.map(1..3, fn _ ->
+      resource_hub_fixture(ctx.creator, ctx.space2, name: "Some name")
+    end)
+    hubs = hubs1 ++ hubs2
+
+    Enum.each(hubs, fn hub ->
+      refute hub.name == "Documents & Files"
+    end)
+
+    Operately.Data.Change044RenameResourceHubs.run()
+
+    Enum.each(hubs, fn hub ->
+      hub = Repo.reload(hub)
+      assert hub.name == "Documents & Files"
+    end)
+  end
+end

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -44,7 +44,7 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :navigate_to_resource_hub_page, ctx do
-    UI.click(ctx, testid: "resource-hub")
+    UI.click(ctx, testid: "documents-files")
   end
 
   step :navigate_to_folder, ctx, index: index do
@@ -109,15 +109,15 @@ defmodule Operately.Support.Features.ResourceHubSteps do
 
   step :assert_zero_state, ctx do
     ctx
-    |> UI.assert_text("Resource Hub")
+    |> UI.assert_text("Documents & Files")
     |> UI.assert_text("Nothing here just yet.")
     |> UI.assert_text("A place to share rich text documents, images, videos, and other files")
   end
 
   step :assert_zero_state_on_space_page, ctx do
-    UI.find(ctx, UI.query(testid: "resource-hub"), fn ctx ->
+    UI.find(ctx, UI.query(testid: "documents-files"), fn ctx ->
       ctx
-      |> UI.assert_text("Resource Hub")
+      |> UI.assert_text("Documents & Files")
       |> UI.assert_text("Nothing here just yet.")
       |> UI.assert_text("A place to share rich text documents, images, videos, and other files")
     end)
@@ -175,13 +175,13 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   step :assert_folder_created_on_space_feed, ctx, folder_name do
     ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.space))
-    |> UI.assert_text("created the #{folder_name} folder in Resource Hub")
+    |> UI.assert_text("created the #{folder_name} folder in Documents & Files")
   end
 
   step :assert_folder_created_on_company_feed, ctx, folder_name do
     ctx
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> UI.assert_text("created the #{folder_name} folder in Resource Hub")
+    |> UI.assert_text("created the #{folder_name} folder in Documents & Files")
   end
 
   step :assert_document_created_on_space_feed, ctx, attrs do
@@ -213,13 +213,13 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   step :assert_document_deleted_on_space_feed, ctx, document_name do
     ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.space))
-    |> UI.assert_text("deleted #{document_name} from Resource Hub")
+    |> UI.assert_text("deleted #{document_name} from Documents & Files")
   end
 
   step :assert_document_deleted_on_company_feed, ctx, document_name do
     ctx
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> UI.assert_text("deleted #{document_name} from Resource Hub")
+    |> UI.assert_text("deleted #{document_name} from Documents & Files")
   end
 
   #


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1741.