### PR TITLE
feat: Display timeframe change in goal check-in feed event

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -228,6 +228,8 @@ export interface ActivityContentGoalCheckIn {
   goalId?: string | null;
   goal?: Goal | null;
   update?: GoalProgressUpdate | null;
+  oldTimeframe?: Timeframe | null;
+  newTimeframe?: Timeframe | null;
 }
 
 export interface ActivityContentGoalCheckInAcknowledgement {

--- a/assets/js/features/activities/GoalCheckIn/index.tsx
+++ b/assets/js/features/activities/GoalCheckIn/index.tsx
@@ -12,6 +12,7 @@ import { ActivityHandler } from "../interfaces";
 import { Link } from "@/components/Link";
 import { feedTitle, goalLink } from "../feedItemLinks";
 import { SmallStatusIndicator } from "@/components/status";
+import { TimeframeEdited } from "../GoalTimeframeEditing/TimeframeEdited";
 
 const GoalCheckIn: ActivityHandler = {
   pagePath(activity: Activity): string {
@@ -41,12 +42,15 @@ const GoalCheckIn: ActivityHandler = {
 
   FeedItemContent({ activity }: { activity: Activity; page: string }) {
     const update = content(activity).update!;
+    const newTimeframe = content(activity).newTimeframe;
+    const oldTimeframe = content(activity).oldTimeframe;
 
     return (
       <div className="flex flex-col">
         <RichContent jsonContent={update.message!} />
         <ConditionChanges update={update} />
         <SmallStatusIndicator status={update.status!} />
+        {newTimeframe && oldTimeframe && <TimeframeEdited newTimeframe={newTimeframe} oldTimeframe={oldTimeframe} />}
       </div>
     );
   },

--- a/assets/js/features/activities/GoalTimeframeEditing/TimeframeEdited.tsx
+++ b/assets/js/features/activities/GoalTimeframeEditing/TimeframeEdited.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { IconArrowRight } from "@tabler/icons-react";
+import * as Timeframes from "@/utils/timeframes";
+import * as Goals from "@/models/goals";
+
+interface Props {
+  oldTimeframe: Goals.Timeframe;
+  newTimeframe: Goals.Timeframe;
+}
+
+export function TimeframeEdited({ oldTimeframe, newTimeframe }: Props) {
+  const start = Timeframes.parse(oldTimeframe);
+  const end = Timeframes.parse(newTimeframe);
+
+  return (
+    <div className="my-2 flex items-center gap-1 text-sm">
+      <div className="flex items-center gap-1 font-medium">
+        <div className="border border-stroke-base rounded-md px-2 bg-stone-400/20 font-medium text-sm">
+          {Timeframes.format(start)}
+        </div>
+      </div>
+
+      <IconArrowRight size={14} />
+
+      <div className="flex items-center gap-1 font-medium">
+        <div className="border border-stroke-base rounded-md px-2 bg-stone-400/20 font-medium text-sm">
+          {Timeframes.format(end)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/assets/js/features/activities/GoalTimeframeEditing/index.tsx
+++ b/assets/js/features/activities/GoalTimeframeEditing/index.tsx
@@ -12,6 +12,8 @@ import { Activity, ActivityContentGoalTimeframeEditing } from "@/api";
 import RichContent from "@/components/RichContent";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { ActivityHandler } from "../interfaces";
+import { TimeframeEdited } from "./TimeframeEdited";
+import { assertPresent } from "@/utils/assertions";
 
 const GoalTimeframeEditing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -77,29 +79,17 @@ const GoalTimeframeEditing: ActivityHandler = {
   },
 
   FeedItemContent({ activity }: { activity: Activity }) {
-    const oldTimeframe = Timeframes.parse(content(activity).oldTimeframe!);
-    const newTimeframe = Timeframes.parse(content(activity).newTimeframe!);
+    const data = content(activity);
+
+    assertPresent(data.newTimeframe, "newTimeframe must be present in activity");
+    assertPresent(data.oldTimeframe, "oldTimeframe must be present in activity");
 
     return (
-      <div className="my-2">
-        <div className="flex items-center gap-1 text-sm">
-          <div className="flex items-center gap-1 font-medium">
-            <div className="border border-stroke-base rounded-md px-2 bg-stone-400/20 font-medium text-sm">
-              {Timeframes.format(oldTimeframe)}
-            </div>
-          </div>
-
-          <Icons.IconArrowRight size={14} />
-
-          <div className="flex items-center gap-1 font-medium">
-            <div className="border border-stroke-base rounded-md px-2 bg-stone-400/20 font-medium text-sm">
-              {Timeframes.format(newTimeframe)}
-            </div>
-          </div>
-        </div>
+      <div>
+        <TimeframeEdited newTimeframe={data.newTimeframe} oldTimeframe={data.oldTimeframe} />
 
         {activity.commentThread && !isContentEmpty(activity.commentThread.message) && (
-          <div className="mt-2">
+          <div className="my-2">
             <RichContent jsonContent={activity.commentThread!.message!} />
           </div>
         )}

--- a/assets/js/models/goals/index.tsx
+++ b/assets/js/models/goals/index.tsx
@@ -4,6 +4,7 @@ export type Goal = api.Goal;
 export type Target = api.Target;
 
 export {
+  Timeframe,
   getGoal,
   getGoals,
   useGetGoals,

--- a/lib/operately_web/api/serializers/activity_content/goal_check_in.ex
+++ b/lib/operately_web/api/serializers/activity_content/goal_check_in.ex
@@ -1,11 +1,24 @@
 defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GoalCheckIn do
   alias OperatelyWeb.Api.Serializer
+  alias OperatelyWeb.Api.Serializers.Timeframe
 
   def serialize(content, level: :essential) do
     %{
       goal_id: OperatelyWeb.Paths.goal_id(content["goal"]),
       goal: Serializer.serialize(content["goal"], level: :essential),
-      update: Serializer.serialize(content["update"], level: :essential),
+      update: Serializer.serialize(content["update"], level: :essential)
     }
+    |> maybe_include_timeframes(content)
+  end
+
+  defp maybe_include_timeframes(result, content) do
+    if content["new_timeframe"] && content["old_timeframe"] do
+      Map.merge(result, %{
+        new_timeframe: Timeframe.serialize(content["new_timeframe"]),
+        old_timeframe: Timeframe.serialize(content["old_timeframe"])
+      })
+    else
+      result
+    end
   end
 end

--- a/lib/operately_web/api/types.ex
+++ b/lib/operately_web/api/types.ex
@@ -559,6 +559,9 @@ defmodule OperatelyWeb.Api.Types do
     field :goal_id, :string
     field :goal, :goal
     field :update, :goal_progress_update
+
+    field :old_timeframe, :timeframe
+    field :new_timeframe, :timeframe
   end
 
   object :activity_content_discussion_posting do


### PR DESCRIPTION
If a Goal check-in includes a timeframe change, it will now be displayed in the feed. 

The timeframe changes in the `GoalCheckIn` and `GoalTimeframeEditing` activities now share the same component:

![tmp](https://github.com/user-attachments/assets/715444f2-db10-41d9-954e-f38dd52605d3)
