### PR TITLE
fix: Several adjustments in new Goal Page

### DIFF
--- a/assets/js/components/Forms/TitleInput.tsx
+++ b/assets/js/components/Forms/TitleInput.tsx
@@ -10,7 +10,11 @@ import { validateTextLength } from "./validations/textLength";
 import { useFieldValue, useFieldError } from "./FormContext";
 import { createTestId } from "@/utils/testid";
 
-interface TitleInputProps {
+interface StyleOptions {
+  fontBold?: boolean;
+}
+
+interface TitleInputProps extends StyleOptions {
   field: string;
   autoFocus?: boolean;
   placeholder?: string;
@@ -38,14 +42,14 @@ export function TitleInput(props: TitleInputProps) {
   return (
     <InputField field={field} error={error}>
       {props.readonly ? (
-        <div className={styles(false)}>{value}</div>
+        <div className={styles(false, { fontBold: props.fontBold })}>{value}</div>
       ) : (
         <input
           name={field}
           autoFocus={props.autoFocus}
           placeholder={placeholder}
           data-test-id={props.testId ?? createTestId(field)}
-          className={styles(!!error)}
+          className={styles(!!error, { fontBold: props.fontBold })}
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -55,11 +59,10 @@ export function TitleInput(props: TitleInputProps) {
   );
 }
 
-function styles(error: boolean | undefined) {
+function styles(error: boolean | undefined, opts: StyleOptions) {
   return classNames(
     "bg-surface-base",
     "text-3xl",
-    "font-semibold",
     "border-none",
     "outline-none",
     "focus:outline-none",
@@ -70,9 +73,7 @@ function styles(error: boolean | undefined) {
     "ring-0",
     "placeholder:text-content-subtle",
     "leading-wide",
-    {
-      "border-surface-outline": !error,
-      "border-red-500": error,
-    },
+    error ? "border-red-500" : "border-surface-outline",
+    opts.fontBold ? "font-bold" : "font-semibold",
   );
 }

--- a/assets/js/pages/GoalV2Page/Description.tsx
+++ b/assets/js/pages/GoalV2Page/Description.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import Forms from "@/components/Forms";
+import { useFieldValue } from "@/components/Forms/FormContext";
+import { useIsViewMode } from "@/components/Pages";
+import { richContentToString } from "@/components/RichContent";
+
+import { useLoadedData } from "./loader";
+
+export function Description() {
+  const { goal } = useLoadedData();
+  const isViewMode = useIsViewMode();
+  const [description] = useFieldValue("description");
+
+  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
+  const strDescription = description ? richContentToString(description).trim() : "";
+
+  if (!strDescription && isViewMode) return null;
+
+  return (
+    <Forms.FieldGroup>
+      <div className="-ml-2">
+        <Forms.RichTextArea
+          field="description"
+          placeholder="Write here..."
+          mentionSearchScope={mentionSearchScope}
+          readonly={isViewMode}
+          height="3rem"
+          hideBorder
+          hideToolbar
+        />
+      </div>
+    </Forms.FieldGroup>
+  );
+}

--- a/assets/js/pages/GoalV2Page/Form.tsx
+++ b/assets/js/pages/GoalV2Page/Form.tsx
@@ -20,9 +20,9 @@ export function Form() {
 
   return (
     <Forms.Form form={form} preventSubmitOnEnter>
-      <div className="flex gap-12">
-        <div className="flex-1">
-          <ParentGoal />
+      <div className="grid grid-cols-[1fr_260px] gap-x-12">
+        <ParentGoal />
+        <div className="col-start-1 row-start-2 flex-1">
           <GoalName />
           <Description />
           <HorizontalRule />
@@ -32,8 +32,7 @@ export function Form() {
           <HorizontalRule />
           <RelatedWork />
         </div>
-
-        <div className="w-[260px] flex flex-col gap-4 sticky top-0 self-start">
+        <div className="col-start-2 row-start-2 flex flex-col gap-4 sticky top-0 self-start">
           <NextCheckIn />
           <Timeframe />
           <Champion />

--- a/assets/js/pages/GoalV2Page/Form.tsx
+++ b/assets/js/pages/GoalV2Page/Form.tsx
@@ -4,7 +4,6 @@ import Forms from "@/components/Forms";
 import { useIsViewMode } from "@/components/Pages";
 import { EditBar } from "@/components/Pages/EditBar";
 
-import { useLoadedData } from "./loader";
 import { Messages } from "./Messages";
 import { HorizontalRule, Title } from "./components";
 import { Champion, Contributors, Reviewer } from "./contributors";
@@ -14,6 +13,7 @@ import { RelatedWork } from "./RelatedWork";
 import { GoalName } from "./Name";
 import { ParentGoal } from "./ParentGoal";
 import { useForm } from "./useForm";
+import { Description } from "./Description";
 
 export function Form() {
   const form = useForm();
@@ -44,29 +44,6 @@ export function Form() {
 
       <EditBar save={form.actions.submit} cancel={form.actions.cancel} />
     </Forms.Form>
-  );
-}
-
-function Description() {
-  const { goal } = useLoadedData();
-  const isViewMode = useIsViewMode();
-
-  const mentionSearchScope = { type: "goal", id: goal.id! } as const;
-
-  return (
-    <Forms.FieldGroup>
-      <div className="-ml-2">
-        <Forms.RichTextArea
-          field="description"
-          placeholder="Write here..."
-          mentionSearchScope={mentionSearchScope}
-          readonly={isViewMode}
-          height="3rem"
-          hideBorder
-          hideToolbar
-        />
-      </div>
-    </Forms.FieldGroup>
   );
 }
 

--- a/assets/js/pages/GoalV2Page/Name.tsx
+++ b/assets/js/pages/GoalV2Page/Name.tsx
@@ -20,7 +20,7 @@ function ViewName() {
   return (
     <Forms.FieldGroup>
       <div className="flex items-start gap-2">
-        <Forms.TitleInput field="name" readonly />
+        <Forms.TitleInput field="name" readonly fontBold />
         <GoalStatusBadge status={status} className="mt-3" />
       </div>
     </Forms.FieldGroup>
@@ -30,7 +30,7 @@ function ViewName() {
 function EditName() {
   return (
     <Forms.FieldGroup>
-      <Forms.TitleInput field="name" />
+      <Forms.TitleInput field="name" fontBold />
     </Forms.FieldGroup>
   );
 }

--- a/assets/js/pages/GoalV2Page/components.tsx
+++ b/assets/js/pages/GoalV2Page/components.tsx
@@ -18,7 +18,7 @@ export function DisableInEditMode({ children }) {
 }
 
 export function Title({ title }: { title: string }) {
-  return <div className="my-2 uppercase text-xs font-semibold tracking-wide">{title}</div>;
+  return <div className="my-2 uppercase text-xs font-bold tracking-wide">{title}</div>;
 }
 
 export function HorizontalRule() {

--- a/assets/js/pages/GoalV2Page/contributors.tsx
+++ b/assets/js/pages/GoalV2Page/contributors.tsx
@@ -59,7 +59,7 @@ function ReadonlyPerson({ label, person }) {
   return (
     <div>
       <Title title={label} />
-      <div className="flex items-center gap-1.5 -mt-2">
+      <div className="text-sm flex items-center gap-1.5 -mt-2">
         <AvatarLink person={person} size={20} className="mt-2" /> {person.fullName}
       </div>
     </div>


### PR DESCRIPTION
I've made several adjustments in the new Goal Page:
- No extra space is now displayed when the Goal doesn't have a description
- Titles are now bold
- The champion and reviewer names are now displayed with smaller font.
- "Next Check-in" section is now aligned with the Goal title.