### PR TITLE
fix: Fix npm tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -48,7 +48,7 @@ blocks:
           commands:
             - make test.mix.unit
             - make test.ee
-            - make test.npm || true # temp disable unit tests
+            - make test.npm
 
         - name: Features
           parallelism: 6

--- a/app/jest.config.json
+++ b/app/jest.config.json
@@ -1,0 +1,16 @@
+{
+  "transform": {
+    "^.+\\.(ts|tsx)$": ["ts-jest", { "tsconfig": "tsconfig.json", "isolatedModules": true }]
+  },
+  "testMatch": [
+    "**/?(*.)+(test).+(ts|tsx|js)"
+  ],
+  "modulePaths": [
+    "<rootDir>/node_modules"
+  ],
+  "moduleNameMapper": {
+    "^turboui$": "<rootDir>/../turboui/src",
+    "^@/ee/(.*)$": "<rootDir>/ee/assets/js/$1",
+    "^@/(.*)$": "<rootDir>/assets/js/$1"
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -65,17 +65,5 @@
     "test": "jest",
     "knip": "knip --no-progress",
     "prettier:check": "prettier --check js"
-  },
-  "jest": {
-    "transform": {
-      "^.+\\.(ts|tsx)$": "ts-jest"
-    },
-    "testMatch": [
-      "**/?(*.)+(test).+(ts|tsx|js)"
-    ],
-    "moduleNameMapper": {
-      "^@/ee/(.*)$": "<rootDir>/ee/assets/js/$1",
-      "^@/(.*)$": "<rootDir>/assets/js/$1"
-    }
   }
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -26,28 +26,25 @@
     "noUncheckedIndexedAccess": true, // accessing index must always check for undefined
     "noUnusedLocals": true, // Report errors on unused local variables.
     "noUnusedParameters": true, // Report errors on unused parameters in functions
-
     "jsx": "react",
 
     // A series of entries which re-map imports to lookup locations relative to the baseUrl
     "paths": {
       "@/ee/*": ["./ee/assets/js/*"],
-      "@/*": ["./assets/js/*"]
+      "@/*": ["./assets/js/*"],
+      "turboui": ["../turboui/src"],
+      "turboui/*": ["../turboui/src/*"]
     }
   },
 
   "include": [
-    "./assets/js/**/*.ts", 
-    "./assets/js/**/*.tsx", 
-    "./ee/assets/js/**/*.ts", 
+    "./assets/js/**/*.ts",
+    "./assets/js/**/*.tsx",
+    "./ee/assets/js/**/*.ts",
     "./ee/assets/js/**/*.tsx"
   ],
-
   "exclude": ["node_modules/**/*"],
-
   "linterOptions": {
-    "exclude": [
-      "./ee/assets/js/admin_api/**/*",
-    ]
+    "exclude": ["./ee/assets/js/admin_api/**/*"]
   }
 }

--- a/turboui/tsconfig.json
+++ b/turboui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "esnext",  // Use ESM format
+    "module": "esnext", // Use ESM format
     "lib": ["dom", "dom.iterable", "esnext"],
     "jsx": "react-jsx",
     "declaration": true,
@@ -12,7 +12,15 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["../app/node_modules/*"],
+      "react": ["../app/node_modules/react", "../app/node_modules/@types/react"],
+      "react/*": ["../app/node_modules/react/*", "../app/node_modules/@types/react/*"]
+    },
+    "typeRoots": ["../app/node_modules/@types"],
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Currently, because jest was not working with the new configuration, in the `semaphore.yml` file, we are skipping npm tests by using the command `make test.npm || true`.

In this PR, I'm fixing the npm tests and I'm changing the command to run the tests back to just `make test.npm`.