### PR TITLE
fix: Autofocus in modals

### DIFF
--- a/assets/js/app.tsx
+++ b/assets/js/app.tsx
@@ -20,6 +20,7 @@ import "./i18n";
 import { setupTestErrorLogger } from "@/utils/errorLogger";
 
 import "@/api/socket";
+import ReactModal from "react-modal";
 
 setupTestErrorLogger();
 
@@ -57,6 +58,10 @@ const App: JSX.Element = (
 
 if (rootElement !== null) {
   createRoot(rootElement).render(App);
+
+  // The app element must be set for all ReactModal instances
+  // read more: https://reactcommunity.org/react-modal/accessibility/#app-element
+  ReactModal.setAppElement(rootElement);
 } else {
   console.error("Root element not found");
 }

--- a/assets/js/components/Forms/TextInput.tsx
+++ b/assets/js/components/Forms/TextInput.tsx
@@ -46,7 +46,6 @@ export function TextInput(props: TextInputProps) {
       <div className="relative">
         <input
           name={field}
-          autoFocus={props.autoFocus}
           placeholder={placeholder}
           data-test-id={props.testId ?? createTestId(field)}
           className={styles(!!error)}
@@ -58,6 +57,16 @@ export function TextInput(props: TextInputProps) {
               props.onEnter(e);
             }
           }}
+          //
+          // The standard autoFocus works if the input is rendered outside of a modal.
+          // However, if the input is inside of a modal, the autoFocus prop does not work.
+          //
+          // To handle this edge case, we set the data-autofocus attribute to true, and then
+          // in the component/Modal, we use a onOpen callback to focus the input field
+          // with the data-autofocus attribute.
+          //
+          autoFocus={props.autoFocus}
+          data-autofocus={props.autoFocus}
         />
 
         {!error && props.okSign && (

--- a/assets/js/components/Modal/index.tsx
+++ b/assets/js/components/Modal/index.tsx
@@ -38,46 +38,16 @@ const SIZES = {
 };
 
 export default function Modal({ isOpen, hideModal, title, children, height, size }: ModalProps) {
-  const mode = useColorMode();
   size = size ?? "base";
+  height = height ?? "auto";
+
+  const { ref, autoFocusOnOpen } = useAutoFocusOnOpen();
+  const modalStyle = useModalStyle(size, height);
+  const showHeader = Boolean(title && hideModal);
 
   return (
-    <ReactModal
-      isOpen={isOpen}
-      contentLabel={title}
-      ariaHideApp={false}
-      style={{
-        overlay: {
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: mode === "light" ? "rgba(0,0,0,0.6)" : "rgba(0,0,0,0.7)",
-          zIndex: 999,
-        },
-        content: {
-          top: "48%",
-          left: "50%",
-          right: "auto",
-          bottom: "auto",
-          width: SIZES[size],
-          transform: "translate(-50%, -50%)",
-          borderRadius: "8px",
-          overflowY: "auto",
-          maxHeight: "90%",
-          height: height ?? "auto",
-          maxWidth: "95%",
-          backgroundColor: "var(--color-surface-base)",
-          border: "1px solid var(--color-surface-outline)",
-          boxShadow: "0px 0px 10px 0px rgba(0,0,0,0.1)",
-          padding: "32px",
-          display: "flex",
-          flexDirection: "column",
-        },
-      }}
-    >
-      {Boolean(title && hideModal) && <Header title={title} hideModal={hideModal} />}
+    <ReactModal isOpen={isOpen} contentLabel={title} ref={ref} onAfterOpen={autoFocusOnOpen} style={modalStyle}>
+      {showHeader && <Header title={title} hideModal={hideModal} />}
       <div className="flex-1">{children}</div>
     </ReactModal>
   );
@@ -101,4 +71,60 @@ function CloseButton({ hideModal }) {
       <Icons.IconX size={20} />
     </div>
   );
+}
+
+function useAutoFocusOnOpen() {
+  const ref = React.useRef(null);
+
+  const autoFocusOnOpen = React.useCallback(() => {
+    if (ref.current) {
+      const current = ref.current as any;
+      const node = current.node as HTMLElement;
+
+      const firstInput = node.querySelector("[data-autofocus]");
+
+      if (firstInput && firstInput instanceof HTMLElement) {
+        firstInput.focus();
+      }
+    }
+  }, []);
+
+  return { ref, autoFocusOnOpen };
+}
+
+function useModalStyle(size: string, height: string): ReactModal.Styles {
+  const mode = useColorMode();
+
+  return React.useMemo(() => {
+    return {
+      overlay: {
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: mode === "light" ? "rgba(0,0,0,0.6)" : "rgba(0,0,0,0.7)",
+        zIndex: 999,
+      },
+      content: {
+        top: "48%",
+        left: "50%",
+        right: "auto",
+        bottom: "auto",
+        width: SIZES[size],
+        transform: "translate(-50%, -50%)",
+        borderRadius: "8px",
+        overflowY: "auto",
+        maxHeight: "90%",
+        height: height,
+        maxWidth: "95%",
+        backgroundColor: "var(--color-surface-base)",
+        border: "1px solid var(--color-surface-outline)",
+        boxShadow: "0px 0px 10px 0px rgba(0,0,0,0.1)",
+        padding: "32px",
+        display: "flex",
+        flexDirection: "column",
+      },
+    } as ReactModal.Styles;
+  }, [mode, size, height]);
 }


### PR DESCRIPTION
fixes https://github.com/operately/operately/issues/1963

---

I learned way too much details about autofocus today. 🙉 

TLDR: It is a completely broken feature in browsers, React decided to roll their 
own monkeypatch called autoFocus  which is different than autofocus.

Neither of them work out of the box, reliably, in modals.

---

In this PR I'm implementing a manual autofocus mechanism that triggers the first auto-focusable element in the modal.