### PR TITLE
fix: Tab can be used to jump between title and content on new discussion page

### DIFF
--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -61,6 +61,7 @@ interface UseEditorProps {
   editable?: boolean;
   autoFocus?: boolean;
   mentionSearchScope: People.SearchScope;
+  tabindex?: string;
 }
 
 export interface EditorState {
@@ -94,6 +95,7 @@ function useEditor(props: UseEditorProps): EditorState {
     editorProps: {
       attributes: {
         class: "focus:outline-none" + " " + props.className,
+        tabindex: props.tabindex ?? "",
       },
     },
     extensions: [

--- a/assets/js/components/FormTitleInput/index.tsx
+++ b/assets/js/components/FormTitleInput/index.tsx
@@ -49,6 +49,7 @@ export function FormTitleInput({ value, onChange, error, testId }: FormTitleInpu
         value={value}
         onChange={(e) => onChange(e.target.value)}
         data-test-id={testId}
+        tabIndex={1}
       ></textarea>
     </>
   );

--- a/assets/js/features/DiscussionForm/useForm.tsx
+++ b/assets/js/features/DiscussionForm/useForm.tsx
@@ -55,6 +55,7 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     className: "min-h-[350px] py-2 px-1",
     content: discussion?.body && JSON.parse(discussion.body),
     mentionSearchScope: { type: "space", id: space ? space.id! : discussion!.space!.id! },
+    tabindex: "2",
   });
 
   const validate = () => {


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/2003.

https://github.com/user-attachments/assets/53cd9dfa-d39a-4bb5-8cbf-5e06a1718d95

