### PR TITLE
chore: Kill the vite dev server when the mix server shuts down

### DIFF
--- a/app/vite.config.mjs
+++ b/app/vite.config.mjs
@@ -3,13 +3,28 @@ import { fileURLToPath } from 'url';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Based on: https://github.com/vitejs/vite/issues/19091
+const resumeStdinPlugin = {
+  name: "resume-stdin",
+  configureServer: () => {
+    // runs when the dev server is triggered, but not on other commands:
+    process.stdin.resume();
+    // an 'end' listener is already added in `setupSIGTERMListener` here: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L1537
+  },
+};
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Check for deployment mode
 const isProd = process.env.NODE_ENV === 'production';
 
 export default defineConfig({
-  plugins: [react(), splitVendorChunkPlugin()],
+  plugins: [
+    resumeStdinPlugin,
+    react(), 
+    splitVendorChunkPlugin()
+  ],
+
   root: __dirname,
   
   build: {


### PR DESCRIPTION
fix found here: https://github.com/vitejs/vite/issues/19091
once this PR is merged we can remove the extra stuff in the vite config: https://github.com/vitejs/vite/pull/19092

fixes https://github.com/operately/operately/issues/2276