### PR TITLE
fix: Handle blur event in target ValueEdit component

### DIFF
--- a/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -215,7 +215,9 @@ function TimeframeEditButton({ value, setValue }: TimeframeEditButtonProps) {
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger>
-        <SecondaryButton size="xxs">Edit</SecondaryButton>
+        <SecondaryButton size="xxs" spanButton>
+          Edit
+        </SecondaryButton>
       </Popover.Trigger>
 
       <Popover.Portal>

--- a/assets/js/features/goals/GoalTargetsV2/TargetValue.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/TargetValue.tsx
@@ -68,12 +68,21 @@ function ValueEdit({ index }: { index: number }) {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleBlur();
+      e.currentTarget.blur();
+    }
+  };
+
   return (
     <div>
       <input
         type="text"
         onChange={(e) => setTempValue(e.target.value)}
         onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
         value={tempValue || ""}
         className="ring-0 bg-surface-base text-content-accent outline-none px-2 py-1.5 text-sm font-medium w-32 text-right border border-stroke-base rounded"
       />


### PR DESCRIPTION
Previously, on the Goal Check-in page, when the `ValueEdit` component was focused, pressing the "enter" key would move the focus to the description field and unexpectedly enable the bold style for the description. Now, pressing "enter" simply removes the focus from `ValueEdit`.