### PR TITLE
fix: Space privacy indicator tooltip is now above everything else

### DIFF
--- a/assets/js/components/Tooltip/index.tsx
+++ b/assets/js/components/Tooltip/index.tsx
@@ -9,12 +9,13 @@ interface TextTooltipProps extends TestableElement {
   content: React.ReactNode | string;
   children: React.ReactNode;
   delayDuration?: number;
+  className?: string;
 }
 
-export function Tooltip({ content, delayDuration, children, testId }: TextTooltipProps): JSX.Element {
+export function Tooltip({ content, delayDuration, children, testId, className }: TextTooltipProps): JSX.Element {
   const mode = useColorMode();
 
-  const className = classNames(
+  const tooltipClassName = classNames(
     "bg-surface-base rounded-lg",
     "py-4 px-5",
     "text-content-accent",
@@ -24,6 +25,7 @@ export function Tooltip({ content, delayDuration, children, testId }: TextToolti
     "shadow-xl",
     "whitespace-normal",
     "border border-stroke-dimmed",
+    className || "",
   );
 
   const arrowStyle = {
@@ -34,7 +36,7 @@ export function Tooltip({ content, delayDuration, children, testId }: TextToolti
     <ReactTooltip.Provider>
       <ReactTooltip.Root delayDuration={delayDuration || 200}>
         <ReactTooltip.Trigger data-test-id={testId}>{children}</ReactTooltip.Trigger>
-        <ReactTooltip.Content sideOffset={5} className={className}>
+        <ReactTooltip.Content sideOffset={5} className={tooltipClassName}>
           {content}
           <ReactTooltip.Arrow style={arrowStyle} />
         </ReactTooltip.Content>

--- a/assets/js/features/spaces/PrivacyIndicator/index.tsx
+++ b/assets/js/features/spaces/PrivacyIndicator/index.tsx
@@ -54,7 +54,7 @@ function InviteOnly({ size }: { size: number }) {
   );
 
   return (
-    <Tooltip content={content} testId="secret-space-tooltip" delayDuration={100}>
+    <Tooltip content={content} testId="secret-space-tooltip" delayDuration={100} className="z-50">
       <Icons.IconLockFilled size={size} />
     </Tooltip>
   );


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/1962.