### PR TITLE
fix: Align space th and td in Work Map

### DIFF
--- a/turboui/src/WorkMap/components/WorkMapTable.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTable.tsx
@@ -42,7 +42,7 @@ export function TableHeader({ filter }: HeaderProps) {
         <HeaderCell className={isCompletedPage ? "w-[100px] md:w-[120px] md:px-4" : "hidden lg:table-cell max-w-[120px] md:px-4"}>
           {isCompletedPage ? "Completed On" : "Deadline"}
         </HeaderCell>
-        <HeaderCell className="hidden lg:table-cell max-w-[100px] w-auto px-1 md:px-2">Space</HeaderCell>
+        <HeaderCell className="hidden lg:table-cell max-w-[100px] w-auto md:px-4">Space</HeaderCell>
         <HeaderCell className="hidden xl:table-cell w-[120px] md:px-4">Champion</HeaderCell>
         <HeaderCell hidden={isCompletedPage} className="hidden xl:table-cell xl:w-[200px] 2xl:w-[300px] md:px-4">
           Next step


### PR DESCRIPTION
The Space header and the Space names weren't correctly aligned.