### PR TITLE
fix: Handle large files

### DIFF
--- a/priv/repo/migrations/20250103173929_update_blob_size_field_from_int_to_bigint.exs
+++ b/priv/repo/migrations/20250103173929_update_blob_size_field_from_int_to_bigint.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.UpdateBlobSizeFieldFromIntToBigint do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blobs) do
+      modify :size, :bigint
+    end
+  end
+end


### PR DESCRIPTION
We were storing the size of files as integers in the `blobs` schema. However, as we were storing the size of files as its number of bytes, a large file would have too many bytes and wouldn't fit in the Postgres integer field. After modifying the size field from integer to bigint, uploads of large files started working.

I'm not sure if these changes will be enough to fix the issue in production, but it was enough to fix it locally. 