### PR TITLE
fix: Created-document feed event is now aligned

### DIFF
--- a/assets/js/features/activities/ResourceHubDocumentCreated/index.tsx
+++ b/assets/js/features/activities/ResourceHubDocumentCreated/index.tsx
@@ -41,7 +41,7 @@ const ResourceHubDocumentCreating: ActivityHandler = {
   },
 
   feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
-    return "items-center";
+    return "items-start";
   },
 
   commentCount(_activity: Activity): number {


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1993.

