### PR TITLE
fix: Display space name in subject of Resource Hub emails

### DIFF
--- a/lib/operately_email/emails/resource_hub_document_commented_email.ex
+++ b/lib/operately_email/emails/resource_hub_document_commented_email.ex
@@ -7,14 +7,16 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentCommentedEmail do
 
   def send(person, activity) do
     %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
-    {:ok, document} = Document.get(:system, id: activity.content["document_id"], opts: [preload: [:node, :resource_hub]])
+    {:ok, document} = Document.get(:system, id: activity.content["document_id"], opts: [
+      preload: [:node, :space]
+    ])
     comment = Updates.get_comment!(activity.content["comment_id"])
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: document.resource_hub.name, who: author, action: "commented on: #{document.node.name}")
+    |> subject(where: document.space.name, who: author, action: "commented on: #{document.node.name}")
     |> assign(:author, author)
     |> assign(:comment, comment)
     |> assign(:name, document.node.name)

--- a/lib/operately_email/emails/resource_hub_document_created_email.ex
+++ b/lib/operately_email/emails/resource_hub_document_created_email.ex
@@ -9,7 +9,7 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentCreatedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, document} = Document.get(:system, id: activity.content["document_id"], opts: [
-      preload: [resource_hub: :space],
+      preload: [:node, :space],
     ])
 
     copied_document = get_copied_document(activity.content.copied_document_id)
@@ -19,7 +19,7 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentCreatedEmail do
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: document.resource_hub.name, who: author, action: "#{action} a document: #{document.node.name}")
+    |> subject(where: document.space.name, who: author, action: "#{action} a document: #{document.node.name}")
     |> assign(:author, author)
     |> assign(:document, document)
     |> assign(:copied_document, copied_document)

--- a/lib/operately_email/emails/resource_hub_document_deleted_email.ex
+++ b/lib/operately_email/emails/resource_hub_document_deleted_email.ex
@@ -9,7 +9,7 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentDeletedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, document} = Document.get(:system, id: activity.content["document_id"], opts: [
-      preload: [:node, :resource_hub],
+      preload: [:node, :space, :resource_hub],
       with_deleted: true,
     ])
 
@@ -17,7 +17,7 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentDeletedEmail do
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: document.resource_hub.name, who: author, action: "deleted a document: #{document.node.name}")
+    |> subject(where: document.space.name, who: author, action: "deleted a document: #{document.node.name}")
     |> assign(:author, author)
     |> assign(:document, document)
     |> assign(:cta_url, OperatelyWeb.Paths.resource_hub_path(company, document.resource_hub) |> OperatelyWeb.Paths.to_url())

--- a/lib/operately_email/emails/resource_hub_document_edited_email.ex
+++ b/lib/operately_email/emails/resource_hub_document_edited_email.ex
@@ -9,14 +9,14 @@ defmodule OperatelyEmail.Emails.ResourceHubDocumentEditedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, document} = Document.get(:system, id: activity.content["document_id"], opts: [
-      preload: :resource_hub,
+      preload: [:node, :space],
     ])
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: document.resource_hub.name, who: author, action: "edited a document: #{document.node.name}")
+    |> subject(where: document.space.name, who: author, action: "edited a document: #{document.node.name}")
     |> assign(:author, author)
     |> assign(:document, document)
     |> assign(:cta_url, OperatelyWeb.Paths.document_path(company, document) |> OperatelyWeb.Paths.to_url())

--- a/lib/operately_email/emails/resource_hub_file_commented_email.ex
+++ b/lib/operately_email/emails/resource_hub_file_commented_email.ex
@@ -7,14 +7,16 @@ defmodule OperatelyEmail.Emails.ResourceHubFileCommentedEmail do
 
   def send(person, activity) do
     %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
-    {:ok, file} = File.get(:system, id: activity.content["file_id"], opts: [preload: [:node, :resource_hub]])
+    {:ok, file} = File.get(:system, id: activity.content["file_id"], opts: [
+      preload: [:node, :space]
+    ])
     comment = Updates.get_comment!(activity.content["comment_id"])
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: file.resource_hub.name, who: author, action: "commented on: #{file.node.name}")
+    |> subject(where: file.space.name, who: author, action: "commented on: #{file.node.name}")
     |> assign(:author, author)
     |> assign(:comment, comment)
     |> assign(:name, file.node.name)

--- a/lib/operately_email/emails/resource_hub_file_created_email.ex
+++ b/lib/operately_email/emails/resource_hub_file_created_email.ex
@@ -9,14 +9,14 @@ defmodule OperatelyEmail.Emails.ResourceHubFileCreatedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, file} = File.get(:system, id: activity.content["file_id"], opts: [
-      preload: [resource_hub: :space],
+      preload: [:node, :space],
     ])
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: file.resource_hub.name, who: author, action: "added a file: #{file.node.name}")
+    |> subject(where: file.space.name, who: author, action: "added a file: #{file.node.name}")
     |> assign(:author, author)
     |> assign(:file, file)
     |> assign(:cta_url, OperatelyWeb.Paths.file_path(company, file) |> OperatelyWeb.Paths.to_url())

