### PR TITLE
chore: GoalCheckInEdit operation updates timeframe

### DIFF
--- a/assets/js/api/index.tsx
+++ b/assets/js/api/index.tsx
@@ -2538,6 +2538,7 @@ export interface EditGoalProgressUpdateInput {
   status?: string | null;
   content?: string | null;
   newTargetValues?: string | null;
+  timeframe?: Timeframe | null;
 }
 
 export interface EditGoalProgressUpdateResult {

--- a/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import * as People from "@/models/people";
+import Forms from "@/components/Forms";
+import { Spacer } from "@/components/Spacer";
+import { Goal } from "@/models/goals";
+import { assertPresent } from "@/utils/assertions";
+
+interface Props {
+  form: any;
+  readonly: boolean;
+  goal: Goal;
+  children: React.ReactNode;
+}
+
+export function Form({ form, readonly, goal, children }: Props) {
+  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
+
+  assertPresent(goal.reviewer, "reviewer must be present in goal");
+
+  return (
+    <Forms.Form form={form}>
+      <Forms.FieldGroup>
+        <div className="flex items-start gap-8 mt-6">
+          <Forms.SelectGoalStatus
+            readonly={readonly}
+            label="Status"
+            field="status"
+            reviewerFirstName={People.firstName(goal.reviewer)}
+          />
+          <Forms.TimeframeField readonly={readonly} label="Timeframe" field="timeframe" />
+        </div>
+      </Forms.FieldGroup>
+
+      <Spacer size={4} />
+
+      <Forms.FieldGroup>
+        <Forms.GoalTargetsField readonly={readonly} field="targets" label={readonly ? "Targets" : "Update targets"} />
+      </Forms.FieldGroup>
+
+      <Spacer size={4} />
+
+      <Forms.FieldGroup>
+        <Forms.RichTextArea
+          label={readonly ? "Key wins, obstacles and needs" : "Describe key wins, obstacles and needs"}
+          field="description"
+          placeholder="Write here..."
+          mentionSearchScope={mentionSearchScope}
+          readonly={readonly}
+          required
+        />
+      </Forms.FieldGroup>
+
+      {children}
+    </Forms.Form>
+  );
+}

--- a/assets/js/features/goals/GoalCheckIn/index.tsx
+++ b/assets/js/features/goals/GoalCheckIn/index.tsx
@@ -2,3 +2,4 @@ export { LastCheckInMessage } from "./LastCheckInMessage";
 export { StatusSection } from "./StatusSection";
 export { DescriptionSection } from "./DescriptionSection";
 export { TargetsSection } from "./TargetsSection";
+export { useForm } from "./useForm";

--- a/assets/js/features/goals/GoalCheckIn/index.tsx
+++ b/assets/js/features/goals/GoalCheckIn/index.tsx
@@ -3,3 +3,4 @@ export { StatusSection } from "./StatusSection";
 export { DescriptionSection } from "./DescriptionSection";
 export { TargetsSection } from "./TargetsSection";
 export { useForm } from "./useForm";
+export { Form } from "./Form";

--- a/assets/js/features/goals/GoalCheckIn/useForm.tsx
+++ b/assets/js/features/goals/GoalCheckIn/useForm.tsx
@@ -1,0 +1,96 @@
+import { useNavigate } from "react-router-dom";
+import { Update, useEditGoalProgressUpdate, usePostGoalProgressUpdate } from "@/models/goalCheckIns";
+import { Goal } from "@/models/goals";
+
+import * as Timeframes from "@/utils/timeframes";
+import * as Pages from "@/components/Pages";
+
+import Forms from "@/components/Forms";
+import { Paths } from "@/routes/paths";
+import { emptyContent } from "@/components/RichContent";
+import { assertPresent } from "@/utils/assertions";
+import { Options, SubscriptionsState } from "@/features/Subscriptions";
+
+interface EditProps {
+  mode: "edit";
+  update: Update;
+  goal: Goal;
+}
+
+interface CreateProps {
+  mode: "create";
+  goal: Goal;
+  subscriptionsState: SubscriptionsState;
+}
+
+export function useForm(props: EditProps | CreateProps) {
+  const { mode, goal } = props;
+  const [post] = usePostGoalProgressUpdate();
+  const [edit] = useEditGoalProgressUpdate();
+
+  const navigate = useNavigate();
+  const setPageMode = Pages.useSetPageMode();
+
+  assertPresent(goal?.timeframe, "timeframe must be present in goal");
+  assertPresent(goal?.targets, "targets must be present in goal");
+
+  const currTimeframe = { startDate: new Date(goal.timeframe.startDate!), endDate: new Date(goal.timeframe.endDate!) };
+
+  const form = Forms.useForm({
+    fields: {
+      status: mode === "edit" ? props.update.status : null,
+      timeframe: currTimeframe,
+      targets: goal.targets,
+      description: mode === "edit" ? JSON.parse(props.update.message!) : emptyContent(),
+    },
+    cancel: () => {
+      if (mode === "create") {
+        navigate(Paths.goalPath(goal.id!));
+      } else {
+        setPageMode("view");
+      }
+    },
+    submit: async () => {
+      const commonAttrs = {
+        status: form.values.status,
+        content: JSON.stringify(form.values.description),
+        newTargetValues: JSON.stringify(form.values.targets.map((t) => ({ id: t.id, value: t.value }))),
+      };
+
+      if (mode === "create") {
+        const { subscriptionsState } = props;
+        const payload = {
+          ...commonAttrs,
+          goalId: goal.id,
+          sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
+          subscriberIds: subscriptionsState.currentSubscribersList,
+        };
+        maybeIncludeTimeframe(payload, form.values.timeframe, currTimeframe);
+
+        const res = await post(payload);
+
+        navigate(Paths.goalProgressUpdatePath(res.update!.id));
+      } else {
+        const payload = { ...commonAttrs, id: props.update.id };
+        maybeIncludeTimeframe(payload, form.values.timeframe, currTimeframe);
+
+        await edit(payload);
+
+        setPageMode("view");
+      }
+    },
+  });
+
+  return form;
+}
+
+function maybeIncludeTimeframe(payload, newTimeframe, oldTimeframe) {
+  const timeframesEqual = Timeframes.equalDates(
+    newTimeframe as Timeframes.Timeframe,
+    oldTimeframe as Timeframes.Timeframe,
+  );
+
+  if (!timeframesEqual) {
+    payload.timeframe = Timeframes.serialize({ ...newTimeframe, type: "days" });
+  }
+}

--- a/assets/js/pages/GoalCheckInNewPage/Form.tsx
+++ b/assets/js/pages/GoalCheckInNewPage/Form.tsx
@@ -1,61 +1,25 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 
 import * as People from "@/models/people";
-import * as Timeframes from "@/utils/timeframes";
-
 import { Goal } from "@/models/goals";
-import { usePostGoalProgressUpdate } from "@/models/goalCheckIns";
 
 import Forms from "@/components/Forms";
-
-import { Options, SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
-import { emptyContent } from "@/components/RichContent";
+import { SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
 import { Spacer } from "@/components/Spacer";
 import { assertPresent } from "@/utils/assertions";
-import { Paths } from "@/routes/paths";
+import { useForm } from "@/features/goals/GoalCheckIn";
 
 export function Form({ goal }: { goal: Goal }) {
-  const [post] = usePostGoalProgressUpdate();
-  const navigate = useNavigate();
-
   assertPresent(goal.space, "space must be present in goal");
-  assertPresent(goal.targets, "targets must be present in goal");
   assertPresent(goal.reviewer, "reviewer must be present in goal");
-  assertPresent(goal.timeframe, "timeframe must be present in goal");
   assertPresent(goal.potentialSubscribers, "potentialSubscribers must be present in goal");
 
-  const currTimeframe = { startDate: new Date(goal.timeframe.startDate!), endDate: new Date(goal.timeframe.endDate!) };
   const subscriptionsState = useSubscriptions(goal.potentialSubscribers, {
     ignoreMe: true,
     notifyPrioritySubscribers: true,
   });
 
-  const form = Forms.useForm({
-    fields: {
-      status: null,
-      timeframe: currTimeframe,
-      targets: goal.targets,
-      description: emptyContent(),
-    },
-    cancel: () => navigate(Paths.goalPath(goal.id!)),
-    submit: async () => {
-      const payload = {
-        goalId: goal.id,
-        status: form.values.status,
-        content: JSON.stringify(form.values.description),
-        newTargetValues: JSON.stringify(form.values.targets.map((t) => ({ id: t.id, value: t.value }))),
-        sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
-        subscriberIds: subscriptionsState.currentSubscribersList,
-      };
-      maybeIncludeTimeframe(payload, form.values.timeframe, currTimeframe);
-
-      const res = await post(payload);
-
-      navigate(Paths.goalProgressUpdatePath(res.update!.id));
-    },
-  });
-
+  const form = useForm({ mode: "create", goal, subscriptionsState });
   const mentionSearchScope = { type: "goal", id: goal.id! } as const;
 
   return (
@@ -97,15 +61,4 @@ export function Form({ goal }: { goal: Goal }) {
       <Forms.Submit saveText="Check In" />
     </Forms.Form>
   );
-}
-
-function maybeIncludeTimeframe(payload, newTimeframe, oldTimeframe) {
-  const timeframesEqual = Timeframes.equalDates(
-    newTimeframe as Timeframes.Timeframe,
-    oldTimeframe as Timeframes.Timeframe,
-  );
-
-  if (!timeframesEqual) {
-    payload.timeframe = Timeframes.serialize({ ...newTimeframe, type: "days" });
-  }
 }

--- a/assets/js/pages/GoalCheckInNewPage/Form.tsx
+++ b/assets/js/pages/GoalCheckInNewPage/Form.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 
-import * as People from "@/models/people";
 import { Goal } from "@/models/goals";
 
 import Forms from "@/components/Forms";
 import { SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
 import { Spacer } from "@/components/Spacer";
 import { assertPresent } from "@/utils/assertions";
-import { useForm } from "@/features/goals/GoalCheckIn";
+import { useForm, Form as CheckInForm } from "@/features/goals/GoalCheckIn";
 
 export function Form({ goal }: { goal: Goal }) {
   assertPresent(goal.space, "space must be present in goal");
-  assertPresent(goal.reviewer, "reviewer must be present in goal");
   assertPresent(goal.potentialSubscribers, "potentialSubscribers must be present in goal");
 
   const subscriptionsState = useSubscriptions(goal.potentialSubscribers, {
@@ -20,45 +18,12 @@ export function Form({ goal }: { goal: Goal }) {
   });
 
   const form = useForm({ mode: "create", goal, subscriptionsState });
-  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
 
   return (
-    <Forms.Form form={form}>
-      <Forms.FieldGroup>
-        <div className="flex items-start gap-8 mt-6">
-          <Forms.SelectGoalStatus
-            required
-            label="Status"
-            field="status"
-            reviewerFirstName={People.firstName(goal.reviewer)}
-          />
-          <Forms.TimeframeField label="Timeframe" field="timeframe" />
-        </div>
-      </Forms.FieldGroup>
-
+    <CheckInForm form={form} goal={goal} readonly={false}>
       <Spacer size={4} />
-
-      <Forms.FieldGroup>
-        <Forms.GoalTargetsField field="targets" label="Update targets" />
-      </Forms.FieldGroup>
-
-      <Spacer size={4} />
-
-      <Forms.FieldGroup>
-        <Forms.RichTextArea
-          label="Describe key wins, obstacles and needs"
-          field="description"
-          placeholder="Write here..."
-          mentionSearchScope={mentionSearchScope}
-          required
-        />
-      </Forms.FieldGroup>
-
-      <Spacer size={4} />
-
       <SubscribersSelector state={subscriptionsState} spaceName={goal.space.name!} />
-
       <Forms.Submit saveText="Check In" />
-    </Forms.Form>
+    </CheckInForm>
   );
 }

--- a/assets/js/pages/GoalCheckInPage/Form.tsx
+++ b/assets/js/pages/GoalCheckInPage/Form.tsx
@@ -1,50 +1,23 @@
 import React from "react";
 
-import { useEditGoalProgressUpdate } from "@/models/goalCheckIns";
 import * as People from "@/models/people";
 import * as Pages from "@/components/Pages";
 
 import Forms from "@/components/Forms";
 import { assertPresent } from "@/utils/assertions";
 import { Spacer } from "@/components/Spacer";
-
-import { useLoadedData } from "./loader";
 import { EditBar } from "@/components/Pages/EditBar";
+import { useForm } from "@/features/goals/GoalCheckIn";
+import { useLoadedData } from "./loader";
 
 export function Form() {
   const { update, goal } = useLoadedData();
-  const [edit] = useEditGoalProgressUpdate();
-
   const isViewMode = Pages.useIsViewMode();
-  const setPageMode = Pages.useSetPageMode();
 
-  assertPresent(update.goal?.timeframe, "goal.timeframe must be present in update");
+  const form = useForm({ mode: "edit", goal, update });
+  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
+
   assertPresent(goal.reviewer, "reviewer must be present in goal");
-
-  const form = Forms.useForm({
-    fields: {
-      status: update.status,
-      timeframe: {
-        startDate: new Date(update.goal.timeframe.startDate!),
-        endDate: new Date(update.goal.timeframe.endDate!),
-      },
-      targets: update.goal.targets!,
-      description: JSON.parse(update.message!),
-    },
-    cancel: () => setPageMode("view"),
-    submit: async () => {
-      await edit({
-        id: update.id,
-        status: form.values.status,
-        content: JSON.stringify(form.values.description),
-        newTargetValues: JSON.stringify(form.values.targets.map((t) => ({ id: t.id, value: t.value }))),
-      });
-
-      setPageMode("view");
-    },
-  });
-
-  const mentionSearchScope = { type: "goal", id: update.goal.id! } as const;
 
   return (
     <Forms.Form form={form}>

--- a/assets/js/pages/GoalCheckInPage/Form.tsx
+++ b/assets/js/pages/GoalCheckInPage/Form.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 
-import * as People from "@/models/people";
 import * as Pages from "@/components/Pages";
 
-import Forms from "@/components/Forms";
-import { assertPresent } from "@/utils/assertions";
-import { Spacer } from "@/components/Spacer";
 import { EditBar } from "@/components/Pages/EditBar";
-import { useForm } from "@/features/goals/GoalCheckIn";
+import { useForm, Form as CheckInForm } from "@/features/goals/GoalCheckIn";
 import { useLoadedData } from "./loader";
 
 export function Form() {
@@ -15,48 +11,10 @@ export function Form() {
   const isViewMode = Pages.useIsViewMode();
 
   const form = useForm({ mode: "edit", goal, update });
-  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
-
-  assertPresent(goal.reviewer, "reviewer must be present in goal");
 
   return (
-    <Forms.Form form={form}>
-      <Forms.FieldGroup>
-        <div className="flex items-start gap-8 mt-6">
-          <Forms.SelectGoalStatus
-            readonly={isViewMode}
-            label="Status"
-            field="status"
-            reviewerFirstName={People.firstName(goal.reviewer)}
-          />
-          <Forms.TimeframeField readonly={isViewMode} label="Timeframe" field="timeframe" />
-        </div>
-      </Forms.FieldGroup>
-
-      <Spacer size={4} />
-
-      <Forms.FieldGroup>
-        <Forms.GoalTargetsField
-          readonly={isViewMode}
-          field="targets"
-          label={isViewMode ? "Targets" : "Update targets"}
-        />
-      </Forms.FieldGroup>
-
-      <Spacer size={4} />
-
-      <Forms.FieldGroup>
-        <Forms.RichTextArea
-          label={isViewMode ? "Key wins, obstacles and needs" : "Describe key wins, obstacles and needs"}
-          field="description"
-          placeholder="Write here..."
-          mentionSearchScope={mentionSearchScope}
-          readonly={isViewMode}
-          required
-        />
-      </Forms.FieldGroup>
-
+    <CheckInForm form={form} goal={goal} readonly={isViewMode}>
       <EditBar save={form.actions.submit} cancel={form.actions.cancel} />
-    </Forms.Form>
+    </CheckInForm>
   );
 }

--- a/lib/operately/activities/content/goal_check_in_edit.ex
+++ b/lib/operately/activities/content/goal_check_in_edit.ex
@@ -5,12 +5,17 @@ defmodule Operately.Activities.Content.GoalCheckInEdit do
     belongs_to :company, Operately.Companies.Company
     belongs_to :goal, Operately.Goals.Goal
     belongs_to :check_in, Operately.Goals.Update
+
+    embeds_one :old_timeframe, Operately.Goals.Timeframe
+    embeds_one :new_timeframe, Operately.Goals.Timeframe
   end
 
   def changeset(attrs) do
     %__MODULE__{}
-    |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields))
+    |> cast(attrs, [:company_id, :goal_id, :check_in_id])
+    |> cast_embed(:old_timeframe)
+    |> cast_embed(:new_timeframe)
+    |> validate_required([:company_id, :goal_id, :check_in_id])
   end
 
   def build(params) do

--- a/lib/operately/operations/goal_check_in_edit.ex
+++ b/lib/operately/operations/goal_check_in_edit.ex
@@ -71,6 +71,7 @@ defmodule Operately.Operations.GoalCheckInEdit do
         goal_id: goal.id,
         check_in_id: changes.check_in.id
       }
+      |> maybe_add_timeframes_to_activity(changes[:goal], goal)
     end)
   end
 
@@ -89,5 +90,18 @@ defmodule Operately.Operations.GoalCheckInEdit do
 
   defp timeframe_changed?(new, old) do
     new.start_date != old.start_date or new.end_date != old.end_date
+  end
+
+  defp maybe_add_timeframes_to_activity(content, nil, _), do: content
+
+  defp maybe_add_timeframes_to_activity(content, updated_goal, goal) do
+    if timeframe_changed?(updated_goal.timeframe, goal.timeframe) do
+      Map.merge(content, %{
+        new_timeframe: Map.from_struct(updated_goal.timeframe),
+        old_timeframe: Map.from_struct(goal.timeframe)
+      })
+    else
+      content
+    end
   end
 end

--- a/lib/operately/operations/goal_check_in_edit.ex
+++ b/lib/operately/operations/goal_check_in_edit.ex
@@ -1,40 +1,32 @@
 defmodule Operately.Operations.GoalCheckInEdit do
   alias Ecto.Multi
   alias Operately.{Repo, Activities}
-  alias Operately.Goals.Target
-  alias Operately.Goals.Update
+  alias Operately.Goals.{Goal, Update, Target}
   alias Operately.Notifications.SubscriptionList
 
-  def run(author, goal, update, attrs) do
-    encoded_new_target_values = encode_new_target_values(attrs.new_target_values, update)
-
-    changeset = Update.changeset(update, %{
-      status: attrs.status,
-      message: attrs.content,
-      targets: encoded_new_target_values,
-    })
-
+  def run(author, goal, check_in, attrs) do
     Multi.new()
-    |> Multi.update(:update, changeset)
+    |> update_check_in(check_in, attrs)
     |> update_targets(goal.targets, attrs.new_target_values)
-    |> Multi.run(:subscription_list, fn _, changes ->
-      SubscriptionList.get(:system, parent_id: changes.update.id, opts: [
-        preload: :subscriptions
-      ])
-    end)
-    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(attrs.content)
+    |> update_subscriptions(attrs.content)
+    |> maybe_update_goal(goal, attrs[:timeframe])
     |> record_activity(author, goal)
     |> Repo.transaction()
-    |> Repo.extract_result(:update)
+    |> Repo.extract_result(:check_in)
   end
 
-  defp encode_new_target_values(new_target_values, update) do
-    Enum.map(new_target_values, fn target_value ->
-      update.targets
-      |> Enum.find(fn target -> target.id == target_value["id"] end)
-      |> Map.merge(%{value: target_value["value"]})
-      |> Map.from_struct()
-    end)
+  defp update_check_in(multi, check_in, attrs) do
+    encoded_new_target_values = encode_new_target_values(attrs.new_target_values, check_in)
+
+    multi
+    |> Multi.update(
+      :check_in,
+      Update.changeset(check_in, %{
+        status: attrs.status,
+        message: attrs.content,
+        targets: encoded_new_target_values
+      })
+    )
   end
 
   defp update_targets(multi, targets, new_target_values) do
@@ -47,12 +39,55 @@ defmodule Operately.Operations.GoalCheckInEdit do
     end)
   end
 
+  defp update_subscriptions(multi, content) do
+    multi
+    |> Multi.run(:subscription_list, fn _, changes ->
+      SubscriptionList.get(:system,
+        parent_id: changes.check_in.id,
+        opts: [
+          preload: :subscriptions
+        ]
+      )
+    end)
+    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(content)
+  end
+
+  defp maybe_update_goal(multi, _, nil), do: multi
+
+  defp maybe_update_goal(multi, goal, timeframe) do
+    if timeframe_changed?(goal.timeframe, timeframe) do
+      multi
+      |> Multi.update(:goal, Goal.changeset(goal, %{timeframe: timeframe}))
+    else
+      multi
+    end
+  end
+
   defp record_activity(multi, author, goal) do
     multi
-    |> Activities.insert_sync(author.id, :goal_check_in_edit, fn changes -> %{
-      company_id: goal.company_id,
-      goal_id: goal.id,
-      check_in_id: changes.update.id,
-    } end)
+    |> Activities.insert_sync(author.id, :goal_check_in_edit, fn changes ->
+      %{
+        company_id: goal.company_id,
+        goal_id: goal.id,
+        check_in_id: changes.check_in.id
+      }
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp encode_new_target_values(new_target_values, check_in) do
+    Enum.map(new_target_values, fn target_value ->
+      check_in.targets
+      |> Enum.find(fn target -> target.id == target_value["id"] end)
+      |> Map.merge(%{value: target_value["value"]})
+      |> Map.from_struct()
+    end)
+  end
+
+  defp timeframe_changed?(new, old) do
+    new.start_date != old.start_date or new.end_date != old.end_date
   end
 end

--- a/lib/operately_web/api/mutations/edit_goal_progress_update.ex
+++ b/lib/operately_web/api/mutations/edit_goal_progress_update.ex
@@ -10,6 +10,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdate do
     field :status, :string
     field :content, :string
     field :new_target_values, :string
+    field :timeframe, :timeframe
   end
 
   outputs do
@@ -45,6 +46,7 @@ defmodule OperatelyWeb.Api.Mutations.EditGoalProgressUpdate do
       status: inputs.status,
       content: Jason.decode!(inputs.content),
       new_target_values: Jason.decode!(inputs.new_target_values),
+      timeframe: inputs[:timeframe],
     }}
   end
 


### PR DESCRIPTION
The `Operately.Operations.GoalCheckInEdit` operation now also updates the timeframe.

I noticed that there was a lot of repeated code in the check-in create and edit forms, so I've combined them into a single `Form` component and `useForm` hook.