### PR TITLE
chore: Add EE License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Files in the 'ee' directory are subject to the Operately Enterprise Edition License located in the 'ee/LICENSE' file.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +188,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023-present Operately DOO
+   Copyright 2023-present Operately doo
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/ee/LICENSE
+++ b/ee/LICENSE
@@ -1,0 +1,44 @@
+The Operately Enterprise Edition (EE) license (the "EE License")
+Copyright (c) 2024-present Operately doo
+
+With regard to the Operately Software:
+
+This software and associated documentation files (the "Software") may only be
+used if you (and any entity that you represent) have:
+(1) agreed to, and are in compliance with, the Operately Terms of Service, available
+at https://operately.com/legal/terms/ (the "Terms"), or other written
+agreement with Operately doo governing the use of the Software, and
+(2) have either:
+    (a) a valid paid subscription to Operately's hosted service offering, or
+    (b) a valid Operately Enterprise Edition license for self-hosted deployments.
+
+Subject to the foregoing conditions, you are free to modify this Software and publish
+patches to the Software. You agree that Operately doo and/or its licensors
+(as applicable) retain all right, title and interest in and to all such
+modifications and/or patches, and all such modifications and/or patches may only
+be used, copied, modified, displayed, distributed, or otherwise exploited with a
+valid subscription or license as described above. Notwithstanding the foregoing,
+you may copy and modify the Software for development and testing purposes, without
+requiring a subscription or license. You agree that Operately doo and/or its
+licensors (as applicable) retain all right, title and interest in and to all such
+modifications. You are not granted any other rights beyond what is expressly
+stated herein. Subject to the foregoing, it is forbidden to copy, merge, publish,
+distribute, sublicense, and/or sell the Software.
+
+This EE License applies only to the part of this Software that is not
+distributed as part of Operately Community Edition (CE). Any part of this Software
+distributed as part of Operately CE is copyrighted under the Apache License,
+Version 2.0. The full text of this EE License shall be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+For all third party components incorporated into the Operately Software, those
+components are licensed under the original license provided by the owner of the
+applicable component.


### PR DESCRIPTION
The goal of the EE license is to protect our enterprise features, which includes our current SaaS-specific functionality and, in the future, any features that may not be available in the free-to-download self-hosted version.

The license is forward-looking - it defines what will be CE once we make that distinction. Until then, our current self-hosted version remains as is, while the EE license protects specific features in our `ee` folder that are part of our proprietary SaaS offering, whether user-facing or not.

The license is based on GitLab's, which is the gold standard for open core software companies.

Fixes #2026.


