### PR TITLE
chore: Add assertions to file notification activities

### DIFF
--- a/assets/js/features/activities/ResourceHubFileCommented/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileCommented/index.tsx
@@ -8,6 +8,7 @@ import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
 import React from "react";
 import { feedTitle, fileLink, spaceLink } from "../feedItemLinks";
+import { assertPresent } from "@/utils/assertions";
 
 const ResourceHubFileCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +16,10 @@ const ResourceHubFileCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.resourceHubFilePath(content(activity).file!.id!);
+    const data = content(activity);
+    assertPresent(data.file?.id, "file must be present in activity");
+
+    return Paths.resourceHubFilePath(data.file.id);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -33,8 +37,11 @@ const ResourceHubFileCommented: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const data = content(activity);
 
-    const file = fileLink(data.file!);
-    const space = spaceLink(data.space!);
+    assertPresent(data.file, "file must be present in activity");
+    assertPresent(data.space, "space must be present in activity");
+
+    const file = fileLink(data.file);
+    const space = spaceLink(data.space);
 
     if (page === "space") {
       return feedTitle(activity, "commented on", file);
@@ -44,8 +51,10 @@ const ResourceHubFileCommented: ActivityHandler = {
   },
 
   FeedItemContent({ activity }: { activity: Activity }) {
-    const comment = content(activity).comment!;
-    const commentContent = JSON.parse(comment.content!)["message"];
+    const data = content(activity);
+    assertPresent(data.comment?.content, "comment must be present in activity");
+
+    const commentContent = JSON.parse(data.comment.content)["message"];
     return <Summary jsonContent={commentContent} characterCount={200} />;
   },
 

--- a/assets/js/features/activities/ResourceHubFileCreated/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileCreated/index.tsx
@@ -18,11 +18,12 @@ const ResourceHubFileCreated: ActivityHandler = {
     const data = content(activity);
 
     assertPresent(data.files, "files must be present in FileCreated activity");
+    assertPresent(data.resourceHub?.id, "resourceHub must be present in FileCreated activity");
 
-    if (data.files.length > 1) {
-      return Paths.resourceHubPath(data.resourceHub?.id!);
+    if (data.files.length === 1 && data.files[0]) {
+      return Paths.resourceHubFilePath(data.files[0].id!);
     } else {
-      return Paths.resourceHubFilePath(data.files[0]?.id!);
+      return Paths.resourceHubPath(data.resourceHub.id);
     }
   },
 
@@ -41,11 +42,15 @@ const ResourceHubFileCreated: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const data = content(activity);
 
-    const space = spaceLink(data.space!);
-    const resourceHub = resourceHubLink(data.resourceHub!);
+    assertPresent(data.space, "space must be present in FileCreated activity");
+    assertPresent(data.files, "files must be present in FileCreated activity");
+    assertPresent(data.resourceHub, "resourceHub must be present in FileCreated activity");
 
-    if (data.files?.length === 1) {
-      const file = fileLink(data.files[0]!);
+    const space = spaceLink(data.space);
+    const resourceHub = resourceHubLink(data.resourceHub);
+
+    if (data.files.length === 1 && data.files[0]) {
+      const file = fileLink(data.files[0]);
 
       if (page === "space") {
         return feedTitle(activity, "added a file:", file);
@@ -68,8 +73,11 @@ const ResourceHubFileCreated: ActivityHandler = {
       return (
         <ul className="list-disc ml-4">
           {data.files.map((file, idx) => {
-            const path = Paths.resourceHubFilePath(file.id!);
-            const name = file.name!;
+            assertPresent(file.id, "id must be present in file");
+            assertPresent(file.name, "name must be present in file");
+
+            const path = Paths.resourceHubFilePath(file.id);
+            const name = file.name;
 
             return (
               <li key={idx}>

--- a/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
+++ b/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
@@ -5,6 +5,7 @@ import type { ActivityContentResourceHubFileDeleted } from "@/api";
 import type { ActivityHandler } from "../interfaces";
 import { Paths } from "@/routes/paths";
 import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import { assertPresent } from "@/utils/assertions";
 
 const ResourceHubFileDeleted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,6 +13,9 @@ const ResourceHubFileDeleted: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
+    const data = content(activity);
+    assertPresent(data.resourceHub?.id, "resourceHub must be present in activity");
+
     return Paths.resourceHubPath(content(activity).resourceHub!.id!);
   },
 


### PR DESCRIPTION
I was trying to find out why the notifications page was crashing, as described in https://github.com/operately/operately/issues/1925. 

I couldn't find the reason precisely. However, judging by the error in the console, it seems that the bug is caused by a `null` value in a file page path. So, in this PR I'm adding some assertions to the file notifications. Hopefully, this will enable me to find out which activity has null values. 