### PR TITLE
chore: Chronometer component can be displayed in gray

### DIFF
--- a/assets/js/components/Forms/TimeframeField.tsx
+++ b/assets/js/components/Forms/TimeframeField.tsx
@@ -5,7 +5,7 @@ import * as Popover from "@radix-ui/react-popover";
 import { Timeframe } from "@/utils/timeframes";
 
 import { SecondaryButton } from "@/components/Buttons";
-import { Chronometer } from "@/components/Chronometer";
+import { Chronometer, CompletedColor } from "@/components/Chronometer";
 import { CustomRangePicker } from "@/components/TimeframeSelector/CustomRangePicker";
 
 import { useFieldValue } from "./FormContext";
@@ -16,6 +16,7 @@ interface Props {
   label?: string;
   readonly?: boolean;
   customLabel?: React.ReactNode;
+  completedColor?: CompletedColor;
 }
 
 //
@@ -33,7 +34,7 @@ interface Props {
 // });
 //
 
-export function TimeframeField({ field, label, readonly, customLabel }: Props) {
+export function TimeframeField({ field, label, readonly, customLabel, completedColor }: Props) {
   const [open, setOpen] = React.useState(false);
   const [value] = useFieldValue<Timeframe>(field);
 
@@ -51,7 +52,7 @@ export function TimeframeField({ field, label, readonly, customLabel }: Props) {
             </Popover.Trigger>
           )}
         </div>
-        <Chronometer start={value.startDate!} end={value.endDate!} />
+        <Chronometer start={value.startDate!} end={value.endDate!} completedColor={completedColor} />
       </div>
 
       <PopoverContent field={field} />

--- a/assets/js/pages/GoalV2Page/Timeframe.tsx
+++ b/assets/js/pages/GoalV2Page/Timeframe.tsx
@@ -19,7 +19,12 @@ export function Timeframe() {
   return (
     <div>
       <Forms.FieldGroup>
-        <Forms.TimeframeField readonly={isViewMode} field="timeframe" customLabel={<Title title="Timeframe" />} />
+        <Forms.TimeframeField
+          readonly={isViewMode}
+          field="timeframe"
+          customLabel={<Title title="Timeframe" />}
+          completedColor={isViewMode ? "stone" : "indigo"}
+        />
       </Forms.FieldGroup>
       <div className="mt-2 text-xs text-content-dimmed">{timeLeft}</div>
     </div>


### PR DESCRIPTION
On the new Goal Page, while on "view" mode, the Timeframe Chronometer is displayed in gray.