### PR TITLE
chore: Display last update/check-in timestamps in Goal tree

### DIFF
--- a/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 
+import { Update } from "@/models/goalCheckIns";
 import * as Goals from "@/models/goals";
 import * as Timeframes from "@/utils/timeframes";
 import * as Icons from "@tabler/icons-react";
@@ -14,6 +15,7 @@ import { SecondaryButton } from "@/components/Buttons";
 import { DivLink } from "@/components/Link";
 import { AvatarLink } from "@/components/Avatar";
 import { DescriptionSection, StatusSection, TargetsSection } from "@/features/goals/GoalCheckIn";
+import FormattedTime from "@/components/FormattedTime";
 
 import { GoalNode, Node } from "../tree";
 import { useExpandable } from "../context/Expandable";
@@ -86,14 +88,23 @@ function GoalStatus({ goal }: { goal: GoalNode }) {
       <Status node={goal}>
         {goal.lastCheckIn && (
           <>
-            <StatusSection update={goal.lastCheckIn!} reviewer={goal.reviewer || undefined} />
-            <DescriptionSection update={goal.lastCheckIn!} limit={120} />
-            <TargetsSection update={goal.asGoalNode().lastCheckIn!} />
+            <LastUpdateTimestamp update={goal.lastCheckIn} />
+            <StatusSection update={goal.lastCheckIn} reviewer={goal.reviewer || undefined} />
+            <DescriptionSection update={goal.lastCheckIn} limit={120} />
+            <TargetsSection update={goal.lastCheckIn} />
           </>
         )}
       </Status>
     );
   }
+}
+
+function LastUpdateTimestamp({ update }: { update: Update }) {
+  return (
+    <div className="mt-4 font-bold">
+      Updated on <FormattedTime time={update.insertedAt!} format="long-date" />
+    </div>
+  );
 }
 
 function GoalTimeframe({ goal }: { goal: Goals.Goal }) {

--- a/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
 import { useWindowSizeBreakpoints } from "@/components/Pages";
+import { ProjectCheckIn } from "@/models/projectCheckIns";
 
 import classNames from "classnames";
 import { match } from "ts-pattern";
@@ -56,11 +57,20 @@ function ProjectStatus({ node }: { node: ProjectNode }) {
   } else {
     return (
       <Status node={node}>
+        <LastCheckInTimestamp checkIn={node.lastCheckIn!} />
         <StatusSection checkIn={node.lastCheckIn!} reviewer={node.reviewer || undefined} />
         <DescriptionSection checkIn={node.lastCheckIn!} limit={120} />
       </Status>
     );
   }
+}
+
+function LastCheckInTimestamp({ checkIn }: { checkIn: ProjectCheckIn }) {
+  return (
+    <div className="mt-4 font-bold">
+      Checked in on <FormattedTime time={checkIn.insertedAt!} format="long-date" />
+    </div>
+  );
 }
 
 function NextMilestone({ project }: { project: Project }) {


### PR DESCRIPTION
I've added the date for when a Goal was updated and when a Project was checked in, as requested in https://github.com/operately/operately/issues/1706.

I'm not sure about the design, though. The best option I found was making it bold and similar to the other titles, but a bit smaller. Let me know if you have any suggestions for improvement, @markoa and @shiroyasha.

https://github.com/user-attachments/assets/15406472-8919-434e-9e3f-642e9f2809c0

