### PR TITLE
fix: Work Map item without owner no longer raises errors

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1494,8 +1494,8 @@ export interface WorkMapItem {
   progress: number;
   space: Space;
   spacePath: string;
-  owner: Person;
-  ownerPath: string;
+  owner: Person | null;
+  ownerPath: string | null;
   nextStep: string;
   isNew: boolean;
   completedOn: string | null;

--- a/app/assets/js/models/workMap/index.tsx
+++ b/app/assets/js/models/workMap/index.tsx
@@ -28,7 +28,7 @@ export function convertToWorkMapItem(item: WorkMapItem): WorkMap.Item {
       name: item.space.name,
     },
     spacePath: item.spacePath,
-    owner: {
+    owner: item.owner && {
       id: item.owner.id,
       fullName: item.owner.fullName,
       avatarUrl: item.owner.avatarUrl,

--- a/app/lib/operately_web/api/queries/get_work_map.ex
+++ b/app/lib/operately_web/api/queries/get_work_map.ex
@@ -28,6 +28,6 @@ defmodule OperatelyWeb.Api.Queries.GetWorkMap do
         include_assignees: inputs[:include_assignees] || false
       })
 
-    {:ok, %{work_map: Serializer.serialize(work_map, level: :full)}}
+    {:ok, %{work_map: Serializer.serialize(work_map)}}
   end
 end

--- a/app/lib/operately_web/api/serializers/work_map_item.ex
+++ b/app/lib/operately_web/api/serializers/work_map_item.ex
@@ -10,13 +10,6 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
       progress: item.progress,
       type: item.type,
       item_path: item_path(item),
-      children: OperatelyWeb.Api.Serializer.serialize(item.children, level: :essential)
-    }
-  end
-
-  def serialize(item, level: :full) do
-    serialize(item, level: :essential)
-    |> Map.merge(%{
       space: OperatelyWeb.Api.Serializer.serialize(item.space),
       space_path: Paths.space_work_map_path(item.company, item.space),
       owner: OperatelyWeb.Api.Serializer.serialize(item.owner),
@@ -25,10 +18,10 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
       is_new: item.is_new,
       completed_on: OperatelyWeb.Api.Serializer.serialize(item.completed_on),
       timeframe: OperatelyWeb.Api.Serializers.Timeframe.serialize(item.timeframe),
-      children: OperatelyWeb.Api.Serializer.serialize(item.children, level: :full),
+      children: OperatelyWeb.Api.Serializer.serialize(item.children),
       privacy: OperatelyWeb.Api.Serializer.serialize(item.privacy),
       assignees: OperatelyWeb.Api.Serializer.serialize(item.assignees)
-    })
+    }
   end
 
   defp item_id(item) do

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1543,8 +1543,8 @@ defmodule OperatelyWeb.Api.Types do
     field :progress, :float, optional: false, nullable: false
     field :space, :space, optional: false, nullable: false
     field :space_path, :string, optional: false, nullable: false
-    field :owner, :person, optional: false, nullable: false
-    field :owner_path, :string, optional: false, nullable: false
+    field :owner, :person, optional: false, nullable: true
+    field :owner_path, :string, optional: false, nullable: true
     field :next_step, :string, optional: false, nullable: false
     field :is_new, :boolean, optional: false, nullable: false
     field :completed_on, :date, optional: false, nullable: true

--- a/turboui/src/WorkMap/components/index.tsx
+++ b/turboui/src/WorkMap/components/index.tsx
@@ -92,7 +92,7 @@ export namespace WorkMap {
     space: Space;
     spacePath: string;
     owner: Person | null;
-    ownerPath: string;
+    ownerPath: string | null;
     nextStep: string;
     isNew: boolean;
     children: Item[];


### PR DESCRIPTION
The Work Map page was breaking when items didn't have an owner.