### PR TITLE
chore: Add Operately.Assignments.Loader

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -1266,12 +1266,13 @@ export interface ResourceHubUploadedFile {
 }
 
 export interface ReviewAssignment {
-  id?: string | null;
+  resourceId?: string | null;
   name?: string | null;
   due?: string | null;
   type?: string | null;
-  championId?: string | null;
-  championName?: string | null;
+  authorId?: string | null;
+  authorName?: string | null;
+  path?: string | null;
 }
 
 export interface Space {
@@ -2302,14 +2303,14 @@ export interface CreateEmailActivationCodeInput {
 export interface CreateEmailActivationCodeResult {}
 
 export interface CreateGoalInput {
-  spaceId?: string | null;
+  spaceId?: Id | null;
   name?: string | null;
-  championId?: string | null;
-  reviewerId?: string | null;
+  championId?: Id | null;
+  reviewerId?: Id | null;
   timeframe?: Timeframe | null;
   targets?: CreateTargetInput[] | null;
   description?: string | null;
-  parentGoalId?: string | null;
+  parentGoalId?: Id | null;
   anonymousAccessLevel?: number | null;
   companyAccessLevel?: number | null;
   spaceAccessLevel?: number | null;

--- a/assets/js/pages/ReviewPage/AssignmentsList.tsx
+++ b/assets/js/pages/ReviewPage/AssignmentsList.tsx
@@ -4,25 +4,25 @@ import { IconTarget, IconHexagons } from "@tabler/icons-react";
 import { ReviewAssignment, AssignmentType } from "@/models/assignments";
 
 import FormattedTime from "@/components/FormattedTime";
-import { Paths } from "@/routes/paths";
 import { parseDate, relativeDay } from "@/utils/time";
 import { match } from "ts-pattern";
 import { DivLink } from "@/components/Link";
 import classNames from "classnames";
+import { assertPresent } from "@/utils/assertions";
 
 export function AssignmentsList({ assignments }: { assignments: ReviewAssignment[] }) {
   return (
     <div className="flex flex-col mt-4">
       {assignments.map((assignment) => (
-        <AssignmentItem assignment={assignment} key={assignment.id} />
+        <AssignmentItem assignment={assignment} key={assignment.resourceId} />
       ))}
     </div>
   );
 }
 
 function AssignmentItem({ assignment }: { assignment: ReviewAssignment }) {
-  const path = findPath(assignment);
-  const testId = `assignment-${assignment.id}`;
+  assertPresent(assignment.path, "path must be present in assingment");
+  const testId = `assignment-${assignment.resourceId}`;
 
   const className = classNames(
     "flex gap-4 items-center",
@@ -32,7 +32,7 @@ function AssignmentItem({ assignment }: { assignment: ReviewAssignment }) {
   );
 
   return (
-    <DivLink to={path} className={className} testId={testId}>
+    <DivLink to={assignment.path} className={className} testId={testId}>
       <DueDate date={assignment.due!} />
 
       <div className="flex gap-4 items-center">
@@ -92,7 +92,7 @@ function AcknowledgeProjectCheckIn({ assignment }: { assignment: ReviewAssignmen
         <span className="font-bold">Review:</span> {assignment.name}
       </div>
 
-      <p className="text-xs">{assignment.championName} submitted a weekly check-in</p>
+      <p className="text-xs">{assignment.authorName} submitted a weekly check-in</p>
     </div>
   );
 }
@@ -111,16 +111,7 @@ function AcknowledgeGoalUpdate({ assignment }: { assignment: ReviewAssignment })
       <div>
         <span className="font-bold">Review:</span> {assignment.name}
       </div>
-      <p className="text-xs">{assignment.championName} submitted an update</p>
+      <p className="text-xs">{assignment.authorName} submitted an update</p>
     </div>
   );
-}
-
-function findPath(assignment: ReviewAssignment) {
-  return match(assignment.type as AssignmentType)
-    .with("project", () => Paths.projectCheckInNewPath(assignment.id!))
-    .with("goal", () => Paths.goalProgressUpdateNewPath(assignment.id!))
-    .with("check_in", () => Paths.projectCheckInPath(assignment.id!))
-    .with("goal_update", () => Paths.goalProgressUpdatePath(assignment.id!))
-    .exhaustive();
 }

--- a/lib/operately/assignments/assignment.ex
+++ b/lib/operately/assignments/assignment.ex
@@ -39,16 +39,6 @@ defmodule Operately.Assignments.Assignment do
     }
   end
 
-  def build(milestone = %Projects.Milestone{}, company) do
-    %__MODULE__{
-      resource_id: Paths.milestone_id(milestone),
-      name: milestone.title,
-      due: normalize_date(milestone.deadline_at),
-      type: :milestone,
-      path: Paths.project_milestone_path(company, milestone),
-    }
-  end
-
   def build(goal = %Goals.Goal{}, company) do
     %__MODULE__{
       resource_id: Paths.goal_id(goal),

--- a/lib/operately/assignments/assignment.ex
+++ b/lib/operately/assignments/assignment.ex
@@ -2,14 +2,14 @@ defmodule Operately.Assignments.Assignment do
   alias Operately.{Goals, Projects}
   alias OperatelyWeb.Paths
 
-  @enforce_keys [:resource_id, :name, :due, :type]
+  @enforce_keys [:resource_id, :name, :due, :type, :path]
   defstruct [
     :resource_id,
     :name,
     :due,
     :type,
     :path,
-    :author_short_id,
+    :author_id,
     :author_name,
   ]
 
@@ -34,7 +34,7 @@ defmodule Operately.Assignments.Assignment do
       due: normalize_date(check_in.inserted_at),
       type: :check_in,
       path: Paths.project_check_in_path(company, check_in),
-      author_short_id: Paths.person_id(check_in.author),
+      author_id: Paths.person_id(check_in.author),
       author_name: check_in.author.full_name,
     }
   end
@@ -66,7 +66,7 @@ defmodule Operately.Assignments.Assignment do
       due: normalize_date(update.inserted_at),
       type: :goal_update,
       path: Paths.goal_check_in_path(company, update),
-      author_short_id: Paths.person_id(update.author),
+      author_id: Paths.person_id(update.author),
       author_name: update.author.full_name,
     }
   end

--- a/lib/operately/assignments/assignment.ex
+++ b/lib/operately/assignments/assignment.ex
@@ -2,14 +2,14 @@ defmodule Operately.Assignments.Assignment do
   alias Operately.{Goals, Projects}
   alias OperatelyWeb.Paths
 
-  @enforce_keys [:id, :name, :due, :type]
+  @enforce_keys [:resource_id, :name, :due, :type]
   defstruct [
-    :id,
+    :resource_id,
     :name,
     :due,
     :type,
-    :url,
-    :author_id,
+    :path,
+    :author_short_id,
     :author_name,
   ]
 
@@ -19,54 +19,54 @@ defmodule Operately.Assignments.Assignment do
 
   def build(project = %Projects.Project{}, company) do
     %__MODULE__{
-      id: project.id,
+      resource_id: Paths.project_id(project),
       name: project.name,
       due: normalize_date(project.next_check_in_scheduled_at),
       type: :project,
-      url: Paths.project_path(company, project),
+      path: Paths.project_check_in_new_path(company, project) ,
     }
   end
 
   def build(check_in = %Projects.CheckIn{}, company) do
     %__MODULE__{
-      id: check_in.id,
+      resource_id: Paths.project_check_in_id(check_in),
       name: check_in.project.name,
       due: normalize_date(check_in.inserted_at),
       type: :check_in,
-      url: Paths.project_check_in_path(company, check_in),
-      author_id: check_in.author.id,
+      path: Paths.project_check_in_path(company, check_in),
+      author_short_id: Paths.person_id(check_in.author),
       author_name: check_in.author.full_name,
     }
   end
 
   def build(milestone = %Projects.Milestone{}, company) do
     %__MODULE__{
-      id: milestone.id,
+      resource_id: Paths.milestone_id(milestone),
       name: milestone.title,
       due: normalize_date(milestone.deadline_at),
       type: :milestone,
-      url: Paths.project_milestone_path(company, milestone),
+      path: Paths.project_milestone_path(company, milestone),
     }
   end
 
   def build(goal = %Goals.Goal{}, company) do
     %__MODULE__{
-      id: goal.id,
+      resource_id: Paths.goal_id(goal),
       name: goal.name,
       due: normalize_date(goal.next_update_scheduled_at),
       type: :goal,
-      url: Paths.goal_path(company, goal),
+      path: Paths.goal_check_in_new_path(company, goal),
     }
   end
 
   def build(update = %Goals.Update{}, company) do
     %__MODULE__{
-      id: update.id,
+      resource_id: Paths.goal_update_id(update),
       name: update.goal.name,
       due: normalize_date(update.inserted_at),
       type: :goal_update,
-      url: Paths.goal_check_in_path(company, update),
-      author_id: update.author.id,
+      path: Paths.goal_check_in_path(company, update),
+      author_short_id: Paths.person_id(update.author),
       author_name: update.author.full_name,
     }
   end

--- a/lib/operately/assignments/assignment.ex
+++ b/lib/operately/assignments/assignment.ex
@@ -1,0 +1,12 @@
+defmodule Operately.Assignments.Assignment do
+  @enforce_keys [:id, :name, :due, :type, :url]
+  defstruct [
+    :id,
+    :name,
+    :due,
+    :type,
+    :url,
+    :champion_id,
+    :champion_name,
+  ]
+end

--- a/lib/operately/assignments/assignment.ex
+++ b/lib/operately/assignments/assignment.ex
@@ -1,12 +1,77 @@
 defmodule Operately.Assignments.Assignment do
-  @enforce_keys [:id, :name, :due, :type, :url]
+  alias Operately.{Goals, Projects}
+  alias OperatelyWeb.Paths
+
+  @enforce_keys [:id, :name, :due, :type]
   defstruct [
     :id,
     :name,
     :due,
     :type,
     :url,
-    :champion_id,
-    :champion_name,
+    :author_id,
+    :author_name,
   ]
+
+  def build(assingments, company) when is_list(assingments) do
+    Enum.map(assingments, fn a -> build(a, company) end)
+  end
+
+  def build(project = %Projects.Project{}, company) do
+    %__MODULE__{
+      id: project.id,
+      name: project.name,
+      due: normalize_date(project.next_check_in_scheduled_at),
+      type: :project,
+      url: Paths.project_path(company, project),
+    }
+  end
+
+  def build(check_in = %Projects.CheckIn{}, company) do
+    %__MODULE__{
+      id: check_in.id,
+      name: check_in.project.name,
+      due: normalize_date(check_in.inserted_at),
+      type: :check_in,
+      url: Paths.project_check_in_path(company, check_in),
+      author_id: check_in.author.id,
+      author_name: check_in.author.full_name,
+    }
+  end
+
+  def build(milestone = %Projects.Milestone{}, company) do
+    %__MODULE__{
+      id: milestone.id,
+      name: milestone.title,
+      due: normalize_date(milestone.deadline_at),
+      type: :milestone,
+      url: Paths.project_milestone_path(company, milestone),
+    }
+  end
+
+  def build(goal = %Goals.Goal{}, company) do
+    %__MODULE__{
+      id: goal.id,
+      name: goal.name,
+      due: normalize_date(goal.next_update_scheduled_at),
+      type: :goal,
+      url: Paths.goal_path(company, goal),
+    }
+  end
+
+  def build(update = %Goals.Update{}, company) do
+    %__MODULE__{
+      id: update.id,
+      name: update.goal.name,
+      due: normalize_date(update.inserted_at),
+      type: :goal_update,
+      url: Paths.goal_check_in_path(company, update),
+      author_id: update.author.id,
+      author_name: update.author.full_name,
+    }
+  end
+
+  defp normalize_date(date) do
+    DateTime.from_naive!(date, "Etc/UTC")
+  end
 end

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -15,7 +15,6 @@ defmodule Operately.Assignments.Loader do
       Task.async(fn -> load_projects(person) end),
       Task.async(fn -> load_goals(person) end),
       Task.async(fn -> load_due_project_check_ins(person) end),
-      Task.async(fn -> load_due_milestones(person) end),
       Task.async(fn -> load_due_goal_updates(person) end),
     ]
     |> Task.await_many()
@@ -49,16 +48,6 @@ defmodule Operately.Assignments.Loader do
       where: contrib.person_id == ^person.id and contrib.role == :reviewer,
       where: is_nil(c.acknowledged_by_id),
       preload: [project: project, author: author]
-    )
-    |> Repo.all()
-  end
-
-  defp load_due_milestones(person) do
-    from(m in Operately.Projects.Milestone,
-      join: project in assoc(m, :project),
-      join: champion in assoc(project, :champion),
-      where: champion.id == ^person.id,
-      where: m.deadline_at <= ^DateTime.utc_now() and is_nil(m.completed_at)
     )
     |> Repo.all()
   end

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -1,0 +1,79 @@
+defmodule Operately.Assignments.Loader do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  def load(person) do
+    load_all(person)
+  end
+
+  defp load_all(person) do
+    [
+      load_projects(person),
+      load_goals(person),
+      load_due_project_check_ins(person),
+      load_due_milestones(person),
+      load_due_goal_updates(person),
+    ]
+    |> List.flatten()
+  end
+
+  defp load_projects(person) do
+    from(p in Operately.Projects.Project,
+      join: company in assoc(p, :company),
+      join: contrib in assoc(p, :contributors),
+      left_join: milestones in assoc(p, :milestones),
+      where: contrib.person_id == ^person.id and contrib.role == :champion,
+      where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
+      where: p.status == "active",
+      preload: [milestones: milestones, company: company]
+    )
+    |> Repo.all()
+  end
+
+  defp load_goals(person) do
+    from(g in Operately.Goals.Goal,
+      join: company in assoc(g, :company),
+      where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
+      where: is_nil(g.closed_at),
+      where: g.champion_id == ^person.id,
+      preload: [company: company]
+    )
+    |> Repo.all()
+  end
+
+  defp load_due_project_check_ins(person) do
+    from(c in Operately.Projects.CheckIn,
+      join: project in assoc(c, :project),
+      join: author in assoc(c, :author),
+      join: contrib in assoc(project, :contributors),
+      where: contrib.person_id == ^person.id and contrib.role == :reviewer,
+      where: is_nil(c.acknowledged_by_id),
+      preload: [project: project, author: author]
+    )
+    |> Repo.all()
+  end
+
+  defp load_due_milestones(person) do
+    from(m in Operately.Projects.Milestone,
+      join: project in assoc(m, :project),
+      join: champion in assoc(project, :champion),
+      where: champion.id == ^person.id,
+      where: m.deadline_at <= ^DateTime.utc_now() and is_nil(m.completed_at),
+      preload: [project: project]
+    )
+    |> Repo.all()
+  end
+
+  defp load_due_goal_updates(person) do
+    from(u in Operately.Goals.Update,
+      join: goal in assoc(u, :goal),
+      join: author in assoc(u, :author),
+      where: goal.reviewer_id == ^person.id,
+      where: is_nil(goal.deleted_at),
+      where: is_nil(u.acknowledged_by_id),
+      preload: [goal: goal, author: author]
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -2,42 +2,41 @@ defmodule Operately.Assignments.Loader do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
+  alias Operately.Assignments.Assignment
 
-  def load(person) do
-    load_all(person)
+  def load(person, company) do
+    person
+    |> load_all()
+    |> Assignment.build(company)
   end
 
   defp load_all(person) do
     [
-      load_projects(person),
-      load_goals(person),
-      load_due_project_check_ins(person),
-      load_due_milestones(person),
-      load_due_goal_updates(person),
+      Task.async(fn -> load_projects(person) end),
+      Task.async(fn -> load_goals(person) end),
+      Task.async(fn -> load_due_project_check_ins(person) end),
+      Task.async(fn -> load_due_milestones(person) end),
+      Task.async(fn -> load_due_goal_updates(person) end),
     ]
+    |> Task.await_many()
     |> List.flatten()
   end
 
   defp load_projects(person) do
     from(p in Operately.Projects.Project,
-      join: company in assoc(p, :company),
-      join: contrib in assoc(p, :contributors),
-      left_join: milestones in assoc(p, :milestones),
-      where: contrib.person_id == ^person.id and contrib.role == :champion,
+      join: champion in assoc(p, :champion),
+      where: champion.id == ^person.id,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
-      where: p.status == "active",
-      preload: [milestones: milestones, company: company]
+      where: p.status == "active"
     )
     |> Repo.all()
   end
 
   defp load_goals(person) do
     from(g in Operately.Goals.Goal,
-      join: company in assoc(g, :company),
       where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
       where: is_nil(g.closed_at),
-      where: g.champion_id == ^person.id,
-      preload: [company: company]
+      where: g.champion_id == ^person.id
     )
     |> Repo.all()
   end
@@ -59,8 +58,7 @@ defmodule Operately.Assignments.Loader do
       join: project in assoc(m, :project),
       join: champion in assoc(project, :champion),
       where: champion.id == ^person.id,
-      where: m.deadline_at <= ^DateTime.utc_now() and is_nil(m.completed_at),
-      preload: [project: project]
+      where: m.deadline_at <= ^DateTime.utc_now() and is_nil(m.completed_at)
     )
     |> Repo.all()
   end

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -2,127 +2,19 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
   use TurboConnect.Query
   use OperatelyWeb.Api.Helpers
 
