### PR TITLE
chore: Assignments.Loader includes reports' assignments

### DIFF
--- a/lib/operately/assignments/filter_late_assignments.ex
+++ b/lib/operately/assignments/filter_late_assignments.ex
@@ -1,39 +1,42 @@
 defmodule Operately.Assignments.FilterLateAssignments do
-  alias Operately.Goals.Goal
-  alias Operately.Projects.Project
+  alias Operately.Goals.{Goal, Update}
+  alias Operately.Projects.{CheckIn, Project}
 
   def filter(assignments, reports, person) do
     Enum.filter(assignments, fn assignment ->
       case assignment do
-        %Project{} -> late_project(assignment, reports, person)
-        %Goal{} -> late_goal(assignment, reports, person)
+        %Project{} -> late_goal_or_project?(assignment, reports, person)
+        %Goal{} -> late_goal_or_project?(assignment, reports, person)
+        %CheckIn{} -> late_check_in_or_update?(assignment, reports)
+        %Update{} -> late_check_in_or_update?(assignment, reports)
       end
     end)
   end
 
-  defp late_project(project, reports, person) do
-    days_late = business_days_between(project.next_check_in_scheduled_at, Date.utc_today())
+  defp late_goal_or_project?(assignment, reports, person) do
+    days_late = find_days_late(assignment)
 
-    if is_reviewer?(project, person) do
+    if is_reviewer?(assignment, person) do
       days_late >= 3
     else
-      project
+      assignment
       |> find_manager_level(reports)
       |> is_late?(days_late)
     end
   end
 
-  defp late_goal(goal, reports, person) do
-    days_late = business_days_between(goal.next_update_scheduled_at, Date.utc_today())
+  defp late_check_in_or_update?(assignment, reports) do
+    days_late = find_days_late(assignment)
 
-    if is_reviewer?(goal, person) do
-      days_late >= 3
-    else
-      goal
-      |> find_manager_level(reports)
-      |> is_late?(days_late)
-    end
+    assignment
+    |> find_manager_level(reports)
+    |> is_late?(days_late)
   end
+
+  defp find_days_late(%Project{} = project), do: business_days_between(project.next_check_in_scheduled_at, Date.utc_today())
+  defp find_days_late(%Goal{} = goal), do: business_days_between(goal.next_update_scheduled_at, Date.utc_today())
+  defp find_days_late(%CheckIn{} = check_in), do: business_days_between(check_in.inserted_at, Date.utc_today())
+  defp find_days_late(%Update{} = update), do: business_days_between(update.inserted_at, Date.utc_today())
 
   def business_days_between(from, to) do
     if Date.before?(from, to) do
@@ -59,9 +62,14 @@ defmodule Operately.Assignments.FilterLateAssignments do
 
   defp find_manager_level(resource, reports) do
     Enum.find_value(reports, fn {person_id, level} ->
-      if is_champion?(resource, person_id), do: level
+      if is_resposible_for_resource?(resource, person_id), do: level
     end)
   end
+
+  defp is_resposible_for_resource?(resource = %Project{}, person_id), do: resource.champion.id == person_id
+  defp is_resposible_for_resource?(resource = %Goal{}, person_id), do: resource.champion_id == person_id
+  defp is_resposible_for_resource?(resource = %CheckIn{}, person_id), do: resource.project.reviewer.id == person_id
+  defp is_resposible_for_resource?(resource = %Update{}, person_id), do: resource.goal.reviewer_id == person_id
 
   defp is_late?(_manager_level = 0, days_late), do: days_late >= 5
   defp is_late?(_manager_level = 1, days_late), do: days_late >= 10
@@ -69,7 +77,4 @@ defmodule Operately.Assignments.FilterLateAssignments do
 
   defp is_reviewer?(resource = %Project{}, person), do: resource.reviewer.id == person.id
   defp is_reviewer?(resource = %Goal{}, person), do: resource.reviewer_id == person.id
-
-  defp is_champion?(resource = %Project{}, person_id), do: resource.champion.id == person_id
-  defp is_champion?(resource = %Goal{}, person_id), do: resource.champion_id == person_id
 end

--- a/lib/operately/assignments/filter_late_assignments.ex
+++ b/lib/operately/assignments/filter_late_assignments.ex
@@ -35,7 +35,7 @@ defmodule Operately.Assignments.FilterLateAssignments do
     end
   end
 
-  defp business_days_between(from, to) do
+  def business_days_between(from, to) do
     if Date.before?(from, to) do
       count_business_days(from, to, 0)
     else

