### PR TITLE
fix: Work Map headers always take only one line

### DIFF
--- a/turboui/src/WorkMap/components/WorkMapTable.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTable.tsx
@@ -61,5 +61,5 @@ interface HeaderCellProps {
 function HeaderCell({ className, hidden, children }: HeaderCellProps) {
   if (hidden) return null;
 
-  return <th className={classNames("text-left py-2 md:py-3.5 px-2 font-semibold", className)}>{children}</th>;
+  return <th className={classNames("text-left py-2 md:py-3.5 px-2 font-semibold whitespace-nowrap", className)}>{children}</th>;
 }


### PR DESCRIPTION
Sometimes, there was a line break in the headers and they would end up taking two lines. This problem is now fixed.