-  alias OperatelyWeb.Paths
-  alias Operately.Repo
+  alias Operately.Assignments.Loader
 
-  import Ecto.Query, only: [from: 2]
 
   outputs do
     field :assignments, list_of(:review_assignment)
   end
 
   def call(conn, _inputs) do
-    assignments = load_assignments(me(conn))
+    company = company(conn)
+    me = me(conn)
 
-    {:ok, %{assignments: assignments}}
-  end
+    assignments = Loader.load(me, company)
 
-  #
-  # Loading data
-  #
-
-  defp load_assignments(person) do
-    load_projects(person)
-    |> load_goals(person)
-    |> load_due_project_check_ins(person)
-    |> load_due_goal_updates(person)
-    |> convert_id()
-    |> Enum.sort(&(DateTime.compare(&1.due, &2.due) == :gt))
-  end
-
-  defp load_projects(person) do
-    from(p in Operately.Projects.Project,
-      join: c in assoc(p, :contributors),
-      where: c.person_id == ^person.id and c.role == :champion,
-      where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
-      where: p.status == "active",
-      select: %{
-        id: p.id,
-        name: p.name,
-        due: p.next_check_in_scheduled_at,
-        type: :project,
-      }
-    )
-    |> Repo.all()
-  end
-
-  defp load_goals(result, person) do
-    from(g in Operately.Goals.Goal,
-      where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
-      where: is_nil(g.closed_at),
-      where: g.champion_id == ^person.id,
-      select: %{
-        id: g.id,
-        name: g.name,
-        due: g.next_update_scheduled_at,
-        type: :goal,
-      }
-    )
-    |> Repo.all()
-    |> Enum.concat(result)
-  end
-
-  defp load_due_project_check_ins(result, person) do
-    from(c in Operately.Projects.CheckIn,
-      join: p in assoc(c, :project),
-      join: contrib in assoc(p, :contributors),
-      join: champion in assoc(c, :author),
-      where: contrib.person_id == ^person.id and contrib.role == :reviewer,
-      where: is_nil(c.acknowledged_by_id),
-      select: %{
-        id: c.id,
-        name: p.name,
-        due: c.inserted_at,
-        type: :check_in,
-        champion_id: champion.id,
-        champion_name: champion.full_name,
-      }
-    )
-    |> Repo.all()
-    |> normalize_date()
-    |> Enum.concat(result)
-  end
-
-  defp load_due_goal_updates(result, person) do
-    from(u in Operately.Goals.Update,
-      join: g in assoc(u, :goal),
-      join: champion in assoc(u, :author),
-      where: g.reviewer_id == ^person.id,
-      where: is_nil(g.deleted_at),
-      where: is_nil(u.acknowledged_by_id),
-      select: %{
-        id: u.id,
-        name: g.name,
-        due: u.inserted_at,
-        type: :goal_update,
-        champion_id: champion.id,
-        champion_name: champion.full_name,
-      }
-    )
-    |> Repo.all()
-    |> normalize_date()
-    |> Enum.concat(result)
-  end
-
-  defp normalize_date(items) do
-    Enum.map(items, fn item ->
-      Map.merge(item, %{due: DateTime.from_naive!(item.due, "Etc/UTC")})
-    end)
-  end
-
-  defp convert_id([]), do: []
-  defp convert_id([head | tail]) do
-    [ Map.merge(head, %{id: convert_id(head)}) | convert_id(tail) ]
-  end
-  defp convert_id(%{type: :project} = project), do: Paths.project_id(project)
-  defp convert_id(%{type: :goal} = goal), do: Paths.goal_id(goal)
-  defp convert_id(%{type: :check_in} = check_in), do: Paths.project_check_in_id(normalize_for_short_id(check_in))
-  defp convert_id(%{type: :goal_update} = goal_update), do: Paths.goal_update_id(normalize_for_short_id(goal_update))
-
-  defp normalize_for_short_id(resource) do
-    %{
-      id: resource.id,
-      inserted_at: resource.due,
-    }
+    {:ok, %{assignments: Serializer.serialize(assignments)}}
   end
 end

