### PR TITLE
fix: Chevron icon changes when target is collapsed

### DIFF
--- a/assets/js/features/goals/GoalTargetsV2/DefaultTargetCard.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/DefaultTargetCard.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 
-import { IconChevronDown } from "@tabler/icons-react";
 import classNames from "classnames";
 
 import { Target } from "./types";
-import { TargetDetails, TargetNameSection, TargetValue } from "./components";
+import { ExpandIcon, TargetDetails, TargetNameSection, TargetValue } from "./components";
 
 interface Props {
   index: number;
@@ -35,7 +34,7 @@ export function DefaultTargetCard(props: Props) {
       <div onClick={handleToggle} className="grid grid-cols-[1fr_auto_14px] gap-2 items-start cursor-pointer">
         <TargetNameSection target={target} truncate={!open} />
         <TargetValue readonly={readonlyValue} index={index} target={target} />
-        <IconChevronDown onClick={handleChevronToggle} size={14} className="mt-1.5" />
+        <ExpandIcon expanded={open} onClick={handleChevronToggle} size={14} className="mt-1.5" />
       </div>
       {open && <TargetDetails target={target} />}
     </div>

--- a/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import * as Goals from "@/models/goals";
-import { IconChevronDown, IconTrash } from "@tabler/icons-react";
+import { IconTrash } from "@tabler/icons-react";
 
 import classNames from "classnames";
 import { PrimaryButton, SecondaryButton } from "@/components/Buttons";
@@ -9,7 +9,7 @@ import { MiniPieChart } from "@/components/charts";
 import { useDragAndDropContext, useDraggable } from "@/features/DragAndDrop";
 
 import { Target } from "./types";
-import { TargetNumericField, TargetTextField, TargetValue } from "./components";
+import { ExpandIcon, TargetNumericField, TargetTextField, TargetValue } from "./components";
 import { useTargetsContext } from "./TargetsContext";
 
 interface Props {
@@ -60,7 +60,7 @@ function TitleSection({ target, index, editing }) {
           <TargetValue readonly index={index} target={target} />
         </div>
       )}
-      <IconChevronDown onClick={toggle} className="cursor-pointer" size={14} />
+      <ExpandIcon expanded={editing} onClick={toggle} className="cursor-pointer" size={14} />
     </>
   );
 }

--- a/assets/js/features/goals/GoalTargetsV2/components/ExpandIcon.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/components/ExpandIcon.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { IconChevronDown, IconChevronLeft, IconProps } from "@tabler/icons-react";
+
+export function ExpandIcon({ expanded, ...rest }: IconProps & { expanded: boolean }) {
+  const Icon = expanded ? IconChevronDown : IconChevronLeft;
+  return <Icon {...rest} />;
+}

--- a/assets/js/features/goals/GoalTargetsV2/components/index.tsx
+++ b/assets/js/features/goals/GoalTargetsV2/components/index.tsx
@@ -3,3 +3,4 @@ export { TargetNumericField } from "./TargetNumericField";
 export { TargetDetails } from "./TargetDetails";
 export { TargetValue } from "./TargetValue";
 export { TargetNameSection } from "./TargetNameSection";
+export { ExpandIcon } from "./ExpandIcon";


### PR DESCRIPTION
The chevron icon for targets now changes based on whether the target is expanded or collapsed.