--- a/lib/operately/assignments/filter_late_assignments.ex
+++ b/lib/operately/assignments/filter_late_assignments.ex
@@ -1,0 +1,75 @@
+defmodule Operately.Assignments.FilterLateAssignments do
+  alias Operately.Goals.Goal
+  alias Operately.Projects.Project
+
+  def filter(assignments, reports, person) do
+    Enum.filter(assignments, fn assignment ->
+      case assignment do
+        %Project{} -> late_project(assignment, reports, person)
+        %Goal{} -> late_goal(assignment, reports, person)
+      end
+    end)
+  end
+
+  defp late_project(project, reports, person) do
+    days_late = business_days_between(project.next_check_in_scheduled_at, Date.utc_today())
+
+    if is_reviewer?(project, person) do
+      days_late >= 3
+    else
+      project
+      |> find_manager_level(reports)
+      |> is_late?(days_late)
+    end
+  end
+
+  defp late_goal(goal, reports, person) do
+    days_late = business_days_between(goal.next_update_scheduled_at, Date.utc_today())
+
+    if is_reviewer?(goal, person) do
+      days_late >= 3
+    else
+      goal
+      |> find_manager_level(reports)
+      |> is_late?(days_late)
+    end
+  end
+
+  defp business_days_between(from, to) do
+    if Date.before?(from, to) do
+      count_business_days(from, to, 0)
+    else
+      0
+    end
+  end
+
+  defp count_business_days(date, to, count) do
+    if Date.before?(date, to) do
+      next_date = Date.add(date, 1)
+
+      if Date.day_of_week(next_date) in [6, 7] do
+        count_business_days(next_date, to, count)
+      else
+        count_business_days(next_date, to, count + 1)
+      end
+    else
+      count
+    end
+  end
+
+  defp find_manager_level(resource, reports) do
+    Enum.find_value(reports, fn {person_id, level} ->
+      if is_champion?(resource, person_id), do: level
+    end)
+  end
+
+  defp is_late?(_manager_level = 0, days_late), do: days_late >= 5
+  defp is_late?(_manager_level = 1, days_late), do: days_late >= 10
+  defp is_late?(_manager_level, days_late), do: days_late >= 15
+
+  defp is_reviewer?(resource = %Project{}, person), do: resource.reviewer.id == person.id
+  defp is_reviewer?(resource = %Goal{}, person), do: resource.reviewer_id == person.id
+
+  defp is_champion?(resource = %Project{}, person_id), do: resource.champion.id == person_id
+  defp is_champion?(resource = %Goal{}, person_id), do: resource.champion_id == person_id
+end

--- a/lib/operately/assignments/filter_late_assignments.ex
+++ b/lib/operately/assignments/filter_late_assignments.ex
@@ -66,8 +66,8 @@ defmodule Operately.Assignments.FilterLateAssignments do
     end)
   end
 
