### PR TITLE
fix: Change ownership of /media directory in Dockerfile.prod

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -97,6 +97,7 @@ ENV LC_ALL en_US.UTF-8
 
 WORKDIR "/app"
 RUN chown nobody /app
+RUN chown nobody /media
 
 # set runner ENV
 ENV MIX_ENV="prod"

--- a/rel/single-host/templates/install.sh.eex
+++ b/rel/single-host/templates/install.sh.eex
@@ -77,7 +77,7 @@ case $MANAGE_CERTS_YN in
                 sed -i '/443:4001/d' docker-compose.yml
                 ;;
 esac
-OPERATELY_BLOB_TOKEN_SECRET_KEY=$(openssl rand -hex 32)
+OPERATELY_BLOB_TOKEN_SECRET_KEY=$(openssl rand -base64 32)
 SECRET_KEY_BASE=$(openssl rand -hex 32)
 
 DB_USERNAME="operately"


### PR DESCRIPTION
In the `Dockerfile.prod` file, the ownership of /media directory is changed. Also, the blob token is now generated using `-base64` instead of `-hex`.