### PR TITLE
feat: Goal can be edited from new Goal Page

### DIFF
--- a/assets/js/pages/GoalV2Page/Form.tsx
+++ b/assets/js/pages/GoalV2Page/Form.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 
-import * as Goals from "@/models/goals";
-import * as Time from "@/utils/time";
-
 import Forms from "@/components/Forms";
-import { useIsViewMode, useSetPageMode } from "@/components/Pages";
+import { useIsViewMode } from "@/components/Pages";
 import { EditBar } from "@/components/Pages/EditBar";
-import { assertPresent } from "@/utils/assertions";
 
 import { useLoadedData } from "./loader";
-import { findUpdatedTargets } from "./utils";
 import { Messages } from "./Messages";
 import { HorizontalRule, Title } from "./components";
 import { Champion, Contributors, Reviewer } from "./contributors";
@@ -18,44 +13,10 @@ import { NextCheckIn } from "./NextCheckIn";
 import { RelatedWork } from "./RelatedWork";
 import { GoalName } from "./Name";
 import { ParentGoal } from "./ParentGoal";
+import { useForm } from "./useForm";
 
 export function Form() {
-  const { goal } = useLoadedData();
-  const [edit] = Goals.useEditGoal();
-  const setPageMode = useSetPageMode();
-
-  assertPresent(goal.targets, "targets must be present in goal");
-  assertPresent(goal.timeframe, "timeframe must be present in goal");
-  assertPresent(goal.champion, "champion must be present in goal");
-  assertPresent(goal.reviewer, "reviewer must be present in goal");
-
-  const currTimeframe = {
-    startDate: Time.parseDate(goal.timeframe.startDate),
-    endDate: Time.parseDate(goal.timeframe.endDate),
-  };
-
-  const form = Forms.useForm({
-    fields: {
-      name: goal.name!,
-      description: JSON.parse(goal.description!),
-      targets: goal.targets,
-      timeframe: currTimeframe,
-      champion: goal.champion.id,
-      reviewer: goal.reviewer.id,
-      parentGoal: goal.parentGoal,
-    },
-    cancel: () => setPageMode("view"),
-    submit: async () => {
-      await edit({
-        goalId: goal.id,
-        name: form.values.name,
-        description: JSON.stringify(form.values.description),
-        updatedTargets: findUpdatedTargets(goal.targets!, form.values.targets),
-      });
-
-      setPageMode("view");
-    },
-  });
+  const form = useForm();
 
   return (
     <Forms.Form form={form} preventSubmitOnEnter>

--- a/assets/js/pages/GoalV2Page/loader.tsx
+++ b/assets/js/pages/GoalV2Page/loader.tsx
@@ -23,6 +23,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       includePermissions: true,
       includeUnreadNotifications: true,
       includeLastCheckIn: true,
+      includeAccessLevels: true,
     }).then((data) => data.goal!),
     Activities.getActivities({
       scopeType: "goal",
@@ -50,4 +51,8 @@ export async function loader({ params }): Promise<LoaderResult> {
 
 export function useLoadedData(): LoaderResult {
   return Pages.useLoadedData() as LoaderResult;
+}
+
+export function useRefresh() {
+  return Pages.useRefresh();
 }

--- a/assets/js/pages/GoalV2Page/useForm.tsx
+++ b/assets/js/pages/GoalV2Page/useForm.tsx
@@ -1,0 +1,61 @@
+import * as Goals from "@/models/goals";
+import * as Time from "@/utils/time";
+
+import Forms from "@/components/Forms";
+import { useSetPageMode } from "@/components/Pages";
+import { assertPresent } from "@/utils/assertions";
+
+import { parseTargets, serializeTimeframe } from "./utils";
+import { useLoadedData, useRefresh } from "./loader";
+
+export function useForm() {
+  const refresh = useRefresh();
+  const { goal } = useLoadedData();
+  const [edit] = Goals.useEditGoal();
+  const setPageMode = useSetPageMode();
+
+  assertPresent(goal.targets, "targets must be present in goal");
+  assertPresent(goal.timeframe, "timeframe must be present in goal");
+  assertPresent(goal.champion, "champion must be present in goal");
+  assertPresent(goal.reviewer, "reviewer must be present in goal");
+
+  const currTimeframe = {
+    startDate: Time.parseDate(goal.timeframe.startDate),
+    endDate: Time.parseDate(goal.timeframe.endDate),
+  };
+
+  const form = Forms.useForm({
+    fields: {
+      name: goal.name!,
+      description: JSON.parse(goal.description!),
+      targets: goal.targets,
+      timeframe: currTimeframe,
+      champion: goal.champion.id,
+      reviewer: goal.reviewer.id,
+      parentGoal: goal.parentGoal,
+    },
+    cancel: () => setPageMode("view"),
+    submit: async () => {
+      assertPresent(goal.accessLevels, "accessLevels must be present in goal");
+
+      await edit({
+        goalId: goal.id,
+        name: form.values.name,
+        championId: form.values.champion,
+        reviewerId: form.values.reviewer,
+        timeframe: serializeTimeframe(form.values.timeframe, currTimeframe),
+        description: JSON.stringify(form.values.description),
+        updatedTargets: parseTargets(form.values.targets),
+        addedTargets: [],
+        anonymousAccessLevel: goal.accessLevels.public,
+        companyAccessLevel: goal.accessLevels.company,
+        spaceAccessLevel: goal.accessLevels.space,
+      });
+
+      refresh();
+      setPageMode("view");
+    },
+  });
+
+  return form;
+}

--- a/assets/js/pages/GoalV2Page/utils.tsx
+++ b/assets/js/pages/GoalV2Page/utils.tsx
@@ -1,19 +1,16 @@
 import * as Goals from "@/models/goals";
 import * as Time from "@/utils/time";
+import * as Timeframes from "@/utils/timeframes";
 
-export function findUpdatedTargets(targets: Goals.Target[], updatedTargets: Goals.Target[]) {
-  const originalTargets: Map<string, Goals.Target> = new Map();
-
-  targets.forEach((target) => {
-    originalTargets.set(target.id!, target);
-  });
-
-  const changedTargets = updatedTargets.filter((target) => {
-    const originalTarget = originalTargets.get(target.id!);
-    return target.value !== originalTarget?.value;
-  });
-
-  return changedTargets;
+export function parseTargets(targets: Goals.Target[]) {
+  return targets.map((t, index) => ({
+    id: t.id,
+    name: t.name,
+    from: t.from,
+    to: t.to,
+    unit: t.unit,
+    index: index,
+  }));
 }
 
 export function findTimeLeft(timeframe: Goals.Timeframe) {
@@ -29,4 +26,17 @@ export function findTimeLeft(timeframe: Goals.Timeframe) {
     return days === 1 ? "1 day left" : `${days} days left`;
   }
   return "";
+}
+
+export function serializeTimeframe(newTimeframe, oldTimeframe) {
+  const timeframesEqual = Timeframes.equalDates(
+    newTimeframe as Timeframes.Timeframe,
+    oldTimeframe as Timeframes.Timeframe,
+  );
+
+  if (timeframesEqual) {
+    return Timeframes.serialize(oldTimeframe);
+  } else {
+    return Timeframes.serialize({ ...newTimeframe, type: "days" });
+  }
 }


### PR DESCRIPTION
A Goal can now be edited from the new Goal Page.  However, the Goal's parent and targets are not edited yet:
- The Goal's parent is still not supported by the `GoalEditing` operation. 
- The Goal's targets section is not ready yet.