### PR TITLE
chore: GoalCheckIn operation updates timeframe

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -2762,6 +2762,7 @@ export interface PostGoalProgressUpdateInput {
   status?: string | null;
   content?: string | null;
   goalId?: string | null;
+  timeframe?: Timeframe | null;
   newTargetValues?: string | null;
   sendNotificationsToEveryone?: boolean | null;
   subscriberIds?: string[] | null;

--- a/lib/operately/activities/content/goal_check_in.ex
+++ b/lib/operately/activities/content/goal_check_in.ex
@@ -6,12 +6,17 @@ defmodule Operately.Activities.Content.GoalCheckIn do
     belongs_to :space, Operately.Groups.Group
     belongs_to :goal, Operately.Goals.Goal
     belongs_to :update, Operately.Goals.Update
+
+    embeds_one :old_timeframe, Operately.Goals.Timeframe
+    embeds_one :new_timeframe, Operately.Goals.Timeframe
   end
 
   def changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields))
+    |> cast(attrs, [:company_id, :space_id, :goal_id, :update_id])
+    |> cast_embed(:old_timeframe)
+    |> cast_embed(:new_timeframe)
+    |> validate_required([:company_id, :space_id, :goal_id, :update_id])
   end
 
   def build(params) do

--- a/lib/operately/goals/timeframe.ex
+++ b/lib/operately/goals/timeframe.ex
@@ -149,12 +149,12 @@ defmodule Operately.Goals.Timeframe do
     parse_json!(Jason.decode!(json))
   end
 
-  def parse_json!(map) do 
+  def parse_json!(map) do
     %{"start_date" => start_date, "end_date" => end_date, "type" => type} = map
 
     %__MODULE__{
-      start_date: Date.from_iso8601!(start_date), 
-      end_date: Date.from_iso8601!(end_date), 
+      start_date: Date.from_iso8601!(start_date),
+      end_date: Date.from_iso8601!(end_date),
       type: type
     }
   end

--- a/lib/operately/operations/goal_check_in.ex
+++ b/lib/operately/operations/goal_check_in.ex
@@ -1,7 +1,7 @@
 defmodule Operately.Operations.GoalCheckIn do
   alias Ecto.Multi
   alias Operately.{Repo, Activities}
-  alias Operately.Goals.{Goal, Update, Target}
+  alias Operately.Goals.{Goal, Update, Target, Timeframe}
   alias Operately.Operations.Notifications.{Subscription, SubscriptionList}
 
   def run(author, goal, attrs) do
@@ -18,43 +18,28 @@ defmodule Operately.Operations.GoalCheckIn do
         status: attrs.status,
         message: attrs.content,
         targets: encoded_new_target_values,
-        subscription_list_id: changes.subscription_list.id,
+        subscription_list_id: changes.subscription_list.id
       })
     end)
     |> SubscriptionList.update(:update)
-    |> update_goal_next_check_in(goal)
+    |> update_goal(goal, attrs[:timeframe])
     |> update_targets(targets, attrs.target_values)
     |> record_activity(author, goal)
     |> Repo.transaction()
     |> Repo.extract_result(:update)
-    |> case do
-      {:ok, update} ->
-        OperatelyWeb.ApiSocket.broadcast!("api:assignments_count:#{author.id}")
-        {:ok, update}
-
-      error -> error
-    end
+    |> handle_result_broadcast()
   end
 
-  defp update_goal_next_check_in(multi, goal) do
-    next_check_in = Operately.Time.calculate_next_monthly_check_in(
-      goal.next_update_scheduled_at,
-      DateTime.utc_now()
-    )
+  defp update_goal(multi, goal, timeframe) do
+    next_check_in =
+      Operately.Time.calculate_next_monthly_check_in(
+        goal.next_update_scheduled_at,
+        DateTime.utc_now()
+      )
 
-    Multi.update(multi, :goal, Goal.changeset(goal, %{
-      next_update_scheduled_at: next_check_in
-    }))
-  end
+    changes = build_goal_changes(next_check_in, timeframe)
 
-  defp record_activity(multi, author, goal) do
-    multi
-    |> Activities.insert_sync(author.id, :goal_check_in, fn changes -> %{
-      company_id: goal.company_id,
-      space_id: goal.group_id,
-      goal_id: goal.id,
-      update_id: changes.update.id,
-    } end)
+    Multi.update(multi, :goal, Goal.changeset(goal, changes))
   end
 
   defp update_targets(multi, targets, new_target_values) do
