### PR TITLE
feat: Display link-commented event in feed

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -579,6 +579,12 @@ export interface ActivityContentResourceHubFolderRenamed {
   newName?: string | null;
 }
 
+export interface ActivityContentResourceHubLinkCommented {
+  space?: Space | null;
+  link?: ResourceHubLink | null;
+  comment?: Comment | null;
+}
+
 export interface ActivityContentResourceHubLinkCreated {
   space?: Space | null;
   resourceHub?: ResourceHub | null;

--- a/assets/js/features/activities/ResourceHubLinkCommented/index.tsx
+++ b/assets/js/features/activities/ResourceHubLinkCommented/index.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import * as People from "@/models/people";
+
+import type { Activity } from "@/models/activities";
+import type { ActivityContentResourceHubLinkCommented } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+
+import { Paths } from "@/routes/paths";
+import { Summary } from "@/components/RichContent";
+import { feedTitle, linkLink, spaceLink } from "../feedItemLinks";
+import { assertPresent } from "@/utils/assertions";
+
+const ResourceHubLinkCommented: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    const data = content(activity);
+    assertPresent(data.link?.id, "link.id must be present in activity");
+
+    return Paths.resourceHubLinkPath(data.link.id);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const data = content(activity);
+
+    const link = linkLink(data.link!);
+    const space = spaceLink(data.space!);
+
+    if (page === "space") {
+      return feedTitle(activity, "commented on", link);
+    } else {
+      return feedTitle(activity, "commented on", link, "in the", space, "space");
+    }
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const comment = content(activity).comment!;
+    const commentContent = JSON.parse(comment.content!)["message"];
+    return <Summary jsonContent={commentContent} characterCount={200} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const data = content(activity);
+    assertPresent(data.link?.name, "link.name must be present in activity");
+
+    return People.firstName(activity.author!) + " commented on: " + data.link.name;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).link!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentResourceHubLinkCommented {
+  return activity.content as ActivityContentResourceHubLinkCommented;
+}
+
+export default ResourceHubLinkCommented;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -120,6 +120,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_link_created",
   "resource_hub_link_edited",
   "resource_hub_link_deleted",
+  "resource_hub_link_commented",
   "space_added",
   "space_joining",
   "space_member_removed",
@@ -191,6 +192,7 @@ import ResourceHubFolderRenamed from "@/features/activities/ResourceHubFolderRen
 import ResourceHubLinkCreated from "@/features/activities/ResourceHubLinkCreated";
 import ResourceHubLinkEdited from "@/features/activities/ResourceHubLinkEdited";
 import ResourceHubLinkDeleted from "@/features/activities/ResourceHubLinkDeleted";
+import ResourceHubLinkCommented from "@/features/activities/ResourceHubLinkCommented";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
 import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
@@ -258,6 +260,7 @@ function handler(activity: Activity) {
     .with("resource_hub_link_created", () => ResourceHubLinkCreated)
     .with("resource_hub_link_edited", () => ResourceHubLinkEdited)
     .with("resource_hub_link_deleted", () => ResourceHubLinkDeleted)
+    .with("resource_hub_link_commented", () => ResourceHubLinkCommented)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)
     .with("space_member_removed", () => SpaceMemberRemoved)

--- a/lib/operately_web/api/serializers/activity_content/resource_hub_link_commented.ex
+++ b/lib/operately_web/api/serializers/activity_content/resource_hub_link_commented.ex
@@ -1,0 +1,13 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ResourceHubLinkCommented do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    link = Map.put(content["link"], :node, content["node"])
+
+    %{
+      space: Serializer.serialize(content["space"], level: :essential),
+      link: Serializer.serialize(link, level: :essential),
+      comment: Serializer.serialize(content["comment"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -519,6 +519,12 @@ defmodule OperatelyWeb.Api.Types do
     field :link, :resource_hub_link
   end
 
+  object :activity_content_resource_hub_link_commented do
+    field :space, :space
+    field :link, :resource_hub_link
+    field :comment, :comment
+  end
+
   object :activity_content_project_discussion_submitted do
     field :project_id, :string
     field :discussion_id, :string

--- a/test/features/resource_hub_link_test.exs
+++ b/test/features/resource_hub_link_test.exs
@@ -133,6 +133,17 @@ defmodule Operately.Features.ResourceHubLinkTest do
       |> Steps.refute_navigation_links(["Resource hub", "one"])
       |> Steps.assert_navigation_links(["Product Space"])
     end
+
+    feature "add comment to link", ctx do
+      ctx
+      |> Steps.visit_resource_hub_page()
+      |> Steps.create_link(@link)
+      |> comment_on_resource()
+      |> Steps.assert_link_commented_on_space_feed(@link.title)
+      |> Steps.assert_link_commented_on_company_feed(@link.title)
+      |> Steps.assert_link_commented_notification_sent(@link.title)
+      |> Steps.assert_link_commented_email_sent(@link.title)
+    end
   end
 
   describe "Delete" do


### PR DESCRIPTION
The `ResourceHubLinkCommented` event is now displayed in the feed.