### PR TITLE
fix: Invitation token is created for new accounts only

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -2123,6 +2123,7 @@ export interface AddCompanyMemberInput {
 
 export interface AddCompanyMemberResult {
   invitation?: Invitation | null;
+  newAccount?: boolean | null;
 }
 
 export interface AddCompanyOwnersInput {

--- a/app/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
@@ -21,9 +21,10 @@ export async function loader({ params }): Promise<LoaderResult> {
   };
 }
 
-type PageState = PageStateForm | PageStateInvited;
+type PageState = PageStateForm | PageStateInvited | PageStateAdded;
 type PageStateForm = { state: "form" };
 type PageStateInvited = { state: "invited"; url: string; fullName: string };
+type PageStateAdded = { state: "added"; fullName: string };
 type SetPageStateFn = (state: PageState) => void;
 
 //
@@ -40,6 +41,7 @@ export function Page() {
       {match(state.state)
         .with("form", () => <InviteForm setPageState={setState} />)
         .with("invited", () => <InvitedPage state={state as PageStateInvited} setPageState={setState} />)
+        .with("added", () => <AddedPage state={state as PageStateAdded} setPageState={setState} />)
         .exhaustive()}
     </Pages.Page>
   );
@@ -64,9 +66,13 @@ function InviteForm({ setPageState }: { setPageState: SetPageStateFn }) {
         email: form.values.email.trim(),
         title: form.values.title.trim(),
       });
-      const url = Companies.createInvitationUrl(res.invitation!.token!);
 
-      setPageState({ state: "invited", url, fullName: form.values.fullName });
+      if (res.newAccount) {
+        const url = Companies.createInvitationUrl(res.invitation!.token!);
+        setPageState({ state: "invited", url, fullName: form.values.fullName });
+      } else {
+        setPageState({ state: "added", fullName: form.values.fullName });
+      }
     },
     onError: (e) => {
       const { data } = (e.response as any) ?? {};
@@ -102,8 +108,9 @@ function InviteForm({ setPageState }: { setPageState: SetPageStateFn }) {
       </Paper.Body>
 
       <div className="my-8 text-center px-20">
-        <span className="font-bold">What happens next?</span> You will get a invitation link to share with the new
-        member which will allow them to join your company. It will be valid for 24 hours.
+        <span className="font-bold">What happens next?</span> If the new member already has an account, they will be
+        added to your company. If they don't have an account, you will get a invitation link to share with them. The
+        link will be valid for 24 hours.
       </div>
     </Paper.Root>
   );
@@ -129,6 +136,25 @@ function InvitedPage({ state, setPageState }: { state: PageStateInvited; setPage
         </div>
 
         <div className="mt-2">This link will expire in 24 hours.</div>
+      </Paper.Body>
+
+      <div className="flex items-center gap-3 mt-8 justify-center">
+        <PrimaryButton onClick={inviteAnother} testId="invite-another-button">
+          Invite Another Member
+        </PrimaryButton>
+      </div>
+    </Paper.Root>
+  );
+}
+
+function AddedPage({ state, setPageState }: { state: PageStateAdded; setPageState: SetPageStateFn }) {
+  const inviteAnother = () => setPageState({ state: "form" });
+
+  return (
+    <Paper.Root size="medium">
+      <Navigation />
+      <Paper.Body minHeight="none">
+        <div className="text-content-accent text-2xl font-extrabold">{state.fullName} has been added 🎉</div>
       </Paper.Body>
 
       <div className="flex items-center gap-3 mt-8 justify-center">

--- a/app/lib/operately/activities/content/company_member_added.ex
+++ b/app/lib/operately/activities/content/company_member_added.ex
@@ -13,7 +13,7 @@ defmodule Operately.Activities.Content.CompanyMemberAdded do
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields))
+    |> validate_required([:name, :email, :title, :company_id])
   end
 
   def build(params) do

--- a/app/lib/operately/people.ex
+++ b/app/lib/operately/people.ex
@@ -50,6 +50,14 @@ defmodule Operately.People do
     if Operately.People.Account.valid_password?(account, password), do: account
   end
 
+  def is_new_account?(email) when is_binary(email) do
+    not Repo.exists?(from(a in Account,
+      join: p in assoc(a, :people),
+      where: a.email == ^email,
+      where: not p.has_open_invitation
+    ))
+  end
+
   defdelegate insert_person(multi, callback), to: Operately.People.InsertPersonIntoOperation, as: :insert
 
   def create_person(attrs \\ %{}) do

--- a/app/test/features/invite_member_test.exs
+++ b/app/test/features/invite_member_test.exs
@@ -22,6 +22,21 @@ defmodule Operately.Features.InviteMemberTest do
     |> Steps.assert_member_invited()
   end
 
+  feature "admin account can add members with existing account", ctx do
+    params = %{
+      fullName: "John Doe",
+      email: "john@some-company.com",
+      title: "Developer",
+    }
+
+    ctx
+    |> Steps.given_that_an_account_exists_in_another_company(params)
+    |> Steps.log_in_as_admin()
+    |> Steps.navigate_to_invitation_page()
+    |> Steps.invite_member(params)
+    |> Steps.assert_member_added(params.fullName)
+  end
+
   feature "joining a company and setting a password", ctx do
     ctx
     |> Steps.given_that_I_was_invited_and_have_a_token(%{name: "John Doe", email: "john@john.com"})

--- a/app/test/support/features/invite_member_steps.ex
+++ b/app/test/support/features/invite_member_steps.ex
@@ -18,6 +18,12 @@ defmodule Operately.Support.Features.InviteMemberSteps do
     Map.merge(ctx, %{company: company, admin: admin})
   end
 
+  step :given_that_an_account_exists_in_another_company, ctx, attrs do
+    company = company_fixture()
+    person_fixture_with_account(%{company_id: company.id, email: attrs.email, full_name: attrs.fullName})
+    ctx
+  end
+
   step :log_in_as_admin, ctx do
     ctx |> UI.login_as(ctx.admin)
   end
@@ -61,6 +67,10 @@ defmodule Operately.Support.Features.InviteMemberSteps do
 
   step :assert_member_invited, ctx do
     ctx |> UI.assert_text("/join?token=")
+  end
+
+  step :assert_member_added, ctx, name do
+    ctx |> UI.assert_text("#{name} has been added")
   end
 
   step :given_that_I_was_invited_and_have_a_token, ctx, params do


### PR DESCRIPTION
Now, when an admin attempts to add a member to the company, if the new member doesn't yet have an Operately account, a link with a token is generated that they can use to log in for the first time. If the new member already has an Operately account, they are added to the company directly.