--- a/lib/operately_web/api/serializers/assigments.ex
+++ b/lib/operately_web/api/serializers/assigments.ex
@@ -5,7 +5,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Assignments.Assignment do
        name: assignment.name,
        due: assignment.due,
        type: Atom.to_string(assignment.type),
-       author_id: assignment.author_short_id,
+       author_id: assignment.author_id,
        author_name: assignment.author_name,
        path: assignment.path,
     }

--- a/lib/operately_web/api/serializers/assigments.ex
+++ b/lib/operately_web/api/serializers/assigments.ex
@@ -1,0 +1,13 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Assignments.Assignment do
+  def serialize(assignment, level: :essential) do
+    %{
+       resource_id: assignment.resource_id,
+       name: assignment.name,
+       due: assignment.due,
+       type: Atom.to_string(assignment.type),
+       author_id: assignment.author_short_id,
+       author_name: assignment.author_name,
+       path: assignment.path,
+    }
+  end
+end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -92,12 +92,13 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :review_assignment do
-    field :id, :string
+    field :resource_id, :string
     field :name, :string
     field :due, :date
     field :type, :string
-    field :champion_id, :string
-    field :champion_name, :string
+    field :author_id, :string
+    field :author_name, :string
+    field :path, :string
   end
 
   union :update_content, types: [

--- a/test/features/review_test.exs
+++ b/test/features/review_test.exs
@@ -62,11 +62,4 @@ defmodule Operately.Features.ReviewTest do
     |> Steps.assert_the_closed_project_is_no_longer_displayed()
   end
 
-  feature "milestone returned in the loader doesn't break the page", ctx do
-    ctx
-    |> Steps.given_there_are_due_project_check_ins()
-    |> Steps.given_there_are_due_project_milestones()
-    |> Steps.assert_loader_returns_milestone()
-    |> Steps.assert_the_due_project_is_listed()
-  end
 end

--- a/test/features/review_test.exs
+++ b/test/features/review_test.exs
@@ -62,4 +62,11 @@ defmodule Operately.Features.ReviewTest do
     |> Steps.assert_the_closed_project_is_no_longer_displayed()
   end
 
+  feature "milestone returned in the loader doesn't break the page", ctx do
+    ctx
+    |> Steps.given_there_are_due_project_check_ins()
+    |> Steps.given_there_are_due_project_milestones()
+    |> Steps.assert_loader_returns_milestone()
+    |> Steps.assert_the_due_project_is_listed()
+  end
 end

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -22,7 +22,7 @@ defmodule Operately.Assignments.LoaderTest do
     end
 
     test "returns all due projects", ctx do
-      assignments = Loader.load(ctx.champion)
+      assignments = Loader.load(ctx.champion, ctx.company)
 
       assert Enum.find(assignments, &(&1.id == ctx.due_project1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_project2.id))
@@ -44,7 +44,7 @@ defmodule Operately.Assignments.LoaderTest do
     end
 
     test "returns all due check-ins", ctx do
-      assignments = Loader.load(ctx.reviewer)
+      assignments = Loader.load(ctx.reviewer, ctx.company)
 
       assert Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
@@ -66,7 +66,7 @@ defmodule Operately.Assignments.LoaderTest do
     end
 
     test "returns all due milestones", ctx do
-      assignments = Loader.load(ctx.champion)
+      assignments = Loader.load(ctx.champion, ctx.company)
 
       assert Enum.find(assignments, &(&1.id == ctx.due_milestone1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_milestone2.id))
@@ -87,7 +87,7 @@ defmodule Operately.Assignments.LoaderTest do
     end
 
     test "returns all due goals", ctx do
-      assignments = Loader.load(ctx.champion)
+      assignments = Loader.load(ctx.champion, ctx.company)
 
       assert Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
@@ -109,7 +109,7 @@ defmodule Operately.Assignments.LoaderTest do
     end
 
     test "returns all due updates", ctx do
-      assignments = Loader.load(ctx.reviewer)
+      assignments = Loader.load(ctx.reviewer, ctx.company)
 
       assert Enum.find(assignments, &(&1.id == ctx.due_update1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_update2.id))

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -30,6 +30,15 @@ defmodule Operately.Assignments.LoaderTest do
       refute Enum.find(assignments, &(&1.id == ctx.project1.id))
       refute Enum.find(assignments, &(&1.id == ctx.project2.id))
     end
+
+    test "doesn't return due projects to non-champions", ctx do
+      assignments = Loader.load(ctx.reviewer, ctx.company)
+
+      refute Enum.find(assignments, &(&1.id == ctx.due_project1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.due_project2.id))
+      refute Enum.find(assignments, &(&1.id == ctx.project1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.project2.id))
+    end
   end
 
   describe "project check-ins" do
@@ -49,6 +58,15 @@ defmodule Operately.Assignments.LoaderTest do
       assert Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
 
+      refute Enum.find(assignments, &(&1.id == ctx.check_in1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.check_in2.id))
+    end
+
+    test "doesn't return due check-ins to non-reviewers", ctx do
+      assignments = Loader.load(ctx.champion, ctx.company)
+
+      refute Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
       refute Enum.find(assignments, &(&1.id == ctx.check_in1.id))
       refute Enum.find(assignments, &(&1.id == ctx.check_in2.id))
     end
@@ -74,6 +92,15 @@ defmodule Operately.Assignments.LoaderTest do
       refute Enum.find(assignments, &(&1.id == ctx.milestone1.id))
       refute Enum.find(assignments, &(&1.id == ctx.milestone2.id))
     end
+
+    test "doesn't return due milestone to non-champions", ctx do
+      assignments = Loader.load(ctx.reviewer, ctx.company)
+
+      refute Enum.find(assignments, &(&1.id == ctx.due_milestone1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.due_milestone2.id))
+      refute Enum.find(assignments, &(&1.id == ctx.milestone1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.milestone2.id))
+    end
   end
 
   describe "goals" do
@@ -92,6 +119,15 @@ defmodule Operately.Assignments.LoaderTest do
       assert Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
 
+      refute Enum.find(assignments, &(&1.id == ctx.goal1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.goal2.id))
+    end
+
+    test "doesn't return due goals to non-champions", ctx do
+      assignments = Loader.load(ctx.reviewer, ctx.company)
+
+      refute Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
       refute Enum.find(assignments, &(&1.id == ctx.goal1.id))
       refute Enum.find(assignments, &(&1.id == ctx.goal2.id))
     end
@@ -114,6 +150,15 @@ defmodule Operately.Assignments.LoaderTest do
       assert Enum.find(assignments, &(&1.id == ctx.due_update1.id))
       assert Enum.find(assignments, &(&1.id == ctx.due_update2.id))
 
+      refute Enum.find(assignments, &(&1.id == ctx.update1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.update2.id))
+    end
+
+    test "doesn't return due updates to non-reviewer", ctx do
+      assignments = Loader.load(ctx.champion, ctx.company)
+
+      refute Enum.find(assignments, &(&1.id == ctx.due_update1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.due_update2.id))
       refute Enum.find(assignments, &(&1.id == ctx.update1.id))
       refute Enum.find(assignments, &(&1.id == ctx.update2.id))
     end

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -73,37 +73,6 @@ defmodule Operately.Assignments.LoaderTest do
     end
   end
 
-  describe "project milestones" do
-    setup ctx do
-      ctx
-      |> Factory.add_project(:project, :space, champion: :champion, reviewer: :reviewer)
-      |> Factory.add_project_milestone(:due_milestone1, :project)
-      |> Factory.add_project_milestone(:due_milestone2, :project)
-      |> Factory.add_project_milestone(:milestone1, :project)
-      |> Factory.add_project_milestone(:milestone2, :project)
-      |> complete_milestones()
-    end
-
-    test "returns all due milestones", ctx do
-      assignments = Loader.load(ctx.champion, ctx.company)
-
-      assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone1)))
-      assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone2)))
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone2)))
-    end
-
-    test "doesn't return due milestone to non-champions", ctx do
-      assignments = Loader.load(ctx.reviewer, ctx.company)
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone2)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone2)))
-    end
-  end
-
   describe "goals" do
     setup ctx do
       ctx
