### PR TITLE
fix: Check-in button changed to secondary

### DIFF
--- a/assets/js/pages/GoalV2Page/Form.tsx
+++ b/assets/js/pages/GoalV2Page/Form.tsx
@@ -38,11 +38,11 @@ export function Form() {
           <div className="flex">
             <GoalStatusBadge status={form.values.status} className="mt-3" />
           </div>
-          <NextCheckIn />
           <Timeframe />
           <Champion />
           <Reviewer />
           <Contributors />
+          <NextCheckIn />
         </div>
       </div>
 

--- a/assets/js/pages/GoalV2Page/NextCheckIn.tsx
+++ b/assets/js/pages/GoalV2Page/NextCheckIn.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { Paths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { assertPresent } from "@/utils/assertions";
-import { PrimaryButton } from "@/components/Buttons";
+import { SecondaryButton } from "@/components/Buttons";
 import FormattedTime from "@/components/FormattedTime";
 
 import { DisableInEditMode, Title } from "./components";
@@ -22,9 +22,9 @@ export function NextCheckIn() {
         Scheduled for <FormattedTime time={goal.nextUpdateScheduledAt} format="long-date" />
       </div>
       <div className="text-base mb-1">
-        <PrimaryButton onClick={navigate} size="xs">
+        <SecondaryButton onClick={navigate} size="xs">
           Check-in Now
-        </PrimaryButton>
+        </SecondaryButton>
       </div>
     </DisableInEditMode>
   );


### PR DESCRIPTION
The "Next Check-in" button was moved to the bottom of the sidebar and changed to secondary.