-  defp is_resposible_for_resource?(resource = %Project{}, person_id), do: resource.champion.id == person_id
-  defp is_resposible_for_resource?(resource = %Goal{}, person_id), do: resource.champion_id == person_id
+  defp is_resposible_for_resource?(resource = %Project{}, person_id), do: resource.reviewer.id == person_id
+  defp is_resposible_for_resource?(resource = %Goal{}, person_id), do: resource.reviewer_id == person_id
   defp is_resposible_for_resource?(resource = %CheckIn{}, person_id), do: resource.project.reviewer.id == person_id
   defp is_resposible_for_resource?(resource = %Update{}, person_id), do: resource.goal.reviewer_id == person_id
 

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -47,7 +47,7 @@ defmodule Operately.Assignments.Loader do
     from(p in Project,
       join: champion in assoc(p, :champion),
       left_join: reviewer in assoc(p, :reviewer),
-      where: champion.id in ^all_person_ids or reviewer.id == ^person_id,
+      where: reviewer.id in ^all_person_ids or champion.id == ^person_id,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
       where: p.status == "active",
       preload: [champion: champion, reviewer: reviewer]
@@ -59,7 +59,7 @@ defmodule Operately.Assignments.Loader do
     from(g in Goal,
       where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
       where: is_nil(g.closed_at),
-      where: g.champion_id in ^all_person_ids or g.reviewer_id == ^person_id
+      where: g.reviewer_id in ^all_person_ids or g.champion_id == ^person_id
     )
     |> Repo.all()
   end

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -2,44 +2,61 @@ defmodule Operately.Assignments.Loader do
   import Ecto.Query, only: [from: 2]
 
   alias Operately.Repo
-  alias Operately.Assignments.Assignment
+  alias Operately.Goals.{Goal, Update}
+  alias Operately.Projects.{Project, CheckIn}
+  alias Operately.Assignments.{Assignment, FilterLateAssignments}
 
+  @doc """
+  Loads assignments for a given person and late assignments
+  from people who report to the given person.
+
+  Returns a keyword list with two assignment groups:
+  [
+    mine: [%Assignment{}],    # Person's direct assignments
+    reports: [%Assignment{}], # Late assignments from people who report to the person
+  ]
+  """
   def load(person, company) do
     reports = load_reports(person)
 
-    tasks = load_all_tasks(person, reports)
-    {person_tasks, _reports_tasks} = separate_reports_tasks(tasks, person)
+    tasks = load_all_assignments(person, reports)
+    {person_assignments, reports_assignments} = separate_assignments(tasks, person)
 
-    Assignment.build(person_tasks, company)
+    late_assignments = FilterLateAssignments.filter(reports_assignments, reports, person)
+
+    [
+      mine: Assignment.build(person_assignments, company),
+      reports: Assignment.build(late_assignments, company),
+    ]
   end
 
-  defp load_all_tasks(person, reports) do
+  defp load_all_assignments(person, reports) do
     person_ids = extract_ids(person, reports)
 
     [
       Task.async(fn -> load_projects(person.id, person_ids) end),
       Task.async(fn -> load_goals(person.id, person_ids) end),
-      Task.async(fn -> load_due_project_check_ins(person_ids) end),
-      Task.async(fn -> load_due_goal_updates(person_ids) end),
+      Task.async(fn -> load_late_project_check_ins(person_ids) end),
+      Task.async(fn -> load_late_goal_updates(person_ids) end),
     ]
     |> Task.await_many()
     |> List.flatten()
   end
 
   defp load_projects(person_id, all_person_ids) do
-    from(p in Operately.Projects.Project,
+    from(p in Project,
       join: champion in assoc(p, :champion),
       join: reviewer in assoc(p, :reviewer),
       where: champion.id in ^all_person_ids or reviewer.id == ^person_id,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
       where: p.status == "active",
-      preload: [champion: champion]
+      preload: [champion: champion, reviewer: reviewer]
     )
     |> Repo.all()
   end
 
   defp load_goals(person_id, all_person_ids) do
-    from(g in Operately.Goals.Goal,
+    from(g in Goal,
       where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
       where: is_nil(g.closed_at),
       where: g.champion_id in ^all_person_ids or g.reviewer_id == ^person_id
@@ -47,8 +64,8 @@ defmodule Operately.Assignments.Loader do
     |> Repo.all()
   end
 
-  defp load_due_project_check_ins(person_ids) do
-    from(c in Operately.Projects.CheckIn,
+  defp load_late_project_check_ins(person_ids) do
+    from(c in CheckIn,
       join: project in assoc(c, :project),
       join: author in assoc(c, :author),
       join: reviewer in assoc(project, :reviewer),
@@ -59,8 +76,8 @@ defmodule Operately.Assignments.Loader do
     |> Repo.all()
   end
 
-  defp load_due_goal_updates(person_ids) do
-    from(u in Operately.Goals.Update,
+  defp load_late_goal_updates(person_ids) do
+    from(u in Update,
       join: goal in assoc(u, :goal),
       join: author in assoc(u, :author),
       where: goal.reviewer_id in ^person_ids,
@@ -71,7 +88,21 @@ defmodule Operately.Assignments.Loader do
     |> Repo.all()
   end
 
-  defp load_reports(person) do
+  @doc """
+  Fetches a list of all the employees under that person in the
+  company's hierarchy based on the manager_id property.
+
+  Returns a list of `{person_id, management_level}` tuples
+  `management_level` indicates the depth in the management chain:
+    - 0: Directly under the given person
+    - 1: Under the people who are directly under the given person
+    - 2: etc...
+
+  The `management_level` is used later to determine notification thresholds:
+  - Level 0 (direct reports): Shorter notification threshold (e.g., 3 business days)
+  - Level 1+ (indirect reports): Longer notification threshold (e.g., 10 business days)
+  """
+  def load_reports(person) do
     query = """
     WITH RECURSIVE reports AS (
       SELECT id, 0 AS level
@@ -88,7 +119,7 @@ defmodule Operately.Assignments.Loader do
     """
 
     {:ok, person_id} = Ecto.UUID.dump(person.id)
-    {:ok, %{rows: result}} = Operately.Repo.query(query, [person_id])
+    {:ok, %{rows: result}} = Repo.query(query, [person_id])
 
     Enum.map(result, fn [id, level] ->
       {:ok, id} = Ecto.UUID.cast(id)
@@ -101,18 +132,18 @@ defmodule Operately.Assignments.Loader do
     [person.id | ids]
   end
 
-  defp separate_reports_tasks(tasks, person) do
+  defp separate_assignments(tasks, person) do
     Enum.split_with(tasks, fn
-      %Operately.Projects.Project{champion: champion} ->
+      %Project{champion: champion} ->
         champion.id == person.id
 
-      %Operately.Goals.Goal{champion_id: champion_id} ->
+      %Goal{champion_id: champion_id} ->
         champion_id == person.id
 
-      %Operately.Projects.CheckIn{project: project} ->
+      %CheckIn{project: project} ->
         project.reviewer.id == person.id
 
-      %Operately.Goals.Update{goal: goal} ->
+      %Update{goal: goal} ->
         goal.reviewer_id == person.id
 
       _ ->

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -46,7 +46,7 @@ defmodule Operately.Assignments.Loader do
   defp load_projects(person_id, all_person_ids) do
     from(p in Project,
       join: champion in assoc(p, :champion),
-      join: reviewer in assoc(p, :reviewer),
+      left_join: reviewer in assoc(p, :reviewer),
       where: champion.id in ^all_person_ids or reviewer.id == ^person_id,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
       where: p.status == "active",
@@ -68,7 +68,7 @@ defmodule Operately.Assignments.Loader do
     from(c in CheckIn,
       join: project in assoc(c, :project),
       join: author in assoc(c, :author),
-      join: reviewer in assoc(project, :reviewer),
+      left_join: reviewer in assoc(project, :reviewer),
       where: reviewer.id in ^person_ids,
       where: is_nil(c.acknowledged_by_id),
       preload: [project: {project, reviewer: reviewer}, author: author]

--- a/lib/operately/assignments/loader.ex
+++ b/lib/operately/assignments/loader.ex
@@ -5,62 +5,118 @@ defmodule Operately.Assignments.Loader do
   alias Operately.Assignments.Assignment
 
   def load(person, company) do
-    person
-    |> load_all()
-    |> Assignment.build(company)
+    reports = load_reports(person)
+
+    tasks = load_all_tasks(person, reports)
+    {person_tasks, _reports_tasks} = separate_reports_tasks(tasks, person)
+
+    Assignment.build(person_tasks, company)
   end
 
-  defp load_all(person) do
+  defp load_all_tasks(person, reports) do
+    person_ids = extract_ids(person, reports)
+
     [
-      Task.async(fn -> load_projects(person) end),
-      Task.async(fn -> load_goals(person) end),
-      Task.async(fn -> load_due_project_check_ins(person) end),
-      Task.async(fn -> load_due_goal_updates(person) end),
+      Task.async(fn -> load_projects(person.id, person_ids) end),
+      Task.async(fn -> load_goals(person.id, person_ids) end),
+      Task.async(fn -> load_due_project_check_ins(person_ids) end),
+      Task.async(fn -> load_due_goal_updates(person_ids) end),
     ]
     |> Task.await_many()
     |> List.flatten()
   end
 
-  defp load_projects(person) do
+  defp load_projects(person_id, all_person_ids) do
     from(p in Operately.Projects.Project,
       join: champion in assoc(p, :champion),
-      where: champion.id == ^person.id,
+      join: reviewer in assoc(p, :reviewer),
+      where: champion.id in ^all_person_ids or reviewer.id == ^person_id,
       where: p.next_check_in_scheduled_at <= ^DateTime.utc_now(),
-      where: p.status == "active"
+      where: p.status == "active",
+      preload: [champion: champion]
     )
     |> Repo.all()
   end
 
-  defp load_goals(person) do
+  defp load_goals(person_id, all_person_ids) do
     from(g in Operately.Goals.Goal,
       where: g.next_update_scheduled_at <= ^DateTime.utc_now(),
       where: is_nil(g.closed_at),
-      where: g.champion_id == ^person.id
+      where: g.champion_id in ^all_person_ids or g.reviewer_id == ^person_id
     )
     |> Repo.all()
   end
 
-  defp load_due_project_check_ins(person) do
+  defp load_due_project_check_ins(person_ids) do
     from(c in Operately.Projects.CheckIn,
       join: project in assoc(c, :project),
       join: author in assoc(c, :author),
-      join: contrib in assoc(project, :contributors),
-      where: contrib.person_id == ^person.id and contrib.role == :reviewer,
+      join: reviewer in assoc(project, :reviewer),
+      where: reviewer.id in ^person_ids,
       where: is_nil(c.acknowledged_by_id),
-      preload: [project: project, author: author]
+      preload: [project: {project, reviewer: reviewer}, author: author]
     )
     |> Repo.all()
   end
 
-  defp load_due_goal_updates(person) do
+  defp load_due_goal_updates(person_ids) do
     from(u in Operately.Goals.Update,
       join: goal in assoc(u, :goal),
       join: author in assoc(u, :author),
-      where: goal.reviewer_id == ^person.id,
+      where: goal.reviewer_id in ^person_ids,
       where: is_nil(goal.deleted_at),
       where: is_nil(u.acknowledged_by_id),
       preload: [goal: goal, author: author]
     )
     |> Repo.all()
+  end
+
+  defp load_reports(person) do
+    query = """
+    WITH RECURSIVE reports AS (
+      SELECT id, 0 AS level
+      FROM people
+      WHERE manager_id = $1
+
+      UNION ALL
+
+      SELECT p.id, r.level + 1 AS level
+      FROM people p
+      INNER JOIN reports r ON p.manager_id = r.id
+    )
+    SELECT * FROM reports
+    """
+
+    {:ok, person_id} = Ecto.UUID.dump(person.id)
+    {:ok, %{rows: result}} = Operately.Repo.query(query, [person_id])
+
+    Enum.map(result, fn [id, level] ->
+      {:ok, id} = Ecto.UUID.cast(id)
+      {id, level}
+    end)
+  end
+
+  defp extract_ids(person, reports) do
+    ids = Enum.map(reports, fn {id, _} -> id end)
+    [person.id | ids]
+  end
+
+  defp separate_reports_tasks(tasks, person) do
+    Enum.split_with(tasks, fn
+      %Operately.Projects.Project{champion: champion} ->
+        champion.id == person.id
+
+      %Operately.Goals.Goal{champion_id: champion_id} ->
+        champion_id == person.id
+
+      %Operately.Projects.CheckIn{project: project} ->
+        project.reviewer.id == person.id
+
+      %Operately.Goals.Update{goal: goal} ->
+        goal.reviewer_id == person.id
+
+      _ ->
+        false
+    end)
   end
 end

--- a/lib/operately_web/api/queries/get_assignments.ex
+++ b/lib/operately_web/api/queries/get_assignments.ex
@@ -13,8 +13,8 @@ defmodule OperatelyWeb.Api.Queries.GetAssignments do
     company = company(conn)
     me = me(conn)
 
-    assignments = Loader.load(me, company)
+    [mine: my_assignments, reports: _] = Loader.load(me, company)
 
-    {:ok, %{assignments: Serializer.serialize(assignments)}}
+    {:ok, %{assignments: Serializer.serialize(my_assignments)}}
   end
 end

--- a/test/operately/assignments/filter_late_assignments_test.exs
+++ b/test/operately/assignments/filter_late_assignments_test.exs
@@ -1,0 +1,40 @@
+defmodule Operately.Assignments.FilterLateAssignmentsTest do
+  use Operately.DataCase
+
+  alias Operately.Assignments.FilterLateAssignments, as: Filter
+
+  describe "business_days_between/2" do
+    test "same date returns 0" do
+      date = ~D[2024-12-10]
+      assert Filter.business_days_between(date, date) == 0
+    end
+
+    test "consecutive business days - Mon -> Tue" do
+      assert Filter.business_days_between(~D[2024-12-09], ~D[2024-12-10]) == 1
+    end
+
+    test "spanning weekend - Fri -> Mon" do
+      assert Filter.business_days_between(~D[2024-12-06], ~D[2024-12-09]) == 1
+    end
+
+    test "2 full weeks" do
+      assert Filter.business_days_between(~D[2024-12-02], ~D[2024-12-13]) == 9
+    end
+
+    test "later dates return 0" do
+      assert Filter.business_days_between(~D[2024-12-11], ~D[2024-12-10]) == 0
+    end
+
+    test "start on weekend - Sat -> Tue" do
+      assert Filter.business_days_between(~D[2024-12-07], ~D[2024-12-10]) == 2
+    end
+
+    test "month boundary - Dec -> Jan" do
+      assert Filter.business_days_between(~D[2024-12-30], ~D[2025-01-02]) == 3
+    end
+
+    test "longer month boundary - Dec -> Jan" do
+      assert Filter.business_days_between(~D[2024-12-23], ~D[2025-01-03]) == 9
+    end
+  end
+end

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -163,12 +163,10 @@ defmodule Operately.Assignments.LoaderTest do
     test "more than 15 days late", ctx do
       [mine: [], reports: reports] = Loader.load(ctx.director, ctx.company)
 
-      assert length(reports) == 1
+      assert length(reports) == 2
 
       assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twenty_days_late)))
-
-      # Takes weekends into account
-      refute Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.fifteen_days_late)))
     end
   end
 
@@ -199,12 +197,10 @@ defmodule Operately.Assignments.LoaderTest do
     test "more than 15 days late", ctx do
       [mine: [], reports: reports] = Loader.load(ctx.director, ctx.company)
 
-      assert length(reports) == 1
+      assert length(reports) == 2
 
       assert Enum.find(reports, &(&1.resource_id == Paths.project_check_in_id(ctx.twenty_days_late)))
-
-      # Takes weekends into account
-      refute Enum.find(reports, &(&1.resource_id == Paths.project_check_in_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_check_in_id(ctx.fifteen_days_late)))
     end
   end
 
@@ -235,12 +231,10 @@ defmodule Operately.Assignments.LoaderTest do
     test "more than 15 days late", ctx do
       [mine: [], reports: reports] = Loader.load(ctx.director, ctx.company)
 
-      assert length(reports) == 1
+      assert length(reports) == 2
 
       assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twenty_days_late)))
-
-      # Takes weekends into account
-      refute Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.fifteen_days_late)))
     end
   end
 
