### PR TITLE
feat: Display banner when Goal is closed or archived

### DIFF
--- a/assets/js/features/goals/GoalPageHeader/index.tsx
+++ b/assets/js/features/goals/GoalPageHeader/index.tsx
@@ -98,7 +98,7 @@ function ParentGoal({ goal }: { goal: Goals.Goal | null | undefined }) {
   );
 }
 
-function Banner({ goal }) {
+export function Banner({ goal }) {
   if (goal.isClosed) {
     return (
       <Paper.Banner>

--- a/assets/js/pages/GoalV2Page/page.tsx
+++ b/assets/js/pages/GoalV2Page/page.tsx
@@ -4,6 +4,7 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import { Navigation } from "@/features/goals/GoalPageNavigation";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { Banner as ArchivedClosedBanner } from "@/features/goals/GoalPageHeader";
 import { assertPresent } from "@/utils/assertions";
 
 import { useLoadedData } from "./loader";
@@ -25,6 +26,7 @@ export function Page() {
         <Navigation space={goal.space} />
 
         <Paper.Body>
+          <ArchivedClosedBanner goal={goal} />
           <Options />
           <Form />
           <GoalFeed />


### PR DESCRIPTION
When a Goal is closed or archived, a banner is displayed informing the user.