### PR TITLE
chore: Redirect to new Goal page if feature enabled

### DIFF
--- a/assets/js/pages/GoalPage/index.tsx
+++ b/assets/js/pages/GoalPage/index.tsx
@@ -10,12 +10,19 @@ import { GoalTargets } from "@/features/goals/GoalTargets";
 import { LastCheckInMessage } from "@/features/goals/GoalCheckIn";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
+import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
+import { Paths } from "@/routes/paths";
 
 interface LoaderResult {
   goal: Goals.Goal;
 }
 
 export async function loader({ params }): Promise<LoaderResult> {
+  await redirectIfFeatureEnabled(params, {
+    feature: "new_goal_page",
+    path: Paths.goalV2Path(params.id),
+  });
+
   return {
     goal: await Goals.getGoal({
       id: params.id,

--- a/assets/js/pages/GoalV2Page/index.tsx
+++ b/assets/js/pages/GoalV2Page/index.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+
+interface LoaderResult {
+  // TODO: Define what is loaded when you visit this page
+}
+
+export async function loader({}): Promise<LoaderResult> {
+  return {}; // TODO: Load data here
+}
+
+export function Page() {
+  // const data = Pages.useLoadedData<LoaderResult>();
+
+  return (
+    <Pages.Page title={"GoalV2Page"}>
+      <Paper.Root>
+        <Paper.Body>
+          <div className="text-content-accent text-3xl font-extrabold">GoalV2Page</div>
+        </Paper.Body>
+      </Paper.Root>
+    </Pages.Page>
+  );
+}

--- a/assets/js/pages/index.tsx
+++ b/assets/js/pages/index.tsx
@@ -51,6 +51,7 @@ import * as GoalProgressUpdateNewPage from "./GoalProgressUpdateNewPage";
 import * as GoalProgressUpdatePage from "./GoalProgressUpdatePage";
 import * as GoalReopenPage from "./GoalReopenPage";
 import * as GoalSubgoalsPage from "./GoalSubgoalsPage";
+import * as GoalV2Page from "./GoalV2Page";
 import * as GoalsAndProjectsPage from "./GoalsAndProjectsPage";
 import * as HomePage from "./HomePage";
 import * as JoinPage from "./JoinPage";
@@ -362,6 +363,11 @@ export default {
     name: "GoalSubgoalsPage",
     loader: GoalSubgoalsPage.loader,
     Page: GoalSubgoalsPage.Page,
+  },
+  GoalV2Page: {
+    name: "GoalV2Page",
+    loader: GoalV2Page.loader,
+    Page: GoalV2Page.Page,
   },
   GoalsAndProjectsPage: {
     name: "GoalsAndProjectsPage",

--- a/assets/js/routes/index.tsx
+++ b/assets/js/routes/index.tsx
@@ -131,6 +131,7 @@ export function createAppRoutes() {
         pageRoute("goals", pages.GoalsAndProjectsPage),
         pageRoute("goals/new", pages.GoalAddPage),
         pageRoute("goals/:id", pages.GoalPage),
+        pageRoute("goals/:id/v2", pages.GoalV2Page),
         pageRoute("goals/:id/subgoals", pages.GoalSubgoalsPage),
         pageRoute("goals/:id/about", pages.GoalAboutPage),
         pageRoute("goals/:goalId/edit", pages.GoalEditPage),

--- a/assets/js/routes/paths.tsx
+++ b/assets/js/routes/paths.tsx
@@ -308,6 +308,11 @@ export class Paths {
     return createCompanyPath(["goals", goalId]);
   }
 
+  // Temporary path
+  static goalV2Path(goalId: string) {
+    return createCompanyPath(["goals", goalId, "v2"]);
+  }
+
   static newGoalPath(params?: { companyWide: boolean }) {
     return createCompanyPath(["goals", "new"]) + (params?.companyWide ? "?company-wide=true" : "");
   }


### PR DESCRIPTION
I've added the `new_goal_page` feature flag. If this feature is enabled, when the user navigates to the Goal page, they are going to be redirected to the Goal V2 page. 

Once the Goal V2 page is ready, it will become the Goal page. 