### PR TITLE
docs: New space form, remove 'team' from form tip

### DIFF
--- a/assets/js/pages/SpaceAddPage/index.tsx
+++ b/assets/js/pages/SpaceAddPage/index.tsx
@@ -73,7 +73,7 @@ function Title() {
 }
 
 function NameInput({ field }: { field: string }) {
-  return <Forms.TextInput label="Space Name" field={field} placeholder="e.g. Marketing Team" required />;
+  return <Forms.TextInput label="Space Name" field={field} placeholder="e.g. Marketing" required />;
 }
 
 function PurposeInput({ field }: { field: string }) {


### PR DESCRIPTION
Tiny detail but it would be wrong to lead people to think that it is optimal to have " Team" appended to every space name.