### PR TITLE
fix: User redirected to correct path after oauth login

### DIFF
--- a/app/lib/operately_web/account_auth.ex
+++ b/app/lib/operately_web/account_auth.ex
@@ -20,7 +20,7 @@ defmodule OperatelyWeb.AccountAuth do
   """
   def log_in_account(conn, account, params \\ %{}) do
     token = People.generate_account_session_token(account)
-    path = params["redirect_to"] || get_session(conn, :redirect_to) || after_login_path(account)
+    path = params["redirect_to"] || get_session(conn, :redirect_to) || get_session(conn, :account_return_to) || after_login_path(account)
 
     conn
     |> renew_session()


### PR DESCRIPTION
This is another attempt at fixing https://github.com/operately/operately/issues/2015.