### PR TITLE
feat: Display folder-copied event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -552,6 +552,13 @@ export interface ActivityContentResourceHubFileEdited {
   file?: ResourceHubFile | null;
 }
 
+export interface ActivityContentResourceHubFolderCopied {
+  space?: Space | null;
+  resourceHub?: ResourceHub | null;
+  folder?: ResourceHubFolder | null;
+  originalFolder?: ResourceHubFolder | null;
+}
+
 export interface ActivityContentResourceHubFolderCreated {
   space?: Space | null;
   resourceHub?: ResourceHub | null;

--- a/assets/js/features/activities/ResourceHubFolderCopied/index.tsx
+++ b/assets/js/features/activities/ResourceHubFolderCopied/index.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubFolderCopied } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+
+import { Paths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { feedTitle, folderLink, spaceLink } from "../feedItemLinks";
+
+const ResourceHubFolderCopied: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    const folder = content(activity).folder;
+    assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderCreated activity content");
+
+    return Paths.resourceHubFolderPath(folder.id);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const data = content(activity);
+
+    const space = spaceLink(data.space!);
+    const folder = folderLink(data.folder!);
+    const originalFolder = folderLink(data.originalFolder!);
+
+    if (page === "space") {
+      return feedTitle(activity, "made a copy of the", originalFolder, "folder and named it", folder);
+    } else {
+      return feedTitle(
+        activity,
+        "made a copy of the",
+        originalFolder,
+        "folder in the",
+        space,
+        "space and named it",
+        folder,
+      );
+    }
+  },
+
+  FeedItemContent({}: { activity: Activity }) {
+    return <></>;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " made a copy of a folder: " + content(activity).folder!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).folder!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubFolderCopied {
+  return activity.content as ActivityContentResourceHubFolderCopied;
+}
+
+export default ResourceHubFolderCopied;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -113,6 +113,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_file_edited",
   "resource_hub_file_deleted",
   "resource_hub_file_commented",
+  "resource_hub_folder_copied",
   "resource_hub_folder_created",
   "resource_hub_folder_deleted",
   "resource_hub_folder_renamed",
@@ -183,6 +184,7 @@ import ResourceHubFileCreated from "@/features/activities/ResourceHubFileCreated
 import ResourceHubFileEdited from "@/features/activities/ResourceHubFileEdited";
 import ResourceHubFileDeleted from "@/features/activities/ResourceHubFileDeleted";
 import ResourceHubFileCommented from "@/features/activities/ResourceHubFileCommented";
+import ResourceHubFolderCopied from "@/features/activities/ResourceHubFolderCopied";
 import ResourceHubFolderCreated from "@/features/activities/ResourceHubFolderCreated";
 import ResourceHubFolderDeleted from "@/features/activities/ResourceHubFolderDeleted";
 import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRenamed";
@@ -249,6 +251,7 @@ function handler(activity: Activity) {
     .with("resource_hub_file_deleted", () => ResourceHubFileDeleted)
     .with("resource_hub_file_edited", () => ResourceHubFileEdited)
     .with("resource_hub_file_commented", () => ResourceHubFileCommented)
+    .with("resource_hub_folder_copied", () => ResourceHubFolderCopied)
     .with("resource_hub_folder_created", () => ResourceHubFolderCreated)
     .with("resource_hub_folder_deleted", () => ResourceHubFolderDeleted)
     .with("resource_hub_folder_renamed", () => ResourceHubFolderRenamed)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_folder_copied.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_folder_copied.ex
@@ -1,0 +1,20 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubFolderCopied do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    original_folder = get_original_folder(content)
+    folder = Map.put(content["folder"], :node, content["node"])
+
+    %{
+      space: Serializer.serialize(content["space"], level: :essential),
+      resource_hub: Serializer.serialize(content["resource_hub"], level: :essential),
+      folder: Serializer.serialize(folder, level: :essential),
+      original_folder: Serializer.serialize(original_folder, level: :essential)
+    }
+  end
+
+  defp get_original_folder(content) do
+    original_folder = content["original_folder"]
+    Map.put(original_folder["folder"], :node, original_folder["node"])
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -420,6 +420,13 @@ defmodule OperatelyWeb.Api.Types do
     :activity_content_task_update
   ]
 
+  object :activity_content_resource_hub_folder_copied do
+    field :space, :space
+    field :resource_hub, :resource_hub
+    field :folder, :resource_hub_folder
+    field :original_folder, :resource_hub_folder
+  end
+
   object :activity_content_resource_hub_folder_created do
     field :space, :space
     field :resource_hub, :resource_hub


### PR DESCRIPTION
The `ResourceHubFolderCopied` event is now displayed in the feed.