@@ -67,6 +52,30 @@ defmodule Operately.Operations.GoalCheckIn do
     end)
   end
 
+  defp record_activity(multi, author, goal) do
+    multi
+    |> Activities.insert_sync(author.id, :goal_check_in, fn changes ->
+      %{
+        company_id: goal.company_id,
+        space_id: goal.group_id,
+        goal_id: goal.id,
+        update_id: changes.update.id
+      }
+      |> maybe_add_timeframes_to_activity(changes.goal.timeframe, goal.timeframe)
+    end)
+  end
+
+  defp handle_result_broadcast({:ok, update}) do
+    OperatelyWeb.ApiSocket.broadcast!("api:assignments_count:#{update.author_id}")
+    {:ok, update}
+  end
+
+  defp handle_result_broadcast(error), do: error
+
+  #
+  # Helpers
+  #
+
   defp encode_new_target_values(targets, new_target_values) do
     Enum.map(new_target_values, fn target_value ->
       target = Enum.find(targets, fn target -> target.id == target_value["id"] end)
@@ -77,5 +86,33 @@ defmodule Operately.Operations.GoalCheckIn do
         previous_value: target.value
       })
     end)
+  end
+
+  defp maybe_add_timeframes_to_activity(content, nil, _), do: content
+
+  defp maybe_add_timeframes_to_activity(content, new = %Timeframe{}, old = %Timeframe{}) do
+    if timeframe_changed?(new, old) do
+      Map.merge(content, %{
+        new_timeframe: Map.from_struct(new),
+        old_timeframe: Map.from_struct(old)
+      })
+    else
+      content
+    end
+  end
+
+  defp timeframe_changed?(new, old) do
+    new.start_date != old.start_date or new.end_date != old.end_date
+  end
+
+  defp build_goal_changes(next_check_in, timeframe) do
+    if timeframe do
+      %{
+        next_update_scheduled_at: next_check_in,
+        timeframe: timeframe
+      }
+    else
+      %{next_update_scheduled_at: next_check_in}
+    end
   end
 end

--- a/lib/operately_web/api/mutations/post_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/post_goal_progress_update.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
     field :status, :string
     field :content, :string
     field :goal_id, :string
+    field :timeframe, :timeframe
     field :new_target_values, :string
     field :send_notifications_to_everyone, :boolean
     field :subscriber_ids, list_of(:string)
@@ -50,6 +51,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
       target_values: Jason.decode!(inputs.new_target_values),
       content: Jason.decode!(inputs.content),
       status: inputs.status,
+      timeframe: inputs[:timeframe],
       send_to_everyone: inputs[:send_notifications_to_everyone] || false,
       subscription_parent_type: :goal_update,
       subscriber_ids: subscriber_ids || []

--- a/test/operately/operations/goal_check_in_test.exs
+++ b/test/operately/operations/goal_check_in_test.exs
@@ -10,6 +10,7 @@ defmodule Operately.Operations.GoalCheckInTest do
   alias Operately.Groups
   alias Operately.Support.RichText
   alias Operately.Access.Binding
+  alias Operately.Operations.GoalCheckIn
 
   setup ctx do
     company = company_fixture()
@@ -17,117 +18,219 @@ defmodule Operately.Operations.GoalCheckInTest do
     reviewer = person_fixture_with_account(%{company_id: company.id})
     space = group_fixture(champion)
 
-    goal = goal_fixture(champion, %{
-      space_id: space.id,
-      reviewer_id: reviewer.id,
-      champion_id: champion.id,
-      company_access_level: Binding.no_access(),
-      space_access_level: Binding.comment_access(),
-    })
+    goal =
+      goal_fixture(champion, %{
+        space_id: space.id,
+        reviewer_id: reviewer.id,
+        champion_id: champion.id,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.comment_access()
+      })
 
     Map.merge(ctx, %{company: company, space: space, champion: champion, reviewer: reviewer, goal: goal})
   end
 
-  test "Creating goal update notifies everyone", ctx do
-    members = create_space_members(ctx)
+  describe "notifications" do
+    test "Creating goal update notifies everyone", ctx do
+      members = create_space_members(ctx)
 
