### PR TITLE
fix: Use deactivate/reactivate instead of remove/restore suspended

### DIFF
--- a/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
+++ b/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
@@ -227,8 +227,8 @@ function PersonOptionRemove({ person, onClick }: { person: People.Person; onClic
   if (me!.id === person.id) return null;
 
   return (
-    <MenuActionItem icon={Icons.IconTrash} onClick={onClick} danger testId={createTestId("remove-person", person.id!)}>
-      Remove
+    <MenuActionItem icon={Icons.IconUserX} onClick={onClick} danger testId={createTestId("remove-person", person.id!)}>
+      Deactivate Account
     </MenuActionItem>
   );
 }
@@ -243,12 +243,18 @@ function RemovePersonModal({ person, state }: { person: People.Person; state: Mo
   };
 
   return (
-    <Modal title="Remove Company Member" isOpen={state.isOpen} hideModal={state.hide}>
-      <div>Are you sure you want to remove {person.fullName} from the company?</div>
-      <div className="mt-8 flex justify-center">
+    <Modal title={`Remove ${People.firstName(person)} from the company?`} isOpen={state.isOpen} hideModal={state.hide}>
+      <div>
+        This will deactivate {People.firstName(person)}'s account, restricting access to company resources. You can
+        restore access later if needed.
+      </div>
+      <div className="mt-8 flex gap-2">
         <PrimaryButton onClick={handleRemoveMember} loading={loading} testId="confirm-remove-member" size="sm">
-          Remove Member
+          Deactivate
         </PrimaryButton>
+        <SecondaryButton onClick={state.hide} testId="cancel-remove-member" size="sm">
+          Cancel
+        </SecondaryButton>
       </div>
     </Modal>
   );

--- a/assets/js/pages/CompanyAdminPage/page.tsx
+++ b/assets/js/pages/CompanyAdminPage/page.tsx
@@ -80,16 +80,16 @@ function AdminsMenu() {
 
         <OptionsMenuItem
           disabled={!(amIAdmin || amIOwner)}
-          linkTo={renameCompanyPath}
-          icon={Icons.IconLetterCase}
-          title="Rename the company"
+          linkTo={restorePath}
+          icon={Icons.IconUser}
+          title="Restore access for previously deactivated team members"
         />
 
         <OptionsMenuItem
           disabled={!(amIAdmin || amIOwner)}
-          linkTo={restorePath}
-          icon={Icons.IconUser}
-          title="Restore suspended people"
+          linkTo={renameCompanyPath}
+          icon={Icons.IconLetterCase}
+          title="Rename the company"
         />
       </div>
     </div>

--- a/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
+++ b/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
@@ -31,15 +31,12 @@ export function Page() {
   const { company, suspendedPeople } = Pages.useLoadedData() as LoaderResult;
 
   return (
-    <Pages.Page title={["Restore Suspended People", company.name!]} testId="restore-suspended-people-page">
+    <Pages.Page title={["Restore Deactivated Team Members", company.name!]} testId="restore-suspended-people-page">
       <Paper.Root size="medium">
         <Navigation />
 
         <Paper.Body>
-          <Paper.Header
-            title="Restore Suspended People"
-            subtitle="Restore access for suspended users to re-enable their company access."
-          />
+          <Paper.Header title="Restore Deactivated Team Members" />
 
           {suspendedPeople.length === 0 ? <NoSuspenedPeopleMessage /> : <SuspendedPeopleList />}
         </Paper.Body>
@@ -62,11 +59,10 @@ function NoSuspenedPeopleMessage() {
   return (
     <div className="max-w-xl mx-auto">
       <InfoCallout
-        message={`No suspended people`}
+        message={`No deactivated team members`}
         description={
           <p>
-            There are no suspended people in {company.name}. Suspended people are users who have been removed from the
-            company. If you want to suspend a user, go to the{" "}
+            There are no deactivated people in {company.name}. To remove access for departing team members, visit the{" "}
             <Link to={Paths.companyManagePeoplePath()}>Manage People</Link> page.
           </p>
         }
@@ -129,7 +125,7 @@ function RestoreButton({ person }: { person: People.Person }) {
 
   return (
     <SecondaryButton size="xs" testId={createTestId("restore", person.id!)} onClick={handler} loading={loading}>
-      Restore
+      Reactivate Account
     </SecondaryButton>
   );
 }

--- a/test/support/features/company_admin_steps.ex
+++ b/test/support/features/company_admin_steps.ex
@@ -351,7 +351,7 @@ defmodule Operately.Support.Features.CompanyAdminSteps do
   step :open_restore_people_page, ctx do
     ctx 
     |> UI.visit(Paths.company_admin_path(ctx.company))
-    |> UI.click(testid: "restore-suspended-people")
+    |> UI.click(testid: "restore-access-for-previously-deactivated-team-members")
     |> UI.assert_has(testid: "restore-suspended-people-page")
   end
 
@@ -389,7 +389,7 @@ defmodule Operately.Support.Features.CompanyAdminSteps do
   end
 
   step :assert_no_suspended_people_message_is_displayed, ctx do
-    ctx |> UI.assert_text("No suspended people")
+    ctx |> UI.assert_text("No deactivated team members")
   end
 
 end


### PR DESCRIPTION
Following claud's advice to make this flow clearer:

- Using "Deactivate Account" instead of "Remove".
- Using a longer label on the company admin page. These are not common actions, so on the rare occasions you use them they should be clear.
- Using "Reactivate" instead of "Restore suspended"

---

The other good suggestion from Claude was to use "Off board" / "Re-instate". I opted to not use the word off board as that would imply a longer process, not just a one-click action. If we implement a longer process like a screen that re-assigns the offboarded person's projects to someone else, then we can come back to use that term.

fixes https://github.com/operately/operately/issues/1766