### PR TITLE
chore: Deleting a goal automatically deletes its children

### DIFF
--- a/lib/operately/activities/context_auto_assigner.ex
+++ b/lib/operately/activities/context_auto_assigner.ex
@@ -59,21 +59,6 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "group_edited",
   ]
 
-  @goal_actions [
-    "goal_check_in",
-    "goal_check_in_acknowledgement",
-    "goal_check_in_commented",
-    "goal_check_in_edit",
-    "goal_closing",
-    "goal_created",
-    "goal_discussion_creation",
-    "goal_discussion_editing",
-    "goal_editing",
-    "goal_reopening",
-    "goal_timeframe_editing",
-    "goal_reparent",
-  ]
-
   @project_actions [
     "project_created",
     "project_archived",
@@ -144,7 +129,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
       activity.action in @deprecated_actions -> :ok
       activity.action in @company_actions -> fetch_company_context(activity.content.company_id)
       activity.action in @space_actions -> fetch_space_context(activity)
-      activity.action in @goal_actions -> fetch_goal_context(activity.content)
+      activity.action in Operately.Goals.goal_actions() -> fetch_goal_context(activity.content)
       activity.action in @project_actions -> fetch_project_context(activity.content.project_id)
       activity.action in @task_actions -> fetch_task_project_context(activity.content.task_id)
       activity.action in @resource_hub_actions-> fetch_resource_hub_context(activity.content.space_id)

--- a/lib/operately/comments.ex
+++ b/lib/operately/comments.ex
@@ -33,6 +33,10 @@ defmodule Operately.Comments do
     end
   end
 
+  def list_comment_threads do
+    Repo.all(CommentThread)
+  end
+
   def list_milestone_comments do
     Repo.all(MilestoneComment)
   end

--- a/lib/operately/goals.ex
+++ b/lib/operately/goals.ex
@@ -179,7 +179,7 @@ defmodule Operately.Goals do
       join: a in Operately.Activities.Activity, on: a.comment_thread_id == t.id,
       where: a.action in ^@goal_actions,
       where: a.content["goal_id"] == ^goal_id,
-      select: t
+      select: t.id
     )
     |> Repo.delete_all()
   end

--- a/lib/operately/goals.ex
+++ b/lib/operately/goals.ex
@@ -25,6 +25,7 @@ defmodule Operately.Goals do
     if condition, do: fun.(query), else: query
   end
 
+  def get_goal(id), do: Repo.get(Goal, id, with_deleted: true)
   def get_goal!(id), do: Repo.get_by_id(Goal, id, :with_deleted)
 
   def get_goal_with_access_level(goal_id, person_id) do
@@ -57,9 +58,17 @@ defmodule Operately.Goals do
     end
   end
 
+  def get_target(id), do: Repo.get(Target, id)
+
   def list_targets(goal_id) do
     from(target in Target, where: target.goal_id == ^goal_id, order_by: target.index)
     |> Repo.all()
+  end
+
+  def create_target(attrs) do
+    %Target{}
+    |> Target.changeset(attrs)
+    |> Repo.insert()
   end
 
   def progress_percentage(goal) do

--- a/lib/operately/goals.ex
+++ b/lib/operately/goals.ex
@@ -174,7 +174,7 @@ defmodule Operately.Goals do
     |> Repo.all()
   end
 
