### PR TITLE
fix: Show correct status in Work Map when project or goal is closed

### DIFF
--- a/app/lib/operately/work_maps/work_map_item.ex
+++ b/app/lib/operately/work_maps/work_map_item.ex
@@ -52,7 +52,7 @@ defmodule Operately.WorkMaps.WorkMapItem do
       id: goal.id,
       parent_id: goal.parent_goal_id,
       name: goal.name,
-      status: if(goal.last_update, do: goal.last_update.status, else: "on_track"),
+      status: goal_status(goal),
       progress: Goals.progress_percentage(goal),
       closed_at: goal.closed_at,
       space: goal.group,
@@ -75,7 +75,7 @@ defmodule Operately.WorkMaps.WorkMapItem do
       id: project.id,
       parent_id: project.goal_id,
       name: project.name,
-      status: if(project.last_check_in, do: project.last_check_in.status, else: "on_track"),
+      status: project_status(project),
       progress: Projects.progress_percentage(project),
       closed_at: project.closed_at,
       space: project.group,
@@ -121,5 +121,22 @@ defmodule Operately.WorkMaps.WorkMapItem do
       end_date: project.deadline,
       type: "days",
     }
+  end
+
+  defp project_status(project = %Project{}) do
+    cond do
+      project.closed_at -> "completed"
+      project.last_check_in -> project.last_check_in.status
+      true -> "on_track"
+    end
+  end
+
+  defp goal_status(goal = %Goal{}) do
+    cond do
+      goal.success == "yes" -> "achieved"
+      goal.success == "no" -> "missed"
+      goal.last_update -> goal.last_update.status
+      true -> "on_track"
+    end
   end
 end

--- a/app/test/operately/work_maps/work_map_item_test.exs
+++ b/app/test/operately/work_maps/work_map_item_test.exs
@@ -1,0 +1,107 @@
+defmodule Operately.WorkMaps.WorkMapItemTest do
+  use Operately.DataCase
+
+  alias Operately.WorkMaps.WorkMapItem
+
+  describe "build_item/2 for projects" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+    end
+
+    test "a closed project should have status 'completed'", ctx do
+      ctx =
+        ctx
+        |> Factory.add_project(:project, :space)
+        |> Factory.close_project(:project)
+        |> Factory.preload(:project, :last_check_in)
+        |> Factory.preload(:project, :milestones)
+
+      item = WorkMapItem.build_item(ctx.project, [])
+      assert item.status == "completed"
+    end
+
+    @status ["on_track", "caution", "issue"]
+
+    tabletest @status do
+      test "given a project's last check-in is #{@test}, its status should also be #{@test}", ctx do
+        ctx =
+          ctx
+          |> Factory.add_project(:project, :space)
+          |> Factory.add_project_check_in(:check_in, :project, :creator, status: @test)
+          |> Factory.preload(:project, :last_check_in)
+          |> Factory.preload(:project, :milestones)
+
+        item = WorkMapItem.build_item(ctx.project, [])
+        assert item.status == @test
+      end
+    end
+
+    test "a project without check-in should be 'on_track'", ctx do
+      ctx =
+        ctx
+        |> Factory.add_project(:project, :space)
+        |> Factory.preload(:project, :last_check_in)
+        |> Factory.preload(:project, :milestones)
+
+      item = WorkMapItem.build_item(ctx.project, [])
+      assert item.status == "on_track"
+    end
+  end
+
+  describe "build_item/2 for goals" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+    end
+
+    test "a closed goal with success 'yes' should have status 'achieved'", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:goal, :space)
+        |> Factory.close_goal(:goal, success: "yes")
+        |> Factory.preload(:goal, :last_update)
+
+      item = WorkMapItem.build_item(ctx.goal, [])
+      assert item.status == "achieved"
+    end
+
+    test "a closed goal with success 'no' should have status 'missed'", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:goal, :space)
+        |> Factory.close_goal(:goal, success: "no")
+        |> Factory.preload(:goal, :last_update)
+
+      item = WorkMapItem.build_item(ctx.goal, [])
+      assert item.status == "missed"
+    end
+
+    @status [:pending, :on_track, :concern, :issue]
+
+    tabletest @status do
+      test "given a goal's last update is #{@test}, its status should also be #{@test}", ctx do
+        ctx =
+          ctx
+          |> Factory.add_goal(:goal, :space)
+          |> Factory.add_goal_update(:update, :goal, :creator, status: @test)
+          |> Factory.preload(:goal, :last_update)
+
+        item = WorkMapItem.build_item(ctx.goal, [])
+        assert item.status == @test
+      end
+    end
+
+    test "a goal without update should be 'on_track'", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:goal, :space)
+        |> Factory.preload(:goal, :last_update)
+
+      item = WorkMapItem.build_item(ctx.goal, [])
+      assert item.status == "on_track"
+    end
+  end
+end