@@ -271,12 +265,10 @@ defmodule Operately.Assignments.LoaderTest do
     test "more than 15 days late", ctx do
       [mine: [], reports: reports] = Loader.load(ctx.director, ctx.company)
 
-      assert length(reports) == 1
+      assert length(reports) == 2
 
       assert Enum.find(reports, &(&1.resource_id == Paths.goal_update_id(ctx.twenty_days_late)))
-
-      # Takes weekends into account
-      refute Enum.find(reports, &(&1.resource_id == Paths.goal_update_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_update_id(ctx.fifteen_days_late)))
     end
   end
 
@@ -287,7 +279,6 @@ defmodule Operately.Assignments.LoaderTest do
   defp managers_setup(ctx) do
     ctx
     |> Factory.add_space_member(:manager, :space)
-    |> Factory.set_person_manager(:champion, :manager)
     |> Factory.set_person_manager(:reviewer, :manager)
     |> Factory.add_space_member(:senior_manager, :space)
     |> Factory.set_person_manager(:manager, :senior_manager)
@@ -433,7 +424,18 @@ defmodule Operately.Assignments.LoaderTest do
 
   defp past_date(num \\ 2) do
     Date.utc_today()
-    |> Date.add(num * -1)
+    |> subtract_days(num)
     |> Operately.Time.as_datetime()