-  def delete_goal_discussion(goal_id) do
+  def delete_goal_discussions(goal_id) do
     from(t in Operately.Comments.CommentThread,
       join: a in Operately.Activities.Activity, on: a.comment_thread_id == t.id,
       where: a.action in ^@goal_actions,

--- a/lib/operately/operations/goal_deleting.ex
+++ b/lib/operately/operations/goal_deleting.ex
@@ -1,26 +1,60 @@
 defmodule Operately.Operations.GoalDeleting do
+  @moduledoc """
+  Handles the deletion of a goal and its related entities.
+
+  ## Deletion Process
+
+  Direct associations to the goal (i.e. check-ins, access context, and access bindings)
+  are automatically cascade deleted at the database level.
+
+  Polymorphic associations (i.e. discussions, comments, and reactions)
+  need to be deleted manually as part of the transaction since they don't have
+  direct foreign key constraints to the goal table.
+  """
+
   alias Ecto.Multi
   alias Operately.{Repo, Goals, Updates}
 
   def run(goal) do
     Multi.new()
-    |> Multi.run(:discussions, fn _, _ ->
-      {_count, discussions} = Goals.delete_goal_discussion(goal.id)
-      {:ok, discussions}
-    end)
-    |> Multi.run(:updates, fn _, _ ->
-      updates = Goals.list_updates(goal)
-      {:ok, updates}
-    end)
-    |> Multi.run(:comments, fn _, changes ->
-      discussion_ids = Enum.map(changes.discussions, fn discussion -> discussion.id end)
-      update_ids = Enum.map(changes.updates, fn update -> update.id end)
-
-      {_count, comments} = Updates.delete_comments(discussion_ids ++ update_ids)
-      {:ok, comments}
-    end)
+    |> delete_discussions(goal)
+    |> collect_check_ins(goal)
+    |> delete_comments()
+    |> delete_reactions()
     |> Multi.delete(:goal, goal)
     |> Repo.transaction()
     |> Repo.extract_result(:goal)
+  end
+
+  defp delete_discussions(multi, goal) do
+    Multi.run(multi, :discussions, fn _, _ ->
+      {_count, discussions} = Goals.delete_goal_discussion(goal.id)
+      {:ok, discussions}
+    end)
+  end
+
+  defp collect_check_ins(multi, goal) do
+    Multi.run(multi, :check_ins, fn _, _ ->
+      check_ins = Goals.list_updates(goal) |> Enum.map(& &1.id)
+      {:ok, check_ins}
+    end)
+  end
+
+  defp delete_comments(multi) do
+    Multi.run(multi, :comments, fn _, changes ->
+      %{discussions: discussion_ids, check_ins: check_in_ids} = changes
+
+      {_count, comments} = Updates.delete_comments(discussion_ids ++ check_in_ids)
+      {:ok, comments}
+    end)
+  end
+
+  defp delete_reactions(multi) do
+    Multi.run(multi, :reactions, fn _, changes ->
+      %{discussions: discussion_ids, check_ins: check_in_ids, comments: comment_ids} = changes
+
+      {_count, reactions} = Updates.delete_reactions(discussion_ids ++ check_in_ids ++ comment_ids)
+      {:ok, reactions}
+    end)
   end
 end

--- a/lib/operately/operations/goal_deleting.ex
+++ b/lib/operately/operations/goal_deleting.ex
@@ -28,7 +28,7 @@ defmodule Operately.Operations.GoalDeleting do
 
   defp delete_discussions(multi, goal) do
     Multi.run(multi, :discussions, fn _, _ ->
-      {_count, discussions} = Goals.delete_goal_discussion(goal.id)
+      {_count, discussions} = Goals.delete_goal_discussions(goal.id)
       {:ok, discussions}
     end)
   end

--- a/lib/operately/operations/goal_deleting.ex
+++ b/lib/operately/operations/goal_deleting.ex
@@ -1,0 +1,26 @@
+defmodule Operately.Operations.GoalDeleting do
+  alias Ecto.Multi
+  alias Operately.{Repo, Goals, Updates}
+
+  def run(goal) do
+    Multi.new()
+    |> Multi.run(:discussions, fn _, _ ->
+      {_count, discussions} = Goals.delete_goal_discussion(goal.id)
+      {:ok, discussions}
+    end)
+    |> Multi.run(:updates, fn _, _ ->
+      updates = Goals.list_updates(goal)
+      {:ok, updates}
+    end)
+    |> Multi.run(:comments, fn _, changes ->
+      discussion_ids = Enum.map(changes.discussions, fn discussion -> discussion.id end)
+      update_ids = Enum.map(changes.updates, fn update -> update.id end)
+
+      {_count, comments} = Updates.delete_comments(discussion_ids ++ update_ids)
+      {:ok, comments}
+    end)
+    |> Multi.delete(:goal, goal)
+    |> Repo.transaction()
+    |> Repo.extract_result(:goal)
+  end
+end

--- a/lib/operately/projects.ex
+++ b/lib/operately/projects.ex
@@ -20,6 +20,8 @@ defmodule Operately.Projects do
     CheckIn
   }
 
+  def get_project(id), do: Repo.get(Project, id, with_deleted: true)
+
   def get_project!(id) do
     query = from p in Project, where: p.id == ^id
 
