### PR TITLE
feat: Display link-edited event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -573,6 +573,15 @@ export interface ActivityContentResourceHubLinkDeleted {
   link?: ResourceHubLink | null;
 }
 
+export interface ActivityContentResourceHubLinkEdited {
+  resourceHub?: ResourceHub | null;
+  space?: Space | null;
+  link?: ResourceHubLink | null;
+  previousName?: string | null;
+  previousType?: string | null;
+  previousUrl?: string | null;
+}
+
 export interface ActivityContentSpaceAdded {
   companyId?: string | null;
   spaceId?: string | null;

--- a/assets/js/features/activities/ResourceHubLinkEdited/index.tsx
+++ b/assets/js/features/activities/ResourceHubLinkEdited/index.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubLinkEdited } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+import { Paths } from "@/routes/paths";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+
+const ResourceHubLinkEdited: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity) {
+    return Paths.resourceHubLinkPath(content(activity).link!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const space = spaceLink(content(activity).space!);
+    const link = content(activity).link!.name!;
+
+    if (page === "space") {
+      return feedTitle(activity, "edited a link:", link);
+    } else {
+      return feedTitle(activity, "edited a link in the", space, "space:", link);
+    }
+  },
+
+  FeedItemContent({ activity }: { activity: Activity; page: any }) {
+    const contentObj = content(activity);
+    const link = contentObj.link!;
+
+    return (
+      <div>
+        <NameEdited currentName={link.name!} previousName={contentObj.previousName!} />
+        <UrlEdited currentUrl={link.url!} previousUrl={contentObj.previousUrl!} />
+        <TypeEdited currentType={link.type!} previousType={contentObj.previousType!} />
+      </div>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " edited a link: " + content(activity).link!.name!;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubLinkEdited {
+  return activity.content as ActivityContentResourceHubLinkEdited;
+}
+
+export default ResourceHubLinkEdited;
+
+function NameEdited({ previousName, currentName }: { previousName: string; currentName: string }) {
+  if (previousName === currentName) return <></>;
+
+  return (
+    <div>
+      <b>Name: </b>
+      <span className="line-through">{previousName}</span> → {currentName}
+    </div>
+  );
+}
+
+function UrlEdited({ previousUrl, currentUrl }: { previousUrl: string; currentUrl: string }) {
+  if (previousUrl === currentUrl) return <></>;
+
+  return (
+    <div>
+      <b>Url: </b>
+      <span className="line-through">{previousUrl}</span> → {currentUrl}
+    </div>
+  );
+}
+
+function TypeEdited({ previousType, currentType }: { previousType: string; currentType: string }) {
+  if (previousType === currentType) return <></>;
+
+  return (
+    <div>
+      <b>Type: </b>
+      <span className="line-through">{previousType}</span> → {currentType}
+    </div>
+  );
+}

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -117,6 +117,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_folder_deleted",
   "resource_hub_folder_renamed",
   "resource_hub_link_created",
+  "resource_hub_link_edited",
   "resource_hub_link_deleted",
   "space_added",
   "space_joining",
@@ -186,6 +187,7 @@ import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCre
 import ResourceHubFolderDeleted from "@/features/activities/ResourceHubFolderDeleted";
 import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRenamed";
 import ResourceHubLinkCreated from "@/features/activities/ResourceHubLinkCreated";
+import ResourceHubLinkEdited from "@/features/activities/ResourceHubLinkEdited";
 import ResourceHubLinkDeleted from "@/features/activities/ResourceHubLinkDeleted";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
@@ -251,6 +253,7 @@ function handler(activity: Activity) {
     .with("resource_hub_folder_deleted", () => ResourceHubFolderDeleted)
     .with("resource_hub_folder_renamed", () => ResourceHubFolderRenamed)
     .with("resource_hub_link_created", () => ResourceHubLinkCreated)
+    .with("resource_hub_link_edited", () => ResourceHubLinkEdited)
     .with("resource_hub_link_deleted", () => ResourceHubLinkDeleted)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_link_edited.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_link_edited.ex
@@ -1,0 +1,17 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubLinkEdited do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    link = Map.put(content["link"], :node, content["node"])
+
+    %{
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      space: Serializer.serialize(content["space"], level: :essential),
+      link: Serializer.serialize(link, level: :essential),
+
+      previous_name: content["previous_link"][:name],
+      previous_type: content["previous_link"][:type],
+      previous_url: content["previous_link"][:url],
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -484,6 +484,16 @@ defmodule OperatelyWeb.Api.Types do
     field :link, :resource_hub_link
   end
 
+  object :activity_content_resource_hub_link_edited do
+    field :resource_hub, :resource_hub
+    field :space, :space
+    field :link, :resource_hub_link
+
+    field :previous_name, :string
+    field :previous_type, :string
+    field :previous_url, :string
+  end
+
   object :activity_content_resource_hub_link_deleted do
     field :resource_hub, :resource_hub
     field :space, :space

--- a/test/features/resource_hub_link_test.exs
+++ b/test/features/resource_hub_link_test.exs
@@ -6,7 +6,7 @@ defmodule Features.ResourceHubLinkTest do
 
   @link %{
     title: "Link",
-    link: "http://localhost:4000",
+    url: "http://localhost:4000",
     notes: "This is a link",
   }
 
@@ -27,8 +27,11 @@ defmodule Features.ResourceHubLinkTest do
     feature "edit link", ctx do
       link = %{
         title: "Link (edited)",
-        link: "http://localhost:3000",
+        url: "http://localhost:3000",
         notes: "This is a link (also edited)",
+
+        previous_title: @link.title,
+        previous_url: @link.url,
       }
 
       ctx
@@ -36,6 +39,8 @@ defmodule Features.ResourceHubLinkTest do
       |> LinkSteps.create_link(@link)
       |> LinkSteps.edit_link(link)
       |> LinkSteps.assert_link_content(link)
+      |> LinkSteps.assert_link_edited_on_space_feed(link)
+      |> LinkSteps.assert_link_edited_on_company_feed(link)
     end
 
     feature "delete link from content list", ctx do

--- a/test/support/features/resource_hub_link_steps.ex
+++ b/test/support/features/resource_hub_link_steps.ex
@@ -31,7 +31,7 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     |> UI.click(testid: "add-options")
     |> UI.click(testid: "link-to-external-resources")
     |> UI.fill(testid: "title", with: attrs.title)
-    |> UI.fill(testid: "link", with: attrs.link)
+    |> UI.fill(testid: "link", with: attrs.url)
     |> UI.fill_rich_text(attrs.notes)
     |> UI.click(testid: "submit")
     |> UI.refute_has(testid: "submit")
@@ -42,7 +42,7 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     |> UI.click(testid: "options-button")
     |> UI.click(testid: "edit-link-link")
     |> UI.fill(testid: "title", with: attrs.title)
-    |> UI.fill(testid: "link", with: attrs.link)
+    |> UI.fill(testid: "link", with: attrs.url)
     |> UI.fill_rich_text(attrs.notes)
     |> UI.click(testid: "submit")
     |> UI.refute_has(testid: "submit")
@@ -71,7 +71,7 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     ctx
     |> UI.assert_page(Paths.link_path(ctx.company, node.link))
     |> UI.assert_text(attrs.title)
-    |> UI.assert_text(attrs.link)
+    |> UI.assert_text(attrs.url)
     |> UI.assert_text(attrs.notes)
   end
 
@@ -89,6 +89,22 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     ctx
     |> UI.visit(Paths.feed_path(ctx.company))
     |> UI.assert_text("added a link: #{link_name}")
+  end
+
+  step :assert_link_edited_on_space_feed, ctx, attrs do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.space))
+    |> UI.assert_text("edited a link: #{attrs.title}")
+    |> UI.assert_text("#{attrs.previous_title} → #{attrs.title}")
+    |> UI.assert_text("#{attrs.previous_url} → #{attrs.url}")
+  end
+
+  step :assert_link_edited_on_company_feed, ctx, attrs do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.assert_text("edited a link in the #{ctx.space.name} space: #{attrs.title}")
+    |> UI.assert_text("#{attrs.previous_title} → #{attrs.title}")
+    |> UI.assert_text("#{attrs.previous_url} → #{attrs.url}")
   end
 
   step :assert_link_deleted_on_space_feed, ctx do


### PR DESCRIPTION
The `ResourceHubLinkEdited` event is now displayed in the feed.