+  end
+
+  def subtract_days(date, 0), do: date
+  def subtract_days(date, days) do
+    prev_date = Date.add(date, -1)
+
+    if Date.day_of_week(prev_date) in [6, 7] do
+      subtract_days(prev_date, days)
+    else
+      subtract_days(prev_date, days - 1)
+    end
   end
 end

--- a/test/operately/assignments/loader_test.exs
+++ b/test/operately/assignments/loader_test.exs
@@ -15,30 +15,24 @@ defmodule Operately.Assignments.LoaderTest do
   describe "projects" do
     setup ctx do
       ctx
-      |> Factory.add_project(:due_project1, :space, champion: :champion, reviewer: :reviewer)
-      |> Factory.add_project(:due_project2, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project(:late_project1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_project(:late_project2, :space, champion: :champion, reviewer: :reviewer)
       |> Factory.add_project(:project1, :space, champion: :champion, reviewer: :reviewer)
       |> Factory.add_project(:project2, :space, champion: :champion, reviewer: :reviewer)
-      |> set_due_projects()
+      |> set_late_projects()
     end
 
-    test "returns all due projects", ctx do
-      assignments = Loader.load(ctx.champion, ctx.company)
+    test "returns all late projects", ctx do
+      [mine: mine, reports: []] = Loader.load(ctx.champion, ctx.company)
 
-      assert Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project1)))
-      assert Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project2)))
+      assert length(mine) == 2
 
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project2)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.project_id(ctx.late_project1)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.project_id(ctx.late_project2)))
     end
 
