### PR TITLE
fix: Resource Hub editing operations don't hit the API when the resource doesn't change

### DIFF
--- a/assets/js/components/RichContent/contentOps.test.tsx
+++ b/assets/js/components/RichContent/contentOps.test.tsx
@@ -1,4 +1,4 @@
-import { extract, shortenContent, countCharacters } from "./contentOps";
+import { extract, shortenContent, countCharacters, areRichTextObjectsEqual } from "./contentOps";
 
 describe("extract", () => {
   it("returns concatenated text", () => {
@@ -200,5 +200,147 @@ describe("countCharacters", () => {
     const input = `{"content":[{"content":[{"text":"Some very long text ","type":"text"},{"attrs":{"id":"fred-williams-H8bQVAffZB6ddLrgofhWL","label":"Fred Williams"},"type":"mention"},{"text":" more text.","type":"text"}],"type":"paragraph"},{"content":[{"text":"Contrary to popular belief, Lorem Ipsum is not simply random text.","type":"text"}],"type":"paragraph"}],"type":"doc"}`;
 
     expect(countCharacters(input)).toEqual(110);
+  });
+});
+
+describe("areRichTextObjectsEqual", () => {
+  it("returns true when simple objects are equal, but have keys in different order", () => {
+    const obj1 = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Document" }] }] };
+    const obj2 = { type: "doc", content: [{ content: [{ text: "Document", type: "text" }], type: "paragraph" }] };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeTruthy();
+  });
+
+  it("returns true when complex objects are equal, but have keys in different order", () => {
+    const obj1 = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "This is " }] },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "A more" }] },
+        { type: "paragraph" },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", marks: [{ type: "bold" }], text: "complete" },
+            { type: "text", text: " " },
+            { type: "text", marks: [{ type: "italic" }], text: "doc" },
+          ],
+        },
+      ],
+    };
+    const obj2 = {
+      content: [
+        { content: [{ type: "text", text: "This is " }], type: "paragraph" },
+        { type: "paragraph" },
+        { content: [{ type: "text", text: "A more" }], type: "paragraph" },
+        { type: "paragraph" },
+        {
+          content: [
+            { type: "text", marks: [{ type: "bold" }], text: "complete" },
+            { type: "text", text: " " },
+            { type: "text", marks: [{ type: "italic" }], text: "doc" },
+          ],
+          type: "paragraph",
+        },
+      ],
+      type: "doc",
+    };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeTruthy();
+  });
+
+  it("returns true when objects with mentions are equal, but have keys in different order", () => {
+    const obj1 = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Some text " },
+            { type: "mention", attrs: { id: "ashe-Dhw2AUUsmXFwMomTgNm73h", label: "Ashe" } },
+            { type: "text", text: " " },
+          ],
+        },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "More text" }] },
+      ],
+    };
+    const obj2 = {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { text: "Some text ", type: "text" },
+            { attrs: { label: "Ashe", id: "ashe-Dhw2AUUsmXFwMomTgNm73h" }, type: "mention" },
+            { type: "text", text: " " },
+          ],
+        },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "More text" }] },
+      ],
+      type: "doc",
+    };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeTruthy();
+  });
+
+  it("returns false when simple objects are different", () => {
+    const obj1 = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Document" }] }] };
+    const obj2 = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Documen" }] }] };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeFalsy();
+  });
+
+  it("returns false when complex objects are different", () => {
+    const obj1 = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "This is " }] },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "A more" }] },
+        { type: "paragraph" },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", marks: [{ type: "bold" }], text: "complete" },
+            { type: "text", text: " " },
+            { type: "text", marks: [{ type: "italic" }], text: "doc" },
+          ],
+        },
+      ],
+    };
+    const obj2 = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "This is" }] },
+        { type: "paragraph" },
+        { type: "paragraph", content: [{ type: "text", text: "A more" }] },
+        { type: "paragraph" },
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", marks: [{ type: "bold" }], text: "complete" },
+            { type: "text", text: " " },
+            { type: "text", marks: [{ type: "italic" }], text: "doc" },
+          ],
+        },
+      ],
+    };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeFalsy();
+  });
+
+  it("returns false when there is an extra empty paragraph", () => {
+    const obj1 = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Document" }] }, { type: "paragraph" }],
+    };
+    const obj2 = {
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "Document" }] }],
+    };
+
+    expect(areRichTextObjectsEqual(obj1, obj2)).toBeFalsy();
   });
 });

