### PR TITLE
fix: Remove tabindexes from rich text editor controls to allow a natural flow of tab jumps

### DIFF
--- a/assets/js/components/Editor/index.tsx
+++ b/assets/js/components/Editor/index.tsx
@@ -76,6 +76,7 @@ export interface EditorState {
 const DEFAULT_EDITOR_PROPS: Partial<UseEditorProps> = {
   editable: true,
   autoFocus: false,
+  tabindex: "",
 };
 
 function useEditor(props: UseEditorProps): EditorState {
@@ -100,7 +101,7 @@ function useEditor(props: UseEditorProps): EditorState {
     editorProps: {
       attributes: {
         class: "focus:outline-none" + " " + props.className,
-        tabindex: props.tabindex ?? "",
+        tabindex: props.tabindex!,
       },
     },
     extensions: [

--- a/assets/js/components/FormTitleInput/index.tsx
+++ b/assets/js/components/FormTitleInput/index.tsx
@@ -49,7 +49,6 @@ export function FormTitleInput({ value, onChange, error, testId }: FormTitleInpu
         value={value}
         onChange={(e) => onChange(e.target.value)}
         data-test-id={testId}
-        tabIndex={1}
       ></textarea>
     </>
   );

--- a/assets/js/features/DiscussionForm/useForm.tsx
+++ b/assets/js/features/DiscussionForm/useForm.tsx
@@ -55,7 +55,6 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     className: "min-h-[350px] py-2 px-1",
     content: discussion?.body && JSON.parse(discussion.body),
     mentionSearchScope: { type: "space", id: space ? space.id! : discussion!.space!.id! },
-    tabindex: "2",
   });
 
   const validate = () => {

--- a/assets/js/features/richtexteditor/components/ColorPicker.tsx
+++ b/assets/js/features/richtexteditor/components/ColorPicker.tsx
@@ -26,7 +26,7 @@ export function ColorPicker({ editor, iconSize }): React.ReactElement {
 
   return (
     <Popover.Root open={open} onOpenChange={setOpen}>
-      <Popover.Trigger className="cursor-pointer" data-test-id={testId}>
+      <Popover.Trigger className="cursor-pointer" data-test-id={testId} tabIndex={-1}>
         <BucketIcon iconSize={iconSize} editor={editor} />
       </Popover.Trigger>
 

--- a/assets/js/features/richtexteditor/components/ToolbarButton.tsx
+++ b/assets/js/features/richtexteditor/components/ToolbarButton.tsx
@@ -20,7 +20,14 @@ export function ToolbarButton({ children, onClick, title, disabled = false }): J
   );
 
   return (
-    <button onClick={handleClick} className={className} disabled={disabled} title={title} data-test-id={testId}>
+    <button
+      onClick={handleClick}
+      className={className}
+      disabled={disabled}
+      title={title}
+      data-test-id={testId}
+      tabIndex={-1}
+    >
       {children}
     </button>
   );

--- a/assets/js/features/richtexteditor/components/ToolbarToggleButton.tsx
+++ b/assets/js/features/richtexteditor/components/ToolbarToggleButton.tsx
@@ -21,7 +21,7 @@ export function ToolbarToggleButton({ children, isActive, title, onClick }): JSX
   );
 
   return (
-    <button onClick={handleClick} className={className} title={title} data-test-id={testId}>
+    <button onClick={handleClick} className={className} title={title} data-test-id={testId} tabIndex={-1}>
       {children}
     </button>
   );


### PR DESCRIPTION
Before:

![CleanShot 2025-03-21 at 17 10 31@2x](https://github.com/user-attachments/assets/94aeeebc-ec42-40f6-8674-ea41bdb1ad6f)

After:

![CleanShot 2025-03-21 at 17 10 12@2x](https://github.com/user-attachments/assets/38cd0d6e-fb64-4b14-bf80-e2bec59c1c6d)

fixes https://github.com/operately/operately/issues/2151