-    {:ok, update} = Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
+      {:ok, update} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          GoalCheckIn.run(ctx.champion, ctx.goal, %{
+            goal_id: ctx.goal.id,
+            status: "on_track",
+            target_values: [],
+            content: RichText.rich_text("Some content"),
+            send_to_everyone: true,
+            subscriber_ids: [],
+            subscription_parent_type: :goal_update
+          })
+        end)
+
+      action = "goal_check_in"
+      activity = get_activity(update, action)
+
+      assert 0 == notifications_count(action: action)
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      # 3 members + reviewer
+      assert 4 == notifications_count(action: action)
+
+      members
+      |> Enum.filter(&(&1.id != ctx.champion.id))
+      |> Enum.each(fn p ->
+        assert Enum.find(notifications, &(&1.person_id == p.id))
+      end)
+    end
+
+    test "Creating goal update notifies selected people", ctx do
+      create_space_members(ctx)
+
+      {:ok, update} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          GoalCheckIn.run(ctx.champion, ctx.goal, %{
+            goal_id: ctx.goal.id,
+            status: "caution",
+            target_values: [],
+            content: RichText.rich_text("Some content"),
+            send_to_everyone: false,
+            subscriber_ids: [ctx.reviewer.id, ctx.champion.id],
+            subscription_parent_type: :goal_update
+          })
+        end)
+
+      action = "goal_check_in"
+      activity = get_activity(update, action)
+
+      assert 0 == notifications_count(action: action)
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      assert 1 == notifications_count(action: action)
+      assert hd(notifications).person_id == ctx.reviewer.id
+    end
+
+    test "Person without permissions is not notified", ctx do
+      # Without permissions
+      person = person_fixture_with_account(%{company_id: ctx.company.id})
+      content = RichText.rich_text(mentioned_people: [person]) |> Jason.decode!()
+
+      {:ok, update} =
+        GoalCheckIn.run(ctx.champion, ctx.goal, %{
+          goal_id: ctx.goal.id,
+          status: "issue",
+          target_values: [],
+          content: content,
+          send_to_everyone: true,
+          subscriber_ids: [],
+          subscription_parent_type: :goal_update
+        })
+
+      action = "goal_check_in"
+      activity = get_activity(update, action)
+
+      assert notifications_count(action: action) == 0
+      assert fetch_notifications(activity.id, action: action) == []
+
+      # With permissions
+      {:ok, _} =
+        Groups.add_members(ctx.champion, ctx.space.id, [
+          %{id: person.id, access_level: Binding.view_access()}
+        ])
+
+      {:ok, update} =
+        GoalCheckIn.run(ctx.champion, ctx.goal, %{
+          goal_id: ctx.goal.id,
+          status: "issue",
+          target_values: [],
+          content: content,
+          send_to_everyone: true,
+          subscriber_ids: [],
+          subscription_parent_type: :goal_update
+        })
+
+      activity = get_activity(update, action)
+      notifications = fetch_notifications(activity.id, action: action)
+
+      assert notifications_count(action: action) == 1
+      assert hd(notifications).person_id == person.id
+    end
+  end
+
+  describe "timeframes" do
+    @action "goal_check_in"
+    @old_timeframe %{ type: "year", start_date: ~D[2024-01-01], end_date: ~D[2024-12-31]}
+    @new_timeframe %{ type: "days", start_date: ~D[2024-02-01], end_date: ~D[2024-03-15]}
+
+    setup ctx do
+      goal = goal_fixture(ctx.champion, %{
+        space_id: ctx.space.id,
+        timeframe: @old_timeframe,
+      })
+
+      Map.put(ctx, :goal, goal)
+    end
+
+    test "timeframe changed", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal, %{
+        goal_id: ctx.goal.id,
+        status: "on_track",
+        target_values: [],
+        content: RichText.rich_text("Some content"),
+        timeframe: @new_timeframe,
+        send_to_everyone: true,
+        subscriber_ids: [],
+        subscription_parent_type: :goal_update
+      })
+
+      goal = Repo.reload(ctx.goal)
+      assert_timeframes(goal.timeframe, @new_timeframe)
+
+      activity = get_activity(update, @action)
+      assert_activity_timeframes(activity.content["new_timeframe"], @new_timeframe)
+      assert_activity_timeframes(activity.content["old_timeframe"], @old_timeframe)
+    end
+
+    test "timeframe NOT changed", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal, %{
+        goal_id: ctx.goal.id,
+        status: "on_track",
+        target_values: [],
+        content: RichText.rich_text("Some content"),
+        timeframe: @old_timeframe,
+        send_to_everyone: true,
+        subscriber_ids: [],
+        subscription_parent_type: :goal_update
+      })
+
+      goal = Repo.reload(ctx.goal)
+      assert_timeframes(goal.timeframe, @old_timeframe)
+
+      activity = get_activity(update, @action)
+      refute_timeframe_in_activity(activity)
+    end
+
+    test "timeframe NOT provided", ctx do
+      {:ok, update} = GoalCheckIn.run(ctx.champion, ctx.goal, %{
         goal_id: ctx.goal.id,
         status: "on_track",
         target_values: [],
         content: RichText.rich_text("Some content"),
         send_to_everyone: true,
         subscriber_ids: [],
-        subscription_parent_type: :goal_update,
+        subscription_parent_type: :goal_update
       })
