### PR TITLE
fix: Goal progress update no longer overflows the container

### DIFF
--- a/assets/js/features/activities/GoalCheckIn/ConditionChanges.tsx
+++ b/assets/js/features/activities/GoalCheckIn/ConditionChanges.tsx
@@ -13,7 +13,7 @@ export function ConditionChanges({ update }: { update: GoalCheckIns.Update }) {
     <div className="flex flex-col gap-2">
       <div className="flex flex-col py-2">
         {targets.map((target) => (
-          <div key={target.id} className="flex justify-between items-center gap-2 py-1.5">
+          <div key={target.id} className="grid grid-cols-[auto,1fr,auto,60px] items-center gap-2 py-1.5">
             <div className="font-medium truncate">{target.name}</div>
             <div className="h-px bg-stroke-base flex-1" />
             <TargetChange target={target} />

--- a/assets/js/features/goals/GoalCheckIn/TargetsSection.tsx
+++ b/assets/js/features/goals/GoalCheckIn/TargetsSection.tsx
@@ -14,7 +14,7 @@ export function TargetsSection({ update }: { update: Update }) {
       <div className="text-lg font-bold mx-auto">3. Success conditions</div>
       <div className="flex flex-col gap-2 mt-2 border border-stroke-base rounded-lg p-4">
         {targets.map((target) => (
-          <div key={target.id} className="flex justify-between items-center gap-2">
+          <div key={target.id} className="grid grid-cols-[auto,1fr,auto,60px] items-center gap-2">
             <div className="truncate">{target.name}</div>
             <div className="h-px bg-stroke-base flex-1" />
             <TargetChange target={target} />

--- a/assets/js/features/goals/GoalCheckInForm/Form.tsx
+++ b/assets/js/features/goals/GoalCheckInForm/Form.tsx
@@ -80,7 +80,7 @@ function TargetInputs() {
         {targets.map((target, index) => {
           return (
             <div
-              className="flex items-center justify-between bg-surface-dimmed border border-stroke-base p-3 rounded"
+              className="grid grid-cols-[1fr,auto] items-center bg-surface-dimmed border border-stroke-base p-3 rounded"
               key={index}
             >
               <div className="flex flex-col">

--- a/assets/js/pages/GoalDiscussionsPage/index.tsx
+++ b/assets/js/pages/GoalDiscussionsPage/index.tsx
@@ -3,7 +3,6 @@ import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
 import * as Goals from "@/models/goals";
 import * as Activities from "@/models/activities";
-import * as Icons from "@tabler/icons-react";
 
 import { Paths } from "@/routes/paths";
 import { Navigation } from "@/features/goals/GoalPageNavigation";
@@ -13,7 +12,6 @@ import { PrimaryButton, SecondaryButton } from "@/components/Buttons";
 import FormattedTime from "@/components/FormattedTime";
 import Avatar from "@/components/Avatar";
 
-import plurarize from "@/utils/plurarize";
 import { DivLink } from "@/components/Link";
 
 import ActivityHandler from "@/features/activities";
@@ -116,15 +114,6 @@ function ActivityItem({ activity }: { activity: Activities.Activity }) {
               <SecondaryButton size="xxs" linkTo={path}>
                 Discuss
               </SecondaryButton>
-
-              {ActivityHandler.hasComments(activity) && (
-                <div className="flex items-center gap-1 text-sm leading-none text-content-dimmed">
-                  <Icons.IconMessage size={14} />{" "}
-                  <DivLink to={path} className="hover:underline cursor-pointer">
-                    {plurarize(ActivityHandler.commentCount(activity), "comment", "comments")}
-                  </DivLink>
-                </div>
-              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1716.

Now, long success conditions should no longer overflow the page. I've checked and handled the issue in following places: 

- Activities feed
- Goal discussions page
- Goal progress update page
- Goal progress update new page

As for the `undefined` comments count, solving it is complex as `Operately.Activities.Preloader` will have to be extended. @shiroyasha and I discussed the issue and decided that for now the comments count won't be displayed on the page. 

A new issue will be opened for extending the activities preloader and adding the comments count back to the page.