### PR TITLE
feat: markdown export with embeds removal for documents

### DIFF
--- a/assets/js/features/ResourceHub/components/DocumentMenu.tsx
+++ b/assets/js/features/ResourceHub/components/DocumentMenu.tsx
@@ -80,7 +80,7 @@ function ExportMarkdownMenuItem({ document }: Props) {
   const handleExport = () => {
     const content = JSON.parse(document.content!);
     const markdown = exportToMarkdown(content, { removeEmbeds: true });
-    downloadMarkdown(markdown, document.name || 'document');
+    downloadMarkdown(markdown, document.name || "document");
   };
 
   return (

--- a/assets/js/features/ResourceHub/components/DocumentMenu.tsx
+++ b/assets/js/features/ResourceHub/components/DocumentMenu.tsx
@@ -10,6 +10,7 @@ import { useNodesContext } from "@/features/ResourceHub";
 import { MoveResourceMenuItem, MoveResourceModal } from "./MoveResource";
 import { CopyResourceMenuItem } from "./CopyResource";
 import { CopyDocumentModal } from "./CopyDocument";
+import { downloadMarkdown, exportToMarkdown } from "@/utils/markdown";
 
 interface Props {
   document: Hub.ResourceHubDocument;
@@ -37,6 +38,7 @@ export function DocumentMenu({ document }: Props) {
         {permissions.canEditDocument && <EditDocumentMenuItem document={document} />}
         {permissions.canCreateDocument && <CopyResourceMenuItem resource={document} showModal={toggleCopyForm} />}
         {permissions.canEditParentFolder && <MoveResourceMenuItem resource={document} showModal={toggleMoveForm} />}
+        {permissions.canView && <ExportMarkdownMenuItem document={document} />}
         {permissions.canDeleteDocument && <DeleteDocumentMenuItem document={document} />}
       </Menu>
 
@@ -70,6 +72,20 @@ function DeleteDocumentMenuItem({ document }: Props) {
   return (
     <MenuActionItem onClick={handleDelete} testId={deleteId} danger>
       Delete
+    </MenuActionItem>
+  );
+}
+
+function ExportMarkdownMenuItem({ document }: Props) {
+  const handleExport = () => {
+    const content = JSON.parse(document.content!);
+    const markdown = exportToMarkdown(content, { removeEmbeds: true });
+    downloadMarkdown(markdown, document.name || 'document');
+  };
+
+  return (
+    <MenuActionItem onClick={handleExport} testId={createTestId("export-markdown", document.id!)}>
+      Export
     </MenuActionItem>
   );
 }

--- a/assets/js/utils/markdown.ts
+++ b/assets/js/utils/markdown.ts
@@ -1,0 +1,209 @@
+import { MarkdownSerializer, MarkdownSerializerState } from 'prosemirror-markdown';
+import { Node, Schema, Fragment, Mark } from 'prosemirror-model';
+
+interface MarkdownExportOptions {
+  removeEmbeds?: boolean;
+}
+
+type NodeSerializerFn = (state: MarkdownSerializerState, node: Node, parent: Node | null, index: number) => void;
+type MarkSerializerSpec = {
+  open: string | ((state: MarkdownSerializerState, mark: Mark, parent: Node, index: number) => string);
+  close: string | ((state: MarkdownSerializerState, mark: Mark, parent: Node, index: number) => string);
+  mixable?: boolean;
+  expelEnclosingWhitespace?: boolean;
+  escape?: boolean;
+};
+
+// ProseMirror schema and serializer aligned with GFM (GitHub Flavored Markdown)
+// See spec: https://github.github.com/gfm/
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*' },
+    text: { group: 'inline' },
+    hardBreak: { group: 'inline', inline: true },
+    heading: {
+      attrs: { level: { default: 1 } },
+      content: 'inline*',
+      group: 'block'
+    },
+    blockquote: { content: 'block+', group: 'block' },
+    bulletList: { content: 'listItem+', group: 'block' },
+    orderedList: {
+      content: 'listItem+',
+      group: 'block',
+      attrs: { start: { default: 1 } }
+    },
+    listItem: { content: 'paragraph block*', group: 'block' },
+    horizontalRule: { group: 'block' },
+    codeBlock: {
+      content: 'text*',
+      marks: '',
+      group: 'block',
+      attrs: { language: { default: null } }
+    },
+  },
+  marks: {
+    bold: {},
+    italic: {},
+    strike: {},
+    code: {},
+    link: { 
+      attrs: { 
+        href: { default: null },
+        title: { default: null }
+      }
+    },
+    highlight: { 
+      attrs: { 
+        highlight: { default: null }
+      }
+    }
+  }
+});
+
+const serializer = new MarkdownSerializer({
+  text: ((state: MarkdownSerializerState, node: Node) => {
+    state.text(node.text || '');
+  }) as NodeSerializerFn,
+  
+  paragraph: ((state: MarkdownSerializerState, node: Node) => {
+    state.renderInline(node);
+    state.closeBlock(node);
+  }) as NodeSerializerFn,
+  
+  heading: ((state: MarkdownSerializerState, node: Node) => {
+    state.write(state.repeat('#', node.attrs.level) + ' ');
+    state.renderInline(node);
+    state.closeBlock(node);
+  }) as NodeSerializerFn,
+  
+  blockquote: ((state: MarkdownSerializerState, node: Node) => {
+    state.wrapBlock('> ', null, node, () => state.renderContent(node));
+  }) as NodeSerializerFn,
+  
+  codeBlock: ((state: MarkdownSerializerState, node: Node) => {
+    const lang = node.attrs.language || '';
+    state.write('```' + lang + '\n');
+    state.text(node.textContent);
+    state.ensureNewLine();
+    state.write('```');
+    state.closeBlock(node);
+  }) as NodeSerializerFn,
+  
+  horizontalRule: ((state: MarkdownSerializerState, node: Node) => {
+    state.write('---');
+    state.closeBlock(node);
+  }) as NodeSerializerFn,
+  
+  hardBreak: ((state: MarkdownSerializerState) => {
+    // GFM requires two spaces followed by newline for hard breaks
+    state.write('  \n');
+  }) as NodeSerializerFn,
+  
+  listItem: ((state: MarkdownSerializerState, node: Node) => {
+    state.renderContent(node);
+  }) as NodeSerializerFn,
+  
+  bulletList: ((state: MarkdownSerializerState, node: Node) => {
+    state.renderList(node, '  ', () => '* ');
+  }) as NodeSerializerFn,
+  
+  orderedList: ((state: MarkdownSerializerState, node: Node) => {
+    const start = node.attrs.start || 1;
+    state.renderList(node, '  ', i => `${start + i}. `);
+  }) as NodeSerializerFn,
+  
+  // Custom nodes
+  blob: ((state: MarkdownSerializerState, node: Node) => {
+    // image syntax with optional title
+    const alt = node.attrs.alt || '';
+    const src = node.attrs.src || '';
+    const title = node.attrs.title;
+    
+    // If it's a non-image file, use link syntax instead
+    if (node.attrs.filetype && !node.attrs.filetype.startsWith('image/')) {
+      state.write(`[${alt || node.attrs.title || 'File'}](${src}${title ? ` "${title}"` : ''})`);
+    } else {
+      state.write(`![${alt}](${src}${title ? ` "${title}"` : ''})`);
+    }
+  }) as NodeSerializerFn,
+  
+  mention: ((state: MarkdownSerializerState, node: Node) => {
+    // user mentions
+    state.write(`@${node.attrs.label || ''}`);
+  }) as NodeSerializerFn
+}, {
+  bold: { open: '**', close: '**', mixable: true },
+  italic: { open: '_', close: '_', mixable: true },
+  strike: { open: '~~', close: '~~', mixable: true },
+  code: { open: '`', close: '`', escape: false },
+  link: {
+    open: '[',
+    close: ((_state: MarkdownSerializerState, mark: Mark) => {
+      const href = mark.attrs.href || '';
+      const title = mark.attrs.title;
+      return `](${href}${title ? ` "${title}"` : ''})`;
+    }) as MarkSerializerSpec['close']
+  },
+  highlight: {
+    open: ((_state: MarkdownSerializerState, mark: Mark) => {
+      const highlight = mark.attrs.highlight;
+      // Use HTML comments for highlight since GFM doesn't have native syntax
+      return highlight ? `<!-- highlight: ${highlight} -->` : '';
+    }) as MarkSerializerSpec['open'],
+    close: ((_state: MarkdownSerializerState, mark: Mark) => {
+      return mark.attrs.highlight ? '<!-- /highlight -->' : '';
+    }) as MarkSerializerSpec['close']
+  }
+});
+
+/**
+ * Recursively removes nodes of a specific type from the document
+ */
+function removeNodes(node: Node, type: string): Node {
+  if (!node?.content || node.type.name === 'text') return node;
+
+  const filteredContent = Array.from(node.content.content)
+    .filter((n: Node) => n.type.name !== type)
+    .map((n: Node) => removeNodes(n, type));
+
+  return node.type.create(
+    node.attrs,
+    Fragment.from(filteredContent),
+    node.marks
+  );
+}
+
+/**
+ * Converts a ProseMirror JSON document to GitHub Flavored Markdown
+ */
+export function exportToMarkdown(json: any, options: MarkdownExportOptions = {}): string {
+  try {
+    let doc = Node.fromJSON(schema, json);
+
+    if (options.removeEmbeds) {
+      doc = removeNodes(doc, 'blob');
+    }
+    
+    return serializer.serialize(doc);
+  } catch (error) {
+    console.error('Error exporting to Markdown:', error);
+    throw error;
+  }
+}
+
+/**
+ * Downloads content as a markdown file
+ */
+export function downloadMarkdown(content: string, filename: string): void {
+  const blob = new Blob([content], { type: 'text/markdown' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  
+  anchor.href = url;
+  anchor.download = `${filename}.md`;
+  anchor.click();
+  
+  URL.revokeObjectURL(url);
+}

--- a/assets/js/utils/markdown.ts
+++ b/assets/js/utils/markdown.ts
@@ -1,5 +1,5 @@
-import { MarkdownSerializer, MarkdownSerializerState } from 'prosemirror-markdown';
-import { Node, Schema, Fragment, Mark } from 'prosemirror-model';
+import { MarkdownSerializer, MarkdownSerializerState } from "prosemirror-markdown";
+import { Node, Schema, Fragment, Mark } from "prosemirror-model";
 
 interface MarkdownExportOptions {
   removeEmbeds?: boolean;
@@ -18,29 +18,29 @@ type MarkSerializerSpec = {
 // See spec: https://github.github.com/gfm/
 const schema = new Schema({
   nodes: {
-    doc: { content: 'block+' },
-    paragraph: { group: 'block', content: 'inline*' },
-    text: { group: 'inline' },
-    hardBreak: { group: 'inline', inline: true },
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*" },
+    text: { group: "inline" },
+    hardBreak: { group: "inline", inline: true },
     heading: {
       attrs: { level: { default: 1 } },
-      content: 'inline*',
-      group: 'block'
+      content: "inline*",
+      group: "block",
     },
-    blockquote: { content: 'block+', group: 'block' },
-    bulletList: { content: 'listItem+', group: 'block' },
+    blockquote: { content: "block+", group: "block" },
+    bulletList: { content: "listItem+", group: "block" },
     orderedList: {
-      content: 'listItem+',
-      group: 'block',
-      attrs: { start: { default: 1 } }
+      content: "listItem+",
+      group: "block",
+      attrs: { start: { default: 1 } },
     },
-    listItem: { content: 'paragraph block*', group: 'block' },
-    horizontalRule: { group: 'block' },
+    listItem: { content: "paragraph block*", group: "block" },
+    horizontalRule: { group: "block" },
     codeBlock: {
-      content: 'text*',
-      marks: '',
-      group: 'block',
-      attrs: { language: { default: null } }
+      content: "text*",
+      marks: "",
+      group: "block",
+      attrs: { language: { default: null } },
     },
   },
   marks: {
@@ -48,131 +48,130 @@ const schema = new Schema({
     italic: {},
     strike: {},
     code: {},
-    link: { 
-      attrs: { 
+    link: {
+      attrs: {
         href: { default: null },
-        title: { default: null }
-      }
+        title: { default: null },
+      },
     },
-    highlight: { 
-      attrs: { 
-        highlight: { default: null }
-      }
-    }
-  }
+    highlight: {
+      attrs: {
+        highlight: { default: null },
+      },
+    },
+  },
 });
 
-const serializer = new MarkdownSerializer({
-  text: ((state: MarkdownSerializerState, node: Node) => {
-    state.text(node.text || '');
-  }) as NodeSerializerFn,
-  
-  paragraph: ((state: MarkdownSerializerState, node: Node) => {
-    state.renderInline(node);
-    state.closeBlock(node);
-  }) as NodeSerializerFn,
-  
-  heading: ((state: MarkdownSerializerState, node: Node) => {
-    state.write(state.repeat('#', node.attrs.level) + ' ');
-    state.renderInline(node);
-    state.closeBlock(node);
-  }) as NodeSerializerFn,
-  
-  blockquote: ((state: MarkdownSerializerState, node: Node) => {
-    state.wrapBlock('> ', null, node, () => state.renderContent(node));
-  }) as NodeSerializerFn,
-  
-  codeBlock: ((state: MarkdownSerializerState, node: Node) => {
-    const lang = node.attrs.language || '';
-    state.write('```' + lang + '\n');
-    state.text(node.textContent);
-    state.ensureNewLine();
-    state.write('```');
-    state.closeBlock(node);
-  }) as NodeSerializerFn,
-  
-  horizontalRule: ((state: MarkdownSerializerState, node: Node) => {
-    state.write('---');
-    state.closeBlock(node);
-  }) as NodeSerializerFn,
-  
-  hardBreak: ((state: MarkdownSerializerState) => {
-    // GFM requires two spaces followed by newline for hard breaks
-    state.write('  \n');
-  }) as NodeSerializerFn,
-  
-  listItem: ((state: MarkdownSerializerState, node: Node) => {
-    state.renderContent(node);
-  }) as NodeSerializerFn,
-  
-  bulletList: ((state: MarkdownSerializerState, node: Node) => {
-    state.renderList(node, '  ', () => '* ');
-  }) as NodeSerializerFn,
-  
-  orderedList: ((state: MarkdownSerializerState, node: Node) => {
-    const start = node.attrs.start || 1;
-    state.renderList(node, '  ', i => `${start + i}. `);
-  }) as NodeSerializerFn,
-  
-  // Custom nodes
-  blob: ((state: MarkdownSerializerState, node: Node) => {
-    // image syntax with optional title
-    const alt = node.attrs.alt || '';
-    const src = node.attrs.src || '';
-    const title = node.attrs.title;
-    
-    // If it's a non-image file, use link syntax instead
-    if (node.attrs.filetype && !node.attrs.filetype.startsWith('image/')) {
-      state.write(`[${alt || node.attrs.title || 'File'}](${src}${title ? ` "${title}"` : ''})`);
-    } else {
-      state.write(`![${alt}](${src}${title ? ` "${title}"` : ''})`);
-    }
-  }) as NodeSerializerFn,
-  
-  mention: ((state: MarkdownSerializerState, node: Node) => {
-    // user mentions
-    state.write(`@${node.attrs.label || ''}`);
-  }) as NodeSerializerFn
-}, {
-  bold: { open: '**', close: '**', mixable: true },
-  italic: { open: '_', close: '_', mixable: true },
-  strike: { open: '~~', close: '~~', mixable: true },
-  code: { open: '`', close: '`', escape: false },
-  link: {
-    open: '[',
-    close: ((_state: MarkdownSerializerState, mark: Mark) => {
-      const href = mark.attrs.href || '';
-      const title = mark.attrs.title;
-      return `](${href}${title ? ` "${title}"` : ''})`;
-    }) as MarkSerializerSpec['close']
+const serializer = new MarkdownSerializer(
+  {
+    text: ((state: MarkdownSerializerState, node: Node) => {
+      state.text(node.text || "");
+    }) as NodeSerializerFn,
+
+    paragraph: ((state: MarkdownSerializerState, node: Node) => {
+      state.renderInline(node);
+      state.closeBlock(node);
+    }) as NodeSerializerFn,
+
+    heading: ((state: MarkdownSerializerState, node: Node) => {
+      state.write(state.repeat("#", node.attrs.level) + " ");
+      state.renderInline(node);
+      state.closeBlock(node);
+    }) as NodeSerializerFn,
+
+    blockquote: ((state: MarkdownSerializerState, node: Node) => {
+      state.wrapBlock("> ", null, node, () => state.renderContent(node));
+    }) as NodeSerializerFn,
+
+    codeBlock: ((state: MarkdownSerializerState, node: Node) => {
+      const lang = node.attrs.language || "";
+      state.write("```" + lang + "\n");
+      state.text(node.textContent);
+      state.ensureNewLine();
+      state.write("```");
+      state.closeBlock(node);
+    }) as NodeSerializerFn,
+
+    horizontalRule: ((state: MarkdownSerializerState, node: Node) => {
+      state.write("---");
+      state.closeBlock(node);
+    }) as NodeSerializerFn,
+
+    hardBreak: ((state: MarkdownSerializerState) => {
+      // GFM requires two spaces followed by newline for hard breaks
+      state.write("  \n");
+    }) as NodeSerializerFn,
+
+    listItem: ((state: MarkdownSerializerState, node: Node) => {
+      state.renderContent(node);
+    }) as NodeSerializerFn,
+
+    bulletList: ((state: MarkdownSerializerState, node: Node) => {
+      state.renderList(node, "  ", () => "* ");
+    }) as NodeSerializerFn,
+
+    orderedList: ((state: MarkdownSerializerState, node: Node) => {
+      const start = node.attrs.start || 1;
+      state.renderList(node, "  ", (i) => `${start + i}. `);
+    }) as NodeSerializerFn,
+
+    // Custom nodes
+    blob: ((state: MarkdownSerializerState, node: Node) => {
+      // image syntax with optional title
+      const alt = node.attrs.alt || "";
+      const src = node.attrs.src || "";
+      const title = node.attrs.title;
+
+      // If it's a non-image file, use link syntax instead
+      if (node.attrs.filetype && !node.attrs.filetype.startsWith("image/")) {
+        state.write(`[${alt || node.attrs.title || "File"}](${src}${title ? ` "${title}"` : ""})`);
+      } else {
+        state.write(`![${alt}](${src}${title ? ` "${title}"` : ""})`);
+      }
+    }) as NodeSerializerFn,
+
+    mention: ((state: MarkdownSerializerState, node: Node) => {
+      // user mentions
+      state.write(`@${node.attrs.label || ""}`);
+    }) as NodeSerializerFn,
   },
-  highlight: {
-    open: ((_state: MarkdownSerializerState, mark: Mark) => {
-      const highlight = mark.attrs.highlight;
-      // Use HTML comments for highlight since GFM doesn't have native syntax
-      return highlight ? `<!-- highlight: ${highlight} -->` : '';
-    }) as MarkSerializerSpec['open'],
-    close: ((_state: MarkdownSerializerState, mark: Mark) => {
-      return mark.attrs.highlight ? '<!-- /highlight -->' : '';
-    }) as MarkSerializerSpec['close']
-  }
-});
+  {
+    bold: { open: "**", close: "**", mixable: true },
+    italic: { open: "_", close: "_", mixable: true },
+    strike: { open: "~~", close: "~~", mixable: true },
+    code: { open: "`", close: "`", escape: false },
+    link: {
+      open: "[",
+      close: ((_state: MarkdownSerializerState, mark: Mark) => {
+        const href = mark.attrs.href || "";
+        const title = mark.attrs.title;
+        return `](${href}${title ? ` "${title}"` : ""})`;
+      }) as MarkSerializerSpec["close"],
+    },
+    highlight: {
+      open: ((_state: MarkdownSerializerState, mark: Mark) => {
+        const highlight = mark.attrs.highlight;
+        // Use HTML comments for highlight since GFM doesn't have native syntax
+        return highlight ? `<!-- highlight: ${highlight} -->` : "";
+      }) as MarkSerializerSpec["open"],
+      close: ((_state: MarkdownSerializerState, mark: Mark) => {
+        return mark.attrs.highlight ? "<!-- /highlight -->" : "";
+      }) as MarkSerializerSpec["close"],
+    },
+  },
+);
 
 /**
  * Recursively removes nodes of a specific type from the document
  */
 function removeNodes(node: Node, type: string): Node {
-  if (!node?.content || node.type.name === 'text') return node;
+  if (!node?.content || node.type.name === "text") return node;
 
   const filteredContent = Array.from(node.content.content)
     .filter((n: Node) => n.type.name !== type)
     .map((n: Node) => removeNodes(n, type));
 
-  return node.type.create(
-    node.attrs,
-    Fragment.from(filteredContent),
-    node.marks
-  );
+  return node.type.create(node.attrs, Fragment.from(filteredContent), node.marks);
 }
 
 /**
@@ -183,12 +182,12 @@ export function exportToMarkdown(json: any, options: MarkdownExportOptions = {})
     let doc = Node.fromJSON(schema, json);
 
     if (options.removeEmbeds) {
-      doc = removeNodes(doc, 'blob');
+      doc = removeNodes(doc, "blob");
     }
-    
+
     return serializer.serialize(doc);
   } catch (error) {
-    console.error('Error exporting to Markdown:', error);
+    console.error("Error exporting to Markdown:", error);
     throw error;
   }
 }
@@ -197,13 +196,13 @@ export function exportToMarkdown(json: any, options: MarkdownExportOptions = {})
  * Downloads content as a markdown file
  */
 export function downloadMarkdown(content: string, filename: string): void {
-  const blob = new Blob([content], { type: 'text/markdown' });
+  const blob = new Blob([content], { type: "text/markdown" });
   const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  
+  const anchor = document.createElement("a");
+
   anchor.href = url;
   anchor.download = `${filename}.md`;
   anchor.click();
-  
+
   URL.revokeObjectURL(url);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "operately",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -27,6 +27,8 @@
         "lucide-react": "^0.475.0",
         "nprogress": "^0.2.0",
         "phoenix": "^1.7.14",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-model": "^1.24.1",
         "prosemirror-state": "^1.4.1",
         "react": "^18.3.0",
         "react-datepicker": "^4.14.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lucide-react": "^0.475.0",
     "nprogress": "^0.2.0",
     "phoenix": "^1.7.14",
+    "prosemirror-markdown": "^1.13.1",
+    "prosemirror-model": "^1.24.1",
     "prosemirror-state": "^1.4.1",
     "react": "^18.3.0",
     "react-datepicker": "^4.14.0",


### PR DESCRIPTION
This pull request adds document export to markdown ⚡️

What's in this:
- Built with ProseMirror's serializer to match GitHub Flavored Markdown spec
- Can strip out embeds when exporting (super helpful for LLMs!)
- Supports all the usual markdown goodies (headings, lists, code blocks)

Closes #2038