### PR TITLE
feat: Display link-deleted event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -567,6 +567,12 @@ export interface ActivityContentResourceHubLinkCreated {
   link?: ResourceHubLink | null;
 }
 
+export interface ActivityContentResourceHubLinkDeleted {
+  resourceHub?: ResourceHub | null;
+  space?: Space | null;
+  link?: ResourceHubLink | null;
+}
+
 export interface ActivityContentSpaceAdded {
   companyId?: string | null;
   spaceId?: string | null;

--- a/assets/js/features/activities/ResourceHubLinkDeleted/index.tsx
+++ b/assets/js/features/activities/ResourceHubLinkDeleted/index.tsx
@@ -1,0 +1,71 @@
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubLinkDeleted } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+
+const ResourceHubLinkDeleted: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const resourceHub = resourceHubLink(content(activity).resourceHub!);
+    const space = spaceLink(content(activity).space!);
+    const link = content(activity).link!.name!;
+
+    if (page === "space") {
+      return feedTitle(activity, "deleted", link, "from", resourceHub);
+    } else {
+      return feedTitle(activity, "deleted", link, "from", resourceHub, "in the", space, "space");
+    }
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " deleted a link: " + content(activity).link!.name!;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubLinkDeleted {
+  return activity.content as ActivityContentResourceHubLinkDeleted;
+}
+
+export default ResourceHubLinkDeleted;

--- a/assets/js/features/activities/feedItemLinks.tsx
+++ b/assets/js/features/activities/feedItemLinks.tsx
@@ -37,3 +37,10 @@ export const spaceLink = (space: api.Space) => {
 
   return <Link to={path}>{name}</Link>;
 };
+
+export const resourceHubLink = (hub: api.ResourceHub) => {
+  const path = Paths.resourceHubPath(hub.id!);
+  const name = hub.name!;
+
+  return <Link to={path}>{name}</Link>;
+};

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -117,6 +117,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_folder_deleted",
   "resource_hub_folder_renamed",
   "resource_hub_link_created",
+  "resource_hub_link_deleted",
   "space_added",
   "space_joining",
   "space_member_removed",
@@ -185,6 +186,7 @@ import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCre
 import ResourceHubFolderDeleted from "@/features/activities/ResourceHubFolderDeleted";
 import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRenamed";
 import ResourceHubLinkCreated from "@/features/activities/ResourceHubLinkCreated";
+import ResourceHubLinkDeleted from "@/features/activities/ResourceHubLinkDeleted";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
 import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
@@ -249,6 +251,7 @@ function handler(activity: Activity) {
     .with("resource_hub_folder_deleted", () => ResourceHubFolderDeleted)
     .with("resource_hub_folder_renamed", () => ResourceHubFolderRenamed)
     .with("resource_hub_link_created", () => ResourceHubLinkCreated)
+    .with("resource_hub_link_deleted", () => ResourceHubLinkDeleted)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)
     .with("space_member_removed", () => SpaceMemberRemoved)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_link_deleted.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_link_deleted.ex
