### PR TITLE
feat: Display comments count for documents and files

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1100,7 +1100,7 @@ export interface ResourceHubDocument {
   insertedAt?: string | null;
   permissions?: ResourceHubPermissions | null;
   reactions?: Reaction[] | null;
-  comments?: Comment[] | null;
+  commentsCount?: number | null;
   potentialSubscribers?: Subscriber[] | null;
   subscriptionList?: SubscriptionList | null;
   notifications?: Notification[] | null;
@@ -1120,6 +1120,7 @@ export interface ResourceHubFile {
   insertedAt?: string | null;
   permissions?: ResourceHubPermissions | null;
   reactions?: Reaction[] | null;
+  commentsCount?: number | null;
   type?: string | null;
   size?: number | null;
   blob?: Blob | null;
@@ -1804,6 +1805,7 @@ export interface GetResourceHubInput {
   includePotentialSubscribers?: boolean | null;
   includePermissions?: boolean | null;
   includeChildrenCount?: boolean | null;
+  includeCommentsCount?: boolean | null;
 }
 
 export interface GetResourceHubResult {
@@ -1849,6 +1851,7 @@ export interface GetResourceHubFolderInput {
   includePermissions?: boolean | null;
   includeChildrenCount?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeCommentsCount?: boolean | null;
 }
 
 export interface GetResourceHubFolderResult {

--- a/assets/js/features/Comments/CommentsCountIndicator.tsx
+++ b/assets/js/features/Comments/CommentsCountIndicator.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export function CommentsCountIndicator({ count }: { count: number }) {
+  if (count < 1) return <></>;
+
+  return (
+    <div>
+      <div className="w-[16px] h-[16px] bg-blue-500 text-white-1 flex items-center justify-center rounded-full text-[9px] font-bold">
+        {count}
+      </div>
+    </div>
+  );
+}

--- a/assets/js/features/Comments/index.tsx
+++ b/assets/js/features/Comments/index.tsx
@@ -1,0 +1,1 @@
+export { CommentsCountIndicator } from "./CommentsCountIndicator";

--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -5,9 +5,10 @@ import * as Hub from "@/models/resourceHubs";
 import classNames from "classnames";
 import { DivLink } from "@/components/Link";
 import { ImageWithPlaceholder } from "@/components/Image";
+import { CommentsCountIndicator } from "@/features/Comments";
 import { assertPresent } from "@/utils/assertions";
 import { createTestId } from "@/utils/testid";
-import { findIcon, findPath, findSubtitle, NodeType, sortNodesWithFoldersFirst } from "./utils";
+import { findCommentsCount, findIcon, findPath, findSubtitle, NodeType, sortNodesWithFoldersFirst } from "./utils";
 import { DocumentMenu, FileMenu, FolderMenu, FolderZeroNodes, HubZeroNodes } from "./components";
 import { NodesProps, NodesProvider } from "./contexts/NodesContext";
 
@@ -45,6 +46,7 @@ function NodeItem({ node, testid }: NodeItemProps) {
   );
   const path = findPath(node.type as NodeType, node);
   const subtitle = findSubtitle(node.type as NodeType, node);
+  const commentsCount = findCommentsCount(node.type as NodeType, node);
 
   return (
     <div className={className} data-test-id={testid}>
@@ -52,7 +54,10 @@ function NodeItem({ node, testid }: NodeItemProps) {
         <FilePreview node={node} />
         <div>
           <div className="font-bold text-lg">{node.name}</div>
-          <div>{subtitle}</div>
+          <div className="flex items-center gap-4">
+            <div>{subtitle}</div>
+            <CommentsCountIndicator count={commentsCount} />
+          </div>
         </div>
       </DivLink>
 

--- a/assets/js/features/ResourceHub/NodesList.tsx
+++ b/assets/js/features/ResourceHub/NodesList.tsx
@@ -52,9 +52,9 @@ function NodeItem({ node, testid }: NodeItemProps) {
     <div className={className} data-test-id={testid}>
       <DivLink to={path} className="flex gap-4 py-4 items-center cursor-pointer">
         <FilePreview node={node} />
-        <div>
+        <div className="w-full">
           <div className="font-bold text-lg">{node.name}</div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center justify-between gap-2">
             <div>{subtitle}</div>
             <CommentsCountIndicator count={commentsCount} />
           </div>

--- a/assets/js/features/ResourceHub/utils.tsx
+++ b/assets/js/features/ResourceHub/utils.tsx
@@ -75,3 +75,18 @@ export function sortNodesWithFoldersFirst(nodes: ResourceHubNode[]) {
 
   return [...folders, ...others];
 }
+
+export function findCommentsCount(nodeType: NodeType, node: ResourceHubNode) {
+  switch (nodeType) {
+    case "document":
+      assertPresent(node.document?.commentsCount, "commentsCount must be present in document");
+      return node.document.commentsCount;
+
+    case "file":
+      assertPresent(node.file?.commentsCount, "commentsCount must be present in file");
+      return node.file.commentsCount;
+
+    default:
+      return 0;
+  }
+}

--- a/assets/js/features/SpaceTools/Discussions.tsx
+++ b/assets/js/features/SpaceTools/Discussions.tsx
@@ -6,6 +6,7 @@ import { Discussion } from "@/models/discussions";
 import { Paths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { richContentToString } from "@/components/RichContent";
+import { CommentsCountIndicator } from "@/features/Comments";
 import Avatar from "@/components/Avatar";
 import classNames from "classnames";
 
@@ -57,7 +58,7 @@ function DiscussionItem({ discussion }: { discussion: Discussion }) {
     <div className={className}>
       <Avatar person={discussion.author} size={30} />
       <DiscussionTitle title={discussion.title!} body={discussion.body!} />
-      <CommnetsCount count={discussion.commentsCount} />
+      <CommentsCountIndicator count={discussion.commentsCount} />
     </div>
   );
 }
@@ -67,18 +68,6 @@ function DiscussionTitle({ title, body }: { title: string; body: string }) {
     <div className="font-bold overflow-hidden">
       <div className="truncate pr-2">{title}</div>
       <div className="font-normal truncate pr-2">{richContentToString(JSON.parse(body))}</div>
-    </div>
-  );
-}
-
-function CommnetsCount({ count }: { count: number }) {
-  if (count < 1) return <></>;
-
-  return (
-    <div>
-      <div className="w-[16px] h-[16px] bg-blue-500 text-white-1 flex items-center justify-center rounded-full text-[9px] font-bold">
-        {count}
-      </div>
     </div>
   );
 }

--- a/assets/js/pages/ResourceHubFolderPage/loader.tsx
+++ b/assets/js/pages/ResourceHubFolderPage/loader.tsx
@@ -15,6 +15,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includePermissions: true,
       includeChildrenCount: true,
       includePotentialSubscribers: true,
+      includeCommentsCount: true,
     }).then((res) => res.folder!),
   };
 }

--- a/assets/js/pages/ResourceHubPage/loader.tsx
+++ b/assets/js/pages/ResourceHubPage/loader.tsx
@@ -15,6 +15,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includePermissions: true,
       includeChildrenCount: true,
       includePotentialSubscribers: true,
+      includeCommentsCount: true,
     }).then((res) => res.resourceHub!),
   };
 }