-    test "doesn't return due projects to non-champions", ctx do
-      assignments = Loader.load(ctx.reviewer, ctx.company)
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.due_project2)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_id(ctx.project2)))
+    test "doesn't return late projects to non-champions", ctx do
+      [mine: [], reports: []] = Loader.load(ctx.reviewer, ctx.company)
     end
   end
 
@@ -46,60 +40,48 @@ defmodule Operately.Assignments.LoaderTest do
     setup ctx do
       ctx
       |> Factory.add_project(:project, :space, champion: :champion, reviewer: :reviewer)
-      |> Factory.add_project_check_in(:due_check_in1, :project, :champion)
-      |> Factory.add_project_check_in(:due_check_in2, :project, :champion)
+      |> Factory.add_project_check_in(:late_check_in1, :project, :champion)
+      |> Factory.add_project_check_in(:late_check_in2, :project, :champion)
       |> Factory.add_project_check_in(:check_in1, :project, :champion)
       |> Factory.add_project_check_in(:check_in2, :project, :champion)
       |> acknowledge_check_ins()
     end
 
-    test "returns all due check-ins", ctx do
-      assignments = Loader.load(ctx.reviewer, ctx.company)
+    test "returns all late check-ins", ctx do
+      [mine: mine, reports: []] = Loader.load(ctx.reviewer, ctx.company)
 
-      assert Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in1)))
-      assert Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in2)))
+      assert length(mine) == 2
 
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in2)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.project_check_in_id(ctx.late_check_in1)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.project_check_in_id(ctx.late_check_in2)))
     end
 
-    test "doesn't return due check-ins to non-reviewers", ctx do
-      assignments = Loader.load(ctx.champion, ctx.company)
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.due_check_in2)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.project_check_in_id(ctx.check_in2)))
+    test "doesn't return late check-ins to non-reviewers", ctx do
+      [mine: [], reports: []] = Loader.load(ctx.champion, ctx.company)
     end
   end
 
   describe "goals" do
     setup ctx do
       ctx
-      |> Factory.add_goal(:due_goal1, :space, champion: :champion, reviewer: :reviewer)
-      |> Factory.add_goal(:due_goal2, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal(:late_goal1, :space, champion: :champion, reviewer: :reviewer)
+      |> Factory.add_goal(:late_goal2, :space, champion: :champion, reviewer: :reviewer)
       |> Factory.add_goal(:goal1, :space, champion: :champion, reviewer: :reviewer)
       |> Factory.add_goal(:goal2, :space, champion: :champion, reviewer: :reviewer)
-      |> set_due_goals()
+      |> set_late_goals()
     end
 
-    test "returns all due goals", ctx do
-      assignments = Loader.load(ctx.champion, ctx.company)
+    test "returns all late goals", ctx do
+      [mine: mine, reports: []] = Loader.load(ctx.champion, ctx.company)
 
-      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal1)))
-      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal2)))
+      assert length(mine) == 2
 
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal2)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.goal_id(ctx.late_goal1)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.goal_id(ctx.late_goal2)))
     end
 
