### PR TITLE
fix: Paused projects are not shown in the 'All work' tab

### DIFF
--- a/app/assets/js/models/workMap/index.tsx
+++ b/app/assets/js/models/workMap/index.tsx
@@ -21,7 +21,7 @@ export function convertToWorkMapItem(item: WorkMapItem): WorkMap.Item {
     id: item.id,
     parentId: item.parentId,
     name: item.name,
-    status: item.status as WorkMap.Item["status"],
+    status: item.status,
     progress: item.progress,
     space: {
       id: item.space.id,
@@ -40,7 +40,7 @@ export function convertToWorkMapItem(item: WorkMapItem): WorkMap.Item {
     timeframe: convertTimeframe(item.timeframe),
     type: item.type,
     itemPath: item.itemPath,
-    privacy: item.privacy as WorkMap.Item["privacy"],
+    privacy: item.privacy,
     children: item.children.map(convertToWorkMapItem),
   };
 }

--- a/app/assets/js/pages/SpaceWorkMapPage/loader.tsx
+++ b/app/assets/js/pages/SpaceWorkMapPage/loader.tsx
@@ -4,10 +4,9 @@ import { getWorkMap, convertToWorkMapItem } from "@/models/workMap";
 import { Space, getSpace } from "@/models/spaces";
 import { Paths } from "@/routes/paths";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
-import { WorkMap } from "turboui";
 
 interface LoaderResult {
-  workMap: WorkMap.Item[];
+  workMap: ReturnType<typeof convertToWorkMapItem>[];
   space: Space;
 }
 

--- a/turboui/src/WorkMap/hooks/useWorkMapTab.ts
+++ b/turboui/src/WorkMap/hooks/useWorkMapTab.ts
@@ -125,7 +125,7 @@ function extractOngoingItems(data: WorkMap.Item[]): WorkMap.Item[] {
       filteredChildren = item.children.map(filterOngoingItems).filter((child) => child !== null);
     }
 
-    const isOngoing = !CLOSED_STATUSES.includes(item.status);
+    const isOngoing = !CLOSED_STATUSES.includes(item.status) && item.status !== "paused";
 
     // Include if item is ongoing or has ongoing children
     if (!isOngoing && filteredChildren.length === 0) {


### PR DESCRIPTION
Now, paused projects are not included in the "All work" tab in the Work Map.