### PR TITLE
feat: Keep a reference to the last check-in in the goal

### DIFF
--- a/lib/operately/data/change_051_populate_goal_last_check_ins.ex
+++ b/lib/operately/data/change_051_populate_goal_last_check_ins.ex
@@ -1,0 +1,18 @@
+defmodule Operately.Data.Change051PopulateGoalLastCheckIns do
+  def run do
+    sql = """
+    UPDATE goals
+    SET last_check_in_id = latest_updates.update_id
+    FROM (
+      SELECT DISTINCT ON (goal_updates.goal_id)
+        goal_updates.goal_id,
+        goal_updates.id AS update_id
+      FROM goal_updates
+      ORDER BY goal_updates.goal_id, goal_updates.inserted_at DESC
+    ) AS latest_updates
+    WHERE goals.id = latest_updates.goal_id
+    """
+    
+    Operately.Repo.query!(sql)
+  end
+end

--- a/lib/operately/goals/goal.ex
+++ b/lib/operately/goals/goal.ex
@@ -3,6 +3,9 @@ defmodule Operately.Goals.Goal do
   use Operately.Repo.Getter
 
   schema "goals" do
+    field :name, :string
+    field :description, :map
+
     belongs_to :company, Operately.Companies.Company, foreign_key: :company_id
     belongs_to :group, Operately.Groups.Group, foreign_key: :group_id
     belongs_to :parent_goal, Operately.Goals.Goal, foreign_key: :parent_goal_id
@@ -11,16 +14,15 @@ defmodule Operately.Goals.Goal do
     belongs_to :reviewer, Operately.People.Person, foreign_key: :reviewer_id
     belongs_to :creator, Operately.People.Person, foreign_key: :creator_id
 
-    has_many :updates, Operately.Goals.Update
     has_many :targets, Operately.Goals.Target
     has_many :projects, Operately.Projects.Project, foreign_key: :goal_id
 
     has_one :access_context, Operately.Access.Context, foreign_key: :goal_id
 
-    field :name, :string
+    # Check-Ins (they are called updates for historical reasons)
+    has_many :updates, Operately.Goals.Update
+    belongs_to :last_update, Operately.Goals.Update, foreign_key: :last_check_in_id
     field :next_update_scheduled_at, :utc_datetime
-
-    field :description, :map
 
     embeds_one :timeframe, Operately.Goals.Timeframe, on_replace: :update
     field :deprecated_timeframe, :string
@@ -31,7 +33,6 @@ defmodule Operately.Goals.Goal do
 
     # populated with after load hooks
     field :my_role, :string, virtual: true
-    field :last_check_in, :any, virtual: true
     field :permissions, :any, virtual: true
     field :access_levels, :any, virtual: true
     field :potential_subscribers, :any, virtual: true

--- a/lib/operately_web/api/queries/get_goal.ex
+++ b/lib/operately_web/api/queries/get_goal.ex
@@ -68,13 +68,13 @@ defmodule OperatelyWeb.Api.Queries.GetGoal do
       include_space_members: [group: [:members, :company]],
       include_targets: [targets: from(t in Target, order_by: t.index)],
       include_potential_subscribers: [:reviewer, :champion, group: :members],
