### PR TITLE
fix: Display N/A when item doesn't have deadline

### DIFF
--- a/turboui/src/WorkMap/TableRow/DeadlineCell.tsx
+++ b/turboui/src/WorkMap/TableRow/DeadlineCell.tsx
@@ -35,7 +35,7 @@ export function DeadlineCell({ filter, status, completedOn, timeframe }: Props) 
         </span>
       ) : (
         <span className={textClassName}>
-          {timeframe?.endDate && <FormattedTime time={timeframe.endDate} format="short-date" />}
+          {timeframe?.endDate ? <FormattedTime time={timeframe.endDate} format="short-date" /> : "N/A"}
         </span>
       )}
     </td>


### PR DESCRIPTION
In the Work Map, when item has no deadline, `N/A` is now displayed.