### PR TITLE
fix: Update existing Resource Hub activities' contexts

### DIFF
--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -148,7 +148,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
       activity.action in @goal_actions -> fetch_goal_context(activity.content)
       activity.action in @project_actions -> fetch_project_context(activity.content.project_id)
       activity.action in @task_actions -> fetch_task_project_context(activity.content.task_id)
-      activity.action in @resource_hub_actions-> fetch_resource_hub_context(activity.content.resource_hub_id)
+      activity.action in @resource_hub_actions-> fetch_resource_hub_context(activity.content.space_id)
       activity.action == "comment_added" -> fetch_comment_added_context(activity)
       true ->
         Logger.error("Unhandled activity: #{inspect(activity)}")
@@ -211,9 +211,9 @@ defmodule Operately.Activities.ContextAutoAssigner do
     |> Repo.one()
   end
 
-  defp fetch_resource_hub_context(resource_hub_id) do
+  defp fetch_resource_hub_context(space_id) do
     from(c in Context,
-      where: c.resource_hub_id == ^resource_hub_id,
+      where: c.group_id == ^space_id,
       select: c.id
     )
     |> Repo.one()

--- a/lib/operately/data/change_045_update_resource_hub_activities_access_context.ex
+++ b/lib/operately/data/change_045_update_resource_hub_activities_access_context.ex
@@ -1,0 +1,34 @@
+defmodule Operately.Data.Change045UpdateResourceHubActivitiesAccessContext do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+
+  def run do
+    Repo.transaction(fn ->
+      fetch_activities()
+      |> update_context()
+    end)
+  end
+
+  defp fetch_activities do
+    from(a in Activity, where: not is_nil(a.content["resource_hub_id"]))
+    |> Repo.all()
+  end
+
+  defp update_context(activities) do
+    Enum.each(activities, fn activity ->
+      context = fetch_context(activity)
+
+      {:ok, _} = Activity.changeset(activity, %{access_context_id: context.id})
+      |> Repo.update
+    end)
+  end
+
+  defp fetch_context(activity) do
+    from(c in Operately.Access.Context,
+      where: c.group_id == ^activity.content["space_id"]
+    )
+    |> Repo.one()
+  end
+end

--- a/priv/repo/migrations/20250103164752_update_resource_hub_activities_access_context.exs
+++ b/priv/repo/migrations/20250103164752_update_resource_hub_activities_access_context.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.UpdateResourceHubActivitiesAccessContext do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change045UpdateResourceHubActivitiesAccessContext.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/operately/data/change_045_update_resource_hub_activities_access_context_test.exs
+++ b/test/operately/data/change_045_update_resource_hub_activities_access_context_test.exs
@@ -1,0 +1,88 @@
+defmodule Operately.Data.Change045UpdateResourceHubActivitiesAccessContextTest do
+  use Operately.DataCase
+
+  import Operately.ActivitiesFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.preload(:space, :access_context)
+    |> Factory.add_resource_hub(:hub, :space, :creator)
+    |> Factory.add_folder(:folder, :hub)
+    |> Factory.add_file(:my_file, :hub)
+    |> Factory.add_document(:document, :hub)
+    |> Factory.add_link(:link, :hub)
+    |> create_activities()
+  end
+
+  test "updates access context of existing resource hub activities", ctx do
+    context = fetch_resource_hub_context(ctx)
+
+    Enum.each(ctx.activities, fn activity ->
+      activity = Repo.preload(activity, :access_context)
+      assert activity.access_context == context
+    end)
+
+    Operately.Data.Change045UpdateResourceHubActivitiesAccessContext.run()
+
+    Enum.each(ctx.activities, fn activity ->
+      activity = Repo.reload(activity) |> Repo.preload(:access_context)
+      assert activity.access_context == ctx.space.access_context
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp fetch_resource_hub_context(ctx) do
+    Operately.Access.get_context(resource_hub_id: ctx.hub.id)
+  end
+
+  #
+  # Setup helpers
+  #
+
+  defp create_activities(ctx) do
+    functions = [&folder_activity/1, &file_activity/1, &link_activity/1, &document_activity/1]
+
+    activities = Enum.reduce(functions, [], fn fun, acc ->
+      acc ++ Enum.map(1..3, fn _ -> fun.(ctx) end)
+    end)
+
+    Map.put(ctx, :activities, activities)
+  end
+
+  defp folder_activity(ctx) do
+    create_activity(ctx, node_id: ctx.folder.node_id, folder_id: ctx.folder.id)
+  end
+
+  defp file_activity(ctx) do
+    create_activity(ctx, node_id: ctx.my_file.node_id, file_id: ctx.my_file.id)
+  end
+
+  defp link_activity(ctx) do
+    create_activity(ctx, node_id: ctx.link.node_id, file_id: ctx.link.id)
+  end
+
+  defp document_activity(ctx) do
+    create_activity(ctx, node_id: ctx.document.node_id, file_id: ctx.document.id)
+  end
+
+  defp create_activity(ctx, content) do
+    content = Enum.into(content, %{
+      company_id: ctx.company.id,
+      space_id: ctx.space.id,
+      resource_hub_id: ctx.hub.id,
+    })
+
+    activity = activity_fixture(author_id: ctx.creator.id, content: content)
+    context = fetch_resource_hub_context(ctx)
+
+    {:ok, activity} = Operately.Activities.Activity.changeset(activity, %{access_context_id: context.id})
+    |> Repo.update
+
+    activity
+  end
+end


### PR DESCRIPTION
Originally, Resource Hubs had been implemented with their own access context. Later, we changed them so that they would use the same context as their Spaces. However, existing Resource Hub activities still hadn't been updated to use the Spaces' context. This PR handles this issue. 