+      include_last_check_in: [last_update: [:author, [reactions: :person]]],
       always_include: :parent_goal,
     ])
   end
 
   defp after_load(inputs, me) do
     Inputs.parse_includes(inputs, [
-      include_last_check_in: &Goal.preload_last_check_in/1,
       include_permissions: &Goal.preload_permissions/1,
       include_access_levels: &Goal.preload_access_levels/1,
       include_potential_subscribers: &Goal.set_potential_subscribers/1,

--- a/lib/operately_web/api/queries/get_goals.ex
+++ b/lib/operately_web/api/queries/get_goals.ex
@@ -42,7 +42,6 @@ defmodule OperatelyWeb.Api.Queries.GetGoals do
     |> include_requested(include_filters)
     |> filter_by_view_access(person.id)
     |> Repo.all()
-    |> Goal.preload_last_check_in()
   end
 
   defp include_requested(query, requested) do
@@ -53,7 +52,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoals do
         :include_space -> from p in q, preload: [:group]
         :include_champion -> from p in q, preload: [:champion]
         :include_reviewer -> from p in q, preload: [:reviewer]
-        :include_last_check_in -> q # this is done after the load
+        :include_last_check_in -> from p in q, preload: [last_update: [:author, [reactions: :person]]]
         _ -> q
       end
     end)

--- a/lib/operately_web/api/serializers/goal.ex
+++ b/lib/operately_web/api/serializers/goal.ex
@@ -32,7 +32,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Goal do
 
       timeframe: OperatelyWeb.Api.Serializer.serialize(goal.timeframe),
       projects: OperatelyWeb.Api.Serializer.serialize(goal.projects, level: :full),
-      last_check_in: OperatelyWeb.Api.Serializer.serialize(goal.last_check_in, level: :full),
+      last_check_in: OperatelyWeb.Api.Serializer.serialize(goal.last_update, level: :full),
       access_levels: OperatelyWeb.Api.Serializer.serialize(goal.access_levels, level: :full),
       potential_subscribers: OperatelyWeb.Api.Serializer.serialize(goal.potential_subscribers),
       notifications: OperatelyWeb.Api.Serializer.serialize(goal.notifications),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "operately",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-popover": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "operately",
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-popover": "^1.0.5",

--- a/priv/repo/migrations/20250325115924_add_last_check_in_id_to_goals.exs
+++ b/priv/repo/migrations/20250325115924_add_last_check_in_id_to_goals.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddLastCheckInIdToGoals do
+  use Ecto.Migration
+
+  def change do
+    alter table(:goals) do
+      add :last_check_in_id, references(:goal_updates, on_delete: :nilify_all, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20250325131944_populate_last_check_in_on_goals.exs
+++ b/priv/repo/migrations/20250325131944_populate_last_check_in_on_goals.exs
@@ -1,0 +1,10 @@
+defmodule Operately.Repo.Migrations.PopulateLastCheckInOnGoals do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change051PopulateGoalLastCheckIns.run()
+  end
+
+  def down do
+  end
+end

--- a/test/operately/data/change_051_populate_goal_last_check_ins_test.exs
+++ b/test/operately/data/change_051_populate_goal_last_check_ins_test.exs
@@ -1,0 +1,58 @@
+defmodule Operately.Data.Change051PopulateGoalLastCheckInsTest do
+  use Operately.DataCase
+  alias Operately.Repo
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:marketing)
+    |> Factory.add_goal(:goal1, :marketing, name: "Goal 1")
+    |> Factory.add_goal(:goal2, :marketing, name: "Goal 2")
+    |> Factory.add_goal(:goal3, :marketing, name: "Goal 3")
+    |> Factory.add_goal_update(:update1, :goal1, :creator)
+    |> Factory.add_goal_update(:update2, :goal1, :creator)
+    |> Factory.add_goal_update(:update3, :goal2, :creator)
+  end
+  
+  test "updates goals with their latest updates", ctx do
+    :ok = nullify_last_check_ins()
+
+    :ok = update_inserted_at(ctx.update1, ~N[2025-03-25 11:00:00])
+    :ok = update_inserted_at(ctx.update2, ~N[2025-03-25 12:00:00])
+    :ok = update_inserted_at(ctx.update3, ~N[2025-03-25 13:00:00])
+
+    # make sure that the last_check_in_id is nil for all goals
+    ctx = reload_goals(ctx)
+
+    assert ctx.goal1.last_check_in_id == nil
+    assert ctx.goal2.last_check_in_id == nil
+    assert ctx.goal3.last_check_in_id == nil
+
+    # run the change
+    Operately.Data.Change051PopulateGoalLastCheckIns.run()
+
+    # assert that the last_check_in_id is updated correctly
+    ctx = reload_goals(ctx)
+    assert ctx.goal1.last_check_in_id == ctx.update2.id
+    assert ctx.goal2.last_check_in_id == ctx.update3.id
+    assert ctx.goal3.last_check_in_id == nil
+  end
+
+  defp reload_goals(ctx) do
+    ctx
+    |> Map.put(:goal1, Repo.reload(ctx.goal1))
+    |> Map.put(:goal2, Repo.reload(ctx.goal2))
+    |> Map.put(:goal3, Repo.reload(ctx.goal3))
+  end
+
+  defp nullify_last_check_ins do
+    {:ok, _} = Repo.query("UPDATE goals SET last_check_in_id = NULL")
+    :ok
+  end
+
+  defp update_inserted_at(update, inserted_at) do
+    {:ok, _} = Repo.update(Ecto.Changeset.change(update, inserted_at: inserted_at))
+    :ok
+  end
+
+end

--- a/test/operately/operations/goal_check_in_test.exs
+++ b/test/operately/operations/goal_check_in_test.exs
@@ -30,6 +30,24 @@ defmodule Operately.Operations.GoalCheckInTest do
     Map.merge(ctx, %{company: company, space: space, champion: champion, reviewer: reviewer, goal: goal})
   end
 
+  describe "last update" do
+    test "creating goal update sets last update on the goal", ctx do
+      {:ok, update} =
+        GoalCheckIn.run(ctx.champion, ctx.goal, %{
+          goal_id: ctx.goal.id,
+          status: "on_track",
+          target_values: [],
+          content: RichText.rich_text("Some content"),
+          send_to_everyone: true,
+          subscriber_ids: [],
+          subscription_parent_type: :goal_update
+        })
+
+      goal = Repo.get!(Operately.Goals.Goal, ctx.goal.id)
+      assert goal.last_check_in_id == update.id
+    end
+  end
+
   describe "notifications" do
     test "Creating goal update notifies everyone", ctx do
       members = create_space_members(ctx)

--- a/test/operately_web/api/queries/get_goal_test.exs
+++ b/test/operately_web/api/queries/get_goal_test.exs
@@ -194,6 +194,7 @@ defmodule OperatelyWeb.Api.Queries.GetGoalTest do
 
       update = goal_update_fixture(ctx.person, goal)
       update = Operately.Repo.preload(update, [:author, [reactions: :author]])
+      goal = Operately.Goals.Goal.changeset(goal, %{last_update_id: update.id}) |> Operately.Repo.update!()
 
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal), include_last_check_in: true})
       assert res.goal.last_check_in == Serializer.serialize(update, level: :full)

