### PR TITLE
fix: Work Map tabs now work in Storybook

### DIFF
--- a/turboui/.storybook/preview.d.ts
+++ b/turboui/.storybook/preview.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  STORYBOOK_ENV?: boolean;
+}

--- a/turboui/.storybook/preview.tsx
+++ b/turboui/.storybook/preview.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import type { Preview } from "@storybook/react";
+
 import { withThemeByClassName } from "@storybook/addon-themes";
 import { RouterDecorator } from "./router";
 
 import "./global.css";
 import "./reactdatepicker.css";
 import "./reactdatepicker-custom.css";
+
+window.STORYBOOK_ENV = true;
 
 const preview: Preview = {
   parameters: {

--- a/turboui/src/WorkMap/hooks/useWorkMapFilter.ts
+++ b/turboui/src/WorkMap/hooks/useWorkMapFilter.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { parse } from "../../utils/time";
 import { TimeframeSelector } from "../../TimeframeSelector";
 import { WorkMap } from "../components";
@@ -211,6 +211,10 @@ function itemOverlapsWithTimeframe(item: WorkMap.Item, timeframe: TimeframeSelec
  * Defaults to "all" if no tab parameter is present
  */
 function useWorkMapUrlFilter(): [WorkMap.Filter, (newFilter: WorkMap.Filter) => void] {
+  if (isStorybook()) {
+    return useLocalFilter();
+  }
+
   const [searchParams, setSearchParams] = useSearchParams();
 
   const rawTab = searchParams.get("tab") as WorkMap.Filter;
@@ -231,3 +235,23 @@ function useWorkMapUrlFilter(): [WorkMap.Filter, (newFilter: WorkMap.Filter) => 
 
   return [tab as WorkMap.Filter, setTab];
 }
+
+/**
+ * Hook that maintains the filter state locally without touching URL params
+ * (used in Storybook)
+ */
+function useLocalFilter(): [WorkMap.Filter, (newFilter: WorkMap.Filter) => void] {
+  const [filter, setFilter] = useState<WorkMap.Filter>("all");
+  return [filter, setFilter];
+}
+
+const isStorybook = () => {
+  return (
+    typeof window !== "undefined" &&
+    // Look for specific Storybook patterns in iframe
+    (window.location.href.includes("iframe.html") ||
+      window.location.href.includes("viewMode=story") ||
+      window.location.href.includes("id=components-workmap") ||
+      (window as any).__STORYBOOK_CLIENT_API__ !== undefined)
+  );
+};

--- a/turboui/src/WorkMap/hooks/useWorkMapFilter.ts
+++ b/turboui/src/WorkMap/hooks/useWorkMapFilter.ts
@@ -246,12 +246,5 @@ function useLocalFilter(): [WorkMap.Filter, (newFilter: WorkMap.Filter) => void]
 }
 
 const isStorybook = () => {
-  return (
-    typeof window !== "undefined" &&
-    // Look for specific Storybook patterns in iframe
-    (window.location.href.includes("iframe.html") ||
-      window.location.href.includes("viewMode=story") ||
-      window.location.href.includes("id=components-workmap") ||
-      (window as any).__STORYBOOK_CLIENT_API__ !== undefined)
-  );
+  return window.STORYBOOK_ENV === true;
 };

--- a/turboui/src/global.d.ts
+++ b/turboui/src/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  STORYBOOK_ENV?: boolean;
+}


### PR DESCRIPTION
In Storybook, the Work Map tabs were overwriting the Storybook URL. Now this problem is fixed.  