### PR TITLE
fix: GoalReparent event appears in the feed and sends notifications

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -300,9 +300,9 @@ export interface ActivityContentGoalReopening {
 }
 
 export interface ActivityContentGoalReparent {
-  companyId?: string | null;
-  oldParentGoalId?: string | null;
-  newParentGoalId?: string | null;
+  goal?: Goal | null;
+  oldParentGoal?: Goal | null;
+  newParentGoal?: Goal | null;
 }
 
 export interface ActivityContentGoalTimeframeEditing {

--- a/assets/js/features/activities/GoalReparent/index.tsx
+++ b/assets/js/features/activities/GoalReparent/index.tsx
@@ -34,14 +34,17 @@ const GoalReparent: ActivityHandler = {
     const data = content(activity);
 
     assertPresent(data.goal, "goal must be present in activity");
-    assertPresent(data.oldParentGoal, "oldParentGoal must be present in activity");
     assertPresent(data.newParentGoal, "newParentGoal must be present in activity");
 
     const goal = goalLink(data.goal);
-    const oldParent = goalLink(data.oldParentGoal);
     const newParent = goalLink(data.newParentGoal);
 
-    return feedTitle(activity, "changed the parent goal of", goal, "from", oldParent, "to", newParent);
+    if (data.oldParentGoal) {
+      const oldParent = goalLink(data.oldParentGoal);
+      return feedTitle(activity, "changed the parent goal of", goal, "from", oldParent, "to", newParent);
+    } else {
+      return feedTitle(activity, "changed the parent goal of", goal, "to", newParent);
+    }
   },
 
   FeedItemContent(_props: { activity: Activity }) {

--- a/assets/js/features/activities/GoalReparent/index.tsx
+++ b/assets/js/features/activities/GoalReparent/index.tsx
@@ -1,0 +1,76 @@
+import * as People from "@/models/people";
+
+import { Activity, ActivityContentGoalReparent } from "@/api";
+import { Paths } from "@/routes/paths";
+import { ActivityHandler } from "../interfaces";
+import { goalLink, feedTitle } from "../feedItemLinks";
+import { assertPresent } from "@/utils/assertions";
+
+const GoalReparent: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(activity: Activity): string {
+    const data = content(activity);
+    assertPresent(data.goal?.id, "goal.id must be present in activity");
+
+    return Paths.goalPath(data.goal.id);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const data = content(activity);
+
+    assertPresent(data.goal, "goal must be present in activity");
+    assertPresent(data.oldParentGoal, "oldParentGoal must be present in activity");
+    assertPresent(data.newParentGoal, "newParentGoal must be present in activity");
+
+    const goal = goalLink(data.goal);
+    const oldParent = goalLink(data.oldParentGoal);
+    const newParent = goalLink(data.newParentGoal);
+
+    return feedTitle(activity, "changed the parent goal of", goal, "from", oldParent, "to", newParent);
+  },
+
+  FeedItemContent(_props: { activity: Activity }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    return People.firstName(activity.author!) + " changed the parent goal of " + content(activity).goal!.name!;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).goal!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentGoalReparent {
+  return activity.content as ActivityContentGoalReparent;
+}
+
+export default GoalReparent;

--- a/assets/js/features/activities/index.tsx
+++ b/assets/js/features/activities/index.tsx
@@ -82,6 +82,7 @@ export const DISPLAYED_IN_FEED = [
   "goal_discussion_creation",
   "goal_editing",
   "goal_reopening",
+  "goal_reparent",
   "goal_timeframe_editing",
   "project_archived",
   "project_check_in_acknowledged",
@@ -155,6 +156,7 @@ import GoalCreated from "@/features/activities/GoalCreated";
 import GoalDiscussionCreation from "@/features/activities/GoalDiscussionCreation";
 import GoalEditing from "@/features/activities/GoalEditing";
 import GoalReopening from "@/features/activities/GoalReopening";
+import GoalReparent from "@/features/activities/GoalReparent";
 import GoalTimeframeEditing from "@/features/activities/GoalTimeframeEditing";
 import ProjectArchived from "@/features/activities/ProjectArchived";
 import ProjectCheckInAcknowledged from "@/features/activities/ProjectCheckInAcknowledged";
@@ -223,6 +225,7 @@ function handler(activity: Activity) {
     .with("goal_discussion_creation", () => GoalDiscussionCreation)
     .with("goal_editing", () => GoalEditing)
     .with("goal_reopening", () => GoalReopening)
+    .with("goal_reparent", () => GoalReparent)
     .with("goal_timeframe_editing", () => GoalTimeframeEditing)
     .with("project_archived", () => ProjectArchived)
     .with("project_check_in_acknowledged", () => ProjectCheckInAcknowledged)

--- a/lib/operately/activities.ex
+++ b/lib/operately/activities.ex
@@ -11,6 +11,11 @@ defmodule Operately.Activities do
     Repo.get!(Activity, id) |> cast_content()
   end
 
+  def get_activity(id) do
+    activity = Repo.get(Activity, id)
+    activity && cast_content(activity)
+  end
+
   def list_activities(scope_type, scope_id, actions) do
     ListActivitiesOperation.run(scope_type, scope_id, actions)
   end

--- a/lib/operately/activities/content/goal_reparent.ex
+++ b/lib/operately/activities/content/goal_reparent.ex
@@ -3,6 +3,8 @@ defmodule Operately.Activities.Content.GoalReparent do
 
   embedded_schema do
     belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :goal, Operately.Goals.Goal
     belongs_to :old_parent_goal, Operately.Goals.Goal
     belongs_to :new_parent_goal, Operately.Goals.Goal
   end
@@ -10,7 +12,7 @@ defmodule Operately.Activities.Content.GoalReparent do
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required([:company_id])
+    |> validate_required(__schema__(:fields))
   end
 
   def build(params) do

--- a/lib/operately/activities/content/goal_reparent.ex
+++ b/lib/operately/activities/content/goal_reparent.ex
@@ -12,7 +12,7 @@ defmodule Operately.Activities.Content.GoalReparent do
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields))
+    |> validate_required([:company_id, :goal_id, :new_parent_goal_id])
   end
 
   def build(params) do

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -71,8 +71,6 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "goal_editing",
     "goal_reopening",
     "goal_timeframe_editing",
-
-    # exceptions
     "goal_reparent",
   ]
 
@@ -169,8 +167,6 @@ defmodule Operately.Activities.ContextAutoAssigner do
     space_id = case activity.action do
       "group_edited" ->
         activity.content.group_id
-      "goal_reparent" ->
-        activity.content.new_parent_goal_id
       _ ->
         activity.content.space_id
     end

--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -178,8 +178,6 @@ defmodule Operately.Activities.ContextAutoAssigner do
     |> Repo.one()
   end
 
-
-  defp fetch_goal_context(%{new_parent_goal_id: goal_id}), do: fetch_goal_context(goal_id)
   defp fetch_goal_context(%{goal_id: goal_id}), do: fetch_goal_context(goal_id)
   defp fetch_goal_context(goal_id) do
     from(c in Context,

--- a/lib/operately/activities/notifications/goal_reparent.ex
+++ b/lib/operately/activities/notifications/goal_reparent.ex
@@ -1,5 +1,20 @@
 defmodule Operately.Activities.Notifications.GoalReparent do
-  def dispatch(_activity) do
-    {:ok, []}
+  def dispatch(activity) do
+    goal_id = activity.content["goal_id"]
+    goal = Operately.Goals.get_goal!(goal_id)
+
+    people = [goal.champion_id, goal.reviewer_id]
+
+    people
+    |> Enum.filter(fn id -> id != nil end)
+    |> Enum.filter(fn id -> id != goal.creator_id end)
+    |> Enum.map(fn id ->
+      %{
+        person_id: id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/lib/operately/data/change_048_delete_goal_reparent_activities_with_missing_data.ex
+++ b/lib/operately/data/change_048_delete_goal_reparent_activities_with_missing_data.ex
@@ -1,0 +1,32 @@
+defmodule Operately.Data.Change048DeleteGoalReparentActivitiesWithMissingData do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+
+  def run do
+    Repo.transaction(fn ->
+      fetch_activities()
+      |> delete_activities()
+    end)
+  end
+
+  defp fetch_activities do
+    from(a in Activity, where: a.action == "goal_reparent")
+    |> Repo.all()
+  end
+
+  defp delete_activities(activities) do
+    ids = find_activities_without_goal(activities)
+    count = length(ids)
+
+    {^count, nil} = from(a in Activity, where: a.id in ^ids)
+    |> Repo.delete_all()
+  end
+
+  defp find_activities_without_goal(activities) do
+    activities
+    |> Enum.filter(fn a -> not Map.has_key?(a.content, "goal_id") end)
+    |> Enum.map(& &1.id)
+  end
+end

--- a/lib/operately/operations/goal_reparent.ex
+++ b/lib/operately/operations/goal_reparent.ex
@@ -9,6 +9,8 @@ defmodule Operately.Operations.GoalReparent do
     |> Activities.insert_sync(author.id, :goal_reparent, fn changes ->
       %{
         company_id: goal.company_id,
+        space_id: goal.group_id,
+        goal_id: goal.id,
         old_parent_goal_id: goal.parent_goal_id,
         new_parent_goal_id: changes.goal.parent_goal_id,
       }

--- a/lib/operately_email/emails/goal_reparent_email.ex
+++ b/lib/operately_email/emails/goal_reparent_email.ex
@@ -1,5 +1,22 @@
 defmodule OperatelyEmail.Emails.GoalReparentEmail do
-  def send(_person, _activity) do
-    raise "Email for GoalReparent not implemented"
+  import OperatelyEmail.Mailers.ActivityMailer
+  alias Operately.{Repo, Goals}
+
+  def send(person, activity) do
+    author = Repo.preload(activity, :author).author
+    company = Repo.preload(author, :company).company
+    goal = Goals.get_goal!(activity.content["goal_id"])
+    new_parent_goal = Goals.get_goal!(activity.content["new_parent_goal_id"])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: goal.name, who: author, action: "changed the goal parent of #{goal.name}")
+    |> assign(:author, author)
+    |> assign(:goal, goal)
+    |> assign(:new_parent_goal, new_parent_goal)
+    |> assign(:cta_url, OperatelyWeb.Paths.goal_path(company, goal) |> OperatelyWeb.Paths.to_url())
+    |> render("goal_reparent")
   end
 end

--- a/lib/operately_email/templates/goal_reparent.html.eex
+++ b/lib/operately_email/templates/goal_reparent.html.eex
@@ -1,1 +1,14 @@
-<%= raise "HTML Email for GoalReparent not implemented" %>
+<%= title("#{short_name(@author)} changed the goal parent of #{@goal.name}") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  The parent goal of <%= @goal.name %> was changed to <%= @new_parent_goal.name %>
+<% end %>
+
+<%= spacer() %>
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Goal") %>
+<% end %>

--- a/lib/operately_email/templates/goal_reparent.text.eex
+++ b/lib/operately_email/templates/goal_reparent.text.eex
@@ -1,1 +1,3 @@
-<%= raise "Text Email for GoalReparent not implemented" %>
+<%= "#{short_name(@author)} changed the parent goal of #{@goal.name}" %>
+
+Link: <%= @cta_url %>

--- a/lib/operately_web/api/serializers/activity.ex
+++ b/lib/operately_web/api/serializers/activity.ex
@@ -157,10 +157,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_content("goal_reparent", _content) do
-    %{}
-  end
-
   def serialize_content("goal_timeframe_editing", content) do
     %{
       goal: serialize_goal(content["goal"]),

--- a/lib/operately_web/api/serializers/activity_content/goal_reparent.ex
+++ b/lib/operately_web/api/serializers/activity_content/goal_reparent.ex
@@ -1,0 +1,11 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalReparent do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      goal: Serializer.serialize(content["goal"], level: :essential),
+      old_parent_goal: Serializer.serialize(content["old_parent_goal"], level: :essential),
+      new_parent_goal: Serializer.serialize(content["new_parent_goal"], level: :essential),
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -1310,9 +1310,9 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :activity_content_goal_reparent do
-    field :company_id, :string
-    field :old_parent_goal_id, :string
-    field :new_parent_goal_id, :string
+    field :goal, :goal
+    field :old_parent_goal, :goal
+    field :new_parent_goal, :goal
   end
 
   object :activity_content_project_created do

--- a/priv/repo/migrations/20250124144013_delete_goal_reparent_activities_with_missing_data.exs
+++ b/priv/repo/migrations/20250124144013_delete_goal_reparent_activities_with_missing_data.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.DeleteGoalReparentActivitiesWithMissingData do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change048DeleteGoalReparentActivitiesWithMissingData.run()
+  end
+
+  def down do
+
+  end
+end

--- a/test/features/goal_test.exs
+++ b/test/features/goal_test.exs
@@ -45,6 +45,8 @@ defmodule Operately.Features.GoalTest do
     |> Steps.assert_goal_reparent_on_goal_feed(new_name: @parent_goal_params.name)
     |> Steps.assert_goal_reparent_on_space_feed(new_name: @parent_goal_params.name)
     |> Steps.assert_goal_reparent_on_company_feed(new_name: @parent_goal_params.name)
+    |> Steps.assert_goal_reparent_notification()
+    |> Steps.assert_goal_reparent_email_sent()
   end
 
   feature "changing goal parent", ctx do
@@ -57,6 +59,8 @@ defmodule Operately.Features.GoalTest do
     |> Steps.assert_goal_reparent_on_goal_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
     |> Steps.assert_goal_reparent_on_space_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
     |> Steps.assert_goal_reparent_on_company_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
+    |> Steps.assert_goal_reparent_notification()
+    |> Steps.assert_goal_reparent_email_sent()
   end
 
   feature "closing goal", ctx do

--- a/test/features/goal_test.exs
+++ b/test/features/goal_test.exs
@@ -36,12 +36,27 @@ defmodule Operately.Features.GoalTest do
     unit: "minutes",
   }
 
-  feature "changing goal parent", ctx do
+  feature "adding goal parent", ctx do
     ctx
     |> Steps.assert_goal_is_company_wide()
     |> Steps.given_a_goal_exists(@parent_goal_params)
     |> Steps.change_goal_parent(@parent_goal_params.name)
     |> Steps.assert_goal_parent_changed(@parent_goal_params.name)
+    |> Steps.assert_goal_reparent_on_goal_feed(new_name: @parent_goal_params.name)
+    |> Steps.assert_goal_reparent_on_space_feed(new_name: @parent_goal_params.name)
+    |> Steps.assert_goal_reparent_on_company_feed(new_name: @parent_goal_params.name)
+  end
+
+  feature "changing goal parent", ctx do
+    ctx = Steps.given_goal_and_potential_parent_goals_exist(ctx)
+
+    ctx
+    |> Steps.visit_page()
+    |> Steps.change_goal_parent(ctx.parent2.name)
+    |> Steps.assert_goal_parent_changed(ctx.parent2.name)
+    |> Steps.assert_goal_reparent_on_goal_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
+    |> Steps.assert_goal_reparent_on_space_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
+    |> Steps.assert_goal_reparent_on_company_feed(new_name: ctx.parent2.name, old_name: ctx.parent1.name)
   end
 
   feature "closing goal", ctx do

--- a/test/operately/access/activity_context_assigner_test.exs
+++ b/test/operately/access/activity_context_assigner_test.exs
@@ -221,7 +221,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
       attrs = %{
         action: "goal_reparent",
         author_id: ctx.author.id,
-        content: %{ new_parent_goal_id: ctx.goal.id, company_id: "-", old_parent_goal_id: "-" }
+        content: %{ goal_id: ctx.goal.id, new_parent_goal_id: "-", company_id: "-" }
       }
 
       create_activity(attrs)

--- a/test/operately/data/change_048_delete_goal_reparent_activities_with_missing_data_test.exs
+++ b/test/operately/data/change_048_delete_goal_reparent_activities_with_missing_data_test.exs
@@ -1,0 +1,68 @@
+defmodule Operately.Data.Change048DeleteGoalReparentActivitiesWithMissingDataTest do
+  use Operately.DataCase
+
+  import Operately.ActivitiesFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_goal(:parent_goal, :space)
+    |> Factory.add_goal(:new_parent_goal, :space)
+    |> Factory.add_goal(:goal, :space, parent_goal: :parent_goal)
+    |> create_activities()
+  end
+
+  test "Adds space_id and goal_id to activity content", ctx do
+    assert_activities_exist(ctx.complete_activities)
+    assert_activities_exist(ctx.incomplete_activities)
+
+    Operately.Data.Change048DeleteGoalReparentActivitiesWithMissingData.run()
+
+    assert_activities_exist(ctx.complete_activities)
+    refute_activities_exist(ctx.incomplete_activities)
+  end
+
+  #
+  # Steps
+  #
+
+  defp assert_activities_exist(activities) do
+    Enum.each(activities, fn a ->
+      assert Operately.Activities.get_activity(a.id)
+    end)
+  end
+
+  defp refute_activities_exist(activities) do
+    Enum.each(activities, fn a ->
+      refute Operately.Activities.get_activity(a.id)
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_activities(ctx) do
+    content =  %{
+      "company_id" => ctx.company.id,
+      "old_parent_goal_id" => ctx.parent_goal.id,
+      "new_parent_goal_id" => ctx.new_parent_goal.id,
+    }
+
+    incomplete_activities = Enum.map(1..3, fn _ ->
+      activity_fixture(author_id: ctx.creator.id, action: "goal_reparent", content: content)
+    end)
+
+    complete_activities = Enum.map(1..3, fn _ ->
+      activity_fixture(author_id: ctx.creator.id, action: "goal_reparent", content: Map.merge(content, %{
+        "space_id" => ctx.space.id,
+        "goal_id" => ctx.goal.id,
+      }))
+    end)
+
+    ctx
+    |> Map.put(:incomplete_activities, incomplete_activities)
+    |> Map.put(:complete_activities, complete_activities)
+  end
+end

--- a/test/support/features/goal_steps.ex
+++ b/test/support/features/goal_steps.ex
@@ -16,7 +16,7 @@ defmodule Operately.Support.Features.GoalSteps do
     |> Factory.add_space_member(:champion, :product)
     |> Factory.add_space_member(:reviewer, :product)
     |> Factory.add_goal(:goal, :product, [
-      name: "Improve support first response time", 
+      name: "Improve support first response time",
       champion: :champion,
       reviewer: :reviewer,
       timeframe: %{
@@ -57,6 +57,13 @@ defmodule Operately.Support.Features.GoalSteps do
     ctx
   end
 
+  step :given_goal_and_potential_parent_goals_exist, ctx do
+    ctx
+    |> Factory.add_goal(:parent1, :product, name: "Parent 1", champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:parent2, :product, name: "Parent 2", champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:goal, :product, name: "Goal", champion: :champion, reviewer: :reviewer, parent_goal: :parent1)
+  end
+
   step :change_goal_parent, ctx, parent_goal_name do
     ctx
     |> UI.click(testid: "goal-options")
@@ -68,6 +75,42 @@ defmodule Operately.Support.Features.GoalSteps do
     ctx
     |> UI.assert_page(Paths.goal_path(ctx.company, ctx.goal))
     |> UI.assert_text(parent_goal_name)
+  end
+
+  step :assert_goal_reparent_on_goal_feed, ctx, new_name: new_name do
+    ctx
+    |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} to #{new_name}")
+  end
+
+  step :assert_goal_reparent_on_goal_feed, ctx, new_name: new_name, old_name: old_name do
+    ctx
+    |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} from #{old_name} to #{new_name}")
+  end
+
+  step :assert_goal_reparent_on_space_feed, ctx, new_name: new_name do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.product))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} to #{new_name}")
+  end
+
+  step :assert_goal_reparent_on_space_feed, ctx, new_name: new_name, old_name: old_name do
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.product))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} from #{old_name} to #{new_name}")
+  end
+
+  step :assert_goal_reparent_on_company_feed, ctx, new_name: new_name do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} to #{new_name}")
+  end
+
+  step :assert_goal_reparent_on_company_feed, ctx, new_name: new_name, old_name: old_name do
+    ctx
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.assert_text("changed the parent goal of #{ctx.goal.name} from #{old_name} to #{new_name}")
   end
 
   step :assert_goal_is_company_wide, ctx do
