### PR TITLE
feat: Task creation in task board

### DIFF
--- a/app/priv/static/.vite/manifest.json
+++ b/app/priv/static/.vite/manifest.json
@@ -1,15 +1,15 @@
 {
-  "_vendor-MJvboJ1g.js": {
-    "file": "assets/vendor-MJvboJ1g.js",
+  "_vendor-SGdvjk5e.js": {
+    "file": "assets/vendor-SGdvjk5e.js",
     "name": "vendor"
   },
   "assets/js/app.tsx": {
-    "file": "assets/app-64Z6L8pc.js",
+    "file": "assets/app-CBDEQYhC.js",
     "name": "app",
     "src": "assets/js/app.tsx",
     "isEntry": true,
     "imports": [
-      "_vendor-MJvboJ1g.js"
+      "_vendor-SGdvjk5e.js"
     ]
   }
 }

--- a/turboui/src/Modal/Modal.stories.tsx
+++ b/turboui/src/Modal/Modal.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+import { Modal } from "./index";
+import { PrimaryButton, SecondaryButton } from "../Button";
+
+/**
+ * Modal is a component that displays content in a layer above the app.
+ * It provides a focused way to display information or collect user input.
+ */
+const meta: Meta<typeof Modal> = {
+  title: "Components/Modal",
+  component: Modal,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isOpen: { control: "boolean" },
+    title: { control: "text" },
+    size: { control: "select", options: ["small", "medium", "large"] },
+    closeOnBackdropClick: { control: "boolean" },
+  },
+  decorators: [
+    (Story, context) => {
+      const [isOpen, setIsOpen] = useState(context.args.isOpen || false);
+      
+      // Override isOpen and onClose to allow the story to control the modal state
+      return (
+        <div className="p-4">
+          <PrimaryButton onClick={() => setIsOpen(true)}>Open Modal</PrimaryButton>
+          <Story args={{ ...context.args, isOpen, onClose: () => setIsOpen(false) }} />
+        </div>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+/**
+ * Basic modal with a title and content
+ */
+export const Basic: Story = {
+  tags: ["autodocs"],
+  args: {
+    title: "Modal Title",
+    children: (
+      <div className="space-y-4">
+        <p>This is the modal content.</p>
+        <div className="flex justify-end">
+          <SecondaryButton>Close</SecondaryButton>
+        </div>
+      </div>
+    ),
+    size: "medium",
+  },
+};
+
+/**
+ * Small modal for simple content
+ */
+export const Small: Story = {
+  tags: ["autodocs"],
+  args: {
+    title: "Small Modal",
+    children: (
+      <div className="space-y-4">
+        <p>This is a small modal.</p>
+        <div className="flex justify-end">
+          <SecondaryButton>Close</SecondaryButton>
+        </div>
+      </div>
+    ),
+    size: "small",
+  },
+};
+
+/**
+ * Large modal for complex content
+ */
+export const Large: Story = {
+  tags: ["autodocs"],
+  args: {
+    title: "Large Modal",
+    children: (
+      <div className="space-y-4">
+        <p>This is a large modal with more content.</p>
+        <p>It's useful for displaying complex forms or a lot of information.</p>
+        <p>The extra space helps organize the content and keeps it from feeling cramped.</p>
+        <div className="flex justify-end space-x-2">
+          <SecondaryButton>Cancel</SecondaryButton>
+          <PrimaryButton>Submit</PrimaryButton>
+        </div>
+      </div>
+    ),
+    size: "large",
+  },
+};
+
+/**
+ * Form modal with fields and buttons
+ */
+export const FormModal: Story = {
+  tags: ["autodocs"],
+  args: {
+    title: "Create New Item",
+    children: (
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium mb-1">Title</label>
+          <input
+            id="title"
+            type="text"
+            className="w-full px-3 py-2 border border-surface-outline rounded-md"
+            placeholder="Enter title"
+          />
+        </div>
+        <div>
+          <label htmlFor="description" className="block text-sm font-medium mb-1">Description</label>
+          <textarea
+            id="description"
+            rows={3}
+            className="w-full px-3 py-2 border border-surface-outline rounded-md"
+            placeholder="Enter description"
+          />
+        </div>
+        <div className="flex justify-end space-x-2">
+          <SecondaryButton>Cancel</SecondaryButton>
+          <PrimaryButton>Save</PrimaryButton>
+        </div>
+      </div>
+    ),
+    size: "medium",
+  },
+};

--- a/turboui/src/Modal/index.tsx
+++ b/turboui/src/Modal/index.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { IconX } from "@tabler/icons-react";
+
+export interface ModalProps {
+  /**
+   * Whether the modal is open
+   */
+  isOpen: boolean;
+  
+  /**
+   * Called when the modal should close
+   */
+  onClose: () => void;
+  
+  /**
+   * Title to display in the modal header
+   */
+  title?: string;
+  
+  /**
+   * Content to render inside the modal
+   */
+  children: React.ReactNode;
+  
+  /**
+   * Size of the modal
+   */
+  size?: "small" | "medium" | "large";
+  
+  /**
+   * Whether to close the modal when clicking the backdrop
+   */
+  closeOnBackdropClick?: boolean;
+  
+  /**
+   * Additional class names to apply to the content container
+   */
+  contentClassName?: string;
+}
+
+export function Modal({
+  isOpen,
+  onClose,
+  title,
+  children,
+  size = "medium",
+  closeOnBackdropClick = true,
+  contentClassName = ""
+}: ModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  
+  // Handle mounting the modal in the DOM
+  useEffect(() => {
+    setMounted(true);
+    
+    // Enable trap focus and disable body scroll when modal is open
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+      
+      // Handle ESC key to close the modal
+      const handleEsc = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          onClose();
+        }
+      };
+      
+      document.addEventListener("keydown", handleEsc);
+      
+      return () => {
+        document.body.style.overflow = "";
+        document.removeEventListener("keydown", handleEsc);
+      };
+    }
+  }, [isOpen, onClose]);
+  
+  // Handle clicks outside the modal
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdropClick && modalRef.current && !modalRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+  
+  // Determine modal width based on size
+  const sizeClasses = {
+    small: "max-w-md",
+    medium: "max-w-lg",
+    large: "max-w-2xl",
+  }[size];
+  
+  if (!mounted || !isOpen) {
+    return null;
+  }
+  
+  const modalContent = (
+    <div 
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/30 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+      aria-modal="true"
+      role="dialog"
+    >
+      <div 
+        ref={modalRef}
+        className={`bg-surface-base rounded-lg shadow-xl w-full overflow-auto ${sizeClasses} ${contentClassName}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-6 py-4 border-b border-surface-outline">
+            <h2 className="text-lg font-semibold text-content-accent">{title}</h2>
+            <button 
+              onClick={onClose}
+              className="text-content-subtle hover:text-content-base transition-colors p-1 rounded-full hover:bg-surface-highlight"
+              aria-label="Close"
+            >
+              <IconX size={20} />
+            </button>
+          </div>
+        )}
+        
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  );
+  
+  // Use a portal to render the modal at the end of the document body
+  return createPortal(modalContent, document.body);
+}
+
+export default Modal;

--- a/turboui/src/TaskBoard/components/TaskCreationModal.tsx
+++ b/turboui/src/TaskBoard/components/TaskCreationModal.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useEffect, useRef } from "react";
+import { PrimaryButton, SecondaryButton } from "../../Button";
+import { TaskBoard } from "./index";
+import Modal from "../../Modal";
+import { IconCalendar, IconUser } from "@tabler/icons-react";
+
+interface TaskCreationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateTask: (task: Omit<TaskBoard.Task, "id">) => void;
+  milestones?: TaskBoard.Milestone[];
+  currentMilestoneId?: string;
+  people?: TaskBoard.Person[];
+}
+
+export function TaskCreationModal({
+  isOpen,
+  onClose,
+  onCreateTask,
+  milestones = [],
+  currentMilestoneId,
+  people = [],
+}: TaskCreationModalProps) {
+  // Form state
+  const [title, setTitle] = useState("");
+  const [dueDate, setDueDate] = useState<string>("");
+  const [assigneeId, setAssigneeId] = useState<string>("");
+  const [milestoneId, setMilestoneId] = useState<string>("");
+  const [createMore, setCreateMore] = useState(false);
+  
+  // Update milestone ID when currentMilestoneId changes or modal opens
+  useEffect(() => {
+    if (isOpen) {
+      // Handle special case for "no-milestone"
+      if (currentMilestoneId === "no-milestone") {
+        setMilestoneId("");
+      } else if (currentMilestoneId) {
+        setMilestoneId(currentMilestoneId);
+      } else {
+        // When adding from main button, clear milestone selection
+        setMilestoneId("");
+      }
+    }
+  }, [isOpen, currentMilestoneId]);
+  
+  // Refs
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  
+  // Reset form after task creation
+  const resetForm = () => {
+    setTitle("");
+    setDueDate("");
+    setAssigneeId("");
+    // Keep the milestone selected for creating multiple tasks in same milestone
+    // Keep the createMore toggle state
+  };
+  
+  // Focus title input when modal opens
+  useEffect(() => {
+    if (isOpen && titleInputRef.current) {
+      setTimeout(() => {
+        titleInputRef.current?.focus();
+      }, 100);
+    } else if (!isOpen) {
+      // Reset the form when the modal is closed
+      resetForm();
+    }
+  }, [isOpen]);
+  
+  // Handle form submission
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // Don't submit if title is empty
+    if (!title.trim()) return;
+    
+    // Create new task object
+    const newTask: Omit<TaskBoard.Task, "id"> = {
+      title: title.trim(),
+      status: "pending",
+    };
+    
+    // Add optional fields if they exist
+    if (dueDate) {
+      newTask.dueDate = new Date(dueDate);
+    }
+    
+    if (assigneeId) {
+      const selectedPerson = people.find(p => p.id === assigneeId);
+      if (selectedPerson) {
+        newTask.assignees = [selectedPerson];
+      }
+    }
+    
+    if (milestoneId) {
+      const selectedMilestone = milestones.find(m => m.id === milestoneId);
+      if (selectedMilestone) {
+        newTask.milestone = selectedMilestone;
+      }
+    }
+    
+    // Submit the task
+    onCreateTask(newTask);
+    
+    // Handle form after submission
+    if (createMore) {
+      resetForm();
+      // Focus title input again
+      setTimeout(() => {
+        titleInputRef.current?.focus();
+      }, 100);
+    } else {
+      onClose();
+    }
+  };
+  
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Create Task"
+      size="medium"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="task-title" className="block text-sm font-medium text-content-base mb-1">
+            Task title
+          </label>
+          <input
+            id="task-title"
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Enter task title"
+            className="w-full px-3 py-2 border border-surface-outline rounded-md focus:outline-none focus:ring-2 focus:ring-primary-base"
+            required
+            autoFocus
+          />
+        </div>
+        
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="due-date" className="block text-sm font-medium text-content-base mb-1">
+              Due date
+            </label>
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <IconCalendar size={16} className="text-content-subtle" />
+              </div>
+              <input
+                id="due-date"
+                type="date"
+                value={dueDate}
+                onChange={(e) => setDueDate(e.target.value)}
+                className="w-full pl-10 pr-3 py-2 border border-surface-outline rounded-md focus:outline-none focus:ring-2 focus:ring-primary-base"
+              />
+            </div>
+          </div>
+          
+          <div>
+            <label htmlFor="assignee" className="block text-sm font-medium text-content-base mb-1">
+              Assignee
+            </label>
+            <div className="relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <IconUser size={16} className="text-content-subtle" />
+              </div>
+              <select
+                id="assignee"
+                value={assigneeId}
+                onChange={(e) => setAssigneeId(e.target.value)}
+                className="w-full pl-10 pr-3 py-2 border border-surface-outline rounded-md focus:outline-none focus:ring-2 focus:ring-primary-base appearance-none"
+              >
+                <option value="">Select assignee</option>
+                {people.map((person) => (
+                  <option key={person.id} value={person.id}>
+                    {person.fullName}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+        
+        <div>
+          <label htmlFor="milestone" className="block text-sm font-medium text-content-base mb-1">
+            Milestone
+          </label>
+          <select
+            id="milestone"
+            value={milestoneId}
+            onChange={(e) => setMilestoneId(e.target.value)}
+            className="w-full px-3 py-2 border border-surface-outline rounded-md focus:outline-none focus:ring-2 focus:ring-primary-base appearance-none"
+          >
+            <option value="">No milestone</option>
+            {milestones.map((milestone) => (
+              <option key={milestone.id} value={milestone.id}>
+                {milestone.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        
+        <div className="flex items-center mt-6">
+          <label className="flex items-center cursor-pointer">
+            <input
+              type="checkbox"
+              checked={createMore}
+              onChange={() => setCreateMore(!createMore)}
+              className="h-4 w-4 text-primary-base border-surface-outline rounded focus:ring-primary-base"
+            />
+            <span className="ml-2 text-sm text-content-base">Create more</span>
+          </label>
+          <div className="flex-1"></div>
+          <div className="flex space-x-3">
+            <SecondaryButton onClick={onClose} type="button">
+              Cancel
+            </SecondaryButton>
+            <PrimaryButton type="submit" disabled={!title.trim()}>
+              Create Task
+            </PrimaryButton>
+          </div>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+export default TaskCreationModal;

--- a/turboui/src/TaskBoard/stories/TaskBoard.stories.tsx
+++ b/turboui/src/TaskBoard/stories/TaskBoard.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
 import { TaskBoard } from "../components";
-import { Page } from "../../Page";
+import TaskCreationModal from "../components/TaskCreationModal";
 import { mockTasks, mockEmptyTasks } from "../tests/mockData";
+import { Page } from "../../Page";
 
 /**
  * TaskBoard is a comprehensive task management component designed for teams.
  */
-const meta = {
+const meta: Meta<typeof TaskBoard> = {
   title: "Components/TaskBoard",
   component: TaskBoard,
   parameters: {
@@ -30,62 +32,70 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Mock people data for the assignee selection
+const mockPeople = [
+  { id: "user-1", fullName: "Alice Johnson", avatarUrl: "https://i.pravatar.cc/150?u=alice" },
+  { id: "user-2", fullName: "Bob Smith", avatarUrl: "https://i.pravatar.cc/150?u=bob" },
+  { id: "user-3", fullName: "Carol Williams", avatarUrl: "https://i.pravatar.cc/150?u=carol" },
+];
+
+// Extract milestones from mock tasks
+const extractMilestones = (tasks) => {
+  const milestoneMap = new Map();
+
+  tasks.forEach((task) => {
+    if (task.milestone && !milestoneMap.has(task.milestone.id)) {
+      milestoneMap.set(task.milestone.id, task.milestone);
+    }
+  });
+
+  return Array.from(milestoneMap.values());
+};
+
 /**
- * Default table view of the TaskBoard with multiple tasks in different statuses
+ * Default table view of the TaskBoard with working task creation
  */
 export const Default: Story = {
   tags: ["autodocs"],
-  args: {
-    title: "Task Board",
-    tasks: mockTasks,
-    viewMode: "table"
-  },
-};
+  render: () => {
+    // Create state for tasks and task creation
+    const [tasks, setTasks] = useState([...mockTasks]);
 
-/**
- * TaskBoard with interactive status selection
- */
-export const InteractiveStatus: Story = {
-  args: {
-    title: "Interactive Task Board",
-    tasks: mockTasks,
-    viewMode: "table",
-    onStatusChange: (taskId, newStatus) => {
+    const handleStatusChange = (taskId, newStatus) => {
       console.log(`Task ${taskId} status changed to ${newStatus}`);
-      // In a real application, this would update the task status in the database
-    }
-  },
-};
 
-/**
- * Empty TaskBoard with no tasks
- */
-export const EmptyState: Story = {
-  args: {
-    title: "Project Tasks",
-    tasks: mockEmptyTasks,
-    viewMode: "table"
-  },
-};
+      // Update the task status locally
+      const updatedTasks = tasks.map((task) => (task.id === taskId ? { ...task, status: newStatus } : task));
+      setTasks(updatedTasks);
+    };
 
-/**
- * Kanban view of the TaskBoard
- */
-export const KanbanView: Story = {
-  args: {
-    title: "Project Tasks",
-    tasks: mockTasks,
-    viewMode: "kanban"
-  },
-};
+    const handleTaskCreate = (newTaskData) => {
+      // Generate a fake UUID for the new task
+      const taskId = `task-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
 
-/**
- * Timeline view of the TaskBoard
- */
-export const TimelineView: Story = {
-  args: {
-    title: "Project Tasks",
-    tasks: mockTasks,
-    viewMode: "timeline"
+      // Create the new task object
+      const newTask = {
+        id: taskId,
+        ...newTaskData,
+      };
+
+      console.log("=== Created new task ===\n", JSON.stringify(newTask, null, 2));
+      console.log("Current tasks count:", tasks.length);
+
+      // Add the new task to the list
+      const updatedTasks = [...tasks, newTask];
+      setTasks(updatedTasks);
+      console.log("New tasks count:", updatedTasks.length);
+    };
+
+    return (
+      <TaskBoard
+        title="Task Board Demo"
+        tasks={tasks}
+        viewMode="table"
+        onStatusChange={handleStatusChange}
+        onTaskCreate={handleTaskCreate}
+      />
+    );
   },
 };

--- a/turboui/src/TaskBoard/stories/TaskCreationModal.stories.tsx
+++ b/turboui/src/TaskBoard/stories/TaskCreationModal.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { TaskCreationModal } from "../components/TaskCreationModal";
+import { PrimaryButton } from "../../Button";
+
+// Sample data for all the stories
+const sampleMilestones = [
+  { id: "milestone-1", name: "Sprint 1", dueDate: new Date(2025, 5, 20) },
+  { id: "milestone-2", name: "Sprint 2", dueDate: new Date(2025, 6, 3) },
+  { id: "milestone-3", name: "Product Launch", dueDate: new Date(2025, 6, 15) },
+];
+
+const samplePeople = [
+  { id: "person-1", fullName: "Jane Smith", avatarUrl: "https://i.pravatar.cc/150?img=1" },
+  { id: "person-2", fullName: "John Doe", avatarUrl: "https://i.pravatar.cc/150?img=2" },
+  { id: "person-3", fullName: "Alex Johnson", avatarUrl: "https://i.pravatar.cc/150?img=3" },
+];
+
+/**
+ * TaskCreationModal is a modal dialog for creating new tasks in the TaskBoard.
+ * It allows users to enter task details and optionally create multiple tasks in succession.
+ */
+const meta = {
+  title: "Components/TaskBoard/TaskCreationModal",
+  component: TaskCreationModal,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isOpen: { control: "boolean" },
+    currentMilestoneId: { control: "text" },
+  },
+} satisfies Meta<typeof TaskCreationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Interactive story that demonstrates the TaskCreationModal
+ */
+export const Default: Story = {
+  args: {}, // Required empty args object to satisfy TypeScript
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [taskCount, setTaskCount] = useState(0);
+    const [lastTaskTitle, setLastTaskTitle] = useState("");
+
+    const handleCreateTask = (task: any) => {
+      console.log("Created task:", task);
+      setTaskCount((count) => count + 1);
+      setLastTaskTitle(task.title);
+    };
+
+    return (
+      <div className="p-6 flex flex-col gap-4 max-w-lg">
+        <div>
+          <h3 className="text-lg font-semibold">Task Creation Demo</h3>
+          <p className="text-content-subtle mt-1 mb-4">Click the button below to open the task creation modal</p>
+
+          <PrimaryButton onClick={() => setIsOpen(true)}>+ Add Task</PrimaryButton>
+        </div>
+
+        {taskCount > 0 && (
+          <div className="mt-2 p-4 bg-surface-accent rounded-md">
+            <p className="text-sm font-medium">Tasks created: {taskCount}</p>
+            {lastTaskTitle && <p className="text-sm text-content-subtle mt-1">Last task: "{lastTaskTitle}"</p>}
+          </div>
+        )}
+
+        <TaskCreationModal
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          milestones={sampleMilestones}
+          people={samplePeople}
+          onCreateTask={handleCreateTask}
+        />
+      </div>
+    );
+  },
+};

--- a/turboui/src/TaskBoard/stories/TaskCreationModal.stories.tsx
+++ b/turboui/src/TaskBoard/stories/TaskCreationModal.stories.tsx
@@ -20,7 +20,7 @@ const samplePeople = [
  * TaskCreationModal is a modal dialog for creating new tasks in the TaskBoard.
  * It allows users to enter task details and optionally create multiple tasks in succession.
  */
-const meta = {
+const meta: Meta<typeof TaskCreationModal> = {
   title: "Components/TaskBoard/TaskCreationModal",
   component: TaskCreationModal,
   parameters: {
@@ -30,16 +30,21 @@ const meta = {
     isOpen: { control: "boolean" },
     currentMilestoneId: { control: "text" },
   },
-} satisfies Meta<typeof TaskCreationModal>;
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof TaskCreationModal>;
 
 /**
  * Interactive story that demonstrates the TaskCreationModal
  */
 export const Default: Story = {
-  args: {}, // Required empty args object to satisfy TypeScript
+  tags: ["autodocs"],
+  args: {
+    isOpen: false,
+    onClose: () => {},
+    onCreateTask: () => {},
+  },
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
     const [taskCount, setTaskCount] = useState(0);


### PR DESCRIPTION
- Add generic `Modal` component to turboui
- Task creation works on general button and on clicking "+" within each milestone
- Can check "Create more" to keep the dialog open and add many tasks quickly
- The dialog features vanilla select boxes. We need to figure out for which ones if any we want to use special components.