--- a/app/test/support/factory.ex
+++ b/app/test/support/factory.ex
@@ -33,7 +33,7 @@ defmodule Operately.Support.Factory do
 
   # goals
   defdelegate add_goal(ctx, testid, space_name, opts \\ []), to: Factory.Goals
-  defdelegate add_goal_update(ctx, testid, goal_name, person_name), to: Factory.Goals
+  defdelegate add_goal_update(ctx, testid, goal_name, person_name, opts \\ []), to: Factory.Goals
   defdelegate set_goal_next_update_date(ctx, goal_name, date), to: Factory.Goals
   defdelegate add_goal_target(ctx, testid, goal_name, attrs \\ []), to: Factory.Goals
   defdelegate close_goal(ctx, testid, opts \\ []), to: Factory.Goals
@@ -45,7 +45,7 @@ defmodule Operately.Support.Factory do
   defdelegate add_project_reviewer(ctx, testid, project_name, opts \\ []), to: Factory.Projects
   defdelegate add_project_contributor(ctx, testid, project_name, opts \\ []), to: Factory.Projects
   defdelegate add_project_retrospective(ctx, testid, project_name, author_name), to: Factory.Projects
-  defdelegate add_project_check_in(ctx, testid, project_name, author_name), to: Factory.Projects
+  defdelegate add_project_check_in(ctx, testid, project_name, author_name, opts \\ []), to: Factory.Projects
   defdelegate add_project_milestone(ctx, testid, project_name, opts \\ []), to: Factory.Projects
   defdelegate edit_project_company_members_access(ctx, project_name, access_level), to: Factory.Projects
   defdelegate edit_project_space_members_access(ctx, project_name, access_level), to: Factory.Projects

--- a/app/test/support/factory/goals.ex
+++ b/app/test/support/factory/goals.ex
@@ -25,13 +25,17 @@ defmodule Operately.Support.Factory.Goals do
     Map.put(ctx, testid, goal)
   end
 
-  def add_goal_update(ctx, testid, goal_name, person_name) do
+  def add_goal_update(ctx, testid, goal_name, person_name, opts \\ []) do
     goal = Map.fetch!(ctx, goal_name)
     person = Map.fetch!(ctx, person_name)
+    status = Keyword.get(opts, :status, "on_track")
 
-    update = Operately.GoalsFixtures.goal_update_fixture(person, goal)
+    update = Operately.GoalsFixtures.goal_update_fixture(person, goal, status: status)
+    {:ok, goal} = Operately.Goals.update_goal(goal, %{last_check_in_id: update.id})
 
-    Map.put(ctx, testid, update)
+    ctx
+    |> Map.put(testid, update)
+    |> Map.put(goal_name, goal)
   end
 
   def set_goal_next_update_date(ctx, goal_name, date) do

--- a/app/test/support/factory/projects.ex
+++ b/app/test/support/factory/projects.ex
@@ -103,16 +103,21 @@ defmodule Operately.Support.Factory.Projects do
     Map.put(ctx, testid, retrospective)
   end
 
-  def add_project_check_in(ctx, testid, project_name, author_name) do
+  def add_project_check_in(ctx, testid, project_name, author_name, opts \\ []) do
     project = Map.fetch!(ctx, project_name)
     author = Map.fetch!(ctx, author_name)
+    status = Keyword.get(opts, :status, "on_track")
 
     check_in = Operately.ProjectsFixtures.check_in_fixture(%{
       project_id: project.id,
       author_id: author.id,
+      status: status,
     })
+    {:ok, project} = Operately.Projects.update_project(project, %{last_check_in_id: check_in.id})
 
-    Map.put(ctx, testid, check_in)
+    ctx
+    |> Map.put(testid, check_in)
+    |> Map.put(project_name, project)
   end
 
   def add_project_milestone(ctx, testid, project_name, opts \\ []) do
@@ -190,7 +195,8 @@ defmodule Operately.Support.Factory.Projects do
         subscriber_ids: []
     })
 
-    ctx
+    project = Repo.reload(project)
+    Map.put(ctx, project_name, project)
   end
 
   #

--- a/app/test/support/fixtures/projects_fixtures.ex
+++ b/app/test/support/fixtures/projects_fixtures.ex
@@ -111,7 +111,7 @@ defmodule Operately.ProjectsFixtures do
     {:ok, check_in} =
       attrs
       |> Enum.into(%{
-        status: "on_track",
+        status: attrs[:status] || "on_track",
         description: %{},
         subscription_list_id: subscription_list.id,
       })


### PR DESCRIPTION
The status of closed projects and goals was not being displayed correctly. 