@@ -189,19 +158,6 @@ defmodule Operately.Assignments.LoaderTest do
         })
         |> Repo.update()
       Map.put(ctx, key, check_in)
-    end)
-  end
-
-  defp complete_milestones(ctx) do
-    Enum.reduce([:milestone1, :milestone2], ctx, fn key, ctx ->
-      {:ok, milestone} =
-        ctx[key]
-        |> Operately.Projects.Milestone.changeset(%{
-          status: :done,
-          completed_at: NaiveDateTime.utc_now(),
-        })
-        |> Repo.update()
-      Map.put(ctx, key, milestone)
     end)
   end
 

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -1,0 +1,190 @@
+defmodule Operately.Assignments.LoaderTest do
+  use Operately.DataCase
+
+  alias Operately.Assignments.Loader
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_space_member(:champion, :space)
+    |> Factory.add_space_member(:reviewer, :space)
+  end
+
+  describe "projects" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:due_project1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project(:due_project2, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project(:project1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project(:project2, :space, champion: :champion, reviewer: :reviewer)
+      |> set_due_projects()
+    end
+
+    test "returns all due projects", ctx do
+      assignments = Loader.load(ctx.champion)
+
+      assert Enum.find(assignments, &(&1.id == ctx.due_project1.id))
+      assert Enum.find(assignments, &(&1.id == ctx.due_project2.id))
+
+      refute Enum.find(assignments, &(&1.id == ctx.project1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.project2.id))
+    end
+  end
+
+  describe "project check-ins" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:project, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project_check_in(:due_check_in1, :project, :champion)
+      |> Factory.add_project_check_in(:due_check_in2, :project, :champion)
+      |> Factory.add_project_check_in(:check_in1, :project, :champion)
+      |> Factory.add_project_check_in(:check_in2, :project, :champion)
+      |> acknowledge_check_ins()
+    end
+
+    test "returns all due check-ins", ctx do
+      assignments = Loader.load(ctx.reviewer)
+
+      assert Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
+      assert Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
+
+      refute Enum.find(assignments, &(&1.id == ctx.check_in1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.check_in2.id))
+    end
+  end
+
+  describe "project milestones" do
+    setup ctx do
+      ctx
+      |> Factory.add_project(:project, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project_milestone(:due_milestone1, :project)
+      |> Factory.add_project_milestone(:due_milestone2, :project)
+      |> Factory.add_project_milestone(:milestone1, :project)
+      |> Factory.add_project_milestone(:milestone2, :project)
+      |> complete_milestones()
+    end
+
+    test "returns all due milestones", ctx do
+      assignments = Loader.load(ctx.champion)
+
+      assert Enum.find(assignments, &(&1.id == ctx.due_milestone1.id))
+      assert Enum.find(assignments, &(&1.id == ctx.due_milestone2.id))
+
+      refute Enum.find(assignments, &(&1.id == ctx.milestone1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.milestone2.id))
+    end
+  end
+
+  describe "goals" do
+    setup ctx do
+      ctx
+      |> Factory.add_goal(:due_goal1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal(:due_goal2, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal(:goal1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal(:goal2, :space, champion: :champion, reviewer: :reviewer)
+      |> set_due_goals()
+    end
+
+    test "returns all due goals", ctx do
+      assignments = Loader.load(ctx.champion)
+
+      assert Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
+      assert Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
+
+      refute Enum.find(assignments, &(&1.id == ctx.goal1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.goal2.id))
+    end
+  end
+
+  describe "goal updates" do
+    setup ctx do
+      ctx
+      |> Factory.add_goal(:goal, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal_update(:due_update1, :goal, :champion)
+      |> Factory.add_goal_update(:due_update2, :goal, :champion)
+      |> Factory.add_goal_update(:update1, :goal, :champion)
+      |> Factory.add_goal_update(:update2, :goal, :champion)
+      |> acknowledge_updates()
+    end
+
+    test "returns all due updates", ctx do
+      assignments = Loader.load(ctx.reviewer)
+
+      assert Enum.find(assignments, &(&1.id == ctx.due_update1.id))
+      assert Enum.find(assignments, &(&1.id == ctx.due_update2.id))
+
+      refute Enum.find(assignments, &(&1.id == ctx.update1.id))
+      refute Enum.find(assignments, &(&1.id == ctx.update2.id))
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp set_due_projects(ctx) do
+    Enum.reduce([:due_project1, :due_project2], ctx, fn key, ctx ->
+      {:ok, due_project} =
+        ctx[key]
+        |> Operately.Projects.Project.changeset(%{next_check_in_scheduled_at: past_date()})
+        |> Repo.update()
+      Map.put(ctx, key, due_project)
+    end)
+  end
+
+  defp acknowledge_check_ins(ctx) do
+    Enum.reduce([:check_in1, :check_in2], ctx, fn key, ctx ->
+      {:ok, check_in} =
+        ctx[key]
+        |> Operately.Projects.CheckIn.changeset(%{
+          acknowledged_by_id: ctx.reviewer.id,
+          acknowledged_at: NaiveDateTime.utc_now(),
+        })
+        |> Repo.update()
+      Map.put(ctx, key, check_in)
+    end)
+  end
+
+  defp complete_milestones(ctx) do
+    Enum.reduce([:milestone1, :milestone2], ctx, fn key, ctx ->
+      {:ok, milestone} =
+        ctx[key]
+        |> Operately.Projects.Milestone.changeset(%{
+          status: :done,
+          completed_at: NaiveDateTime.utc_now(),
+        })
+        |> Repo.update()
+      Map.put(ctx, key, milestone)
+    end)
+  end
+
+  defp set_due_goals(ctx) do
+    Enum.reduce([:due_goal1, :due_goal2], ctx, fn key, ctx ->
+      {:ok, due_goal} =
+        ctx[key]
+        |> Operately.Goals.Goal.changeset(%{next_update_scheduled_at: past_date()})
+        |> Repo.update()
+      Map.put(ctx, key, due_goal)
+    end)
+  end
+
+  defp acknowledge_updates(ctx) do
+    Enum.reduce([:update1, :update2], ctx, fn key, ctx ->
+      {:ok, update} =
+        ctx[key]
+        |> Operately.Goals.Update.changeset(%{
+          acknowledged_at: DateTime.utc_now(),
+          acknowledged_by_id: ctx.reviewer.id,
+        })
+        |> Repo.update()
+      Map.put(ctx, key, update)
+    end)
+  end
+
+  defp past_date do
+    Date.utc_today()
+    |> Date.add(-3)
+    |> Operately.Time.as_datetime()
+  end
+end

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -2,6 +2,7 @@ defmodule Operately.Assignments.LoaderTest do
   use Operately.DataCase
 
   alias Operately.Assignments.Loader
+  alias OperatelyWeb.Paths
 
   setup ctx do
     ctx
@@ -24,20 +25,20 @@ defmodule Operately.Assignments.LoaderTest do
     test "returns all due projects", ctx do
       assignments = Loader.load(ctx.champion, ctx.company)
 
-      assert Enum.find(assignments, &(&1.id == ctx.due_project1.id))
-      assert Enum.find(assignments, &(&1.id == ctx.due_project2.id))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project1)))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project2)))
 
-      refute Enum.find(assignments, &(&1.id == ctx.project1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.project2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project2)))
     end
 
     test "doesn't return due projects to non-champions", ctx do
       assignments = Loader.load(ctx.reviewer, ctx.company)
 
