### PR TITLE
Ensure email login/signup flags are present in .env during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,8 @@ dev.run.script:
 dev.seed.env:
 	touch .env
 	grep "OPERATELY_BLOB_TOKEN_SECRET_KEY" .env || echo "OPERATELY_BLOB_TOKEN_SECRET_KEY=$$(openssl rand -base64 32)" >> .env
+	grep "ALLOW_LOGIN_WITH_EMAIL" .env || printf "\nALLOW_LOGIN_WITH_EMAIL=yes\n" >> .env
+	grep "ALLOW_SIGNUP_WITH_EMAIL" .env || echo "ALLOW_SIGNUP_WITH_EMAIL=yes" >> .env
 
 dev.mix.deps.clean:
 	./devenv mix deps.clean --unlock --unused


### PR DESCRIPTION
This PR resolves Issue #2061: ensures that the following environment variables are present in the .env file when running make dev.setup:
	•	ALLOW_LOGIN_WITH_EMAIL=yes
	•	ALLOW_SIGNUP_WITH_EMAIL=yes

These variables are required to enable email-based login and signup in development.