@@ -1,0 +1,13 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubLinkDeleted do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    link = Map.put(content["link"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      space: Serializer.serialize(content["space"], level: :essential),
+      link: Serializer.serialize(link, level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -484,6 +484,12 @@ defmodule OperatelyWeb.Api.Types do
     field :link, :resource_hub_link
   end
 
+  object :activity_content_resource_hub_link_deleted do
+    field :resource_hub, :resource_hub
+    field :space, :space
+    field :link, :resource_hub_link
+  end
+
   object :activity_content_project_discussion_submitted do
     field :project_id, :string
     field :discussion_id, :string

--- a/test/features/resource_hub_link_test.exs
+++ b/test/features/resource_hub_link_test.exs
@@ -1,0 +1,51 @@
+defmodule Features.ResourceHubLinkTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.ResourceHubSteps, as: Steps
+  alias Operately.Support.Features.ResourceHubLinkSteps, as: LinkSteps
+
+  setup ctx, do: Steps.setup(ctx)
+
+  describe "links" do
+    feature "delete link from content list", ctx do
+      ctx
+      |> LinkSteps.given_link_exists()
+      |> Steps.visit_resource_hub_page("Resource hub")
+      |> LinkSteps.delete_link("Link")
+      |> Steps.assert_zero_state("Resource hub")
+      |> LinkSteps.assert_link_deleted_on_space_feed()
+      |> LinkSteps.assert_link_deleted_on_company_feed()
+    end
+
+    feature "deleting link from link page redirects to resource hub", ctx do
+      ctx
+      |> LinkSteps.given_link_exists()
+      |> LinkSteps.visit_link_page()
+      |> LinkSteps.delete_link()
+      |> Steps.assert_page_is_resource_hub_root(name: "Resource hub")
+      |> Steps.assert_zero_state("Resource hub")
+    end
+
+    feature "deleting link within folder from link page redirects to folder", ctx do
+      ctx
+      |> LinkSteps.given_link_within_nested_folders_exists()
+      |> LinkSteps.visit_link_page()
+      |> LinkSteps.delete_link()
+      |> Steps.assert_page_is_folder_root(folder_key: :five)
+      |> Steps.assert_zero_folder_state()
+    end
+
+    feature "link navigation works", ctx do
+      ctx
+      |> LinkSteps.given_link_within_nested_folders_exists()
+      |> LinkSteps.visit_link_page()
+      |> Steps.assert_navigation_links(["Product Space", "Resource hub", "one", "two", "three", "four", "five"])
+      |> Steps.navigate_back("two")
+      |> Steps.refute_navigation_links(["two", "three", "four", "five"])
+      |> Steps.assert_navigation_links(["Product Space", "Resource hub", "one"])
+      |> Steps.navigate_back("Resource hub")
+      |> Steps.refute_navigation_links(["Resource hub", "one"])
+      |> Steps.assert_navigation_links(["Product Space"])
+    end
+  end
+end

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -166,34 +166,6 @@ defmodule Features.Features.ResourceHubTest do
     end
   end
 
-  describe "links" do
-    feature "delete link from content list", ctx do
-      ctx
-      |> Steps.given_link_exists()
-      |> Steps.visit_resource_hub_page("Resource hub")
-      |> Steps.delete_link("Link")
-      |> Steps.assert_zero_state("Resource hub")
-    end
-
-    feature "deleting link from link page redirects to resource hub", ctx do
-      ctx
-      |> Steps.given_link_exists()
-      |> Steps.visit_link_page()
-      |> Steps.delete_link()
-      |> Steps.assert_page_is_resource_hub_root(name: "Resource hub")
-      |> Steps.assert_zero_state("Resource hub")
-    end
-
-    feature "deleting link within folder from link page redirects to folder", ctx do
-      ctx
-      |> Steps.given_link_within_nested_folders_exists()
-      |> Steps.visit_link_page()
-      |> Steps.delete_link()
-      |> Steps.assert_page_is_folder_root(folder_key: :five)
-      |> Steps.assert_zero_folder_state()
-    end
-  end
-
   describe "comments" do
     feature "add comment to document", ctx do
       ctx
@@ -209,7 +181,7 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_document_commented_email_sent(@document.name)
     end
 
-    test "add comment to file", ctx do
+    feature "add comment to file", ctx do
       ctx
       |> Steps.given_file_exists()
       |> Steps.visit_file_page()
@@ -248,19 +220,6 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.navigate_back("one")
       |> Steps.refute_navigation_links(["one", "two", "three"])
       |> Steps.assert_navigation_links(["Product Space", "Resource hub"])
-    end
-
-    feature "link navigation works", ctx do
-      ctx
-      |> Steps.given_link_within_nested_folders_exists()
-      |> Steps.visit_link_page()
-      |> Steps.assert_navigation_links(["Product Space", "Resource hub", "one", "two", "three", "four", "five"])
-      |> Steps.navigate_back("two")
-      |> Steps.refute_navigation_links(["two", "three", "four", "five"])
-      |> Steps.assert_navigation_links(["Product Space", "Resource hub", "one"])
-      |> Steps.navigate_back("Resource hub")
-      |> Steps.refute_navigation_links(["Resource hub", "one"])
-      |> Steps.assert_navigation_links(["Product Space"])
     end
 
     feature "file navigation works", ctx do

--- a/test/support/features/resource_hub_link_steps.ex
+++ b/test/support/features/resource_hub_link_steps.ex
@@ -1,0 +1,59 @@
+defmodule Operately.Support.Features.ResourceHubLinkSteps do
+  use Operately.FeatureCase
+
+  alias Operately.ResourceHubs.Node
+
+  step :given_link_exists, ctx do
+    ctx
+    |> Factory.add_resource_hub(:hub, :space, :creator)
+    |> Factory.add_link(:link, :hub)
+  end
+
+  step :given_link_within_nested_folders_exists, ctx do
+    ctx
+    |> Factory.add_resource_hub(:hub, :space, :creator)
+    |> Factory.add_folder(:one, :hub)
+    |> Factory.add_folder(:two, :hub, :one)
+    |> Factory.add_folder(:three, :hub, :two)
+    |> Factory.add_folder(:four, :hub, :three)
+    |> Factory.add_folder(:five, :hub, :four)
+    |> Factory.add_link(:link, :hub, folder: :five)
+  end
+
+  step :visit_link_page, ctx do
+    UI.visit(ctx, Paths.link_path(ctx.company, ctx.link))
+  end
+
+  step :delete_link, ctx do
+    ctx
+    |> UI.click(testid: "options-button")
+    |> UI.click(testid: "delete-link")
+  end
+
+  step :delete_link, ctx, link_name do
+    {:ok, node} = Node.get(:system, name: link_name, opts: [preload: :link])
+
+    menu_id = UI.testid(["link-menu", Paths.link_id(node.link)])
+    delete_id = UI.testid(["delete", Paths.link_id(node.link)])
+
+    ctx
+    |> UI.click(testid: menu_id)
+    |> UI.click(testid: delete_id)
+  end
+
+  #
+  # Feed
+  #
+
+  step :assert_link_deleted_on_space_feed, ctx do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.space))
+    |> UI.assert_text("deleted Link from Resource hub")
+  end
+
+  step :assert_link_deleted_on_company_feed, ctx do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.assert_text("deleted Link from Resource hub in the Product Space space")
+  end
+end

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -37,17 +37,6 @@ defmodule Operately.Support.Features.ResourceHubSteps do
     |> Factory.add_document(:document, :hub, folder: :five)
   end
 
-  step :given_link_within_nested_folders_exists, ctx do
-    ctx
-    |> Factory.add_resource_hub(:hub, :space, :creator)
-    |> Factory.add_folder(:one, :hub)
-    |> Factory.add_folder(:two, :hub, :one)
-    |> Factory.add_folder(:three, :hub, :two)
-    |> Factory.add_folder(:four, :hub, :three)
-    |> Factory.add_folder(:five, :hub, :four)
-    |> Factory.add_link(:link, :hub, folder: :five)
-  end
-
   step :given_file_within_nested_folders_exists, ctx do
     ctx =
       ctx
@@ -69,12 +58,6 @@ defmodule Operately.Support.Features.ResourceHubSteps do
     Map.put(ctx, :file, file)
   end
 
-  step :given_link_exists, ctx do
-    ctx
-    |> Factory.add_resource_hub(:hub, :space, :creator)
-    |> Factory.add_link(:link, :hub)
-  end
-
   step :visit_space_page, ctx do
     UI.visit(ctx, Paths.space_path(ctx.company, ctx.space))
   end
@@ -94,10 +77,6 @@ defmodule Operately.Support.Features.ResourceHubSteps do
 
   step :visit_file_page, ctx do
     UI.visit(ctx, Paths.file_path(ctx.company, ctx.file))
-  end
-
-  step :visit_link_page, ctx do
-    UI.visit(ctx, Paths.link_path(ctx.company, ctx.link))
   end
 
   step :navigate_to_resource_hub_page, ctx do
@@ -179,23 +158,6 @@ defmodule Operately.Support.Features.ResourceHubSteps do
 
     menu_id = UI.testid(["document-menu", Paths.document_id(node.document)])
     delete_id = UI.testid(["delete", Paths.document_id(node.document)])
-
-    ctx
-    |> UI.click(testid: menu_id)
-    |> UI.click(testid: delete_id)
-  end
-
-  step :delete_link, ctx do
-    ctx
-    |> UI.click(testid: "options-button")
-    |> UI.click(testid: "delete-link")
-  end
-
-  step :delete_link, ctx, link_name do
-    {:ok, node} = Node.get(:system, name: link_name, opts: [preload: :link])
-
-    menu_id = UI.testid(["link-menu", Paths.link_id(node.link)])
-    delete_id = UI.testid(["delete", Paths.link_id(node.link)])
 
     ctx
     |> UI.click(testid: menu_id)


### PR DESCRIPTION
The `ResourceHubLinkDeleted` event is now displayed in the feed.