### PR TITLE
fix: Links are underlined on hover on Goal page

### DIFF
--- a/assets/js/components/Link/index.tsx
+++ b/assets/js/components/Link/index.tsx
@@ -14,6 +14,7 @@ interface Props {
 interface LinkProps extends Props {
   to: string;
   underline?: "always" | "hover" | "never";
+  disableColorHoverEffect?: boolean;
 }
 
 interface ButtonLinkProps extends Props {
@@ -23,6 +24,7 @@ interface ButtonLinkProps extends Props {
 interface ActionLinkProps extends Props {
   onClick: () => void;
   underline?: "always" | "hover" | "never";
+  disableColorHoverEffect?: boolean;
 }
 
 interface DivLinkProps extends Props {
@@ -43,23 +45,17 @@ function UnstyledLink(props: LinkProps) {
 }
 
 export function Link(props: LinkProps) {
-  const className = classNames(
-    baseLinkClass,
-    underlineClass(props.underline),
-    "text-link-base hover:text-link-hover",
-    props.className,
-  );
+  const className = classNames(baseLinkClass, underlineClass(props.underline), "text-link-base", props.className, {
+    "hover:text-link-hover": !props.disableColorHoverEffect,
+  });
 
   return <UnstyledLink {...props} className={className} />;
 }
 
 export function BlackLink(props: LinkProps) {
-  const className = classNames(
-    baseLinkClass,
-    underlineClass(props.underline),
-    "text-content-base hover:text-content-dimmed",
-    props.className,
-  );
+  const className = classNames(baseLinkClass, underlineClass(props.underline), "text-content-base", props.className, {
+    "hover:text-content-dimmed": !props.disableColorHoverEffect,
+  });
 
   return <UnstyledLink {...props} className={className} />;
 }
@@ -73,12 +69,9 @@ export function ButtonLink({ onClick, children, testId }: ButtonLinkProps) {
 }
 
 export function ActionLink(props: ActionLinkProps) {
-  const className = classNames(
-    baseLinkClass,
-    underlineClass(props.underline),
-    "text-link-base hover:text-link-hover",
-    props.className,
-  );
+  const className = classNames(baseLinkClass, underlineClass(props.underline), "text-link-base", props.className, {
+    "hover:text-link-hover": !props.disableColorHoverEffect,
+  });
 
   return (
     <span data-test-id={props.testId} className={className} onClick={props.onClick}>
@@ -88,12 +81,9 @@ export function ActionLink(props: ActionLinkProps) {
 }
 
 export function DimmedLink(props: LinkProps) {
-  const className = classnames(
-    baseLinkClass,
-    underlineClass(props.underline),
-    "text-content-dimmed hover:text-content-base",
-    props.className,
-  );
+  const className = classnames(baseLinkClass, underlineClass(props.underline), "text-content-dimmed", props.className, {
+    "hover:text-content-base": !props.disableColorHoverEffect,
+  });
 
   return <UnstyledLink {...props} className={className} />;
 }

--- a/assets/js/features/goals/GoalTree/MinimalTree.tsx
+++ b/assets/js/features/goals/GoalTree/MinimalTree.tsx
@@ -9,7 +9,7 @@ import { truncateString } from "@/utils/strings";
 
 import { TreeContextProvider, TreeContextProviderProps, useTreeContext } from "./treeContext";
 import { Node, GoalNode, ProjectNode } from "./tree";
-import { DivLink } from "@/components/Link";
+import { BlackLink } from "@/components/Link";
 
 export function MinimalTree(props: TreeContextProviderProps) {
   return (
@@ -95,9 +95,9 @@ function NodeContainer({ node, children }) {
 function NodeName({ name, link, completed }) {
   name = truncateString(name, 40);
   const nameElement = (
-    <DivLink to={link} className="truncate">
+    <BlackLink underline="hover" to={link} className="truncate" disableColorHoverEffect>
       {name}
-    </DivLink>
+    </BlackLink>
   );
 
   if (!completed) return nameElement;

--- a/assets/js/pages/GoalV2Page/Messages.tsx
+++ b/assets/js/pages/GoalV2Page/Messages.tsx
@@ -152,13 +152,13 @@ function Author({ author }) {
 }
 
 function Container({ children }) {
-  return <div className="flex items-start gap-3 pb-4">{children}</div>;
+  return <div className="flex items-start gap-3 pb-4 group">{children}</div>;
 }
 
 function MessageTitle({ title, children }: { title: string; children?: React.ReactNode }) {
   return (
     <div className="inline-flex items-center gap-2">
-      <span className="font-bold">{title}</span>
+      <span className="font-bold group-hover:underline underline-offset-2">{title}</span>
       {children}
     </div>
   );


### PR DESCRIPTION
On the new Goal Page, in the conversations and related work sections, links are now underlined on hover.