--- a/assets/js/components/RichContent/contentOps.tsx
+++ b/assets/js/components/RichContent/contentOps.tsx
@@ -169,3 +169,38 @@ export function countCharacters(jsonContent: string, opts?: { skipParse?: boolea
 
   return count;
 }
+
+export function areRichTextObjectsEqual(obj1: any, obj2: any) {
+  // Only one is object
+  if (typeof obj1 !== "object" && typeof obj2 === "object") {
+    return false;
+  }
+
+  // Only one is array
+  if (Array.isArray(obj1) && !Array.isArray(obj2)) {
+    return false;
+  }
+
+  // Compare non-objects
+  if (typeof obj1 !== "object" && typeof obj2 !== "object") {
+    return obj1 === obj2;
+  }
+
+  // Compare arrays
+  if (Array.isArray(obj1) && Array.isArray(obj2)) {
+    if (obj1.length !== obj2.length) {
+      return false;
+    }
+    return obj1.every((item, index) => areRichTextObjectsEqual(item, obj2[index]));
+  }
+
+  // Compare objects
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+
+  if (keys1.length !== keys2.length) {
+    return false;
+  }
+
+  return keys1.every((key) => areRichTextObjectsEqual(obj1[key], obj2[key]));
+}

--- a/assets/js/features/ResourceHub/components/FolderMenu.tsx
+++ b/assets/js/features/ResourceHub/components/FolderMenu.tsx
@@ -32,7 +32,14 @@ export function FolderMenu({ folder }: Props) {
         {permissions.canDeleteFolder && <DeleteFolderMenuItem folder={folder} />}
       </Menu>
 
-      <RenameFolderModal folder={folder} showForm={showRenameForm} toggleForm={toggleRenameForm} />
+      <RenameFolderModal
+        folder={folder}
+        showForm={showRenameForm}
+        toggleForm={toggleRenameForm}
+        // Key is needed because when the folder's name changes, if the component
+        // is not rerendered, the old name will appear in the form
+        key={folder.name}
+      />
       <MoveResourceModal resource={folder} resourceType="folder" isOpen={showMoveForm} hideModal={toggleMoveForm} />
     </>
   );
@@ -86,11 +93,15 @@ function RenameFolderModal({ folder, showForm, toggleForm }: FormProps) {
     },
     cancel: toggleForm,
     submit: async () => {
-      await rename({
-        folderId: folder.id,
-        newName: form.values.name,
-      });
-      refetch();
+      const { name } = form.values;
+
+      if (name !== folder.name) {
+        await rename({
+          folderId: folder.id,
+          newName: name,
+        });
+        refetch();
+      }
       toggleForm();
       form.actions.reset();
     },

--- a/test/features/resource_hub_link_test.exs
+++ b/test/features/resource_hub_link_test.exs
@@ -109,6 +109,16 @@ defmodule Features.ResourceHubLinkTest do
       |> LinkSteps.assert_link_edited_email_sent(link.title)
     end
 
+    feature "editing a link without any changes doesn't make an API call", ctx do
+      ctx
+      |> Steps.visit_resource_hub_page()
+      |> LinkSteps.create_link(@link)
+      |> LinkSteps.edit_link(@link)
+      |> LinkSteps.assert_link_content(@link)
+      |> LinkSteps.refute_link_edited_on_space_feed(@link)
+      |> LinkSteps.refute_link_edited_on_company_feed(@link)
+    end
+
     feature "delete link from content list", ctx do
       ctx
       |> Steps.visit_resource_hub_page()

--- a/test/features/resource_hub_test.exs
+++ b/test/features/resource_hub_test.exs
@@ -97,6 +97,16 @@ defmodule Features.Features.ResourceHubTest do
       |> Steps.assert_document_edited_email_sent(new_doc.name)
     end
 
+    feature "editing a document without any changes doesn't make an API call", ctx do
+      ctx
+      |> Steps.visit_resource_hub_page()
+      |> Steps.create_document(@document)
+      |> Steps.assert_document_content(@document)
+      |> Steps.edit_document(@document)
+      |> Steps.refute_document_edited_on_space_feed(@document.name)
+      |> Steps.refute_document_edited_on_company_feed(@document.name)
+    end
+
     feature "delete document from content list", ctx do
       ctx
       |> Steps.visit_resource_hub_page()

--- a/test/support/features/resource_hub_link_steps.ex
+++ b/test/support/features/resource_hub_link_steps.ex
@@ -96,7 +96,7 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     |> UI.click(testid: "options-button")
     |> UI.click(testid: "edit-link-link")
     |> UI.fill(testid: "title", with: attrs.title)
-    |> UI.fill(testid: "link", with: attrs.url)
+    |> UI.fill(testid: "url", with: attrs.url)
     |> UI.fill_rich_text(attrs.notes)
     |> UI.click(testid: "submit")
     |> UI.refute_has(testid: "submit")
@@ -212,6 +212,18 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     |> UI.assert_text("edited a link in the #{ctx.space.name} space: #{attrs.title}")
     |> UI.assert_text("#{attrs.previous_title} → #{attrs.title}")
     |> UI.assert_text("#{attrs.previous_url} → #{attrs.url}")
+  end
+
+  step :refute_link_edited_on_space_feed, ctx, attrs do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.space))
+    |> UI.refute_text("edited a link: #{attrs.title}")
+  end
+
+  step :refute_link_edited_on_company_feed, ctx, attrs do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.refute_text("edited a link in the #{ctx.space.name} space: #{attrs.title}")
   end
 
   step :assert_link_deleted_on_space_feed, ctx do

--- a/test/support/features/resource_hub_steps.ex
+++ b/test/support/features/resource_hub_steps.ex
@@ -312,6 +312,18 @@ defmodule Operately.Support.Features.ResourceHubSteps do
     |> UI.assert_text("edited #{document_name} in the #{ctx.space.name} space")
   end
 
+  step :refute_document_edited_on_space_feed, ctx, document_name do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.space))
+    |> UI.refute_text("edited #{document_name}")
+  end
+
+  step :refute_document_edited_on_company_feed, ctx, document_name do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.refute_text("edited #{document_name} in the #{ctx.space.name} space")
+  end
+
   step :assert_document_deleted_on_space_feed, ctx, document_name do
     ctx
     |> UI.visit(Paths.space_path(ctx.company, ctx.space))


### PR DESCRIPTION
Resource Hub editing operations now don't make an API call if the data hasn't changed. If a user clicks on "Save" without making any changes to the data, they are just redirected back to the resource page.

This applies to documents, links, files and folders.