--- a/lib/operately/resource_hubs/document.ex
+++ b/lib/operately/resource_hubs/document.ex
@@ -21,6 +21,7 @@ defmodule Operately.ResourceHubs.Document do
     field :potential_subscribers, :any, virtual: true
     field :permissions, :any, virtual: true
     field :notifications, :any, virtual: true, default: []
+    field :comments_count, :integer, virtual: true
 
     timestamps()
     soft_delete()

--- a/lib/operately/resource_hubs/file.ex
+++ b/lib/operately/resource_hubs/file.ex
@@ -22,6 +22,7 @@ defmodule Operately.ResourceHubs.File do
     # populated with after load hooks
     field :potential_subscribers, :any, virtual: true
     field :permissions, :any, virtual: true
+    field :comments_count, :integer, virtual: true
 
     timestamps()
     soft_delete()

--- a/lib/operately/resource_hubs/folder.ex
+++ b/lib/operately/resource_hubs/folder.ex
@@ -93,6 +93,11 @@ defmodule Operately.ResourceHubs.Folder do
     Map.put(folder, :path_to_folder, path)
   end
 
+  def load_comments_count(folder = %__MODULE__{}) do
+    nodes = Operately.ResourceHubs.Node.load_comments_count(folder.child_nodes)
+    Map.put(folder, :child_nodes, nodes)
+  end
+
   def load_potential_subscribers(folder = %__MODULE__{}) do
     folder = Repo.preload(folder, space: :members)
 

