### PR TITLE
fix: Display the correct background color in WorkMap rows and TimeframeSelector

### DIFF
--- a/turboui/src/TimeframeSelector/index.tsx
+++ b/turboui/src/TimeframeSelector/index.tsx
@@ -110,6 +110,7 @@ interface TimeframeSelectorTriggerProps {
 
 function TimeframeSelectorTrigger(props: TimeframeSelectorTriggerProps) {
   const className = classNames(
+    "bg-surface-base hover:bg-surface-highlight dark:hover:bg-surface-dimmed/20",
     "border border-surface-outline",
     "rounded-lg",
     "flex items-center gap-1",

--- a/turboui/src/WorkMap/TableRow/RowContainer.tsx
+++ b/turboui/src/WorkMap/TableRow/RowContainer.tsx
@@ -18,7 +18,7 @@ export function RowContainer({ children }: Props) {
     Boolean(item.isNew) && "bg-amber-50/70 dark:bg-amber-900/20",
     isSelected
       ? "bg-surface-highlight dark:bg-surface-dimmed/30"
-      : "hover:bg-surface-highlight dark:hover:bg-surface-dimmed/20"
+      : "bg-surface-base hover:bg-surface-highlight dark:hover:bg-surface-dimmed/20"
   )
 
   return (

--- a/turboui/src/WorkMap/WorkMapTable/index.tsx
+++ b/turboui/src/WorkMap/WorkMapTable/index.tsx
@@ -12,7 +12,7 @@ export interface Props {
 
 export function WorkMapTable({ items, filter, deleteItem, addItem }: Props) {
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto bg-surface-base">
       <table className="min-w-full divide-y divide-surface-outline">
         <TableHeader filter={filter} />
         <tbody>


### PR DESCRIPTION
Now, the WorkMap rows and TimeframeSelector have the correct background color both by default and on hover.