### PR TITLE
fix: Include timeframe type in Goal editing payload

### DIFF
--- a/assets/js/pages/GoalV2Page/useForm.tsx
+++ b/assets/js/pages/GoalV2Page/useForm.tsx
@@ -26,6 +26,7 @@ export function useForm() {
   const currTimeframe = {
     startDate: Time.parseDate(goal.timeframe.startDate),
     endDate: Time.parseDate(goal.timeframe.endDate),
+    type: goal.timeframe.type,
   };
   const parentAccessLevel = space.accessLevels;
 


### PR DESCRIPTION
After https://github.com/operately/operately/pull/2202, editing a Goal on the new Goal page stopped working because the payload didn't include the timeframe type. 