-      refute Enum.find(assignments, &(&1.id == ctx.due_project1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.due_project2.id))
-      refute Enum.find(assignments, &(&1.id == ctx.project1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.project2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project2)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project2)))
     end
   end
 
@@ -55,20 +56,20 @@ defmodule Operately.Assignments.LoaderTest do
     test "returns all due check-ins", ctx do
       assignments = Loader.load(ctx.reviewer, ctx.company)
 
-      assert Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
-      assert Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in1)))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in2)))
 
-      refute Enum.find(assignments, &(&1.id == ctx.check_in1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.check_in2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in2)))
     end
 
     test "doesn't return due check-ins to non-reviewers", ctx do
       assignments = Loader.load(ctx.champion, ctx.company)
 
-      refute Enum.find(assignments, &(&1.id == ctx.due_check_in1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.due_check_in2.id))
-      refute Enum.find(assignments, &(&1.id == ctx.check_in1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.check_in2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in2)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in2)))
     end
   end
 
@@ -86,20 +87,20 @@ defmodule Operately.Assignments.LoaderTest do
     test "returns all due milestones", ctx do
       assignments = Loader.load(ctx.champion, ctx.company)
 
-      assert Enum.find(assignments, &(&1.id == ctx.due_milestone1.id))
-      assert Enum.find(assignments, &(&1.id == ctx.due_milestone2.id))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone1)))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone2)))
 
