### PR TITLE
fix: Too wide text for project check-ins

### DIFF
--- a/assets/js/features/projectCheckIns/DescriptionSection.tsx
+++ b/assets/js/features/projectCheckIns/DescriptionSection.tsx
@@ -1,48 +1,18 @@
 import React from "react";
 
-import RichContent, { countCharacters, shortenContent } from "@/components/RichContent";
+import RichContent, { shortenContent } from "@/components/RichContent";
 import { ProjectCheckIn } from "@/models/projectCheckIns";
-
-const DESCRIPTION_CHAR_LIMIT = 250;
 
 export function DescriptionSection({ checkIn, limit }: { checkIn: ProjectCheckIn; limit?: number }) {
   const message = limit ? shortenContent(checkIn.description!, limit, { suffix: "..." }) : checkIn.description!;
-  const [showMore, setShowMore] = React.useState(false);
-
-  const length = React.useMemo(() => {
-    return message ? countCharacters(message) : 0;
-  }, [message]);
-
-  const description = React.useMemo(() => {
-    if (length <= DESCRIPTION_CHAR_LIMIT) {
-      return message;
-    } else if (showMore) {
-      return message;
-    } else {
-      return shortenContent(message, DESCRIPTION_CHAR_LIMIT, { suffix: "..." });
-    }
-  }, [length, showMore, message]);
 
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
 
       <div className="mt-2 border border-stroke-base rounded p-4">
-        <RichContent jsonContent={description} />
-        {length > DESCRIPTION_CHAR_LIMIT && <ExpandCollapseButton showMore={showMore} setShowMore={setShowMore} />}
+        <RichContent jsonContent={message} />
       </div>
     </div>
-  );
-}
-
-function ExpandCollapseButton({ showMore, setShowMore }) {
-  return (
-    <span
-      onClick={() => setShowMore(!showMore)}
-      className="text-sm text-link-base underline underline-offset-2 cursor-pointer"
-      data-test-id="expand-project-description"
-    >
-      {showMore ? "Collapse" : "Expand"}
-    </span>
   );
 }

--- a/assets/js/features/projectCheckIns/DescriptionSection.tsx
+++ b/assets/js/features/projectCheckIns/DescriptionSection.tsx
@@ -1,18 +1,48 @@
 import React from "react";
 
-import RichContent, { shortenContent } from "@/components/RichContent";
+import RichContent, { countCharacters, shortenContent } from "@/components/RichContent";
 import { ProjectCheckIn } from "@/models/projectCheckIns";
+
+const DESCRIPTION_CHAR_LIMIT = 250;
 
 export function DescriptionSection({ checkIn, limit }: { checkIn: ProjectCheckIn; limit?: number }) {
   const message = limit ? shortenContent(checkIn.description!, limit, { suffix: "..." }) : checkIn.description!;
+  const [showMore, setShowMore] = React.useState(false);
+
+  const length = React.useMemo(() => {
+    return message ? countCharacters(message) : 0;
+  }, [message]);
+
+  const description = React.useMemo(() => {
+    if (length <= DESCRIPTION_CHAR_LIMIT) {
+      return message;
+    } else if (showMore) {
+      return message;
+    } else {
+      return shortenContent(message, DESCRIPTION_CHAR_LIMIT, { suffix: "..." });
+    }
+  }, [length, showMore, message]);
 
   return (
     <div className="my-8">
       <div className="text-lg font-bold mx-auto">2. What's new since the last check-in?</div>
 
       <div className="mt-2 border border-stroke-base rounded p-4">
-        <RichContent jsonContent={message} />
+        <RichContent jsonContent={description} />
+        {length > DESCRIPTION_CHAR_LIMIT && <ExpandCollapseButton showMore={showMore} setShowMore={setShowMore} />}
       </div>
     </div>
+  );
+}
+
+function ExpandCollapseButton({ showMore, setShowMore }) {
+  return (
+    <span
+      onClick={() => setShowMore(!showMore)}
+      className="text-sm text-link-base underline underline-offset-2 cursor-pointer"
+      data-test-id="expand-project-description"
+    >
+      {showMore ? "Collapse" : "Expand"}
+    </span>
   );
 }

--- a/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -24,6 +24,7 @@ import { useMe } from "@/contexts/CurrentCompanyContext";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
+import { banner } from "../ProjectPage/Banner";
 
 export function Page() {
   const { checkIn } = useLoadedData();
@@ -39,7 +40,7 @@ export function Page() {
       <Paper.Root>
         <Navigation project={checkIn.project} />
 
-        <Paper.Body>
+        <Paper.Body className="p-4 md:p-8 lg:px-28 lg:pt-8" noPadding banner={banner(checkIn)}>
           <Options />
           <Title />
           <StatusSection checkIn={checkIn} reviewer={checkIn.project!.reviewer} />


### PR DESCRIPTION
This PR resolves Issue #2206 by broadening the wording used in project check-ins, following the suggested guidelines