@@ -87,6 +89,10 @@ defmodule Operately.Projects do
 
   def change_project(%Project{} = project, attrs \\ %{}) do
     Project.changeset(project, attrs)
+  end
+
+  def delete_project(%Project{} = project) do
+    Repo.delete(project)
   end
 
   def get_milestones(ids) do

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -392,6 +392,14 @@ defmodule Operately.Updates do
     |> Fetch.get_resource_with_access_level(person_id, selected_resource: :comment)
   end
 
+  def delete_comments(entity_ids) when is_list(entity_ids) do
+    from(c in Comment,
+      where: c.entity_id in ^entity_ids,
+      select: c
+    )
+    |> Repo.delete_all()
+  end
+
   # old version. TODO: remove
   def create_comment(_update, attrs) do
     changeset = Comment.changeset(attrs)
@@ -474,6 +482,14 @@ defmodule Operately.Updates do
 
   def delete_reaction(%Reaction{} = reaction) do
     Repo.delete(reaction)
+  end
+
+  def delete_reactions(entity_ids) when is_list(entity_ids) do
+    from(r in Reaction,
+      where: r.entity_id in ^entity_ids,
+      select: r
+    )
+    |> Repo.delete_all()
   end
 
   def change_reaction(%Reaction{} = reaction, attrs \\ %{}) do

--- a/lib/operately/updates.ex
+++ b/lib/operately/updates.ex
@@ -395,7 +395,7 @@ defmodule Operately.Updates do
   def delete_comments(entity_ids) when is_list(entity_ids) do
     from(c in Comment,
       where: c.entity_id in ^entity_ids,
-      select: c
+      select: c.id
     )
     |> Repo.delete_all()
   end
@@ -487,7 +487,7 @@ defmodule Operately.Updates do
   def delete_reactions(entity_ids) when is_list(entity_ids) do
     from(r in Reaction,
       where: r.entity_id in ^entity_ids,
-      select: r
+      select: r.id
     )
     |> Repo.delete_all()
   end

--- a/priv/repo/migrations/20250331193957_add_cascade_delete_to_goal_targets.exs
+++ b/priv/repo/migrations/20250331193957_add_cascade_delete_to_goal_targets.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToGoalTargets do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:targets, "targets_goal_id_fkey")
+
+    alter table(:targets) do
+      modify :goal_id, references(:goals, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+
+  def down do
+    drop constraint(:targets, "targets_goal_id_fkey")
+
+    alter table(:targets) do
+      modify :goal_id, references(:goals, on_delete: :nothing, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20250331194510_add_cascade_delete_to_goal_access_contexts.exs
+++ b/priv/repo/migrations/20250331194510_add_cascade_delete_to_goal_access_contexts.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToGoalAccessContexts do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:access_contexts, "access_contexts_goal_id_fkey")
+
+    alter table(:access_contexts) do
+      modify :goal_id, references(:goals, on_delete: :delete_all, type: :binary_id), null: true
+    end
+  end
+
+  def down do
+    drop constraint(:access_contexts, "access_contexts_goal_id_fkey")
+
+    alter table(:access_contexts) do
+      modify :goal_id, references(:goals, on_delete: :nothing, type: :binary_id), null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20250331194727_add_cascade_delete_to_access_bindings.exs
+++ b/priv/repo/migrations/20250331194727_add_cascade_delete_to_access_bindings.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToAccessBindings do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:access_bindings, "access_bindings_context_id_fkey")
+
+    alter table(:access_bindings) do
+      modify :context_id, references(:access_contexts, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+
+  def down do
+    drop constraint(:access_bindings, "access_bindings_context_id_fkey")
+
+    alter table(:access_bindings) do
+      modify :context_id, references(:access_contexts, on_delete: :nothing, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20250331195524_add_cascade_delete_to_context_activities.exs
+++ b/priv/repo/migrations/20250331195524_add_cascade_delete_to_context_activities.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToContextActivities do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:activities, "activities_context_id_fkey")
+
+    alter table(:activities) do
+      modify :access_context_id, references(:access_contexts, on_delete: :delete_all, type: :binary_id), null: true
+    end
+  end
+
+  def down do
+    drop constraint(:activities, "activities_context_id_fkey")
+
+    alter table(:activities) do
+      modify :access_context_id, references(:access_contexts, on_delete: :nothing, type: :binary_id), null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20250331200245_add_cascade_delete_to_project_access_contexts.exs
+++ b/priv/repo/migrations/20250331200245_add_cascade_delete_to_project_access_contexts.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToProjectAccessContexts do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:access_contexts, "access_contexts_project_id_fkey")
+
+    alter table(:access_contexts) do
+      modify :project_id, references(:projects, on_delete: :delete_all, type: :binary_id), null: true
+    end
+  end
+
+  def down do
+    drop constraint(:access_contexts, "access_contexts_project_id_fkey")
+
+    alter table(:access_contexts) do
+      modify :project_id, references(:projects, on_delete: :nothing, type: :binary_id), null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20250331202813_add_cascade_delete_to_goal_check_ins.exs
+++ b/priv/repo/migrations/20250331202813_add_cascade_delete_to_goal_check_ins.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToGoalCheckIns do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:goal_updates, "goal_updates_goal_id_fkey")
+
+    alter table(:goal_updates) do
+      modify :goal_id, references(:goals, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+
+  def down do
+    drop constraint(:goal_updates, "goal_updates_goal_id_fkey")
+
+    alter table(:goal_updates) do
+      modify :goal_id, references(:goals, on_delete: :nothing, type: :binary_id)
+    end
+  end
+end

--- a/priv/repo/migrations/20250401104505_add_cascade_delete_to_activity_notifications.exs
+++ b/priv/repo/migrations/20250401104505_add_cascade_delete_to_activity_notifications.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.AddCascadeDeleteToActivityNotifications do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:notifications, "notifications_activity_id_fkey")
+
+    alter table(:notifications) do
+      modify :activity_id, references(:activities, on_delete: :delete_all, type: :binary_id)
+    end
+  end
+
+  def down do
+    drop constraint(:notifications, "notifications_activity_id_fkey")
+
+    alter table(:notifications) do
+      modify :activity_id, references(:activities, on_delete: :nothing, type: :binary_id)
+    end
+  end
+end

