### PR TITLE
fix: Fix unit tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -46,7 +46,7 @@ blocks:
 
         - name: Unit Tests
           commands:
-            - make test.mix.unit || true # temp disable unit tests
+            - make test.mix.unit
             - make test.ee
             - make test.npm || true # temp disable unit tests
 

--- a/app/test/operately_web/api/queries/get_goal_test.exs
+++ b/app/test/operately_web/api/queries/get_goal_test.exs
@@ -193,7 +193,9 @@ defmodule OperatelyWeb.Api.Queries.GetGoalTest do
       assert res.goal.last_check_in == nil
 
       update = goal_update_fixture(ctx.person, goal)
-      update = Operately.Repo.preload(update, [:author, [reactions: :author]])
+      update = Operately.Repo.preload(update, [:goal, :author, [reactions: :author]])
+      update = Operately.Goals.Update.preload_permissions(update, :can_view, ctx.person.id)
+
       goal = Operately.Goals.Goal.changeset(goal, %{last_update_id: update.id}) |> Operately.Repo.update!()
 
       assert {200, res} = query(ctx.conn, :get_goal, %{id: Paths.goal_id(goal), include_last_check_in: true})


### PR DESCRIPTION
Currently, in the `semaphore.yml` file, we are skipping unit tests that fail by using the command `make test.mix.unit || true`.  

In this PR, I'm fixing the unit tests that are failing and I'm changing the command to run tests back to `make test.mix.unit`.

