### PR TITLE
feat: Show file size and download button on file page

### DIFF
--- a/assets/js/models/blobs/index.tsx
+++ b/assets/js/models/blobs/index.tsx
@@ -5,7 +5,7 @@ import { createBlob } from "@/api";
 import { findImageDimensions, findVideoDimensions } from "./utils";
 
 export { useDownloadFile } from "./useDownloadFile";
-export { resizeImage, findFileSize, findFileExtension } from "./utils";
+export { resizeImage, findFileSize } from "./utils";
 
 type ProgressCallback = (number: number) => any;
 type UploadResult = { id: string; url: string };

--- a/assets/js/models/blobs/utils.tsx
+++ b/assets/js/models/blobs/utils.tsx
@@ -98,9 +98,3 @@ export function findFileSize(size: number) {
 
   return "";
 }
-
-export function findFileExtension(fileName: string) {
-  const pieces = fileName.split(".");
-  const extension = pieces[pieces.length - 1];
-  return extension?.toUpperCase();
-}

--- a/assets/js/pages/ResourceHubFilePage/loader.tsx
+++ b/assets/js/pages/ResourceHubFilePage/loader.tsx
@@ -9,6 +9,7 @@ export async function loader({ params }): Promise<LoaderResult> {
   return {
     file: await getResourceHubFile({
       id: params.id,
+      includeAuthor: true,
       includeResourceHub: true,
       includeParentFolder: true,
       includeReactions: true,


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1747.

I decided to display the required information similarly to how we display it for rich-text files:

![tmp](https://github.com/user-attachments/assets/f9bf4550-c991-443e-aeec-6cd798ee861f)
