### PR TITLE
fix: Clicking anywhere in item row redirects to item page

### DIFF
--- a/turboui/src/WorkMap/components/TableRow/ItemNameCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ItemNameCell.tsx
@@ -33,6 +33,7 @@ function Name({ item }: { item: WorkMap.Item }) {
   const { isCompleted, isFailed, isDropped, isPending } = useItemStatus(item.status);
 
   const textStyle = classNames(
+    "flex items-center",
     "font-medium text-xs md:text-sm hover:underline transition-colors",
     {
       "line-through": isCompleted || isFailed,
@@ -41,18 +42,10 @@ function Name({ item }: { item: WorkMap.Item }) {
     },
     isCompleted || isFailed || isDropped
       ? "text-content-dimmed dark:text-gray-400"
-      : isCompleted || isFailed || isDropped
-      ? "text-content-dimmed dark:text-gray-400"
-      : "text-content-base dark:text-gray-200 hover:text-link-hover dark:hover:text-white",
+      : "text-content-base hover:text-content-dimmed",
   );
 
-  return (
-    <div className="flex items-center">
-      <BlackLink to={item.itemPath!} className={textStyle} underline="hover">
-        {item.name}
-      </BlackLink>
-    </div>
-  );
+  return <div className={textStyle}>{item.name}</div>;
 }
 
 function Icon({ item }: { item: WorkMap.Item }) {

--- a/turboui/src/WorkMap/components/TableRow/OwnerCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/OwnerCell.tsx
@@ -21,7 +21,7 @@ export function OwnerCell({ item }: Props) {
 
   return (
     <td className="py-2 px-2 md:px-4 hidden xl:table-cell">
-      <div className="max-w-[120px] overflow-hidden">
+      <div className="max-w-[120px] overflow-hidden" data-exclude-row-click>
         <AvatarWithName
           person={item.owner}
           size="tiny"

--- a/turboui/src/WorkMap/components/TableRow/RowContainer.tsx
+++ b/turboui/src/WorkMap/components/TableRow/RowContainer.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import WorkMap from "..";
 import classNames from "../../../utils/classnames";
 
@@ -7,14 +8,25 @@ interface Props {
 }
 
 export function RowContainer({ item, children }: Props) {
+  const navigate = useNavigate();
+
   const className = classNames(
     "group border-b border-stroke-base transition-all duration-150 ease-in-out cursor-pointer relative",
     Boolean(item.isNew) && "bg-amber-50/70 dark:bg-amber-900/20",
     "bg-surface-base hover:bg-surface-highlight dark:hover:bg-surface-dimmed/20",
   );
 
+  // Handle row click to navigate, but exclude clicks on elements with the data-exclude-row-click attribute
+  const handleRowClick = (e: React.MouseEvent) => {
+    const isExcludedClick = (e.target as HTMLElement)?.closest("[data-exclude-row-click]");
+
+    if (!isExcludedClick && item.itemPath) {
+      navigate(item.itemPath);
+    }
+  };
+
   return (
-    <tr data-workmap-selectable="true" className={className}>
+    <tr data-workmap-selectable="true" className={className} onClick={handleRowClick}>
       {children}
     </tr>
   );

--- a/turboui/src/WorkMap/components/TableRow/SpaceCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/SpaceCell.tsx
@@ -19,7 +19,7 @@ export function SpaceCell({ item }: SpaceCellProps) {
 
   return (
     <td className="py-2 px-2 md:px-4 hidden lg:table-cell">
-      <div className="max-w-[100px] min-w-[70px] w-fit overflow-hidden text-ellipsis whitespace-nowrap">
+      <div className="max-w-[100px] min-w-[70px] w-fit overflow-hidden text-ellipsis whitespace-nowrap" data-exclude-row-click>
         <BlackLink to={item.spacePath!} className={className} underline="hover">
           {item.space?.name}
         </BlackLink>


### PR DESCRIPTION
Previously, only clicking the item name would redirect the user to the item page. Now, clicking anywhere in the row, except for the Space and Owner names, redirects the user to the item page.