### PR TITLE
feat: Show ancestors and descendants of goals when filtering by space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ test.mix.features: test.init
 	./devenv mix tests_with_retries $$(find test -name "*_test.exs" | grep "test/features" | ./scripts/split.rb $(INDEX) $(TOTAL))
 
 test.npm: test.init
-	./devenv npm test
+	./devenv npx jest $(shell echo $(FILE) | cut -d':' -f1)
 
 test.db.migrate:
 	./devenv bash -c "MIX_ENV=test mix ecto.migrate"

--- a/assets/js/features/goals/GoalTree/tree/node.tsx
+++ b/assets/js/features/goals/GoalTree/tree/node.tsx
@@ -2,6 +2,7 @@ import type { SortColumn, SortDirection } from "./";
 
 import * as People from "@/models/people";
 import * as Spaces from "@/models/spaces";
+import { compareIds } from "@/routes/paths";
 import * as Time from "@/utils/time";
 
 type NodeTypes = "goal" | "project";
@@ -43,6 +44,18 @@ export abstract class Node {
     }
 
     return true;
+  }
+
+  hasNoParent(): boolean {
+    return this.parent === undefined;
+  }
+
+  isFromSpace(spaceId: string): boolean {
+    return compareIds(this.spaceId, spaceId);
+  }
+
+  hasDescendantFromSpace(spaceId: string): boolean {
+    return this.children.some((child) => child.isFromSpace(spaceId) || child.hasDescendantFromSpace(spaceId));
   }
 
   setParent(parent: Node | undefined): void {


### PR DESCRIPTION
Previously if we had the following structure:

```
G1 Company
  G2 Marketing
    G3 Product
```

We would should only marketing goals on the marketing space (no ancestors):

```
G2 Marketing
  G3 Product
```

Now, we are showing the full lineage:

```
G1 Company
  G2 Marketing
    G3 Product
```