--- a/lib/operately/resource_hubs/resource_hub.ex
+++ b/lib/operately/resource_hubs/resource_hub.ex
@@ -40,6 +40,11 @@ defmodule Operately.ResourceHubs.ResourceHub do
     Map.put(resource_hub, :potential_subscribers, subscribers)
   end
 
+  def load_comments_count(resource_hub = %__MODULE__{}) do
+    nodes = Operately.ResourceHubs.Node.load_comments_count(resource_hub.nodes)
+    Map.put(resource_hub, :nodes, nodes)
+  end
+
   def set_children_count(resource_hubs) when is_list(resource_hubs) do
     Enum.map(resource_hubs, &set_children_count/1)
   end

--- a/lib/operately_web/api/queries/get_resource_hub.ex
+++ b/lib/operately_web/api/queries/get_resource_hub.ex
@@ -11,6 +11,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
     field :include_potential_subscribers, :boolean
     field :include_permissions, :boolean
     field :include_children_count, :boolean
+    field :include_comments_count, :boolean
   end
 
   outputs do
@@ -55,6 +56,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHub do
       include_potential_subscribers: &ResourceHub.load_potential_subscribers/1,
       include_children_count: &ResourceHub.set_children_count/1,
       include_permissions: &ResourceHub.set_permissions/1,
+      include_comments_count: &ResourceHub.load_comments_count/1,
     ])
   end
 end

--- a/lib/operately_web/api/queries/get_resource_hub_folder.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_folder.ex
@@ -12,6 +12,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolder do
     field :include_permissions, :boolean
     field :include_children_count, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_comments_count, :boolean
   end
 
   outputs do
@@ -55,6 +56,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubFolder do
       include_children_count: &Folder.set_children_count/1,
       include_permissions: &Folder.set_permissions/1,
       include_potential_subscribers: &Folder.load_potential_subscribers/1,
+      include_comments_count: &Folder.load_comments_count/1,
     ])
   end
 end

--- a/lib/operately_web/api/serializers/resource_hub_document.ex
+++ b/lib/operately_web/api/serializers/resource_hub_document.ex
@@ -5,6 +5,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Document do
       name: document.node.name,
       content: Jason.encode!(document.content),
       parent_folder_id: document.node.parent_folder_id && OperatelyWeb.Paths.folder_id(document.node.parent_folder_id),
+      comments_count: document.comments_count,
     }
   end
 
@@ -18,7 +19,6 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Document do
       name: document.node.name,
       content: Jason.encode!(document.content),
       reactions: OperatelyWeb.Api.Serializer.serialize(document.reactions),
-      comments: OperatelyWeb.Api.Serializer.serialize(document.comments),
       inserted_at: OperatelyWeb.Api.Serializer.serialize(document.inserted_at),
       permissions: OperatelyWeb.Api.Serializer.serialize(document.permissions),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(document.potential_subscribers),

--- a/lib/operately_web/api/serializers/resource_hub_file.ex
+++ b/lib/operately_web/api/serializers/resource_hub_file.ex
@@ -8,6 +8,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.File do
       size: Ecto.assoc_loaded?(file.blob) && file.blob.size,
       blob: OperatelyWeb.Api.Serializer.serialize(file.preview_blob || file.blob),
       parent_folder_id: file.node.parent_folder_id && OperatelyWeb.Paths.folder_id(file.node.parent_folder_id),
+      comments_count: file.comments_count,
     }
   end
 

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -635,7 +635,7 @@ defmodule OperatelyWeb.Api.Types do
     field :inserted_at, :string
     field :permissions, :resource_hub_permissions
     field :reactions, list_of(:reaction)
-    field :comments, list_of(:comment)
+    field :comments_count, :integer
     field :potential_subscribers, list_of(:subscriber)
     field :subscription_list, :subscription_list
     field :notifications, list_of(:notification)
@@ -655,6 +655,7 @@ defmodule OperatelyWeb.Api.Types do
     field :inserted_at, :string
     field :permissions, :resource_hub_permissions
     field :reactions, list_of(:reaction)
