### PR TITLE
fix: assertGoalStatusValidity supports concern status

### DIFF
--- a/assets/js/models/goals/index.tsx
+++ b/assets/js/models/goals/index.tsx
@@ -65,8 +65,8 @@ export function targetProgressPercentage(target: Target): number {
 
 export function assertGoalStatusValidity(
   status: string,
-): asserts status is "on_track" | "caution" | "issue" | "pending" {
-  if (!["on_track", "caution", "issue", "pending"].includes(status)) {
+): asserts status is "on_track" | "caution" | "concern" | "issue" | "pending" {
+  if (!["on_track", "caution", "concern", "issue", "pending"].includes(status)) {
     throw new Error(`Invalid status: ${status}`);
   }
 }


### PR DESCRIPTION
The `assertGoalStatusValidity` did not support the "concern" status.