### PR TITLE
fix: Remove StatusBadge scale up effect to fix Work Map performance issue

### DIFF
--- a/turboui/src/WorkMap/components/TableRow/index.tsx
+++ b/turboui/src/WorkMap/components/TableRow/index.tsx
@@ -43,9 +43,7 @@ export function TableRow(props: Props) {
 function StatusCell({ status }: { status: WorkMap.Status }) {
   return (
     <td className="py-2 px-2 md:px-4">
-      <div className="transform group-hover:scale-105 transition-transform duration-150">
-        <StatusBadge status={status} />
-      </div>
+      <StatusBadge status={status} />
     </td>
   );
 }


### PR DESCRIPTION
I've removed the scale up effect in the StatusBadge which was causing performance issues.