-      refute Enum.find(assignments, &(&1.id == ctx.milestone1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.milestone2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone2)))
     end
 
     test "doesn't return due milestone to non-champions", ctx do
       assignments = Loader.load(ctx.reviewer, ctx.company)
 
-      refute Enum.find(assignments, &(&1.id == ctx.due_milestone1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.due_milestone2.id))
-      refute Enum.find(assignments, &(&1.id == ctx.milestone1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.milestone2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.due_milestone2)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone2)))
     end
   end
 
@@ -116,20 +117,20 @@ defmodule Operately.Assignments.LoaderTest do
     test "returns all due goals", ctx do
       assignments = Loader.load(ctx.champion, ctx.company)
 
-      assert Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
-      assert Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal1)))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal2)))
 
-      refute Enum.find(assignments, &(&1.id == ctx.goal1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.goal2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal2)))
     end
 
     test "doesn't return due goals to non-champions", ctx do
       assignments = Loader.load(ctx.reviewer, ctx.company)
 
-      refute Enum.find(assignments, &(&1.id == ctx.due_goal1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.due_goal2.id))
-      refute Enum.find(assignments, &(&1.id == ctx.goal1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.goal2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal2)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal2)))
     end
   end
 
@@ -147,20 +148,20 @@ defmodule Operately.Assignments.LoaderTest do
     test "returns all due updates", ctx do
       assignments = Loader.load(ctx.reviewer, ctx.company)
 
