### PR TITLE
feat: Allow posting draft discussion with blank body and add validation message if the title is empty

### DIFF
--- a/assets/js/components/FormTitleInput/index.tsx
+++ b/assets/js/components/FormTitleInput/index.tsx
@@ -38,14 +38,18 @@ export function FormTitleInput({ value, onChange, error, testId }: FormTitleInpu
   }, [value]);
 
   return (
-    <textarea
-      ref={textareaRef}
-      autoFocus
-      className={className}
-      placeholder="Title&hellip;"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      data-test-id={testId}
-    ></textarea>
+    <>
+      {error && <div className="text-red-500 text-sm my-2">Please add a title</div>}
+
+      <textarea
+        ref={textareaRef}
+        autoFocus
+        className={className}
+        placeholder="Title&hellip;"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        data-test-id={testId}
+      ></textarea>
+    </>
   );
 }

--- a/assets/js/features/DiscussionForm/Form.tsx
+++ b/assets/js/features/DiscussionForm/Form.tsx
@@ -11,7 +11,7 @@ export function Form({ form }: { form: FormState }) {
         testId="discussion-title"
         value={form.title}
         onChange={form.setTitle}
-        error={!!form.errors.find((e) => e.field === "name")}
+        error={!!form.errors.find((e) => e.field === "title")}
       />
       <Message editor={form.editor} />
     </>

--- a/assets/js/features/DiscussionForm/useForm.tsx
+++ b/assets/js/features/DiscussionForm/useForm.tsx
@@ -50,7 +50,7 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
   const [errors, setErrors] = React.useState<Error[]>([]);
   const [title, setTitle] = React.useState(() => discussion?.title || "");
 
-  const { editor, uploading, empty } = TipTapEditor.useEditor({
+  const { editor, uploading } = TipTapEditor.useEditor({
     placeholder: "Write here...",
     className: "min-h-[350px] py-2 px-1",
     content: discussion?.body && JSON.parse(discussion.body),
@@ -62,8 +62,7 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     if (uploading) return false;
 
     const foundErrors: Error[] = [];
-    if (!title.trim()) foundErrors.push({ field: "title", message: "Title is required" });
-    if (empty) foundErrors.push({ field: "body", message: "Body is required" });
+    if (title.trim() === "") foundErrors.push({ field: "title", message: "Title is required" });
 
     if (foundErrors.length) {
       setErrors(foundErrors);

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -12,6 +12,13 @@ defmodule Operately.Features.DiscussionsTest do
     |> Steps.assert_validation_error()
   end
 
+  feature "post a discussion with blank body", ctx do
+    ctx
+    |> Steps.start_writting_discussion_with_blank_body()
+    |> Steps.submit_discussion()
+    |> Steps.assert_discussion_is_posted_with_blank_body()
+  end
+
   feature "post a draft discussion", ctx do
     ctx
     |> Steps.post_a_draft_discussion()

--- a/test/features/discussions_test.exs
+++ b/test/features/discussions_test.exs
@@ -5,6 +5,13 @@ defmodule Operately.Features.DiscussionsTest do
 
   setup ctx, do: Steps.setup(ctx)
 
+  feature "trying to post a discussion without a title", ctx do
+    ctx
+    |> Steps.start_writting_discussion_with_no_title()
+    |> Steps.try_to_submit_draft()
+    |> Steps.assert_validation_error()
+  end
+
   feature "post a draft discussion", ctx do
     ctx
     |> Steps.post_a_draft_discussion()

--- a/test/support/features/discussions_steps.ex
+++ b/test/support/features/discussions_steps.ex
@@ -38,6 +38,16 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     |> UI.assert_text(@body)
   end
 
+  step :assert_discussion_is_posted_with_blank_body, ctx do
+    message = last_message(ctx)
+
+    assert message.state == :published
+
+    ctx
+    |> UI.assert_page(Paths.message_path(ctx.company, message))
+    |> UI.assert_text(@title)
+  end
+
   step :assert_discussion_email_sent, ctx do
     ctx
     |> EmailSteps.assert_activity_email_sent(%{
@@ -74,6 +84,14 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
     |> UI.click(testid: "new-discussion")
     |> UI.assert_page(Paths.space_discussions_new_path(ctx.company, ctx.marketing_space))
+  end
+
+  step :start_writting_discussion_with_blank_body, ctx do
+    ctx
+    |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
+    |> UI.click(testid: "new-discussion")
+    |> UI.assert_page(Paths.space_discussions_new_path(ctx.company, ctx.marketing_space))
+    |> UI.fill(testid: "discussion-title", with: @title)
   end
 
   step :try_to_submit_draft, ctx do

--- a/test/support/features/discussions_steps.ex
+++ b/test/support/features/discussions_steps.ex
@@ -69,6 +69,21 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     |> UI.fill(testid: "discussion-title", with: @title)
   end
 
+  step :start_writting_discussion_with_no_title, ctx do
+    ctx
+    |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
+    |> UI.click(testid: "new-discussion")
+    |> UI.assert_page(Paths.space_discussions_new_path(ctx.company, ctx.marketing_space))
+  end
+
+  step :try_to_submit_draft, ctx do
+    ctx |> UI.click(testid: "save-as-draft")
+  end
+
+  step :assert_validation_error, ctx do
+    ctx |> UI.assert_text("Please add a title")
+  end
+
   step :attach_file_to_discussion, ctx do
     # There is no direct way to interact with the file input field in Wallaby
     # so as a workaround, we do two implicit tests:


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/1871