### PR TITLE
chore: CreateBlob mutation can be used to create multiple blobs

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -726,6 +726,21 @@ export interface Blob {
   url?: string | null;
 }
 
+export interface BlobCreationInput {
+  filename?: string | null;
+  size?: number | null;
+  contentType?: string | null;
+  width?: number | null;
+  height?: number | null;
+}
+
+export interface BlobCreationOutput {
+  id?: string | null;
+  url?: string | null;
+  signedUploadUrl?: string | null;
+  uploadStrategy?: string | null;
+}
+
 export interface Comment {
   id?: string | null;
   insertedAt?: string | null;
@@ -1973,7 +1988,7 @@ export interface GetUnreadNotificationCountResult {
 }
 
 export interface ListSpaceToolsInput {
-  spaceId?: string | null;
+  spaceId?: Id | null;
 }
 
 export interface ListSpaceToolsResult {
@@ -2219,18 +2234,11 @@ export interface CreateAccountInput {
 export interface CreateAccountResult {}
 
 export interface CreateBlobInput {
-  filename?: string | null;
-  size?: number | null;
-  contentType?: string | null;
-  width?: number | null;
-  height?: number | null;
+  files?: BlobCreationInput[] | null;
 }
 
 export interface CreateBlobResult {
-  id?: string | null;
-  url?: string | null;
-  signedUploadUrl?: string | null;
-  uploadStrategy?: string | null;
+  blobs?: BlobCreationOutput[] | null;
 }
 
 export interface CreateCommentInput {

--- a/assets/js/models/blobs/index.tsx
+++ b/assets/js/models/blobs/index.tsx
@@ -24,7 +24,13 @@ export async function uploadFile(file: File, progressCallback: ProgressCallback)
     dimensions = await findVideoDimensions(file);
   }
 
-  const blob = await createBlob({ ...attrs, ...dimensions });
+  const res = await createBlob({ files: [{ ...attrs, ...dimensions }] });
+
+  if (!res.blobs || res.blobs!.length === 0) {
+    throw Error("Failed to create blobs");
+  }
+
+  const blob = res.blobs[0]!;
   const url = blob.signedUploadUrl!;
 
   if (blob.uploadStrategy === "direct") {

--- a/lib/operately_web/api/mutations/create_blob.ex
+++ b/lib/operately_web/api/mutations/create_blob.ex
@@ -3,41 +3,60 @@ defmodule OperatelyWeb.Api.Mutations.CreateBlob do
   use OperatelyWeb.Api.Helpers
 
   inputs do
-    field :filename, :string
-    field :size, :integer
-    field :content_type, :string
-    field :width, :integer
-    field :height, :integer
+    field :files, list_of(:blob_creation_input)
   end
 
   outputs do
-    field :id, :string
-    field :url, :string
-    field :signed_upload_url, :string
-    field :upload_strategy, :string # "direct", "multipart"
+    field :blobs, list_of(:blob_creation_output)
   end
 
   def call(conn, inputs) do
-    person = me(conn)
+    Action.new()
+    |> run(:me, fn -> find_me(conn) end)
+    |> run(:blobs, fn ctx -> create_blobs(ctx.me, inputs.files) end)
+    |> run(:serialized, fn ctx -> serialize(ctx.blobs) end)
+    |> respond()
+  end
 
-    {:ok, blob} = Operately.Blobs.create_blob(%{
-      company_id: person.company_id,
-      author_id: person.id,
-      status: :pending,
-      filename: inputs.filename,
-      size: inputs.size,
-      content_type: inputs.content_type,
-      width: inputs[:width],
-      height: inputs[:height],
-    })
+  def respond(result) do
+    case result do
+      {:ok, ctx} -> {:ok, ctx.serialized}
+      {:error, :blobs, _} -> {:error, :bad_request}
+      _ -> {:error, :internal_server_error}
+    end
+  end
 
-    {:ok, url} = Operately.Blobs.get_signed_upload_url(blob)
+  defp create_blobs(person, files) do
+    Repo.transaction(fn ->
+      Enum.map(files, fn file ->
+        {:ok, blob} = Operately.Blobs.create_blob(%{
+          company_id: person.company_id,
+          author_id: person.id,
+          status: :pending,
+          filename: file.filename,
+          size: file.size,
+          content_type: file.content_type,
+          width: file[:width],
+          height: file[:height],
+        })
 
-    {:ok, %{
-      id: blob.id,
-      url: Operately.Blobs.Blob.url(blob),
-      signed_upload_url: url,
-      upload_strategy: Operately.Blobs.Blob.upload_strategy(blob),
-    }}
+        blob
+      end)
+    end)
+  end
+
+  defp serialize(blobs) do
+    files = Enum.map(blobs, fn blob ->
+      {:ok, url} = Operately.Blobs.get_signed_upload_url(blob)
+
+      %{
+        id: blob.id,
+        url: Operately.Blobs.Blob.url(blob),
+        signed_upload_url: url,
+        upload_strategy: Operately.Blobs.Blob.upload_strategy(blob),
+      }
+    end)
+
+    {:ok, %{blobs: files}}
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -604,6 +604,21 @@ defmodule OperatelyWeb.Api.Types do
     field :resource_hubs, list_of(:resource_hub)
   end
 
+  object :blob_creation_input do
+    field :filename, :string
+    field :size, :integer
+    field :content_type, :string
+    field :width, :integer
+    field :height, :integer
+  end
+
+  object :blob_creation_output do
+    field :id, :string
+    field :url, :string
+    field :signed_upload_url, :string
+    field :upload_strategy, :string # "direct", "multipart"
+  end
+
   object :blob do
     field :id, :string
     field :status, :string

--- a/test/operately_web/api/mutations/create_blob_test.exs
+++ b/test/operately_web/api/mutations/create_blob_test.exs
@@ -11,11 +11,14 @@ defmodule OperatelyWeb.Api.Mutations.CreateBlobTest do
     setup :register_and_log_in_account
 
     test "it creates a new blob record in the database", ctx do
-      assert {200, blob} = mutation(ctx.conn, :create_blob, %{
-        filename: "test.txt",
-        size: 1024,
-        content_type: "text/plain"
-      })
+      assert {200, res} = mutation(ctx.conn, :create_blob, %{files: [
+        %{filename: "test.txt",
+          size: 1024,
+          content_type: "text/plain"
+        }
+      ]})
+
+      blob = hd(res.blobs)
 
       assert blob.id != nil
       assert blob.url == "/blobs/#{blob.id}"
@@ -24,5 +27,35 @@ defmodule OperatelyWeb.Api.Mutations.CreateBlobTest do
       blob = Operately.Blobs.get_blob!(blob.id)
       assert blob.storage_type != nil
     end
+
+    test "it creates multiple blob records in the database", ctx do
+      assert {200, res} = mutation(ctx.conn, :create_blob, %{files: [
+        %{filename: "test.txt",
+          size: 1024,
+          content_type: "text/plain"
+        },
+        %{filename: "test.txt",
+          size: 1024,
+          content_type: "image/jpeg",
+          width: 1920,
+          height: 1080,
+        },
+        %{filename: "test.txt",
+          size: 1024,
+          content_type: "image/jpeg",
+        }
+      ]})
+
+      assert length(res.blobs) == 3
+
+      Enum.each(res.blobs, fn blob ->
+        assert blob.id != nil
+        assert blob.url == "/blobs/#{blob.id}"
+        assert blob.signed_upload_url != nil
+
+        blob = Operately.Blobs.get_blob!(blob.id)
+        assert blob.storage_type != nil
+      end)
+    end
   end
-end 
+end


### PR DESCRIPTION
We can now use the `OperatelyWeb.Api.Mutations.CreateBlob` mutation to create multiple blobs at once.