### PR TITLE
feat: Target definition can be edited on the new Goal Page

### DIFF
--- a/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+import * as Goals from "@/models/goals";
+import { IconPencil } from "@tabler/icons-react";
+
+import Forms from "@/components/Forms";
+import { MiniPieChart } from "@/components/charts";
+import { Target } from "./types";
+import { TargetValue } from "./TargetValue";
+import classNames from "classnames";
+import { PrimaryButton } from "@/components/Buttons";
+
+interface Props {
+  target: Target;
+  index: number;
+}
+
+export function EditTargetCard({ target, index }: Props) {
+  const [editing, setEditing] = React.useState(false);
+  const progress = Goals.targetProgressPercentage(target);
+
+  const toggleEditing = () => setEditing(!editing);
+
+  const containerClass = classNames(
+    "relative py-2 px-3 mb-2",
+    "grid grid-cols-[1fr_auto] items-center gap-x-3",
+    "last:mb-0 border border-surface-outline rounded",
+    editing ? "bg-surface-base" : "bg-surface-accent",
+  );
+
+  return (
+    <div className={containerClass}>
+      <div className="flex items-center gap-2 truncate">
+        <MiniPieChart completed={progress} total={100} size={16} />
+        <NameField target={target} index={index} editing={editing} />
+      </div>
+      <div className="mr-2">
+        <TargetValue readonly index={index} target={target} />
+      </div>
+      {!editing && (
+        <IconPencil
+          onClick={toggleEditing}
+          className="absolute right-0.5 top-0.5 rounded-full hover:bg-surface-accent cursor-pointer hover:text-accent-1 transition-colors"
+          size={16}
+        />
+      )}
+
+      <DetailsSection index={index} toggleEditing={toggleEditing} editing={editing} />
+    </div>
+  );
+}
+
+function DetailsSection({ index, editing, toggleEditing }) {
+  if (!editing) return null;
+
+  return (
+    <div className="col-span-2 mt-2">
+      <Forms.FieldGroup layout="grid" layoutOptions={{ columns: 3 }}>
+        <Forms.NumberInput label="Start" field={`targets[${index}].from`} />
+        <Forms.NumberInput label="Target" field={`targets[${index}].to`} />
+        <Forms.TextInput label="Unit" field={`targets[${index}].unit`} />
+      </Forms.FieldGroup>
+      <div className="mt-2">
+        <PrimaryButton size="sm" onClick={toggleEditing}>
+          Done
+        </PrimaryButton>
+      </div>
+    </div>
+  );
+}
+
+function NameField({ index, editing, target }: { index: number; target: Target; editing: boolean }) {
+  if (!editing) {
+    return <div className="font-medium truncate">{target.name}</div>;
+  } else {
+    return (
+      <div className="w-full relative">
+        <Forms.FieldGroup>
+          <Forms.TextInput field={`targets[${index}].name`} />
+        </Forms.FieldGroup>
+      </div>
+    );
+  }
+}

--- a/assets/js/features/goals/GoalTargetsV2/TargetNameSection.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/TargetNameSection.tsx
@@ -3,24 +3,21 @@ import React from "react";
 import * as Goals from "@/models/goals";
 import classNames from "classnames";
 import { MiniPieChart } from "@/components/charts";
-import Forms from "@/components/Forms";
 import { Target } from "./types";
 
 interface Props {
   target: Target;
-  index: number;
-  readonly: boolean;
   dotsBetween?: boolean;
 }
 
