### PR TITLE
fix: Same email can be used to create one person per company

### DIFF
--- a/assets/js/components/Forms/useForm.tsx
+++ b/assets/js/components/Forms/useForm.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { AxiosError } from "axios";
 
 import { FieldObject } from "./useForm/field";
 import { ErrorMap, AddErrorFn, ValidationFn } from "./useForm/errors";
@@ -14,6 +15,7 @@ interface FormProps<T extends FieldObject> {
   submit: (attrs?: any) => Promise<void> | void;
   cancel?: () => Promise<void> | void;
   onChange?: OnChangeFn<T>;
+  onError?: (e: AxiosError) => void;
 }
 
 export interface FormState<T extends FieldObject> {
@@ -92,6 +94,8 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
           setState("idle");
         } catch (e) {
           console.error(e);
+          if (props.onError) props.onError(e);
+
           setState("idle");
         }
       },

--- a/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
+++ b/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
@@ -68,6 +68,18 @@ function InviteForm({ setPageState }: { setPageState: SetPageStateFn }) {
 
       setPageState({ state: "invited", url, fullName: form.values.fullName });
     },
+    onError: (e) => {
+      const { data } = (e.response as any) ?? {};
+
+      if ("message" in data && typeof data.message === "string") {
+        if (data.message.toLowerCase().includes("email")) {
+          form.actions.addErrors({ email: data.message });
+        }
+        if (data.message.toLowerCase().includes("name")) {
+          form.actions.addErrors({ fullName: data.message });
+        }
+      }
+    },
     cancel: () => {
       navigate(Paths.companyManagePeoplePath());
     },

--- a/lib/operately/people/person.ex
+++ b/lib/operately/people/person.ex
@@ -69,6 +69,7 @@ defmodule Operately.People.Person do
     ])
     |> validate_required([:full_name, :company_id])
     |> foreign_key_constraint(:avatar_blob_id, name: :people_avatar_blob_id_fkey)
+    |> unique_constraint([:company_id, :account_id], name: :people_company_id_account_id_index, message: "Email has already been taken")
   end
 
   def short_name(person) do

--- a/lib/operately_web/api/mutations/add_company_member.ex
+++ b/lib/operately_web/api/mutations/add_company_member.ex
@@ -63,6 +63,9 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyMember do
       {:error, [%{field: :full_name, message: message}]} ->
         {:error, :bad_request, "Name " <> message}
 
+      {:error, [%{message: message}]} ->
+        {:error, :bad_request, message}
+
       {:error, e} ->
         Logger.error("Unexpected error: #{inspect(e)}")
         raise "Unexpected error"

--- a/priv/repo/migrations/20250403112800_add_unique_account_plus_company_constraint_to_people.exs
+++ b/priv/repo/migrations/20250403112800_add_unique_account_plus_company_constraint_to_people.exs
@@ -1,0 +1,7 @@
+defmodule Operately.Repo.Migrations.AddUniqueAccountPlusCompanyConstraintToPeople do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:people, [:company_id, :account_id])
+  end
+end

--- a/test/operately_web/api/mutations/add_company_member_test.exs
+++ b/test/operately_web/api/mutations/add_company_member_test.exs
@@ -51,6 +51,18 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyMemberTest do
       assert {400, res} = mutation(ctx.conn, :add_company_member, input)
       assert res == %{:error => "Bad request", :message => "Name can't be blank"}
     end
+
+    test "email can be used to create one and only one account per company", ctx do
+      other_ctx = register_and_log_in_account(ctx) |> promote_to_owner()
+
+      assert {200, _} = mutation(ctx.conn, :add_company_member, @add_company_member_input)
+      assert {200, _} = mutation(other_ctx.conn, :add_company_member, @add_company_member_input)
+
+      assert {400, res} = mutation(ctx.conn, :add_company_member, @add_company_member_input)
+      assert res == %{:error => "Bad request", :message => "Email has already been taken"}
+      assert {400, res} = mutation(other_ctx.conn, :add_company_member, @add_company_member_input)
+      assert res == %{:error => "Bad request", :message => "Email has already been taken"}
+    end
   end
 
   defp promote_to_owner(ctx) do


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/2227:

- Each company can now have a person with a given email address, allowing the same email to be associated with different companies.
- A constraint was added at the database level to make sure two people never have both the same account and company.
- If there is an attempt to create two people with same email in the same company, an error message is displayed in the UI.