--- a/test/operately/goals_test.exs
+++ b/test/operately/goals_test.exs
@@ -135,5 +135,19 @@ defmodule Operately.GoalsTest do
 
       {:ok, _} = Goals.delete_goal(ctx.goal)
     end
+
+    test "when goal is deleted, its discussions are also deleted", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal_discussion(:discussion, :goal)
+        |> Factory.close_goal(:goal)
+        |> Factory.reopen_goal(:goal)
+
+      assert length(Operately.Comments.list_comment_threads()) == 3
+
+      {:ok, _} = Goals.delete_goal(ctx.goal)
+
+      assert length(Operately.Comments.list_comment_threads()) == 0
+    end
   end
 end

--- a/test/operately/goals_test.exs
+++ b/test/operately/goals_test.exs
@@ -149,7 +149,7 @@ defmodule Operately.GoalsTest do
       assert length(Goals.list_goal_discussions(ctx.goal.id)) == 0
     end
 
-    test "when goal is deleted, its discussions and check-ins' comments are also deleted", ctx do
+    test "when goal is deleted, its discussions' and check-ins' comments are also deleted", ctx do
       ctx =
         ctx
         |> Factory.add_goal_discussion(:discussion, :goal)
@@ -167,6 +167,27 @@ defmodule Operately.GoalsTest do
 
       assert length(Updates.list_comments(ctx.discussion.id, :comment_thread)) == 0
       assert length(Updates.list_comments(ctx.check_in.id, :goal_update)) == 0
+    end
+
+    test "when goal is deleted, its discussions', check-ins', comments' and reactions are also deleted", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal_discussion(:discussion, :goal)
+        |> Factory.add_goal_update(:check_in, :goal, :creator)
+        |> Factory.add_comment(:comment, :discussion)
+        |> Factory.add_reactions(:reaction1, :discussion)
+        |> Factory.add_reactions(:reaction2, :check_in)
+        |> Factory.add_reactions(:reaction3, :comment)
+
+      assert length(Operately.Updates.list_reactions(ctx.discussion.id, :comment_thread)) == 1
+      assert length(Operately.Updates.list_reactions(ctx.check_in.id, :goal_update)) == 1
+      assert length(Operately.Updates.list_reactions(ctx.comment.id, :comment)) == 1
+
+      {:ok, _} = Goals.delete_goal(ctx.goal)
+
+      assert length(Operately.Updates.list_reactions(ctx.discussion.id, :comment_thread)) == 0
+      assert length(Operately.Updates.list_reactions(ctx.check_in.id, :goal_update)) == 0
+      assert length(Operately.Updates.list_reactions(ctx.comment.id, :comment)) == 0
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -60,6 +60,7 @@ defmodule Operately.Support.Factory do
 
   # comments
   defdelegate add_comment(ctx, testid, parent_name, opts \\ []), to: Factory.Comments