-export function TargetNameSection({ target, index, readonly, dotsBetween }: Props) {
+export function TargetNameSection({ target, dotsBetween }: Props) {
   const progress = Goals.targetProgressPercentage(target);
-  const nameClass = classNames("flex items-center gap-2 flex-1", { truncate: readonly });
+  const nameClass = classNames("flex items-center gap-2 flex-1 truncate");
 
   return (
     <div className={nameClass}>
       <MiniPieChart completed={progress} total={100} size={16} />
-      {readonly ? <NameView name={target.name!} /> : <NameEdit index={index} />}
+      <NameView name={target.name!} />
       {dotsBetween && <Dots />}
     </div>
   );
@@ -28,23 +25,6 @@ export function TargetNameSection({ target, index, readonly, dotsBetween }: Prop
 
 function NameView({ name }: { name: string }) {
   return <div className="font-medium truncate">{name}</div>;
-}
-
-function NameEdit({ index }: { index: number }) {
-  const [value, setValue] = Forms.useFieldValue(`targets[${index}].name`);
-  const error = Forms.useFieldError(`targets[${index}].name`);
-
-  const className = classNames(
-    "w-full bg-surface-base text-content-accent outline-none ring-0 px-2 py-1 border rounded font-medium",
-    error ? "border-red-500" : "border-stroke-dimmed",
-  );
-
-  return (
-    <div className="w-full relative">
-      <input type="text" onChange={(e) => setValue(e.target.value)} value={value || ""} className={className} />
-      {error && <div className="absolute text-xs text-content-error -bottom-4">{error}</div>}
-    </div>
-  );
 }
 
 function Dots() {

--- a/assets/js/features/goals/GoalTargetsV2/index.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/index.tsx
@@ -10,7 +10,10 @@ import { getReadonlyFlags } from "./utils";
 import { TargetNameSection } from "./TargetNameSection";
 import { TargetDetails } from "./TargetDetails";
 import { TargetValue } from "./TargetValue";
+import { EditTargetCard } from "./EditTargetCard";
 import { Target } from "./types";
+
+export { Target };
 
 interface StylesOptions {
   hideBorder?: boolean;
@@ -58,10 +61,10 @@ function TargetCard(props: TargetCardProps) {
   const [open, setOpen] = React.useState(false);
   const { index, target, readonly, hideBorder, dotsBetween, editValue, editDefinition } = props;
 
-  const { readonlyName, readonlyValue } = getReadonlyFlags({ readonly, editDefinition, editValue });
+  const { readonlyDefinition, readonlyValue } = getReadonlyFlags({ readonly, editDefinition, editValue });
   useValidation(`targets[${index}].name`, validatePresence(true));
 
-  const containerClass = classNames("max-w-full py-2 px-px list-none", {
+  const containerClass = classNames("max-w-full py-2 px-px", {
     "border-t last:border-b border-stroke-base": !hideBorder,
   });
 
@@ -75,15 +78,12 @@ function TargetCard(props: TargetCardProps) {
     setOpen(!open);
   };
 
+  if (!readonlyDefinition) return <EditTargetCard target={target} index={index} />;
+
   return (
     <div className={containerClass}>
       <div onClick={handleToggle} className="grid grid-cols-[1fr_auto_14px] gap-2 items-center cursor-pointer">
-        <TargetNameSection
-          target={target}
-          index={index}
-          readonly={readonlyName}
-          dotsBetween={dotsBetween && readonlyName}
-        />
+        <TargetNameSection target={target} dotsBetween={dotsBetween} />
         <TargetValue readonly={readonlyValue} index={index} target={target} />
         <IconChevronDown onClick={handleChevronToggle} size={14} />
       </div>

--- a/assets/js/features/goals/GoalTargetsV2/utils.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/utils.tsx
@@ -1,6 +1,6 @@
 export function getReadonlyFlags(attrs: { readonly?: boolean; editValue?: boolean; editDefinition?: boolean }) {
   return {
     readonlyValue: Boolean(attrs.readonly || !attrs.editValue),
-    readonlyName: Boolean(attrs.readonly || !attrs.editDefinition),
+    readonlyDefinition: Boolean(attrs.readonly || !attrs.editDefinition),
   };
 }

--- a/assets/js/pages/GoalV2Page/utils.tsx
+++ b/assets/js/pages/GoalV2Page/utils.tsx
@@ -1,13 +1,15 @@
 import * as Goals from "@/models/goals";
 import * as Time from "@/utils/time";
 import * as Timeframes from "@/utils/timeframes";
+import { Target } from "@/features/goals/GoalTargetsV2";
+import { parseToInteger } from "@/utils/numbers";
 
-export function parseTargets(targets: Goals.Target[]) {
+export function parseTargets(targets: Target[]) {
   return targets.map((t, index) => ({
     id: t.id,
     name: t.name,
-    from: t.from,
-    to: t.to,
+    from: parseToInteger(t.from!),
+    to: parseToInteger(t.to!),
     unit: t.unit,
     index: index,
   }));

--- a/assets/js/utils/numbers.tsx
+++ b/assets/js/utils/numbers.tsx
@@ -22,3 +22,8 @@ export function findOrdinalNumberSuffix(num: number) {
       return "th";
   }
 }
+
+export function parseToInteger(num: number | string) {
+  if (typeof num === "string") return parseInt(num);
+  return Math.trunc(num);
+}


### PR DESCRIPTION
On the new Goal Page, targets' `name`, `from`, `to` and `unit` can be now be edited.