-    test "doesn't return due goals to non-champions", ctx do
-      assignments = Loader.load(ctx.reviewer, ctx.company)
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.due_goal2)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_id(ctx.goal2)))
+    test "doesn't return late goals to non-champions", ctx do
+      [mine: [], reports: []] = Loader.load(ctx.reviewer, ctx.company)
     end
   end
 
@@ -107,44 +89,200 @@ defmodule Operately.Assignments.LoaderTest do
     setup ctx do
       ctx
       |> Factory.add_goal(:goal, :space, champion: :champion, reviewer: :reviewer)
-      |> Factory.add_goal_update(:due_update1, :goal, :champion)
-      |> Factory.add_goal_update(:due_update2, :goal, :champion)
+      |> Factory.add_goal_update(:late_update1, :goal, :champion)
+      |> Factory.add_goal_update(:late_update2, :goal, :champion)
       |> Factory.add_goal_update(:update1, :goal, :champion)
       |> Factory.add_goal_update(:update2, :goal, :champion)
       |> acknowledge_updates()
     end
 
-    test "returns all due updates", ctx do
-      assignments = Loader.load(ctx.reviewer, ctx.company)
+    test "returns all late updates", ctx do
+      [mine: mine, reports: []] = Loader.load(ctx.reviewer, ctx.company)
 
-      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update1)))
-      assert Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update2)))
+      assert length(mine) == 2
 
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update2)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.goal_update_id(ctx.late_update1)))
+      assert Enum.find(mine, &(&1.resource_id == Paths.goal_update_id(ctx.late_update2)))
     end
 
-    test "doesn't return due updates to non-reviewer", ctx do
-      assignments = Loader.load(ctx.champion, ctx.company)
-
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.due_update2)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update1)))
-      refute Enum.find(assignments, &(&1.resource_id == Paths.goal_update_id(ctx.update2)))
+    test "doesn't return late updates to non-reviewer", ctx do
+      [mine: [], reports: []] = Loader.load(ctx.champion, ctx.company)
     end