+  defdelegate add_reactions(ctx, testid, parent_name, opts \\ []), to: Factory.Comments
 
   # resource hubs
   defdelegate add_resource_hub(ctx, testid, space_name, creator_name, opts \\ []), to: Factory.ResourceHubs

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -36,6 +36,9 @@ defmodule Operately.Support.Factory do
   defdelegate add_goal_update(ctx, testid, goal_name, person_name), to: Factory.Goals
   defdelegate set_goal_next_update_date(ctx, goal_name, date), to: Factory.Goals
   defdelegate add_goal_target(ctx, testid, goal_name, attrs \\ []), to: Factory.Goals
+  defdelegate close_goal(ctx, testid, opts \\ []), to: Factory.Goals
+  defdelegate reopen_goal(ctx, testid, opts \\ []), to: Factory.Goals
+  defdelegate add_goal_discussion(ctx, testid, goal_name, opts \\ []), to: Factory.Goals
 
   # projects
   defdelegate add_project(ctx, testid, space_name, opts \\ []), to: Factory.Projects

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -33,8 +33,9 @@ defmodule Operately.Support.Factory do
 
   # goals
   defdelegate add_goal(ctx, testid, space_name, opts \\ []), to: Factory.Goals
-  defdelegate add_goal_update(ctx, testid, goal_name, person_name) , to: Factory.Goals
+  defdelegate add_goal_update(ctx, testid, goal_name, person_name), to: Factory.Goals
   defdelegate set_goal_next_update_date(ctx, goal_name, date), to: Factory.Goals
+  defdelegate add_goal_target(ctx, testid, goal_name, attrs \\ []), to: Factory.Goals
 
   # projects
   defdelegate add_project(ctx, testid, space_name, opts \\ []), to: Factory.Projects

--- a/test/support/factory/comments.ex
+++ b/test/support/factory/comments.ex
@@ -10,6 +10,16 @@ defmodule Operately.Support.Factory.Comments do
     Map.put(ctx, testid, comment)
   end
 
+  def add_reactions(ctx, testid, parent_name, opts \\ []) do
+    creator = Keyword.get(opts, :creator, ctx.creator)
+    entity_type = find_entity_type(ctx[parent_name])
+    emoji = Keyword.get(opts, :emoji, "👍")
+
+    {:ok, reaction} = Operately.Operations.ReactionAdding.run(creator, ctx[parent_name].id, entity_type, emoji)
+
+    Map.put(ctx, testid, reaction)
+  end
+
   #
   # Helpers
   #
@@ -22,4 +32,5 @@ defmodule Operately.Support.Factory.Comments do
   defp find_entity_type(%Operately.ResourceHubs.Document{}), do: "resource_hub_document"
   defp find_entity_type(%Operately.ResourceHubs.File{}), do: "resource_hub_file"
   defp find_entity_type(%Operately.ResourceHubs.Link{}), do: "resource_hub_link"
+  defp find_entity_type(%Operately.Updates.Comment{}), do: "comment"
 end

--- a/test/support/factory/goals.ex
+++ b/test/support/factory/goals.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Support.Factory.Goals do
   alias Operately.Access.Binding
   alias Operately.Goals.Timeframe
+  alias Operately.Support.RichText
 
   def add_goal(ctx, testid, space_name, opts \\ []) do
     name = Keyword.get(opts, :name, "some name")
@@ -48,5 +49,34 @@ defmodule Operately.Support.Factory.Goals do
     target = Operately.GoalsFixtures.goal_target_fixture(goal, attrs)
 
     Map.put(ctx, testid, target)
