### PR TITLE
fix: Show outdated items in Work Map

### DIFF
--- a/app/lib/operately/work_maps/work_map_item.ex
+++ b/app/lib/operately/work_maps/work_map_item.ex
@@ -129,7 +129,9 @@ defmodule Operately.WorkMaps.WorkMapItem do
 
   defp project_status(project = %Project{}) do
     cond do
-      project.closed_at -> "completed"
+      project.status == "closed" -> "completed"
+      project.status == "paused" -> "paused"
+      Projects.outdated?(project) -> "outdated"
       project.last_check_in -> project.last_check_in.status
       true -> "on_track"
     end
@@ -139,6 +141,7 @@ defmodule Operately.WorkMaps.WorkMapItem do
     cond do
       goal.success == "yes" -> "achieved"
       goal.success == "no" -> "missed"
+      Goals.outdated?(goal) -> "outdated"
       goal.last_update -> goal.last_update.status
       true -> "on_track"
     end

--- a/turboui/src/StatusBadge/index.tsx
+++ b/turboui/src/StatusBadge/index.tsx
@@ -51,6 +51,13 @@ export function StatusBadge({ status, hideIcon = false, className = "", style }:
       borderColor = "border-gray-200 dark:border-gray-600";
       label = "Dropped";
       break;
+    case "outdated":
+      bgColor = "bg-gray-100 dark:bg-gray-700";
+      textColor = "text-gray-700 dark:text-gray-300";
+      dotColor = "bg-gray-400 dark:bg-gray-400";
+      borderColor = "border-gray-200 dark:border-gray-600";
+      label = "Outdated";
+      break;
     case "caution":
       bgColor = "bg-amber-50 dark:bg-amber-900/30";
       textColor = "text-amber-800 dark:text-amber-300";


### PR DESCRIPTION
Outdated items now have the "outdated" status in the Work Map.