-      assert Enum.find(assignments, &(&1.id == ctx.due_update1.id))
-      assert Enum.find(assignments, &(&1.id == ctx.due_update2.id))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update1)))
+      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update2)))
 
-      refute Enum.find(assignments, &(&1.id == ctx.update1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.update2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update2)))
     end
 
     test "doesn't return due updates to non-reviewer", ctx do
       assignments = Loader.load(ctx.champion, ctx.company)
 
-      refute Enum.find(assignments, &(&1.id == ctx.due_update1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.due_update2.id))
-      refute Enum.find(assignments, &(&1.id == ctx.update1.id))
-      refute Enum.find(assignments, &(&1.id == ctx.update2.id))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update2)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update1)))
+      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update2)))
     end
   end
 

--- a/test/operately_web/api/queries/get_assignments_test.exs
+++ b/test/operately_web/api/queries/get_assignments_test.exs
@@ -36,11 +36,11 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [p1, p2] = assignments
 
-      assert p1.id == Paths.project_id(today_project)
+      assert p1.resource_id == Paths.project_id(today_project)
       assert p1.name == "today"
       assert p1.due
       assert p1.type == "project"
-      assert p2.id == Paths.project_id(due_project)
+      assert p2.resource_id == Paths.project_id(due_project)
       assert p2.name == "3 days ago"
       assert p2.due
       assert p2.type == "project"
@@ -58,7 +58,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [p] = assignments
 
-      assert p.id == Paths.project_id(due_project)
+      assert p.resource_id == Paths.project_id(due_project)
       assert p.name == "single project"
       assert p.due
       assert p.type == "project"
@@ -81,11 +81,11 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [g1, g2] = assignments
 
-      assert g1.id == Paths.goal_id(today_goal)
+      assert g1.resource_id == Paths.goal_id(today_goal)
       assert g1.name == "today"
       assert g1.due
       assert g1.type == "goal"
-      assert g2.id == Paths.goal_id(due_goal)
+      assert g2.resource_id == Paths.goal_id(due_goal)
       assert g2.name == "3 days ago"
       assert g2.due
       assert g2.type == "goal"
@@ -103,7 +103,7 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [g] = assignments
 
-      assert g.id == Paths.goal_id(due_goal)
+      assert g.resource_id == Paths.goal_id(due_goal)
       assert g.name == "single goal"
       assert g.due
       assert g.type == "goal"
@@ -131,19 +131,19 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       [c1, c2] = assignments
 
-      assert c1.id == Paths.project_check_in_id(check_in2)
+      assert c1.resource_id == Paths.project_check_in_id(check_in1)
       assert c1.name == "project"
       assert c1.due
       assert c1.type == "check_in"
-      assert c1.champion_id == another_person.id
-      assert c1.champion_name == "champion"
+      assert c1.author_id == Paths.person_id(another_person)
+      assert c1.author_name == "champion"
 
-      assert c2.id == Paths.project_check_in_id(check_in1)
+      assert c2.resource_id == Paths.project_check_in_id(check_in2)
       assert c2.name == "project"
       assert c2.due
       assert c2.type == "check_in"
-      assert c2.champion_id == another_person.id
-      assert c2.champion_name == "champion"
+      assert c2.author_id == Paths.person_id(another_person)
+      assert c2.author_name == "champion"
     end
 
     test "get_due_goal_updates", ctx do
@@ -167,19 +167,19 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
       assert Repo.aggregate(Update, :count, :id) == 4
       assert length(assignments) == 2
 
-      u1 = Enum.find(assignments, &(&1.id == Paths.goal_update_id(update1)))
+      u1 = Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(update1)))
       assert u1.name == "goal"
       assert u1.due
       assert u1.type == "goal_update"
-      assert u1.champion_id == another_person.id
-      assert u1.champion_name == "champion"
+      assert u1.author_id == Paths.person_id(another_person)
+      assert u1.author_name == "champion"
 
-      u2 = Enum.find(assignments, &(&1.id == Paths.goal_update_id(update2)))
+      u2 = Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(update2)))
       assert u2.name == "goal"
       assert u2.due
       assert u2.type == "goal_update"
-      assert u2.champion_id == another_person.id
-      assert u2.champion_name == "champion"
+      assert u2.author_id == Paths.person_id(another_person)
+      assert u2.author_name == "champion"
     end
 
     test "returns project check-in creator, not current champion", ctx do
@@ -193,8 +193,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       # Before updating champion
       assert {200, %{assignments: [check_in]}} = query(ctx.conn, :get_assignments, %{})
-      assert check_in.champion_name == "first"
-      assert check_in.champion_id == champion1.id
+      assert check_in.author_name == "first"
+      assert check_in.author_id == Paths.person_id(champion1)
 
       # Update champion
       champion2 = person_fixture_with_account(%{full_name: "second", company_id: ctx.company.id})
@@ -203,8 +203,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       # After updating champion
       assert {200, %{assignments: [check_in]}} = query(ctx.conn, :get_assignments, %{})
-      assert check_in.champion_name == "first"
-      assert check_in.champion_id == champion1.id
+      assert check_in.author_name == "first"
+      assert check_in.author_id == Paths.person_id(champion1)
     end
 
     test "returns goal update creator, not current champion", ctx do
@@ -218,8 +218,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       # Before updating champion
       assert {200, %{assignments: [update]}} = query(ctx.conn, :get_assignments, %{})
-      assert update.champion_name == "first"
-      assert update.champion_id == champion1.id
+      assert update.author_name == "first"
+      assert update.author_id == Paths.person_id(champion1)
 
       # Update champion
       champion2 = person_fixture_with_account(%{full_name: "second", company_id: ctx.company.id})
@@ -227,8 +227,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignmentsTest do
 
       # After updating champion
       assert {200, %{assignments: [update]}} = query(ctx.conn, :get_assignments, %{})
-      assert update.champion_name == "first"
-      assert update.champion_id == champion1.id
+      assert update.author_name == "first"
+      assert update.author_id == Paths.person_id(champion1)
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -48,6 +48,7 @@ defmodule Operately.Support.Factory do
   defdelegate edit_project_company_members_access(ctx, project_name, access_level), to: Projects
   defdelegate edit_project_space_members_access(ctx, project_name, access_level), to: Projects
   defdelegate set_project_next_check_in_date(ctx, project_name, date), to: Projects
+  defdelegate set_project_milestone_deadline(ctx, milestone_name, date), to: Projects
   defdelegate close_project(ctx, project_name), to: Projects
 
   # messages

