### PR TITLE
feat: Rename goals page to Goal map

### DIFF
--- a/assets/js/pages/GoalsAndProjectsPage/page.tsx
+++ b/assets/js/pages/GoalsAndProjectsPage/page.tsx
@@ -21,9 +21,9 @@ export function Page() {
   });
 
   return (
-    <Pages.Page title="Goals & Projects" testId="goals-and-projects-page">
-      <Paper.Root size="xlarge">
-        <Paper.Body noPadding={noPadding} className={bodyClassName}>
+    <Pages.Page title="Goal Map" testId="goals-and-projects-page">
+      <Paper.Root size="large">
+        <Paper.Body noPadding={noPadding} className={bodyClassName} minHeight="500px">
           <Header />
           <GoalTree goals={goals} projects={projects} options={{}} />
         </Paper.Body>
@@ -37,9 +37,11 @@ function Header() {
   const newProjectPath = Paths.newProjectPath();
 
   return (
-    <div className="flex items-center justify-between mb-8">
-      <h1 className="text-3xl font-bold mb-2">Goals & Projects</h1>
-      <AddGoalOrProjectButton newGoalPath={newGoalPath} newProjectPath={newProjectPath} />
-    </div>
+    <Paper.Header
+      title="Goal Map"
+      actions={<AddGoalOrProjectButton newGoalPath={newGoalPath} newProjectPath={newProjectPath} />}
+      layout="title-center-actions-left"
+      underline
+    />
   );
 }

--- a/assets/js/pages/SpaceGoalsPage/page.tsx
+++ b/assets/js/pages/SpaceGoalsPage/page.tsx
@@ -13,7 +13,7 @@ export function Page() {
   const { space, goals, projects } = useLoadedData();
 
   return (
-    <Pages.Page title={space.name!}>
+    <Pages.Page title={["Goal Map", space.name!]} testId="space-goals-page">
       <Paper.Root size="large">
         <SpacePageNavigation space={space} />
 
@@ -33,9 +33,11 @@ function Header() {
   const newProjectPath = Paths.spaceNewProjectPath(space.id!);
 
   return (
-    <div className="flex items-center justify-between mb-8">
-      <div className="font-extrabold text-3xl">Goals in {space.name}</div>
-      <AddGoalOrProjectButton newGoalPath={newGoalPath} newProjectPath={newProjectPath} />
-    </div>
+    <Paper.Header
+      title="Goal Map"
+      actions={<AddGoalOrProjectButton newGoalPath={newGoalPath} newProjectPath={newProjectPath} />}
+      layout="title-center-actions-left"
+      underline
+    />
   );
 }


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/1783

+ uses the now standard title=center actions=left layout

![Screenshot 2024-12-31 at 13 41 29](https://github.com/user-attachments/assets/0400ae2f-9e74-42ce-b51b-4ae1d0b2a5c4)

