### PR TITLE
fix: Check-in form is not submitted when target is edited

### DIFF
--- a/assets/js/components/Forms/Form.tsx
+++ b/assets/js/components/Forms/Form.tsx
@@ -3,10 +3,19 @@ import * as React from "react";
 import { FormContext } from "./FormContext";
 import { FormState } from "./useForm";
 
-export function Form({ form, children, testId }: { form: FormState<any>; children: React.ReactNode; testId?: string }) {
+interface Props {
+  form: FormState<any>;
+  children: React.ReactNode;
+  testId?: string;
+  preventSubmitOnEnter?: boolean;
+}
+
+export function Form({ form, children, testId, preventSubmitOnEnter }: Props) {
   const action = (e: React.FormEvent) => {
     e.preventDefault();
-    form.actions.submit("primary");
+    if (!preventSubmitOnEnter) {
+      form.actions.submit("primary");
+    }
   };
 
   return (

--- a/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -10,7 +10,7 @@ interface Props {
   form: any;
   readonly: boolean;
   goal: Goal;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export function Form({ form, readonly, goal, children }: Props) {
@@ -19,7 +19,7 @@ export function Form({ form, readonly, goal, children }: Props) {
   assertPresent(goal.reviewer, "reviewer must be present in goal");
 
   return (
-    <Forms.Form form={form}>
+    <Forms.Form form={form} preventSubmitOnEnter>
       <Forms.FieldGroup>
         <div className="flex items-start gap-8 mt-6">
           <Forms.SelectGoalStatus


### PR DESCRIPTION
In the goal check-in form, when a target is updated by pressing "enter", it no longer submits the form. 