### PR TITLE
fix: Add cancel button to document edit page

### DIFF
--- a/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
@@ -26,6 +26,7 @@ export function Form({ document }: { document: ResourceHubDocument }) {
         addError("content", "Content is required");
       }
     },
+    cancel: () => navigate(Paths.resourceHubDocumentPath(document.id!)),
     submit: async (type: "save" | "publish-draft") => {
       const { title, content } = form.values;
 
@@ -88,6 +89,7 @@ function FormActions({ document }: { document: ResourceHubDocument }) {
           onClick={() => form.actions.submit("publish-draft")}
         />
       )}
+      <Forms.SubmitButton name="cancel" text="Cancel" buttonSize="base" onClick={() => form.actions.cancel()} />
     </div>
   );
 }

--- a/app/test/features/resource_hub_document_test.exs
+++ b/app/test/features/resource_hub_document_test.exs
@@ -48,6 +48,15 @@ defmodule Operately.Features.ResourceHubDocumentTest do
     |> Steps.refute_document_edited_on_company_feed(@document.name)
   end
 
+  feature "cancel document editing returns to document page", ctx do
+    ctx
+    |> Steps.visit_resource_hub_page()
+    |> Steps.create_document(@document)
+    |> Steps.assert_document_content(@document)
+    |> Steps.cancel_document_editing()
+    |> Steps.assert_page_is_document_page()
+  end
+
   feature "copy document in the same folder", ctx do
     new_name = "Document - Copy"
 
@@ -117,6 +126,15 @@ defmodule Operately.Features.ResourceHubDocumentTest do
       |> Steps.assert_draft_document_not_visible_and_state_is_zero()
       |> Steps.click_on_continue_writing_draft_link()
       |> Steps.assert_page_is_document_editing()
+    end
+
+    feature "Cancel draft document editing returns to document page", ctx do
+      ctx
+      |> Steps.given_a_single_draft_document_exists()
+      |> Steps.visit_document_page()
+      |> Steps.assert_document_is_draft()
+      |> Steps.cancel_draft_document_editing()
+      |> Steps.assert_page_is_document_page()
     end
 
     feature "Link to continue editing several drafts is displayed", ctx do

--- a/app/test/support/features/resource_hub_document_steps.ex
+++ b/app/test/support/features/resource_hub_document_steps.ex
@@ -129,6 +129,28 @@ defmodule Operately.Support.Features.ResourceHubDocumentSteps do
     |> UI.refute_has(testid: "submit")
   end
 
+  step :cancel_document_editing, ctx do
+    {:ok, node} = Node.get(:system, type: :document, opts: [preload: :document])
+
+    ctx
+    |> UI.click(testid: "edit-document-link")
+    |> UI.assert_page(Paths.edit_document_path(ctx.company, node.document))
+    |> UI.sleep(200)
+    |> UI.click(testid: "cancel")
+    |> UI.sleep(200)
+    |> UI.assert_page(Paths.document_path(ctx.company, node.document))
+  end
+
+  step :cancel_draft_document_editing, ctx do
+    ctx
+    |> UI.click(testid: "continue-editing")
+    |> UI.assert_page(Paths.edit_document_path(ctx.company, ctx.document))
+    |> UI.sleep(200)
+    |> UI.click(testid: "cancel")
+    |> UI.sleep(200)
+    |> UI.assert_page(Paths.document_path(ctx.company, ctx.document))
+  end
+
   step :copy_document, ctx, new_name do
     ctx
     |> UI.click(testid: UI.testid("menu-#{Paths.document_id(ctx.document)}"))


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/2114.