### PR TITLE
fix: shortName util handles person without last name

### DIFF
--- a/assets/js/models/people/index.tsx
+++ b/assets/js/models/people/index.tsx
@@ -60,6 +60,9 @@ export function firstName(person: Pick<Person, "fullName">): string {
 }
 
 export function shortName(person: Pick<Person, "fullName">): string {
+  const length = person.fullName!.split(" ").length;
+
+  if (length < 2) return firstName(person);
   return firstName(person) + " " + lastNameInitial(person) + ".";
 }
 


### PR DESCRIPTION
The `shortName` util didn't handle correctly cases where a person had only a first name. Previously, if the name was just "Adriano," `shortName` would return "Adriano A.".

Now, if no last name is present, `shortName` returns only the first name.