### PR TITLE
fix: Reopening a goal now removes it from the Completed Tab

### DIFF
--- a/app/lib/operately/operations/goal_reopening.ex
+++ b/app/lib/operately/operations/goal_reopening.ex
@@ -8,7 +8,7 @@ defmodule Operately.Operations.GoalReopening do
   @action :goal_reopening
 
   def run(author, goal, message) do
-    changeset = Goals.Goal.changeset(goal, %{closed_at: nil, closed_by_id: nil})
+    changeset = Goals.Goal.changeset(goal, %{closed_at: nil, closed_by_id: nil, success: nil})
 
     Multi.new()
     |> Multi.update(:goal, changeset)

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -104,6 +104,7 @@
         "react": "^18.3.0",
         "react-datepicker": "^4.14.0",
         "react-dom": "^18.3.0",
+        "react-i18next": "^12.2.0",
         "react-router-dom": "^6.10.0",
         "react-spinners": "^0.13.8",
         "react-textarea-autosize": "^8.5.9",


### PR DESCRIPTION
If a Goal was closed and then reopened, it would remais in the "Completed" tab. Now, if a goal is reopened, it's correctly displayed in the "All Work" and "Goals" tabs.