### PR TITLE
fix: Document navigation includes complete path back to the space

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1110,6 +1110,7 @@ export interface ResourceHubDocument {
   potentialSubscribers?: Subscriber[] | null;
   subscriptionList?: SubscriptionList | null;
   notifications?: Notification[] | null;
+  pathToDocument?: ResourceHubFolder[] | null;
 }
 
 export interface ResourceHubFile {
@@ -1831,6 +1832,7 @@ export interface GetResourceHubDocumentInput {
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
   includeUnreadNotifications?: boolean | null;
+  includePathToDocument?: boolean | null;
 }
 
 export interface GetResourceHubDocumentResult {

--- a/assets/js/components/PaperContainer/Navigation.tsx
+++ b/assets/js/components/PaperContainer/Navigation.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
 import * as Icons from "@tabler/icons-react";
 
+import { Space } from "@/models/spaces";
+import { ResourceHub, ResourceHubFolder } from "@/models/resourceHubs";
+
+import { Paths } from "@/routes/paths";
 import { Link } from "@/components/Link";
+import { truncateString } from "@/utils/strings";
 import classNames from "classnames";
 
 export function Navigation({ children, testId }: { children: React.ReactNode; testId?: string }) {
@@ -52,4 +57,16 @@ export function NavigateBack({ to, title }) {
       </Link>
     </div>
   );
+}
+
+export function NavSpaceLink({ space }: { space: Space }) {
+  return <NavItem linkTo={Paths.spacePath(space.id!)}>{space.name}</NavItem>;
+}
+
+export function NavResourceHubLink({ resourceHub }: { resourceHub: ResourceHub }) {
+  return <NavItem linkTo={Paths.resourceHubPath(resourceHub.id!)}>{resourceHub.name}</NavItem>;
+}
+
+export function NavFolderLink({ folder }: { folder: ResourceHubFolder }) {
+  return <NavItem linkTo={Paths.resourceHubFolderPath(folder.id!)}>{truncateString(folder.name!, 20)}</NavItem>;
 }

--- a/assets/js/features/ResourceHub/NestedFolderNavigation.tsx
+++ b/assets/js/features/ResourceHub/NestedFolderNavigation.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import * as Paper from "@/components/PaperContainer";
+import { ResourceHubFolder } from "@/models/resourceHubs";
+
+export function NestedFolderNavigation({ folders }: { folders: ResourceHubFolder[] }) {
+  return (
+    <>
+      {folders.map((folder) => (
+        <React.Fragment key={folder.id}>
+          <Paper.NavSeparator />
+          <Paper.NavFolderLink folder={folder} />
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/assets/js/features/ResourceHub/index.tsx
+++ b/assets/js/features/ResourceHub/index.tsx
@@ -8,3 +8,4 @@ export { AddFolderModal } from "./AddFolderModal";
 export { AddFileModal } from "./AddFileModal";
 export { FileDragAndDropArea } from "./FileDragAndDropArea";
 export { FolderSelectField } from "./components/MoveResources/FolderSelectField";
+export { NestedFolderNavigation } from "./NestedFolderNavigation";

--- a/assets/js/pages/ResourceHubDocumentPage/loader.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/loader.tsx
@@ -17,6 +17,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includePotentialSubscribers: true,
       includeSubscriptionsList: true,
       includeUnreadNotifications: true,
+      includePathToDocument: true,
     }).then((res) => res.document!),
   };
 }

--- a/assets/js/pages/ResourceHubDocumentPage/page.tsx
+++ b/assets/js/pages/ResourceHubDocumentPage/page.tsx
@@ -9,12 +9,12 @@ import RichContent from "@/components/RichContent";
 import Avatar from "@/components/Avatar";
 import { TextSeparator } from "@/components/TextSeparator";
 import { Spacer } from "@/components/Spacer";
-import { Paths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useComments } from "@/features/CommentSection";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { NestedFolderNavigation } from "@/features/ResourceHub";
 
 import { useLoadedData } from "./loader";
 import { Options } from "./Options";
@@ -48,15 +48,15 @@ function Navigation() {
   const { document } = useLoadedData();
 
   assertPresent(document.resourceHub, "resourceHub must be present in document");
-
-  const name = document.parentFolder?.name || document.resourceHub.name;
-  const path = document.parentFolder
-    ? Paths.resourceHubFolderPath(document.parentFolder.id!)
-    : Paths.resourceHubPath(document.resourceHub.id!);
+  assertPresent(document.resourceHub.space, "space must be present in document.resourceHub");
+  assertPresent(document.pathToDocument, "pathToDocument must be present in document");
 
   return (
-    <Paper.Navigation>
-      <Paper.NavItem linkTo={path}>{name}</Paper.NavItem>
+    <Paper.Navigation testId="navigation">
+      <Paper.NavSpaceLink space={document.resourceHub.space} />
+      <Paper.NavSeparator />
+      <Paper.NavResourceHubLink resourceHub={document.resourceHub} />
+      <NestedFolderNavigation folders={document.pathToDocument} />
     </Paper.Navigation>
   );
 }

--- a/assets/js/pages/ResourceHubFolderPage/page.tsx
+++ b/assets/js/pages/ResourceHubFolderPage/page.tsx
@@ -6,8 +6,6 @@ import * as Hub from "@/features/ResourceHub";
 
 import { useLoadedData, useRefresh } from "./loader";
 import { assertPresent } from "@/utils/assertions";
-import { Paths } from "@/routes/paths";
-import { truncateString } from "@/utils/strings";
 
 export function Page() {
   const { folder } = useLoadedData();
@@ -41,31 +39,15 @@ function PageNavigation() {
   const { folder } = useLoadedData();
 
   assertPresent(folder.resourceHub, "resourceHub must be present in folder");
+  assertPresent(folder.resourceHub.space, "space must be present in folder.resourceHub");
   assertPresent(folder.pathToFolder, "pathToFolder must be present in folder");
 
   return (
     <Paper.Navigation testId="navigation">
-      <NavSpaceLink />
+      <Paper.NavSpaceLink space={folder.resourceHub.space} />
       <Paper.NavSeparator />
-      <Paper.NavItem linkTo={Paths.resourceHubPath(folder.resourceHub.id!)}>{folder.resourceHub.name}</Paper.NavItem>
-      {folder.pathToFolder.map((folder) => (
-        <React.Fragment key={folder.id}>
-          <Paper.NavSeparator />
-          <Paper.NavItem linkTo={Paths.resourceHubFolderPath(folder.id!)}>
-            {truncateString(folder.name!, 20)}
-          </Paper.NavItem>
-        </React.Fragment>
-      ))}
+      <Paper.NavResourceHubLink resourceHub={folder.resourceHub} />
+      <Hub.NestedFolderNavigation folders={folder.pathToFolder} />
     </Paper.Navigation>
-  );
-}
-
-function NavSpaceLink() {
-  const { folder } = useLoadedData();
-
-  return (
-    <Paper.NavItem linkTo={Paths.spacePath(folder.resourceHub!.space!.id!)}>
-      {folder.resourceHub!.space!.name}
-    </Paper.NavItem>
   );
 }

--- a/lib/operately/resource_hubs/document.ex
+++ b/lib/operately/resource_hubs/document.ex
@@ -22,6 +22,7 @@ defmodule Operately.ResourceHubs.Document do
     field :permissions, :any, virtual: true
     field :notifications, :any, virtual: true, default: []
     field :comments_count, :integer, virtual: true
+    field :path_to_document, :any, virtual: true
 
     timestamps()
     soft_delete()
@@ -74,5 +75,11 @@ defmodule Operately.ResourceHubs.Document do
   def set_permissions(document = %__MODULE__{}) do
     perms = Operately.ResourceHubs.Permissions.calculate(document.request_info.access_level)
     Map.put(document, :permissions, perms)
+  end
+
+  def find_path_to_document(document = %__MODULE__{}) do
+    path = Operately.ResourceHubs.Node.find_all_parent_folders(document.id, "resource_documents")
+
+    Map.put(document, :path_to_document, path)
   end
 end

--- a/lib/operately/resource_hubs/folder.ex
+++ b/lib/operately/resource_hubs/folder.ex
@@ -62,33 +62,7 @@ defmodule Operately.ResourceHubs.Folder do
   #
 
   def find_path_to_folder(folder = %__MODULE__{}) do
-    q = """
-      WITH RECURSIVE folder_hierarchy AS (
-        SELECT f.id, n.parent_folder_id, n.name
-        FROM resource_folders f
-        JOIN resource_nodes n ON f.node_id = n.id
-        WHERE f.id = $1
-
-        UNION ALL
-
-        SELECT f.id, n.parent_folder_id, n.name
-        FROM resource_folders f
-        JOIN resource_nodes n ON f.node_id = n.id
-        JOIN folder_hierarchy fh ON f.id = fh.parent_folder_id
-
-      )
-      SELECT id, name FROM folder_hierarchy WHERE id != $1;
-    """
-    {:ok, folder_id} = Ecto.UUID.dump(folder.id)
-    {:ok, %{rows: rows}} = Operately.Repo.query(q, [folder_id])
-
-    path =
-      rows
-      |> Enum.reverse()
-      |> Enum.map(fn [id, name] ->
-        {:ok, str_id} = Ecto.UUID.cast(id)
-        %__MODULE__{id: str_id, node: %{name: name, parent_folder_id: nil}}
-      end)
+    path = Operately.ResourceHubs.Node.find_all_parent_folders(folder.id, "resource_folders")
 
     Map.put(folder, :path_to_folder, path)
   end

--- a/lib/operately_web/api/queries/get_resource_hub_document.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_document.ex
@@ -14,6 +14,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
     field :include_unread_notifications, :boolean
+    field :include_path_to_document, :boolean
   end
 
   outputs do
@@ -59,6 +60,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
       include_permissions: &Document.set_permissions/1,
       include_unread_notifications: load_unread_notifications(me),
       include_potential_subscribers: &Document.load_potential_subscribers/1,
+      include_path_to_document: &Document.find_path_to_document/1,
     ])
   end
 

--- a/lib/operately_web/api/serializers/resource_hub_document.ex
+++ b/lib/operately_web/api/serializers/resource_hub_document.ex
@@ -26,6 +26,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.ResourceHubs.Document do
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(document.potential_subscribers),
       subscription_list: OperatelyWeb.Api.Serializer.serialize(document.subscription_list),
       notifications: OperatelyWeb.Api.Serializer.serialize(document.notifications),
+      path_to_document: OperatelyWeb.Api.Serializer.serialize(document.path_to_document),
     }
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -647,6 +647,7 @@ defmodule OperatelyWeb.Api.Types do
     field :potential_subscribers, list_of(:subscriber)
     field :subscription_list, :subscription_list
     field :notifications, list_of(:notification)
+    field :path_to_document, list_of(:resource_hub_folder)
   end
 
   object :resource_hub_file do

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -50,19 +50,6 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_items_count(%{index: 0, items_count: "1 item"})
     end
 
-    feature "folder navigation works", ctx do
-      ctx
-      |> Steps.given_nested_folders_exist()
-      |> Steps.visit_folder_page(:five)
-      |> Steps.assert_navigation_links(["Resource hub", "one", "two", "three", "four"])
-      |> Steps.navigate_back("three")
-      |> Steps.refute_navigation_links(["three", "four"])
-      |> Steps.assert_navigation_links(["Resource hub", "one", "two"])
-      |> Steps.navigate_back("one")
-      |> Steps.refute_navigation_links(["one", "two"])
-      |> Steps.assert_navigation_links(["Resource hub"])
-    end
-
     feature "folder created feed event", ctx do
       folder = "Documents"
 
@@ -208,6 +195,34 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_file_commented_on_space_feed()
       |> Steps.assert_file_commented_notification_sent()
       |> Steps.assert_file_commented_email_sent()
+    end
+  end
+
+  describe "navigation" do
+    feature "folder navigation works", ctx do
+      ctx
+      |> Steps.given_nested_folders_exist()
+      |> Steps.visit_folder_page(:five)
+      |> Steps.assert_navigation_links(["Resource hub", "one", "two", "three", "four"])
+      |> Steps.navigate_back("three")
+      |> Steps.refute_navigation_links(["three", "four"])
+      |> Steps.assert_navigation_links(["Resource hub", "one", "two"])
+      |> Steps.navigate_back("one")
+      |> Steps.refute_navigation_links(["one", "two"])
+      |> Steps.assert_navigation_links(["Resource hub"])
+    end
+
+    feature "document navigation works", ctx do
+      ctx
+      |> Steps.given_document_within_nested_folders_exists()
+      |> Steps.visit_document_page()
+      |> Steps.assert_navigation_links(["Resource hub", "one", "two", "three", "four", "five"])
+      |> Steps.navigate_back("four")
+      |> Steps.refute_navigation_links(["four", "five"])
+      |> Steps.assert_navigation_links(["Resource hub", "one", "two", "three"])
+      |> Steps.navigate_back("one")
+      |> Steps.refute_navigation_links(["one", "two", "three"])
+      |> Steps.assert_navigation_links(["Resource hub"])
     end
   end
 end

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -26,6 +26,17 @@ defmodule Operately.Support.Features.ResourceHubSteps do
     |> Factory.add_folder(:five, :hub, :four)
   end
 
+  step :given_document_within_nested_folders_exists, ctx do
+    ctx
+    |> Factory.add_resource_hub(:hub, :space, :creator)
+    |> Factory.add_folder(:one, :hub)
+    |> Factory.add_folder(:two, :hub, :one)
+    |> Factory.add_folder(:three, :hub, :two)
+    |> Factory.add_folder(:four, :hub, :three)
+    |> Factory.add_folder(:five, :hub, :four)
+    |> Factory.add_document(:document, :hub, folder: :five)
+  end
+
   step :given_file_exists, ctx do
     {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
 


### PR DESCRIPTION
The navigation in the Document page now includes to all the document's nested parent folders, resource hub and space:

https://github.com/user-attachments/assets/dd37639b-e962-442f-9035-441ee6a1f528