--- a/test/operately_web/api/queries/get_goals_test.exs
+++ b/test/operately_web/api/queries/get_goals_test.exs
@@ -145,10 +145,10 @@ defmodule OperatelyWeb.Api.Queries.GetGoalsTest do
       goal2 = goal_fixture(ctx.person, company_id: ctx.company.id, space_id: ctx.company.company_space_id)
 
       update1 = create_update(ctx.person, goal1)
-      _update2 = create_update(ctx.person, goal1)
-
       update3 = create_update(ctx.person, goal2)
-      _update4 = create_update(ctx.person, goal2)
+
+      goal1 = Operately.Goals.Goal.changeset(goal1, %{last_check_in_id: update1.id}) |> Repo.update!()
+      goal2 = Operately.Goals.Goal.changeset(goal2, %{last_check_in_id: update3.id}) |> Repo.update!()
 
       update1 = Operately.Repo.preload(update1, [:author, [reactions: :author]])
       update3 = Operately.Repo.preload(update3, [:author, [reactions: :author]])


### PR DESCRIPTION
Two reasons for doing this:

- Performance: Looking up the latest check-in is common, needs to be fast.
- Preparation for limiting update operations for goal check-ins. The logic will be "if update.id == goal.last_update_id" then you can update the values otherwise no.