### PR TITLE
fix: Use dev JS loading strategy for local tests to fix Wallaby failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ test.js.fmt.check:
 test.seed.env:
 	touch .env
 	echo 'OPERATELY_BLOB_TOKEN_SECRET_KEY="lPEuB9ITpbHP1GTf98TPWcHb/CrdeNLzqLcm0zF5mfo="' >> .env
+	echo 'CI=$(CI)' >> .env
 
 test.elixir.warnings:
 	./devenv bash -c "cd app && MIX_ENV=test mix compile --warnings-as-errors --all-warnings"

--- a/app/lib/operately_web/controllers/page.html.heex
+++ b/app/lib/operately_web/controllers/page.html.heex
@@ -46,7 +46,7 @@
       2. Production strategy: Used in production or in CI test environments.
          JavaScript is loaded from the static assets that are built by Vite.
     -->
-    <%= if Application.get_env(:operately, :app_env) == :dev or (Application.get_env(:operately, :app_env) == :test and System.get_env("CI") == nil) do %>
+    <%= if OperatelyWeb.PageController.development_mode?() do %>
       <script type="module">
         import RefreshRuntime from 'http://localhost:4005/@react-refresh'
         RefreshRuntime.injectIntoGlobalHook(window)

--- a/app/lib/operately_web/controllers/page.html.heex
+++ b/app/lib/operately_web/controllers/page.html.heex
@@ -37,15 +37,16 @@
 
     <!-- 
       Load the app's JavaScript. There are two separate strategies for
-      loading the JavaScript: one for development and one for
-      test and production. 
+      loading the JavaScript:
 
-      In development, the JavaScript is loaded from the local Vite server,
-      which allows for hot reloading and other development features. In
-      test and production, the JavaScript is loaded from the static
-      assets that are built by Vite.
+      1. Development strategy: Used in development mode or in local test mode (non-CI).
+         JavaScript is loaded from the local Vite server, which allows for hot reloading
+         and other development features.
+
+      2. Production strategy: Used in production or in CI test environments.
+         JavaScript is loaded from the static assets that are built by Vite.
     -->
-    <%= if Application.get_env(:operately, :app_env) == :dev do %>
+    <%= if Application.get_env(:operately, :app_env) == :dev or (Application.get_env(:operately, :app_env) == :test and System.get_env("CI") == nil) do %>
       <script type="module">
         import RefreshRuntime from 'http://localhost:4005/@react-refresh'
         RefreshRuntime.injectIntoGlobalHook(window)

--- a/app/lib/operately_web/controllers/page_controller.ex
+++ b/app/lib/operately_web/controllers/page_controller.ex
@@ -7,6 +7,10 @@ defmodule OperatelyWeb.PageController do
     conn |> assign(:app_config, config) |> render(:page)
   end
 
+  def development_mode? do
+    Application.get_env(:operately, :app_env) == :dev or (Application.get_env(:operately, :app_env) == :test and System.get_env("CI") != "true")
+  end
+
   defp app_config(conn) do
     config = %{
       environment: Application.get_env(:operately, :app_env),


### PR DESCRIPTION
Fixes Wallaby feature tests that were failing with MIME type errors when loading JavaScript modules. The solution uses the Vite dev server for local tests while maintaining the production asset loading for CI environments.