+  end
+
+  describe "late project notifies reviewer" do
+    setup :late_projects_setup
+
+    test "only more than 3 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.reviewer, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 2
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.three_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.seven_days_late)))
+    end
+  end
+
+  describe "late goal notifies reviewer" do
+    setup :late_goals_setup
+
+    test "only more than 3 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.reviewer, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 2
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.three_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.seven_days_late)))
+    end
+  end
+
+  describe "late project notifies managers" do
+    setup [:managers_setup, :late_projects_setup, :very_late_projects_setup]
+
+    test "more than 5 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.manager, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 4
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.seven_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twelve_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twenty_days_late)))
+    end
+
+    test "more than 10 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.senior_manager, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 3
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twelve_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twenty_days_late)))
+    end
+
+    test "more than 15 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.director, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 1
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.twenty_days_late)))
+
+      # Takes weekends into account
+      refute Enum.find(reports, &(&1.resource_id == Paths.project_id(ctx.fifteen_days_late)))
+    end
+  end
+
+  describe "late goal notifies managers" do
+    setup [:managers_setup, :late_goals_setup, :very_late_goals_setup]
+
+    test "more than 5 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.manager, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 4
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.seven_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twelve_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twenty_days_late)))
+    end
+
+    test "more than 10 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.senior_manager, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 3
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twelve_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.fifteen_days_late)))
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twenty_days_late)))
+    end
+
+    test "more than 15 days late", ctx do
+      [mine: mine, reports: reports] = Loader.load(ctx.director, ctx.company)
+
+      assert length(mine) == 0
+      assert length(reports) == 1
+
+      assert Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.twenty_days_late)))
+
+      # Takes weekends into account
+      refute Enum.find(reports, &(&1.resource_id == Paths.goal_id(ctx.fifteen_days_late)))
+    end
+  end
+
+  #
+  # Setup
+  #
+
+  defp managers_setup(ctx) do
+    ctx
+    |> Factory.add_space_member(:manager, :space)
+    |> Factory.set_person_manager(:champion, :manager)
+    |> Factory.add_space_member(:senior_manager, :space)
+    |> Factory.set_person_manager(:manager, :senior_manager)
+    |> Factory.add_space_member(:director, :space)
+    |> Factory.set_person_manager(:senior_manager, :director)
+  end
+
+  defp late_projects_setup(ctx) do
+    ctx
+    |> Factory.add_project(:not_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project(:two_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project(:three_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project(:seven_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.set_project_next_check_in_date(:two_days_late, past_date(2))
+    |> Factory.set_project_next_check_in_date(:three_days_late, past_date(3))
+    |> Factory.set_project_next_check_in_date(:seven_days_late, past_date(7))
+  end
+
+  defp very_late_projects_setup(ctx) do
+    ctx
+    |> Factory.add_project(:twelve_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project(:fifteen_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project(:twenty_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.set_project_next_check_in_date(:twelve_days_late, past_date(12))
+    |> Factory.set_project_next_check_in_date(:fifteen_days_late, past_date(15))
+    |> Factory.set_project_next_check_in_date(:twenty_days_late, past_date(20))
+  end
+
+  defp late_goals_setup(ctx) do
+    ctx
+    |> Factory.add_goal(:not_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:two_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:three_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:seven_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.set_goal_next_update_date(:two_days_late, past_date(2))
+    |> Factory.set_goal_next_update_date(:three_days_late, past_date(3))
+    |> Factory.set_goal_next_update_date(:seven_days_late, past_date(7))
+  end
+
+  defp very_late_goals_setup(ctx) do
+    ctx
+    |> Factory.add_goal(:twelve_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:fifteen_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_goal(:twenty_days_late, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.set_goal_next_update_date(:twelve_days_late, past_date(12))
+    |> Factory.set_goal_next_update_date(:fifteen_days_late, past_date(15))
+    |> Factory.set_goal_next_update_date(:twenty_days_late, past_date(20))
   end
 
   #
   # Helpers
   #
 
-  defp set_due_projects(ctx) do
-    Enum.reduce([:due_project1, :due_project2], ctx, fn key, ctx ->
-      {:ok, due_project} =
+  defp set_late_projects(ctx) do
+    Enum.reduce([:late_project1, :late_project2], ctx, fn key, ctx ->
+      {:ok, late_project} =
         ctx[key]
         |> Operately.Projects.Project.changeset(%{next_check_in_scheduled_at: past_date()})
         |> Repo.update()
-      Map.put(ctx, key, due_project)
+      Map.put(ctx, key, late_project)
     end)
   end
 
@@ -161,13 +299,13 @@ defmodule Operately.Assignments.LoaderTest do
     end)
   end
 
-  defp set_due_goals(ctx) do
-    Enum.reduce([:due_goal1, :due_goal2], ctx, fn key, ctx ->
-      {:ok, due_goal} =
+  defp set_late_goals(ctx) do
+    Enum.reduce([:late_goal1, :late_goal2], ctx, fn key, ctx ->
+      {:ok, late_goal} =
         ctx[key]
         |> Operately.Goals.Goal.changeset(%{next_update_scheduled_at: past_date()})
         |> Repo.update()
-      Map.put(ctx, key, due_goal)
+      Map.put(ctx, key, late_goal)
     end)
   end
 
@@ -184,9 +322,9 @@ defmodule Operately.Assignments.LoaderTest do
     end)
   end
 
-  defp past_date do
+  defp past_date(num \\ 2) do
     Date.utc_today()
-    |> Date.add(-3)
+    |> Date.add(num * -1)
     |> Operately.Time.as_datetime()
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,6 +26,7 @@ defmodule Operately.Support.Factory do
   defdelegate add_company_member(ctx, testid, opts \\ []), to: Companies
   defdelegate add_company_admin(ctx, testid, opts \\ []), to: Companies
   defdelegate add_company_owner(ctx, testid, opts \\ []), to: Companies
+  defdelegate set_person_manager(ctx, testid, manager_key), to: Companies
   defdelegate suspend_company_member(ctx, testid, opts \\ []), to: Companies
   defdelegate enable_feature(ctx, feature_name), to: Companies
 

--- a/test/support/factory/companies.ex
+++ b/test/support/factory/companies.ex
@@ -42,7 +42,7 @@ defmodule Operately.Support.Factory.Companies do
     person = Operately.PeopleFixtures.person_fixture_with_account(attrs)
 
     set_access_level(ctx, person, Operately.Access.Binding.edit_access())
-    
+
     Map.put(ctx, testid, person)
   end
 
@@ -59,13 +59,22 @@ defmodule Operately.Support.Factory.Companies do
 
     group = Operately.Access.get_group(company_id: ctx.company.id, tag: :full_access)
     {:ok, _} = Operately.Access.add_to_group(group, person_id: person.id)
-    
+
     Map.put(ctx, testid, person)
   end
 
   defp set_access_level(ctx, person, access_level) do
     context = Operately.Access.get_context(company_id: ctx.company.id)
     Operately.Access.bind(context, person_id: person.id, level: access_level)
+  end
+
+  def set_person_manager(ctx, testid, manager_key) do
+    person = Map.fetch!(ctx, testid)
+    manager = Map.fetch!(ctx, manager_key)
+
+    {:ok, person} = Operately.People.update_person(person, %{manager_id: manager.id})
+
+    Map.put(ctx, testid, person)
   end
 
   def suspend_company_member(ctx, key, _opts \\ []) do


### PR DESCRIPTION
Now, `Operately.Assignments.Loader` returns both a given person's assignments and the assignments of the people reporting to that person in the company hierarchy. Both lists use the new `Assignment` struct.

However, I’m not entirely sure if the criteria for filtering late and on-time assignments are correct. However, I’ve kept the filtering logic isolated, so if we need to update it, it should be easy and quick.