+  end
+
+  def add_goal_discussion(ctx, testid, goal_name, opts \\ []) do
+    goal = Map.fetch!(ctx, goal_name)
+    title = Keyword.get(opts, :title, "some title")
+    message = Keyword.get(opts, :message, RichText.rich_text("content", :as_string))
+
+    {:ok, discussion} = Operately.Operations.GoalDiscussionCreation.run(ctx.creator, goal, title, message)
+
+    Map.put(ctx, testid, discussion)
+  end
+
+  def close_goal(ctx, testid, opts \\ []) do
+    goal = Map.fetch!(ctx, testid)
+    success = Keyword.get(opts, :success, "success")
+    retrospective = Keyword.get(opts, :retrospective, RichText.rich_text("content", :as_string))
+
+    {:ok, goal} = Operately.Operations.GoalClosing.run(ctx.creator, goal, success, retrospective)
+
+    Map.put(ctx, testid, goal)
+  end
+
+  def reopen_goal(ctx, testid, opts \\ []) do
+    goal = Map.fetch!(ctx, testid)
+    message = Keyword.get(opts, :message, RichText.rich_text("content", :as_string))
+
+    {:ok, goal} = Operately.Operations.GoalReopening.run(ctx.creator, goal, message)
+
+    Map.put(ctx, testid, goal)
   end
 end

--- a/test/support/factory/goals.ex
+++ b/test/support/factory/goals.ex
@@ -56,7 +56,8 @@ defmodule Operately.Support.Factory.Goals do
     title = Keyword.get(opts, :title, "some title")
     message = Keyword.get(opts, :message, RichText.rich_text("content", :as_string))
 
-    {:ok, discussion} = Operately.Operations.GoalDiscussionCreation.run(ctx.creator, goal, title, message)
+    {:ok, activity} = Operately.Operations.GoalDiscussionCreation.run(ctx.creator, goal, title, message)
+    discussion = Operately.Repo.preload(activity, :comment_thread).comment_thread
 
     Map.put(ctx, testid, discussion)
   end

--- a/test/support/factory/goals.ex
+++ b/test/support/factory/goals.ex
@@ -43,4 +43,10 @@ defmodule Operately.Support.Factory.Goals do
     Map.put(ctx, goal_name, goal)
   end
 
+  def add_goal_target(ctx, testid, goal_name, attrs \\ []) do
+    goal = Map.fetch!(ctx, goal_name)
+    target = Operately.GoalsFixtures.goal_target_fixture(goal, attrs)
+
+    Map.put(ctx, testid, target)
+  end
 end

--- a/test/support/fixtures/goals_fixtures.ex
+++ b/test/support/fixtures/goals_fixtures.ex
@@ -1,4 +1,5 @@
 defmodule Operately.GoalsFixtures do
+  alias Operately.Goals
   alias Operately.Access.Binding
   alias Operately.Goals.Timeframe
 
@@ -29,9 +30,9 @@ defmodule Operately.GoalsFixtures do
       anonymous_access_level: Binding.view_access(),
     })
 
-    {:ok, goal} = Operately.Goals.create_goal(creator, attrs)
+    {:ok, goal} = Goals.create_goal(creator, attrs)
 
-    Operately.Goals.get_goal!(goal.id)
+    Goals.get_goal!(goal.id)
   end
 
   def goal_update_fixture(author, goal, attrs \\ []) do
@@ -48,5 +49,19 @@ defmodule Operately.GoalsFixtures do
 
     {:ok, update} = Operately.Operations.GoalCheckIn.run(author, goal, attrs)
     update
+  end
+
+  def goal_target_fixture(goal, attrs \\ []) do
+    attrs = Enum.into(attrs, %{
+      goal_id: goal.id,
+      name: "Increase total active users",
+      from: 110,
+      to: 900,
+      value: 110,
+      unit: "users",
+      index: 0,
+    })
+    {:ok, target} = Goals.create_target(attrs)
+    target
   end
 end


### PR DESCRIPTION
I made changes and added tests to ensure that:

- If a Goal has a child Project or a child Goal, it cannot be deleted.
- When a Goal is deleted, its related resources are also deleted.

Some resources, such as Check-ins, Access Context and Access Bindings, have a direct relationship to the Goal at the database level. These resources are cascade deleted with the Goal.

Other resources, such as Goal Discussions and Comments, don't have a relationship to the Goal at the database level. These resources are deleted manually as part of the Goal deletion transaction.