+    field :comments_count, :integer
     field :type, :string
     field :size, :integer
     field :blob, :blob

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -133,4 +133,38 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_document_deleted_email_sent(doc.name)
     end
   end
+
+  describe "comments" do
+    feature "add comment to document", ctx do
+      doc = %{
+        name: "My First Document",
+        content: "This is the document's content",
+      }
+
+      ctx
+      |> Steps.visit_resource_hub_page()
+      |> Steps.create_document(doc)
+      |> Steps.leave_comment()
+      |> Steps.leave_comment()
+      |> Steps.navigate_back("Documents & Files")
+      |> Steps.assert_comments_count(%{index: 0, count: "2"})
+      |> Steps.assert_document_commented_on_company_feed(doc.name)
+      |> Steps.assert_document_commented_on_space_feed(doc.name)
+      |> Steps.assert_document_commented_notification_sent(doc.name)
+      |> Steps.assert_document_commented_email_sent(doc.name)
+    end
+
+    test "add comment to file", ctx do
+      ctx
+      |> Steps.given_file_exists()
+      |> Steps.visit_file_page()
+      |> Steps.leave_comment()
+      |> Steps.navigate_back("Documents & Files")
+      |> Steps.assert_comments_count(%{index: 0, count: "1"})
+      |> Steps.assert_file_commented_on_company_feed()
+      |> Steps.assert_file_commented_on_space_feed()
+      |> Steps.assert_file_commented_notification_sent()
+      |> Steps.assert_file_commented_email_sent()
+    end
+  end
 end

--- a/test/operately_web/api/mutations/edit_resource_hub_document_test.exs
+++ b/test/operately_web/api/mutations/edit_resource_hub_document_test.exs
@@ -78,7 +78,7 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocumentTest do
     end
 
     test "edits document", ctx do
-      assert ctx.document.node.name == "some name"
+      assert ctx.document.node.name == "Document"
       assert ctx.document.content == RichText.rich_text("Content")
 
       assert {200, _} = mutation(ctx.conn, :edit_resource_hub_document, %{

--- a/test/support/features/ui.ex
+++ b/test/support/features/ui.ex
@@ -162,7 +162,7 @@ defmodule Operately.Support.Features.UI do
     # 10ms, but that was too short.
     #
     execute(ctx, fn session ->
-      session 
+      session
       |> sleep(50)
       |> Browser.clear(query)
       |> Browser.fill_in(query, with: value)
@@ -267,8 +267,20 @@ defmodule Operately.Support.Features.UI do
     {_, opts} = Keyword.pop(opts, :in)
     css_query = compose_css_query(opts)
 
+    refute_has(state, Query.css(css_query), attempts: [50, 150, 250, 400, 1000])
+  end
+
+  defp refute_has(state, query, attempts: [delay | attempts]) do
     execute(state, fn session ->
-      session |> Browser.refute_has(Query.css(css_query))
+      :timer.sleep(delay)
+
+      has_element = session |> Browser.has?(query)
+
+      cond do
+        not has_element -> session
+        attempts == [] -> raise "Element matching '#{query}' was found on the page"
+        true -> refute_has(state, query, attempts: attempts).session
+      end
     end)
   end
 

--- a/test/support/fixtures/resource_hubs_fixtures.ex
+++ b/test/support/fixtures/resource_hubs_fixtures.ex
@@ -34,7 +34,7 @@ defmodule Operately.ResourceHubsFixtures do
     {:ok, node} = Operately.ResourceHubs.create_node(%{
       resource_hub_id: hub_id,
       parent_folder_id: attrs[:parent_folder_id] && attrs.parent_folder_id,
-      name: attrs[:name] || "some name",
+      name: attrs[:name] || "Document",
       type: :document,
     })
 


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1745.

The logic for loading the comments count is in place. Since comments count is something we will have to display in many places, I made a component for it.

I'm just not sure where it looks better. Here is what it looks like right after the description:
![tmp-1](https://github.com/user-attachments/assets/84d008fc-8689-4888-b68c-a289d8ce5ba4)

And here is what it looks like at the end of the container:
![tmp-2](https://github.com/user-attachments/assets/89b07d22-2a02-4a19-a8b0-38243823f34c)

If we decide to go with the second picture, then this PR should be ready. If the first picture is better, then I would have to remove the last commit.

Also, if you think the count would look better positioned somewhere else, just let me know!
 