### PR TITLE
chore: Optimize GetWorkMap query

### DIFF
--- a/app/lib/operately/work_maps/get_work_map_query.ex
+++ b/app/lib/operately/work_maps/get_work_map_query.ex
@@ -25,7 +25,7 @@ defmodule Operately.WorkMaps.GetWorkMapQuery do
     company_id = Map.get(args, :company_id)
     include_assignees = Map.get(args, :include_assignees, false)
 
-    goals_task = Task.async(fn -> get_goals_tree(person, company_id, include_assignees) end)
+    goals_task = Task.async(fn -> get_goals(person, company_id, include_assignees) end)
     projects_task = Task.async(fn -> get_projects(person, company_id, include_assignees) end)
 
     goals = Task.await(goals_task)
@@ -37,30 +37,28 @@ defmodule Operately.WorkMaps.GetWorkMapQuery do
   end
 
   defp get_projects(person, company_id, include_assignees) do
-    ids_query =
+    project_ids =
       from(Project, as: :projects)
       |> where([p], p.company_id == ^company_id)
       |> filter_by_view_access(person, :projects)
       |> select([projects: p], p.id)
+      |> Repo.all()
 
-    from(Project, as: :projects)
-    |> where([p], p.id in subquery(ids_query))
-    |> join_preload_project_associations(include_assignees)
-    |> load_access_levels()
+    from(p in Project, where: p.id in ^project_ids)
+    |> preload_project_associations(include_assignees)
     |> Repo.all()
   end
 
-  defp get_goals_tree(person, company_id, include_assignees) do
-    ids_query =
-      from(Goal, as: :goals)
+  defp get_goals(person, company_id, include_assignees) do
+    goal_ids =
+      from(Goal, as: :goal)
       |> where([g], g.company_id == ^company_id)
-      |> filter_by_view_access(person, :goals)
-      |> select([goals: g], g.id)
+      |> filter_by_view_access(person, :goal)
+      |> select([goal: g], g.id)
+      |> Repo.all()
 
-    from(Goal, as: :goals)
-    |> where([g], g.id in subquery(ids_query))
-    |> join_preload_goal_associations(include_assignees)
-    |> load_access_levels()
+    from(g in Goal, as: :goal, where: g.id in ^goal_ids)
+    |> preload_goal_associations(include_assignees)
     |> Repo.all()
   end
 
@@ -75,71 +73,76 @@ defmodule Operately.WorkMaps.GetWorkMapQuery do
   end
 
   #
-  # Associations and Preloads
+  # Preloads
   #
 
-  defp join_preload_goal_associations(query, include_assignees) do
-    query
-    |> join(:left, [g], company in assoc(g, :company), as: :company)
-    |> join(:left, [g], c in assoc(g, :champion), as: :champion)
-    |> join(:left, [g], gr in assoc(g, :group), as: :group)
-    |> join(:left, [g], t in assoc(g, :targets), as: :targets)
-    |> preload([company: company, champion: c, group: gr, targets: t],
-      company: company,
-      champion: c,
-      group: gr,
-      targets: t
-    )
-    |> maybe_preload_goal_assignees(include_assignees)
-  end
-
-  defp join_preload_project_associations(query, include_assignees) do
+  defp preload_project_associations(query, include_assignees) do
     query
     |> join(:left, [p], company in assoc(p, :company), as: :company)
     |> join(:left, [p], c in assoc(p, :champion), as: :champion)
     |> join(:left, [p], gr in assoc(p, :group), as: :group)
-    |> join(:left, [p], m in assoc(p, :milestones), as: :milestones)
     |> join(:left, [p], lci in assoc(p, :last_check_in), as: :last_check_in)
-    |> preload([company: company, champion: c, group: gr, milestones: m, last_check_in: lci],
+    |> preload([company: company, champion: c, group: gr, last_check_in: lci], [
       company: company,
       champion: c,
       group: gr,
-      milestones: m,
       last_check_in: lci
+    ])
+    |> preload_project_milestones()
+    |> preload_access_levels()
+    |> maybe_preload_project_contributor(include_assignees)
+  end
+
+  defp preload_project_milestones(query) do
+    subquery = from(m in Operately.Projects.Milestone,
+      where: m.status == :pending,
+      select: %{id: m.id, title: m.title, status: m.status, deadline_at: m.deadline_at}
     )
-    |> maybe_preload_project_assignees(include_assignees)
+
+    preload(query, [], milestones: ^subquery)
+  end
+
+  defp preload_goal_associations(query, include_assignees) do
+    query
+    |> join(:left, [goal: g], company in assoc(g, :company), as: :company)
+    |> join(:left, [goal: g], c in assoc(g, :champion), as: :champion)
+    |> join(:left, [goal: g], gr in assoc(g, :group), as: :group)
+    |> preload([company: company, champion: c, group: gr], [
+      :targets,
+      company: company,
+      champion: c,
+      group: gr
+    ])
+    |> preload_access_levels()
+    |> maybe_preload_goal_reviewer(include_assignees)
   end
 
   #
   # Assignees
   #
 
-  defp maybe_preload_goal_assignees(query, true) do
+  defp maybe_preload_project_contributor(query, true), do: preload(query, [], :contributing_people)
+  defp maybe_preload_project_contributor(query, _), do: query
+
+  defp maybe_preload_goal_reviewer(query, true) do
     query
-    |> join(:left, [g], r in assoc(g, :reviewer), as: :reviewer)
+    |> join(:left, [goal: g], r in assoc(g, :reviewer), as: :reviewer)
     |> preload([reviewer: r], reviewer: r)
   end
-  defp maybe_preload_goal_assignees(query, _), do: query
-
-  defp maybe_preload_project_assignees(query, true) do
-    query
-    |> join(:left, [p], a in assoc(p, :contributing_people), as: :contributing_people)
-    |> preload([contributing_people: a], contributing_people: a)
-  end
-  defp maybe_preload_project_assignees(query, _), do: query
+  defp maybe_preload_goal_reviewer(query, _), do: query
 
   #
   # Access
   #
 
-  defp load_access_levels(query) do
-    query
-    |> join(:left, [r], c in assoc(r, :access_context), as: :context)
-    |> join(:left, [context: c], b in assoc(c, :bindings), as: :bindings)
-    |> join(:left, [bindings: b], g in assoc(b, :group), as: :access_group)
-    |> preload([bindings: b, context: c, access_group: g],
-      access_context: {c, [bindings: {b, group: g}]}
+  defp preload_access_levels(query) do
+    subquery = from(c in Operately.Access.Context,
+      join: b in assoc(c, :bindings),
+      join: g in assoc(b, :group),
+      preload: [bindings: {b, group: g}]
     )
+
+    preload(query, [], access_context: ^subquery)
   end
 
   defp filter_by_view_access(query, :system, _name), do: query


### PR DESCRIPTION
Previously we were using join-based preloads for one-to-many relationships, which caused the main query to return many duplicated rows. 

Now, one-to-many associations are loaded in separate queries, which eliminates duplication and improves performance.