### PR TITLE
feat: Display link-created event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -562,6 +562,11 @@ export interface ActivityContentResourceHubFolderRenamed {
   newName?: string | null;
 }
 
+export interface ActivityContentResourceHubLinkCreated {
+  resourceHub?: ResourceHub | null;
+  link?: ResourceHubLink | null;
+}
+
 export interface ActivityContentSpaceAdded {
   companyId?: string | null;
   spaceId?: string | null;

--- a/assets/js/features/activities/ResourceHubLinkCreated/index.tsx
+++ b/assets/js/features/activities/ResourceHubLinkCreated/index.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubLinkCreated } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { Link } from "@/components/Link";
+import { feedTitle } from "../feedItemLinks";
+
+const ResourceHubLinkCreated: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubLinkPath(content(activity).link?.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const path = Paths.resourceHubLinkPath(content(activity).link?.id!);
+    const link = <Link to={path}>{content(activity).link?.name}</Link>;
+
+    return feedTitle(activity, "added a link:", link);
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " added a link: " + content(activity).link?.name;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubLinkCreated {
+  return activity.content as ActivityContentResourceHubLinkCreated;
+}
+
+export default ResourceHubLinkCreated;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -116,6 +116,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_folder_created",
   "resource_hub_folder_deleted",
   "resource_hub_folder_renamed",
+  "resource_hub_link_created",
   "space_added",
   "space_joining",
   "space_member_removed",
@@ -183,6 +184,7 @@ import ResourceHubFileCommented from "@/features/activities/ResourceHubFileComme
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import ResourceHubFolderDeleted from "@/features/activities/ResourceHubFolderDeleted";
 import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRenamed";
+import ResourceHubLinkCreated from "@/features/activities/ResourceHubLinkCreated";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
 import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
@@ -246,6 +248,7 @@ function handler(activity: Activity) {
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("resource_hub_folder_deleted", () => ResourceHubFolderDeleted)
     .with("resource_hub_folder_renamed", () => ResourceHubFolderRenamed)
+    .with("resource_hub_link_created", () => ResourceHubLinkCreated)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)
     .with("space_member_removed", () => SpaceMemberRemoved)

--- a/assets/js/routes/paths.tsx
+++ b/assets/js/routes/paths.tsx
@@ -236,6 +236,10 @@ export class Paths {
     return createCompanyPath(["documents", documentId, "copy"]) + `?${parentType}=${parentId}`;
   }
 
+  static resourceHubLinkPath(linkId: string) {
+    return createCompanyPath(["links", linkId]);
+  }
+
   static spacePath(spaceId: string) {
     return createCompanyPath(["spaces", spaceId]);
   }

--- a/lib/operately/activities/preloader.ex
+++ b/lib/operately/activities/preloader.ex
@@ -25,6 +25,7 @@ defmodule Operately.Activities.Preloader do
     |> preload(Operately.ResourceHubs.Folder)
     |> preload(Operately.ResourceHubs.File)
     |> preload(Operately.ResourceHubs.Document)
+    |> preload(Operately.ResourceHubs.Link)
     |> preload(Operately.ResourceHubs.Node)
     |> preload_sub_activities()
   end

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_link_created.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_link_created.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubLinkCreated do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    link = Map.put(content["link"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      link: Serializer.serialize(link, level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -479,6 +479,11 @@ defmodule OperatelyWeb.Api.Types do
     field :comment, :comment
   end
 
+  object :activity_content_resource_hub_link_created do
+    field :resource_hub, :resource_hub
+    field :link, :resource_hub_link
+  end
+
   object :activity_content_project_discussion_submitted do
     field :project_id, :string
     field :discussion_id, :string


### PR DESCRIPTION
The `ResourceHubLinkCreated` event is now displayed in the feed.