-    end)
 
-    action = "goal_check_in"
-    activity = get_activity(update, action)
+      goal = Repo.reload(ctx.goal)
+      assert_timeframes(goal.timeframe, @old_timeframe)
 
-    assert 0 == notifications_count(action: action)
-
-    perform_job(activity.id)
-    notifications = fetch_notifications(activity.id, action: action)
-
-    assert 4 == notifications_count(action: action) # 3 members + reviewer
-
-    members
-    |> Enum.filter(&(&1.id != ctx.champion.id))
-    |> Enum.each(fn p ->
-      assert Enum.find(notifications, &(&1.person_id == p.id))
-    end)
+      activity = get_activity(update, @action)
+      refute_timeframe_in_activity(activity)
+    end
   end
 
-  test "Creating goal update notifies selected people", ctx do
-    create_space_members(ctx)
+  #
+  # Steps
+  #
 
-    {:ok, update} = Oban.Testing.with_testing_mode(:manual, fn ->
-      Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
-        goal_id: ctx.goal.id,
-        status: "caution",
-        target_values: [],
-        content: RichText.rich_text("Some content"),
-        send_to_everyone: false,
-        subscriber_ids: [ctx.reviewer.id, ctx.champion.id],
-        subscription_parent_type: :goal_update,
-      })
-    end)
-
-    action = "goal_check_in"
-    activity = get_activity(update, action)
-
-    assert 0 == notifications_count(action: action)
-
-    perform_job(activity.id)
-    notifications = fetch_notifications(activity.id, action: action)
-
-    assert 1 == notifications_count(action: action)
-    assert hd(notifications).person_id == ctx.reviewer.id
+  defp assert_timeframes(one, two) do
+    assert one.type == two.type
+    assert one.start_date == two.start_date
+    assert one.end_date == two.end_date
   end
 
-  test "Person without permissions is not notified", ctx do
-    # Without permissions
-    person = person_fixture_with_account(%{company_id: ctx.company.id})
-    content = RichText.rich_text(mentioned_people: [person]) |> Jason.decode!()
+  defp assert_activity_timeframes(one, two) do
+    assert one["type"] == two.type
+    assert one["start_date"] == Date.to_string(two.start_date)
+    assert one["end_date"] == Date.to_string(two.end_date)
+  end
 
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
-      goal_id: ctx.goal.id,
-      status: "issue",
-      target_values: [],
-      content: content,
-      send_to_everyone: true,
-      subscriber_ids: [],
-      subscription_parent_type: :goal_update,
-    })
-
-    action = "goal_check_in"
-    activity = get_activity(update, action)
-
-    assert notifications_count(action: action) == 0
-    assert fetch_notifications(activity.id, action: action) == []
-
-    # With permissions
-    {:ok, _} = Groups.add_members(ctx.champion, ctx.space.id, [
-      %{id: person.id, access_level: Binding.view_access()}
-    ])
-
-    {:ok, update} = Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal,%{
-      goal_id: ctx.goal.id,
-      status: "issue",
-      target_values: [],
-      content: content,
-      send_to_everyone: true,
-      subscriber_ids: [],
-      subscription_parent_type: :goal_update,
-    })
-
-    activity = get_activity(update, action)
-    notifications = fetch_notifications(activity.id, action: action)
-
-    assert notifications_count(action: action) == 1
-    assert hd(notifications).person_id == person.id
+  defp refute_timeframe_in_activity(activity) do
+    refute activity.content["new_timeframe"]
+    refute activity.content["old_timeframe"]
   end
 
   #


### PR DESCRIPTION
I've updated the `Operately.Operations.GoalCheckIn` operation. Now, it also updates a Goal's timeframe if it detects changes.

The `:goal_check_in` activity includes the new and old timeframes only if there are changes. I chose this approach for several reasons:
- If timeframes were required and always present in the activity, we would likely need to write a migration to populate the timeframe fields in existing activities.
- The check-in operation and activity should remain compatible with both the old and new check-in forms since the new form is used only when this feature is enabled.
- Timeframe changes should be displayed in the feed only if changes exist. This way, if the timeframe is not present in the activity, it means there are no differences and it shouldn't be displayed.