@@ -505,7 +548,7 @@ defmodule Operately.Support.Features.GoalSteps do
   end
 
   step :assert_warning_about_active_subitems, ctx do
-    ctx 
+    ctx
     |> UI.assert_text("This goal contains 2 sub-goals and 1 project that will remain active:")
     |> UI.assert_text(ctx.subgoal1.name)
     |> UI.assert_text(ctx.subgoal2.name)

--- a/test/support/features/goal_steps.ex
+++ b/test/support/features/goal_steps.ex
@@ -113,6 +113,25 @@ defmodule Operately.Support.Features.GoalSteps do
     |> UI.assert_text("changed the parent goal of #{ctx.goal.name} from #{old_name} to #{new_name}")
   end
 
+  step :assert_goal_reparent_notification, ctx do
+    ctx
+    |> UI.login_as(ctx.reviewer)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.champion,
+      action: "changed the parent goal of #{ctx.goal.name}"
+    })
+  end
+
+  step :assert_goal_reparent_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.goal.name,
+      to: ctx.reviewer,
+      author: ctx.champion,
+      action: "changed the goal parent of #{ctx.goal.name}"
+    })
+  end
+
   step :assert_goal_is_company_wide, ctx do
     ctx
     |> UI.assert_text("Company-wide goal")


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1917.

This was a tricky problem. Currently, `GoalReparent` activities only have the `company`, `old_parent_goal` and `new_parent_goal` in its content, but they lack a reference to the specific goal that was reparented. This makes it impossible to determine which goal the activity belongs to.

When there is missing data in an activity, the solution is usually to run a data migration to add/create the missing data. However, in this case, I didn't see any way to find out which goal the activity belonged to.

Another problem is that currently we don't have a clean way to filter out activities that have missing data. So, the activities with missing data were breaking the feed. 
Of course, I could handle those activities so that they don't break the feed, but then the feed item would be pretty much meaningless. 

Therefore, I decided to write a migration to delete these activities. 
I'm aware that any other solution would be better than deleting the activities, but I couldn't come up with any, considering that I couldn't fix the missing data in these existing activities and they serve no purpose without their associated goal references.