### PR TITLE
feat: Resource Hub notifications are marked as read when page loads

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1223,6 +1223,7 @@ export interface ResourceHubLink {
   permissions?: ResourceHubPermissions | null;
   reactions?: Reaction[] | null;
   pathToLink?: ResourceHubFolder[] | null;
+  notifications?: Notification[] | null;
   commentsCount?: number | null;
 }
 
@@ -1950,6 +1951,7 @@ export interface GetResourceHubLinkInput {
   includePermissions?: boolean | null;
   includeSubscriptionsList?: boolean | null;
   includePotentialSubscribers?: boolean | null;
+  includeUnreadNotifications?: boolean | null;
   includePathToLink?: boolean | null;
 }
 

--- a/assets/js/pages/ResourceHubLinkPage/loader.tsx
+++ b/assets/js/pages/ResourceHubLinkPage/loader.tsx
@@ -16,6 +16,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeReactions: true,
       includePathToLink: true,
       includeResourceHub: true,
+      includeUnreadNotifications: true,
       includeParentFolder: true,
     }).then((res) => res.link!),
   };

--- a/assets/js/pages/ResourceHubLinkPage/page.tsx
+++ b/assets/js/pages/ResourceHubLinkPage/page.tsx
@@ -17,12 +17,16 @@ import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { CommentSection, useComments } from "@/features/CommentSection";
 import { ResourcePageNavigation } from "@/features/ResourceHub";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
 
 import { Options } from "./Options";
 import { useLoadedData } from "./loader";
 
 export function Page() {
   const { link } = useLoadedData();
+
+  assertPresent(link.notifications, "notifications must be present in link");
+  useClearNotificationsOnLoad(link.notifications);
 
   return (
     <Pages.Page title={link.name!}>

--- a/lib/operately/goals/goal.ex
+++ b/lib/operately/goals/goal.ex
@@ -121,25 +121,6 @@ defmodule Operately.Goals.Goal do
     [goal] |> preload_last_check_in() |> hd()
   end
 
-  def load_unread_notifications(goal = %__MODULE__{}, person) do
-    actions = [
-      "goal_created",
-      "goal_editing",
-      "goal_archived",
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["goal_id"] == ^goal.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(goal, :notifications, notifications)
-  end
-
   def set_permissions(%{goal: goal = %__MODULE__{}} = parent) do
     goal = preload_permissions(goal, parent.request_info.access_level)
 

--- a/lib/operately/goals/update.ex
+++ b/lib/operately/goals/update.ex
@@ -44,24 +44,6 @@ defmodule Operately.Goals.Update do
   # After load hooks
   #
 
-  def load_unread_notifications(update = %__MODULE__{}, person) do
-    actions = [
-      "goal_check_in",
-      "goal_check_in_acknowledgement"
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["update_id"] == ^update.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(update, :notifications, notifications)
-  end
-
   def set_potential_subscribers(update = %__MODULE__{}) do
     subs =
       update

--- a/lib/operately/groups/group.ex
+++ b/lib/operately/groups/group.ex
@@ -57,23 +57,6 @@ defmodule Operately.Groups.Group do
     %{group | is_member: is_member}
   end
 
-  def load_unread_notifications(space = %__MODULE__{}, person) do
-    actions = [
-      "space_members_added",
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["space_id"] == ^space.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(space, :notifications, notifications)
-  end
-
   def preload_access_levels(group) do
     context = Operately.Access.get_context!(group_id: group.id)
     access_levels = Operately.Access.AccessLevels.load(context.id, group.company_id, group.id)

--- a/lib/operately/messages/message.ex
+++ b/lib/operately/messages/message.ex
@@ -59,19 +59,6 @@ defmodule Operately.Messages.Message do
 
   import Ecto.Query, only: [from: 2]
 
-  def load_unread_notifications(message = %__MODULE__{}, person) do
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action == "discussion_posting" and a.content["discussion_id"] == ^message.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(message, :notifications, notifications)
-  end
-
   def load_comments_count(messages) do
     message_ids = Enum.map(messages, &(&1.id))
 

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -63,3 +63,8 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Proj
   end
   def field(_), do: "project_id"
 end
+
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Groups.Group do
+  def actions(_), do: ["space_members_added"]
+  def field(_), do: "space_id"
+end

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -39,6 +39,11 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.ResourceHubs.
   def field(_), do: "document_id"
 end
 
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Goals.Goal do
+  def actions(_), do: ["goal_created", "goal_editing", "goal_archived"]
+  def field(_), do: "goal_id"
+end
+
 defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Project do
   def actions(_) do
     [

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -1,0 +1,35 @@
+defmodule Operately.Notifications.UnreadNotificationsLoader do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Notifications.NotifiableResource
+
+  def load(resource, person) do
+    actions = NotifiableResource.actions(resource)
+    id_field = NotifiableResource.field(resource)
+
+    notifications =
+      from(n in Operately.Notifications.Notification,
+        join: a in assoc(n, :activity),
+        where: a.action in ^actions and a.content[^id_field] == ^resource.id,
+        where: n.person_id == ^person.id and not n.read,
+        select: n
+      )
+      |> Repo.all()
+
+    Map.put(resource, :notifications, notifications)
+  end
+end
+
+defprotocol Operately.Notifications.NotifiableResource do
+  @doc "Returns list of notification actions for this resource"
+  def actions(resource)
+
+  @doc "Returns the ID field used in activity content"
+  def field(resource)
+end
+
+defimpl Operately.Notifications.NotifiableResource, for: Operately.ResourceHubs.Link do
+  def actions(_), do: ["resource_hub_link_created", "resource_hub_link_edited"]
+  def field(_), do: "link_id"
+end

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -70,6 +70,11 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Proj
   def field(_), do: "project_id"
 end
 
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.CheckIn do
+  def actions(_), do: ["project_check_in_submitted", "project_check_in_acknowledged"]
+  def field(_), do: "check_in_id"
+end
+
 defimpl Operately.Notifications.NotifiableResource, for: Operately.Groups.Group do
   def actions(_), do: ["space_members_added"]
   def field(_), do: "space_id"

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -44,6 +44,11 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.Goals.Goal do
   def field(_), do: "goal_id"
 end
 
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Goals.Update do
+  def actions(_), do: ["goal_check_in", "goal_check_in_acknowledgement"]
+  def field(_), do: "update_id"
+end
+
 defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Project do
   def actions(_) do
     [

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -4,6 +4,12 @@ defmodule Operately.Notifications.UnreadNotificationsLoader do
   alias Operately.Repo
   alias Operately.Notifications.NotifiableResource
 
+  def load(person = %Operately.People.Person{}) do
+    fn resource ->
+      load(resource, person)
+    end
+  end
+
   def load(resource, person) do
     actions = NotifiableResource.actions(resource)
     id_field = NotifiableResource.field(resource)
@@ -67,4 +73,9 @@ end
 defimpl Operately.Notifications.NotifiableResource, for: Operately.Groups.Group do
   def actions(_), do: ["space_members_added"]
   def field(_), do: "space_id"
+end
+
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Messages.Message do
+  def actions(_), do: ["discussion_posting"]
+  def field(_), do: "discussion_id"
 end

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -75,6 +75,11 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Chec
   def field(_), do: "check_in_id"
 end
 
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Retrospective do
+  def actions(_), do: ["project_closed"]
+  def field(_), do: "retrospective_id"
+end
+
 defimpl Operately.Notifications.NotifiableResource, for: Operately.Groups.Group do
   def actions(_), do: ["space_members_added"]
   def field(_), do: "space_id"

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -33,3 +33,8 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.ResourceHubs.
   def actions(_), do: ["resource_hub_link_created", "resource_hub_link_edited"]
   def field(_), do: "link_id"
 end
+
+defimpl Operately.Notifications.NotifiableResource, for: Operately.ResourceHubs.Document do
+  def actions(_), do: ["resource_hub_document_created", "resource_hub_document_edited"]
+  def field(_), do: "document_id"
+end

--- a/lib/operately/notifications/unread_notifications_loader.ex
+++ b/lib/operately/notifications/unread_notifications_loader.ex
@@ -38,3 +38,18 @@ defimpl Operately.Notifications.NotifiableResource, for: Operately.ResourceHubs.
   def actions(_), do: ["resource_hub_document_created", "resource_hub_document_edited"]
   def field(_), do: "document_id"
 end
+
+defimpl Operately.Notifications.NotifiableResource, for: Operately.Projects.Project do
+  def actions(_) do
+    [
+      "project_created",
+      "project_closed",
+      "project_goal_connection",
+      "project_moved",
+      "project_pausing",
+      "project_resuming",
+      "project_timeline_edited"
+    ]
+  end
+  def field(_), do: "project_id"
+end

--- a/lib/operately/projects/check_in.ex
+++ b/lib/operately/projects/check_in.ex
@@ -42,24 +42,6 @@ defmodule Operately.Projects.CheckIn do
 
   import Ecto.Query, only: [from: 2]
 
-  def load_unread_notifications(check_in = %__MODULE__{}, person) do
-    actions = [
-      "project_check_in_submitted",
-      "project_check_in_acknowledged"
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["check_in_id"] == ^check_in.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(check_in, :notifications, notifications)
-  end
-
   def load_potential_subscribers(check_in = %__MODULE__{}) do
     q = from(c in Operately.Projects.Contributor, join: p in assoc(c, :person), preload: :person)
     tmp_check_in = Repo.preload(check_in, [:access_context, [project: [contributors: q]]], force: true)

--- a/lib/operately/projects/project.ex
+++ b/lib/operately/projects/project.ex
@@ -163,29 +163,6 @@ defmodule Operately.Projects.Project do
     end
   end
 
-  def load_unread_notifications(project = %__MODULE__{}, person) do
-    actions = [
-      "project_created",
-      "project_closed",
-      "project_goal_connection",
-      "project_moved",
-      "project_pausing",
-      "project_resuming",
-      "project_timeline_edited"
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["project_id"] == ^project.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(project, :notifications, notifications)
-  end
-
   def load_contributor_access_levels(project) do
     contribs = Contributor.load_project_access_levels(project.contributors)
     Map.put(project, :contributors, contribs)

--- a/lib/operately/projects/retrospective.ex
+++ b/lib/operately/projects/retrospective.ex
@@ -38,24 +38,6 @@ defmodule Operately.Projects.Retrospective do
   # After load hooks
   #
 
-  def load_unread_notifications(retrospective = %__MODULE__{}, person) do
-    actions = [
-      "project_closed",
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["retrospective_id"] == ^retrospective.id,
-        where: n.person_id == ^person.id and not n.read,
-        preload: :activity,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(retrospective, :notifications, notifications)
-  end
-
   def set_permissions(retrospective = %__MODULE__{}) do
     perms = Operately.Projects.Permissions.calculate(retrospective.request_info.access_level)
     Map.put(retrospective, :permissions, perms)

--- a/lib/operately/resource_hubs/document.ex
+++ b/lib/operately/resource_hubs/document.ex
@@ -57,24 +57,6 @@ defmodule Operately.ResourceHubs.Document do
   # After load hooks
   #
 
-  def load_unread_notifications(document = %__MODULE__{}, person) do
-    actions = [
-      "resource_hub_document_created",
-      "resource_hub_document_edited"
-    ]
-
-    notifications =
-      from(n in Operately.Notifications.Notification,
-        join: a in assoc(n, :activity),
-        where: a.action in ^actions and a.content["document_id"] == ^document.id,
-        where: n.person_id == ^person.id and not n.read,
-        select: n
-      )
-      |> Repo.all()
-
-    Map.put(document, :notifications, notifications)
-  end
-
   def load_potential_subscribers(document = %__MODULE__{}) do
     document = Repo.preload(document, [:access_context, resource_hub: [space: :members]])
 

--- a/lib/operately_web/api/queries/get_discussion.ex
+++ b/lib/operately_web/api/queries/get_discussion.ex
@@ -4,6 +4,7 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
 
   alias Operately.Messages.Message
   alias Operately.Groups.Permissions
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :string
@@ -62,14 +63,8 @@ defmodule OperatelyWeb.Api.Queries.GetDiscussion do
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &Message.set_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
       include_permissions: &Message.set_permissions/1,
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn message ->
-      Message.load_unread_notifications(message, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -83,7 +83,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
 
   defp load_unread_notifications(person) do
     fn goal ->
-      Goal.load_unread_notifications(goal, person)
+      Operately.Notifications.UnreadNotificationsLoader.load(goal, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -4,6 +4,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
 
   alias OperatelyWeb.Api.Serializer
   alias Operately.Goals.{Goal, Permissions}
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :id
@@ -77,13 +78,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
       include_permissions: &Goal.preload_permissions/1,
       include_access_levels: &Goal.preload_access_levels/1,
       include_potential_subscribers: &Goal.set_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn goal ->
-      Operately.Notifications.UnreadNotificationsLoader.load(goal, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_goal_progress_update.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_update.ex
@@ -85,8 +85,8 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
   end
 
   defp load_unread_notifications(person) do
-    fn activity ->
-      Update.load_unread_notifications(activity, person)
+    fn update ->
+      Operately.Notifications.UnreadNotificationsLoader.load(update, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_goal_progress_update.ex
+++ b/lib/operately_web/api/queries/get_goal_progress_update.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.Goals.{Goal, Update, Permissions}
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :string
@@ -69,7 +70,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_potential_subscribers: &Update.set_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
       include_permissions: &Goal.set_permissions/1,
       always_include: &load_goal_permissions/1,
     ])
@@ -81,12 +82,6 @@ defmodule OperatelyWeb.Api.Queries.GetGoalProgressUpdate do
       %{update | goal: goal}
     else
       update
-    end
-  end
-
-  defp load_unread_notifications(person) do
-    fn update ->
-      Operately.Notifications.UnreadNotificationsLoader.load(update, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -4,6 +4,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
 
   alias Operately.Projects.Project
   alias OperatelyWeb.Api.Serializer
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :string
@@ -66,7 +67,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
       include_access_levels: &Project.load_access_levels/1,
       include_privacy: &Project.load_privacy/1,
       include_potential_subscribers: &Project.load_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(person),
+      include_unread_notifications: UnreadNotificationsLoader.load(person),
     ])
   end
 
@@ -84,12 +85,6 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
 
       true ->
         :ok
-    end
-  end
-
-  defp load_unread_notifications(person) do
-    fn project ->
-      Operately.Notifications.UnreadNotificationsLoader.load(project, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_project.ex
+++ b/lib/operately_web/api/queries/get_project.ex
@@ -89,7 +89,7 @@ defmodule OperatelyWeb.Api.Queries.GetProject do
 
   defp load_unread_notifications(person) do
     fn project ->
-      Project.load_unread_notifications(project, person)
+      Operately.Notifications.UnreadNotificationsLoader.load(project, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_project_check_in.ex
+++ b/lib/operately_web/api/queries/get_project_check_in.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.Projects.{CheckIn, Project}
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :string
@@ -58,13 +59,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectCheckIn do
     Inputs.parse_includes(inputs, [
       include_project: &Project.set_permissions/1,
       include_potential_subscribers: &CheckIn.load_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(person),
+      include_unread_notifications: UnreadNotificationsLoader.load(person),
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn check_in ->
-      CheckIn.load_unread_notifications(check_in, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_project_retrospective.ex
+++ b/lib/operately_web/api/queries/get_project_retrospective.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.Projects.{Permissions, Retrospective}
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :project_id, :string
@@ -61,13 +62,7 @@ defmodule OperatelyWeb.Api.Queries.GetProjectRetrospective do
     Inputs.parse_includes(inputs, [
       include_permissions: &Retrospective.set_permissions/1,
       include_potential_subscribers: &Retrospective.load_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(person),
+      include_unread_notifications: UnreadNotificationsLoader.load(person),
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn retrospective ->
-      Retrospective.load_unread_notifications(retrospective, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_resource_hub_document.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_document.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.ResourceHubs.Document
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :id
@@ -60,15 +61,9 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_permissions: &Document.set_permissions/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
       include_potential_subscribers: &Document.load_potential_subscribers/1,
       include_path_to_document: &Document.find_path_to_document/1,
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn document ->
-      Operately.Notifications.UnreadNotificationsLoader.load(document, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_resource_hub_document.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_document.ex
@@ -68,7 +68,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubDocument do
 
   defp load_unread_notifications(person) do
     fn document ->
-      Document.load_unread_notifications(document, person)
+      Operately.Notifications.UnreadNotificationsLoader.load(document, person)
     end
   end
 end

--- a/lib/operately_web/api/queries/get_resource_hub_link.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_link.ex
@@ -14,6 +14,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubLink do
     field :include_permissions, :boolean
     field :include_subscriptions_list, :boolean
     field :include_potential_subscribers, :boolean
+    field :include_unread_notifications, :boolean
     field :include_path_to_link, :boolean
   end
 
@@ -40,7 +41,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubLink do
   defp load(ctx, inputs) do
     Link.get(ctx.me, id: inputs.id, opts: [
       preload: preload(inputs),
-      after_load: after_load(inputs),
+      after_load: after_load(inputs, ctx.me),
     ])
   end
 
@@ -56,11 +57,18 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubLink do
     ])
   end
 
-  defp after_load(inputs) do
+  defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_permissions: &Link.set_permissions/1,
+      include_unread_notifications: load_unread_notifications(me),
       include_potential_subscribers: &Link.load_potential_subscribers/1,
       include_path_to_link: &Link.find_path_to_link/1,
     ])
+  end
+
+  defp load_unread_notifications(person) do
+    fn link ->
+      Operately.Notifications.UnreadNotificationsLoader.load(link, person)
+    end
   end
 end

--- a/lib/operately_web/api/queries/get_resource_hub_link.ex
+++ b/lib/operately_web/api/queries/get_resource_hub_link.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubLink do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.ResourceHubs.Link
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :id
@@ -60,15 +61,9 @@ defmodule OperatelyWeb.Api.Queries.GetResourceHubLink do
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
       include_permissions: &Link.set_permissions/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
       include_potential_subscribers: &Link.load_potential_subscribers/1,
       include_path_to_link: &Link.find_path_to_link/1,
     ])
-  end
-
-  defp load_unread_notifications(person) do
-    fn link ->
-      Operately.Notifications.UnreadNotificationsLoader.load(link, person)
-    end
   end
 end

--- a/lib/operately_web/api/queries/get_space.ex
+++ b/lib/operately_web/api/queries/get_space.ex
@@ -3,6 +3,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
   use OperatelyWeb.Api.Helpers
 
   alias Operately.Groups.{Group, Permissions}
+  alias Operately.Notifications.UnreadNotificationsLoader
 
   inputs do
     field :id, :id
@@ -58,7 +59,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
       include_access_levels: &Group.preload_access_levels/1,
       include_members_access_levels: &Group.preload_members_access_level/1,
       include_potential_subscribers: &Group.set_potential_subscribers/1,
-      include_unread_notifications: load_unread_notifications(me),
+      include_unread_notifications: UnreadNotificationsLoader.load(me),
       always_include: preload_is_member(me),
       always_include: &sort_members/1,
     ])
@@ -74,10 +75,4 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
     %{group | members: Enum.sort_by(group.members, & &1.full_name) }
   end
   defp sort_members(group), do: group
-
-  defp load_unread_notifications(person) do
-    fn space ->
-      Operately.Notifications.UnreadNotificationsLoader.load(space, person)
-    end
-  end
 end

--- a/lib/operately_web/api/queries/get_space.ex
+++ b/lib/operately_web/api/queries/get_space.ex
@@ -77,7 +77,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpace do
 
   defp load_unread_notifications(person) do
     fn space ->
-      Group.load_unread_notifications(space, person)
+      Operately.Notifications.UnreadNotificationsLoader.load(space, person)
     end
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -757,6 +757,7 @@ defmodule OperatelyWeb.Api.Types do
     field :permissions, :resource_hub_permissions
     field :reactions, list_of(:reaction)
     field :path_to_link, list_of(:resource_hub_folder)
+    field :notifications, list_of(:notification)
     field :comments_count, :integer
   end
 


### PR DESCRIPTION
When a Resource Hub resource page loads, unread notifications related to that resource are marked as read.

I've added `Operately.Notifications.UnreadNotificationsLoader` and was able to remove a lot of repeated code.