### PR TITLE
chore: Extract Statusbadge component to turboui

### DIFF
--- a/design/src/components/WorkMap/TableRow.tsx
+++ b/design/src/components/WorkMap/TableRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { StatusBadge } from "./StatusBadge";
+import { StatusBadge } from "../../../../turboui/src/StatusBadge";
 import { ProgressBar } from "./ProgressBar";
 import {
   IconTargetArrow,

--- a/design/src/pages/design-system.astro
+++ b/design/src/pages/design-system.astro
@@ -274,6 +274,26 @@ import Logo from "../components/Logo.astro";
               </a>
               <a
                 class="p-2 first:border-t border-b border-stroke-base cursor-pointer flex items-center gap-4 hover:bg-surface-highlight"
+                href="/design-system/status-badges"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="tabler-icon tabler-icon-badge"
+                >
+                  <path d="M17 17v-13l-5 3l-5 -3v13l5 3z"></path>
+                </svg>
+                Status Badges
+              </a>
+              <a
+                class="p-2 first:border-t border-b border-stroke-base cursor-pointer flex items-center gap-4 hover:bg-surface-highlight"
                 href="/design-system/radix"
               >
                 <svg

--- a/design/src/pages/design-system/status-badges.astro
+++ b/design/src/pages/design-system/status-badges.astro
@@ -1,0 +1,289 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { StatusBadge } from "../../../../turboui/src/StatusBadge";
+---
+
+<Layout>
+  <div id="root">
+    <div class="flex flex-col h-dvh">
+      <div class="flex-1 overflow-y-auto">
+        <div>
+          <div class="mx-auto relative sm:my-10 max-w-4xl">
+            <div
+              class="bg-surface-dimmed flex items-center flex-wrap justify-center gap-1 pt-2 pb-1 mx-0 sm:mx-10 font-semibold rounded-t border-b sm:border-b-0 sm:border-t sm:border-x border-surface-outline"
+            >
+              <a
+                class="cursor-pointer transition-colors underline underline-offset-2 text-link-base hover:text-link-hover"
+                href="/"><span class="flex items-center gap-1.5">Lobby</span></a
+              ><div class="shrink-0">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="tabler-icon tabler-icon-slash"
+                  ><path d="M17 5l-10 14"></path></svg
+                >
+              </div><a
+                class="cursor-pointer transition-colors underline underline-offset-2 text-link-base hover:text-link-hover"
+                href="/design-system/"
+                ><span class="flex items-center gap-1.5">Design System</span></a
+              >
+            </div>
+            <div
+              class="relative bg-surface-base px-12 py-10 min-h-dvh sm:min-h-0 sm:border sm:border-surface-outline sm:rounded-lg sm:shadow-xl"
+            >
+              <div class="flex items-center justify-between mb-6">
+                <div>
+                  <div
+                    class="text-content-accent text-lg md:text-2xl font-extrabold"
+                  >
+                    Status Badges
+                  </div>
+                </div><div></div>
+              </div>
+              <div class="mt-2 mb-10">
+                Status badges are used to visually represent the current state of items like goals, projects, tasks, etc. 
+                They provide an immediate visual indicator of an item's status through color coding and icons.
+              </div>
+
+              <h3 class="font-bold mt-8 text-lg text-content-accent">
+                Progress States
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                These badges indicate items that are currently in progress or awaiting action.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <div class="flex flex-wrap gap-4">
+                  <StatusBadge status="on_track" client:load />
+                  <StatusBadge status="pending" client:load />
+                  <StatusBadge status="caution" client:load />
+                  <StatusBadge status="issue" client:load />
+                  <StatusBadge status="paused" client:load />
+                </div>
+                <div
+                  class="mt-6 p-4 bg-surface-base rounded border border-surface-outline"
+                >
+                  <p class="text-sm text-content-dimmed mb-2 font-semibold">
+                    When to use each status:
+                  </p>
+                  <ul class="text-sm text-content-dimmed space-y-2">
+                    <li>
+                      <strong>On Track:</strong> Item is progressing as expected with no issues.
+                    </li>
+                    <li>
+                      <strong>Pending:</strong> Item is waiting to start or for approval.
+                    </li>
+                    <li>
+                      <strong>Attention:</strong> Item requires attention but is not at serious risk.
+                    </li>
+                    <li>
+                      <strong>At Risk:</strong> Item is at significant risk of not being completed successfully.
+                    </li>
+                    <li>
+                      <strong>Paused:</strong> Work on the item has been temporarily halted.
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
+              <h3 class="font-bold mt-12 text-lg text-content-accent">
+                Completion States
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                These badges represent the final state of completed items.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <div class="flex flex-wrap gap-4">
+                  <StatusBadge status="achieved" client:load />
+                  <StatusBadge status="completed" client:load />
+                  <StatusBadge status="partial" client:load />
+                  <StatusBadge status="missed" client:load />
+                  <StatusBadge status="dropped" client:load />
+                </div>
+                <div
+                  class="mt-6 p-4 bg-surface-base rounded border border-surface-outline"
+                >
+                  <p class="text-sm text-content-dimmed mb-2 font-semibold">
+                    When to use each status:
+                  </p>
+                  <ul class="text-sm text-content-dimmed space-y-2">
+                    <li>
+                      <strong>Achieved/Completed:</strong> Item was successfully completed.
+                    </li>
+                    <li>
+                      <strong>Partial:</strong> Item was partially completed or achieved.
+                    </li>
+                    <li>
+                      <strong>Missed:</strong> Item was not completed successfully by the deadline.
+                    </li>
+                    <li>
+                      <strong>Dropped:</strong> Item was intentionally abandoned.
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
+              <h3 class="font-bold mt-12 text-lg text-content-accent">
+                Badges Without Icons
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                For a more minimal look, badges can be displayed without icons.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <div class="flex flex-wrap gap-4">
+                  <StatusBadge status="on_track" hideIcon={true} client:load />
+                  <StatusBadge status="pending" hideIcon={true} client:load />
+                  <StatusBadge status="achieved" hideIcon={true} client:load />
+                  <StatusBadge status="partial" hideIcon={true} client:load />
+                  <StatusBadge status="missed" hideIcon={true} client:load />
+                </div>
+                <div
+                  class="mt-6 p-4 bg-surface-base rounded border border-surface-outline"
+                >
+                  <p class="text-sm text-content-dimmed">
+                    Use the <code>hideIcon</code> prop to display badges without icons. This is useful when screen space is limited or 
+                    when you want a more minimal look.
+                  </p>
+                </div>
+              </div>
+
+              <h3 class="font-bold mt-12 text-lg text-content-accent">
+                Custom Status
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                For edge cases, you can provide a custom status string.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <div class="flex flex-wrap gap-4">
+                  <StatusBadge status="Custom Status" client:load />
+                  <StatusBadge status="Another Custom" hideIcon={true} client:load />
+                </div>
+                <div
+                  class="mt-6 p-4 bg-surface-base rounded border border-surface-outline"
+                >
+                  <p class="text-sm text-content-dimmed">
+                    When you pass a string that doesn't match any predefined status, the component will render a neutral badge with that text.
+                  </p>
+                </div>
+              </div>
+
+              <h3 class="font-bold mt-12 text-lg text-content-accent">
+                Interactive Behaviors
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                Status badges can be enhanced with interactive behaviors like hover effects.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <div>
+                  <p class="text-sm text-content-dimmed mb-4 font-semibold">
+                    Hover over these badges to see the "pop out" effect used in the Work Map:
+                  </p>
+                  <table class="w-full border-collapse">
+                    <thead>
+                      <tr class="text-left">
+                        <th class="py-2 px-4 text-sm font-medium text-content-base">Item</th>
+                        <th class="py-2 px-4 text-sm font-medium text-content-base">Status</th>
+                        <th class="py-2 px-4 text-sm font-medium text-content-base">Progress</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr class="group border-b border-surface-outline hover:bg-surface-highlight transition-colors duration-150">
+                        <td class="py-2 px-4 text-sm">Project Alpha</td>
+                        <td class="py-2 px-4">
+                          <div class="transform group-hover:scale-105 transition-transform duration-150">
+                            <StatusBadge status="on_track" client:load />
+                          </div>
+                        </td>
+                        <td class="py-2 px-4 text-sm">75%</td>
+                      </tr>
+                      <tr class="group border-b border-surface-outline hover:bg-surface-highlight transition-colors duration-150">
+                        <td class="py-2 px-4 text-sm">Goal Beta</td>
+                        <td class="py-2 px-4">
+                          <div class="transform group-hover:scale-105 transition-transform duration-150">
+                            <StatusBadge status="caution" client:load />
+                          </div>
+                        </td>
+                        <td class="py-2 px-4 text-sm">45%</td>
+                      </tr>
+                      <tr class="group border-b border-surface-outline hover:bg-surface-highlight transition-colors duration-150">
+                        <td class="py-2 px-4 text-sm">Task Gamma</td>
+                        <td class="py-2 px-4">
+                          <div class="transform group-hover:scale-105 transition-transform duration-150">
+                            <StatusBadge status="completed" client:load />
+                          </div>
+                        </td>
+                        <td class="py-2 px-4 text-sm">100%</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div
+                  class="mt-6 p-4 bg-surface-base rounded border border-surface-outline"
+                >
+                  <p class="text-sm text-content-dimmed mb-2">
+                    To implement the hover effect, wrap the StatusBadge in a div with the following classes:
+                  </p>
+                  <pre class="text-sm bg-gray-800 text-gray-200 p-4 rounded overflow-x-auto mt-2">
+{`<!-- Row has 'group' class to enable group-hover functionality -->
+<tr class="group hover:bg-surface-highlight">
+  <td>
+    <!-- This wrapper enables the scale effect on hover -->
+    <div class="transform group-hover:scale-105 transition-transform duration-150">
+      <StatusBadge status="on_track" />
+    </div>
+  </td>
+</tr>`}
+                  </pre>
+                </div>
+              </div>
+
+              <h3 class="font-bold mt-12 text-lg text-content-accent">
+                Usage
+              </h3>
+              <p class="text-content-base text-sm mb-4">
+                How to use the StatusBadge component in your code.
+              </p>
+              <div
+                class="p-6 border border-surface-outline rounded-lg mb-8 bg-surface-base"
+              >
+                <pre class="text-sm bg-gray-800 text-gray-200 p-4 rounded overflow-x-auto">
+{`// Import the component
+import { StatusBadge } from "turboui";
+
+// Basic usage
+<StatusBadge status="on_track" />
+
+// Without icon
+<StatusBadge status="completed" hideIcon={true} />
+
+// Custom styling
+<StatusBadge 
+  status="pending" 
+  className="my-custom-class" 
+  style={{ fontSize: '12px' }} 
+/>`}
+                </pre>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</Layout>

--- a/design/src/types/workmap.ts
+++ b/design/src/types/workmap.ts
@@ -1,49 +1,42 @@
 /**
  * Types specific to the WorkMap functionality
  */
-import type { BaseComponentProps, WithChildren, WithId } from './common';
+import type { BaseComponentProps, WithChildren, WithId } from "./common";
 
 /**
  * Goal status values
- * 
+ *
  * Progress states:
  * - on_track: Goal is currently in progress and on track
  * - caution/issue: Goal is at risk or needs attention
  * - paused: Goal is temporarily paused
  * - pending: Goal is waiting to start or for approval
- * 
+ *
  * Completion states (per goal completion model):
  * - achieved: Goal was fully accomplished (green)
  * - partial: Goal was partially accomplished (amber/yellow)
  * - missed: Goal was not accomplished (red)
- * 
+ *
  * Legacy/alternative states:
  * - completed: Legacy term for achieved
  * - dropped: Goal was intentionally abandoned
  * - failed: Legacy term for missed (red)
  */
-export type GoalStatus = 
+export type GoalStatus =
   // Progress states
-  | 'on_track' 
-  | 'caution'
-  | 'issue'
-  | 'paused'
-  | 'pending'
+  | "on_track"
+  | "caution"
+  | "issue"
+  | "paused"
+  | "pending"
   // Completion states
-  | 'achieved'   // Goal fully accomplished (green)
-  | 'partial'    // Goal partially accomplished (amber/yellow)
-  | 'missed'     // Goal not accomplished (red)
+  | "achieved" // Goal fully accomplished (green)
+  | "partial" // Goal partially accomplished (amber/yellow)
+  | "missed" // Goal not accomplished (red)
   // Legacy/alternative states
-  | 'completed'  // Legacy term for achieved
-  | 'dropped'    // Goal abandoned
-  | 'failed';    // Legacy term for missed
-
-/**
- * StatusBadge component props
- */
-export interface StatusBadgeProps extends BaseComponentProps {
-  status: GoalStatus | string;
-}
+  | "completed" // Legacy term for achieved
+  | "dropped" // Goal abandoned
+  | "failed"; // Legacy term for missed
 
 /**
  * Owner information structure
@@ -76,7 +69,7 @@ export interface CompletedOn {
  */
 export interface WorkMapItem extends WithId {
   name: string;
-  type: 'goal' | 'project';
+  type: "goal" | "project";
   status: GoalStatus;
   progress: number; // 0-100
   space: string;
@@ -128,6 +121,6 @@ export interface TableRowProps extends BaseComponentProps {
  */
 export interface ProgressBarProps extends BaseComponentProps {
   progress: number;
-  size?: 'sm' | 'md' | 'lg';
+  size?: "sm" | "md" | "lg";
   showLabel?: boolean;
 }

--- a/turboui/src/StatusBadge/index.tsx
+++ b/turboui/src/StatusBadge/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import type { StatusBadgeProps } from "../../types/workmap";
+import { StatusBadgeProps } from "./types";
 
-export function StatusBadge({ status }: StatusBadgeProps): React.ReactElement {
+export function StatusBadge({ status, className = "", style }: StatusBadgeProps): React.ReactElement {
   let bgColor: string,
     textColor: string,
     dotColor: string,
@@ -66,6 +66,7 @@ export function StatusBadge({ status }: StatusBadgeProps): React.ReactElement {
       label = "At risk";
       break;
     case "missed":
+    case "failed":
       bgColor = "bg-red-50 dark:bg-red-900/30";
       textColor = "text-red-700 dark:text-red-300";
       dotColor = "bg-red-500 dark:bg-red-400";
@@ -128,6 +129,7 @@ export function StatusBadge({ status }: StatusBadgeProps): React.ReactElement {
           </svg>
         );
       case "missed":
+      case "failed":
       case "dropped":
         return (
           <svg
@@ -173,7 +175,8 @@ export function StatusBadge({ status }: StatusBadgeProps): React.ReactElement {
 
   return (
     <span
-      className={`inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-[10px] sm:text-xs font-medium ${bgColor} ${textColor} border ${borderColor} shadow-sm backdrop-blur-[2px]`}
+      className={`inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-[10px] sm:text-xs font-medium ${bgColor} ${textColor} border ${borderColor} shadow-sm backdrop-blur-[2px] ${className}`}
+      style={style}
     >
       {getStatusIcon()}
       {label}

--- a/turboui/src/StatusBadge/index.tsx
+++ b/turboui/src/StatusBadge/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StatusBadgeProps } from "./types";
 
-export function StatusBadge({ status, className = "", style }: StatusBadgeProps): React.ReactElement {
+export function StatusBadge({ status, hideIcon = false, className = "", style }: StatusBadgeProps): React.ReactElement {
   let bgColor: string,
     textColor: string,
     dotColor: string,
@@ -178,7 +178,7 @@ export function StatusBadge({ status, className = "", style }: StatusBadgeProps)
       className={`inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-[10px] sm:text-xs font-medium ${bgColor} ${textColor} border ${borderColor} shadow-sm backdrop-blur-[2px] ${className}`}
       style={style}
     >
-      {getStatusIcon()}
+      {!hideIcon && getStatusIcon()}
       {label}
     </span>
   );

--- a/turboui/src/StatusBadge/types.ts
+++ b/turboui/src/StatusBadge/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Status values for the StatusBadge component
+ */
+export type BadgeStatus = 
+  // Progress states
+  | 'on_track' 
+  | 'caution'
+  | 'issue'
+  | 'paused'
+  | 'pending'
+  // Completion states
+  | 'achieved'   // Goal fully accomplished (green)
+  | 'partial'    // Goal partially accomplished (amber/yellow)
+  | 'missed'     // Goal not accomplished (red)
+  // Legacy/alternative states
+  | 'completed'  // Legacy term for achieved
+  | 'dropped'    // Goal abandoned
+  | 'failed'     // Legacy term for missed
+  | string;      // Allow custom status strings
+
+/**
+ * Props for the StatusBadge component
+ */
+export interface StatusBadgeProps {
+  status: BadgeStatus;
+  className?: string;
+  style?: React.CSSProperties;
+}

--- a/turboui/src/StatusBadge/types.ts
+++ b/turboui/src/StatusBadge/types.ts
@@ -23,6 +23,7 @@ export type BadgeStatus =
  */
 export interface StatusBadgeProps {
   status: BadgeStatus;
+  hideIcon?: boolean; // Option to hide the status icon
   className?: string;
   style?: React.CSSProperties;
 }

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -3,3 +3,4 @@ export * from "./TestableElement";
 export * from "./Button";
 export * from "./Link";
 export * from "./Menu";
+export * from "./StatusBadge";


### PR DESCRIPTION
- Moved the component from `design/` to `turboui/`
- Created a showcase page in design system
- I don't consider the color and state combinations to be final, but changing them will be trivial
![CleanShot 2025-04-08 at 14 34 43@2x](https://github.com/user-attachments/assets/86e46076-a7e5-40d0-a1cb-092613ff6b16)