--- a/lib/operately_email/emails/resource_hub_file_deleted_email.ex
+++ b/lib/operately_email/emails/resource_hub_file_deleted_email.ex
@@ -9,7 +9,7 @@ defmodule OperatelyEmail.Emails.ResourceHubFileDeletedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, file} = File.get(:system, id: activity.content["file_id"], opts: [
-      preload: [:node, :resource_hub],
+      preload: [:node, :resource_hub, :space],
       with_deleted: true,
     ])
 
@@ -17,7 +17,7 @@ defmodule OperatelyEmail.Emails.ResourceHubFileDeletedEmail do
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: file.resource_hub.name, who: author, action: "deleted a file: #{file.node.name}")
+    |> subject(where: file.space.name, who: author, action: "deleted a file: #{file.node.name}")
     |> assign(:author, author)
     |> assign(:file, file)
     |> assign(:cta_url, OperatelyWeb.Paths.resource_hub_path(company, file.resource_hub) |> OperatelyWeb.Paths.to_url())

--- a/lib/operately_email/emails/resource_hub_link_commented_email.ex
+++ b/lib/operately_email/emails/resource_hub_link_commented_email.ex
@@ -7,7 +7,9 @@ defmodule OperatelyEmail.Emails.ResourceHubLinkCommentedEmail do
 
   def send(person, activity) do
     %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
-    {:ok, link} = Link.get(:system, id: activity.content["link_id"], opts: [preload: [:node, :resource_hub]])
+    {:ok, link} = Link.get(:system, id: activity.content["link_id"], opts: [
+      preload: [:node, :space]
+    ])
 
     comment = Updates.get_comment!(activity.content["comment_id"])
 
@@ -15,7 +17,7 @@ defmodule OperatelyEmail.Emails.ResourceHubLinkCommentedEmail do
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: link.resource_hub.name, who: author, action: "commented on: #{link.node.name}")
+    |> subject(where: link.space.name, who: author, action: "commented on: #{link.node.name}")
     |> assign(:author, author)
     |> assign(:comment, comment)
     |> assign(:name, link.node.name)

--- a/lib/operately_email/emails/resource_hub_link_created_email.ex
+++ b/lib/operately_email/emails/resource_hub_link_created_email.ex
@@ -9,14 +9,14 @@ defmodule OperatelyEmail.Emails.ResourceHubLinkCreatedEmail do
     company = Repo.preload(author, :company).company
 
     {:ok, link} = Link.get(:system, id: activity.content["link_id"], opts: [
-      preload: [:resource_hub],
+      preload: [:node, :space],
     ])
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: link.resource_hub.name, who: author, action: "added a link")
+    |> subject(where: link.space.name, who: author, action: "added a link")
     |> assign(:author, author)
     |> assign(:link, link)
     |> assign(:cta_url, OperatelyWeb.Paths.link_path(company, link) |> OperatelyWeb.Paths.to_url())

--- a/test/support/features/resource_hub_link_steps.ex
+++ b/test/support/features/resource_hub_link_steps.ex
@@ -1,7 +1,7 @@
 defmodule Operately.Support.Features.ResourceHubLinkSteps do
   use Operately.FeatureCase
 
-  alias Operately.ResourceHubs.{ResourceHub, Node}
+  alias Operately.ResourceHubs.Node
   alias Operately.Support.Features.NotificationsSteps
   alias Operately.Support.Features.EmailSteps
 
@@ -148,10 +148,8 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
   #
 
   step :assert_link_created_email_sent, ctx do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "added a link",
       author: ctx.creator,

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -430,10 +430,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   #
 
   step :assert_document_created_email_sent, ctx, document_name do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "added a document: #{document_name}",
       author: ctx.creator,
@@ -441,10 +439,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :assert_document_edited_email_sent, ctx, document_name do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "edited a document: #{document_name}",
       author: ctx.creator,
@@ -452,10 +448,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :assert_document_deleted_email_sent, ctx, document_name do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "deleted a document: #{document_name}",
       author: ctx.creator,
@@ -463,10 +457,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :assert_document_copied_email_sent, ctx, document_name do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "copied a document: #{document_name}",
       author: ctx.creator,
@@ -474,10 +466,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :assert_document_commented_email_sent, ctx, document_name do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "commented on: #{document_name}",
       author: ctx.creator,
@@ -485,10 +475,8 @@ defmodule Operately.Support.Features.ResourceHubSteps do
   end
 
   step :assert_file_commented_email_sent, ctx do
-    {:ok, hub} = ResourceHub.get(:system, space_id: ctx.space.id)
-
     ctx |> EmailSteps.assert_activity_email_sent(%{
-      where: hub.name,
+      where: ctx.space.name,
       to: ctx.other_user,
       action: "commented on: File",
       author: ctx.creator,


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1791.