--- a/test/support/factory/projects.ex
+++ b/test/support/factory/projects.ex
@@ -115,7 +115,7 @@ defmodule Operately.Support.Factory.Projects do
 
   def add_project_milestone(ctx, testid, project_name, opts \\ []) do
     project = Map.fetch!(ctx, project_name)
-    
+
     attrs = %{
       project_id: project.id,
       title: Keyword.get(opts, :title, "Milestone #{testid}"),
@@ -159,6 +159,16 @@ defmodule Operately.Support.Factory.Projects do
     })
 
     Map.put(ctx, project_name, project)
+  end
+
+  def set_project_milestone_deadline(ctx, milestone_name, date) do
+    milestone = Map.fetch!(ctx, milestone_name)
+
+    {:ok, milestone} = Operately.Projects.update_milestone(milestone, %{
+      deadline_at: date
+    })
+
+    Map.put(ctx, milestone_name, milestone)
   end
 
   def close_project(ctx, project_name) do
@@ -211,7 +221,7 @@ defmodule Operately.Support.Factory.Projects do
         deadline: Keyword.get(opts, :deadline)
       })
 
-      project 
+      project
     else
       project
     end

--- a/test/support/features/review_steps.ex
+++ b/test/support/features/review_steps.ex
@@ -32,12 +32,6 @@ defmodule Operately.Support.Features.ReviewSteps do
     |> Factory.set_project_next_check_in_date(:project, past_date())
   end
 
-  step :given_there_are_due_project_milestones, ctx do
-    ctx
-    |> Factory.add_project_milestone(:milestone, :project)
-    |> Factory.set_project_milestone_deadline(:milestone, past_date())
-  end
-
   step :assert_the_due_project_is_listed, ctx do
     ctx
     |> UI.visit(Paths.review_path(ctx.company))
@@ -168,13 +162,6 @@ defmodule Operately.Support.Features.ReviewSteps do
     ctx
     |> UI.visit(Paths.review_path(ctx.company))
     |> UI.refute_text(ctx.project.name)
-  end
-
-  step :assert_loader_returns_milestone, ctx do
-    assignments = Operately.Assignments.Loader.load(ctx.me, ctx.company)
-    assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone)))
-
-    ctx
   end
 
   #

--- a/test/support/features/review_steps.ex
+++ b/test/support/features/review_steps.ex
@@ -25,15 +25,21 @@ defmodule Operately.Support.Features.ReviewSteps do
   step :given_there_are_due_project_check_ins, ctx do
     ctx
     |> Factory.add_project(:project, :product_space, [
-      champion: :me, 
-      reviewer: :my_manager, 
+      champion: :me,
+      reviewer: :my_manager,
       name: "Release Dunder Mifflin Infinity"
     ])
     |> Factory.set_project_next_check_in_date(:project, past_date())
   end
 
+  step :given_there_are_due_project_milestones, ctx do
+    ctx
+    |> Factory.add_project_milestone(:milestone, :project)
+    |> Factory.set_project_milestone_deadline(:milestone, past_date())
+  end
+
   step :assert_the_due_project_is_listed, ctx do
-    ctx 
+    ctx
     |> UI.visit(Paths.review_path(ctx.company))
     |> UI.assert_text("Write the weekly check-in: #{ctx.project.name}")
   end
@@ -49,17 +55,17 @@ defmodule Operately.Support.Features.ReviewSteps do
   end
 
   step :assert_the_checked_in_project_is_no_longer_displayed, ctx do
-    ctx 
+    ctx
     |> UI.visit(Paths.review_path(ctx.company))
     |> UI.refute_text(ctx.project.name)
     |> UI.assert_text("All caught up!")
   end
 
   step :given_there_are_due_goal_updates, ctx do
-    ctx 
+    ctx
     |> Factory.add_goal(:goal, :product_space, [
-      champion: :me, 
-      reviewer: :my_manager, 
+      champion: :me,
+      reviewer: :my_manager,
       name: "Expand the customer base"
     ])
     |> Factory.set_goal_next_update_date(:goal, past_date())
@@ -72,7 +78,7 @@ defmodule Operately.Support.Features.ReviewSteps do
   end
 
   step :when_a_goal_update_is_submitted, ctx do
-    ctx 
+    ctx
     |> UI.click(testid: "assignment-" <> Paths.goal_id(ctx.goal))
     |> UI.click(testid: "status-dropdown")
     |> UI.click(testid: "status-dropdown-on_track")
@@ -91,8 +97,8 @@ defmodule Operately.Support.Features.ReviewSteps do
   step :given_there_are_submitted_project_check_ins, ctx do
     ctx
     |> Factory.add_project(:project, :product_space, [
-      champion: :my_report, 
-      reviewer: :me, 
+      champion: :my_report,
+      reviewer: :me,
       name: "Release Dunder Mifflin Infinity"
     ])
     |> Factory.add_project_check_in(:check_in, :project, :my_report)
@@ -119,17 +125,17 @@ defmodule Operately.Support.Features.ReviewSteps do
   end
 
   step :given_there_are_submitted_goal_updates, ctx do
-    ctx 
+    ctx
     |> Factory.add_goal(:goal, :product_space, [
-      champion: :my_report, 
-      reviewer: :me, 
+      champion: :my_report,
+      reviewer: :me,
       name: "Expand the customer base"
     ])
     |> Factory.add_goal_update(:goal_update, :goal, :my_report)
   end
 
   step :assert_the_submitted_goal_is_listed, ctx do
-    ctx 
+    ctx
     |> UI.visit(Paths.review_path(ctx.company))
     |> UI.assert_text(ctx.goal.name)
   end
@@ -162,6 +168,13 @@ defmodule Operately.Support.Features.ReviewSteps do
     ctx
     |> UI.visit(Paths.review_path(ctx.company))
     |> UI.refute_text(ctx.project.name)
+  end
+
+  step :assert_loader_returns_milestone, ctx do
+    assignments = Operately.Assignments.Loader.load(ctx.me, ctx.company)
+    assert Enum.find(assignments, &(&1.resource_id == Paths.milestone_id(ctx.milestone)))
+
+    ctx
   end
 
   #


### PR DESCRIPTION
I've added a new module for loading a person's assignments. The `GetAssignments` query has already been updated to use the new loader.

In my next PR, I plan to update `OperatelyEmail.Emails.AssignmentsEmail` so that the emails and the Review page use the same data.

It's worth noting that the emails include due milestones, while the Review page does not. I've ensured that milestones won't break the page, but we might want to either display due milestones on the Review page or remove them from the emails to maintain consistency between the emails and the Review page.