### PR TITLE
chore: 'Goals & Projects' tool redirects to Work Map if feature is enabled

### DIFF
--- a/app/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/app/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import { Space } from "@/models/spaces";
 import { Goal } from "@/models/goals";
@@ -9,6 +9,8 @@ import { ZeroState } from "./GoalsAndProjects/ZeroState";
 import { AllDoneState } from "./GoalsAndProjects/AllDoneState";
 import { RegularState } from "./GoalsAndProjects/RegularState";
 import { match } from "ts-pattern";
+import { hasFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
+import { useParams } from "react-router-dom";
 
 interface Props {
   title: string;
@@ -18,7 +20,18 @@ interface Props {
 }
 
 export function GoalsAndProjects(props: Props) {
-  const path = Paths.spaceGoalsPath(props.space.id!);
+  const params = useParams();
+  const [isSpaceWorkMapEnabled, setIsSpaceWorkMapEnabled] = useState(false);
+
+  useEffect(() => {
+    if (params.companyId) {
+      hasFeatureEnabled(params.companyId, "space_work_map")
+        .then((enabled) => setIsSpaceWorkMapEnabled(enabled || false))
+        .catch(() => setIsSpaceWorkMapEnabled(false));
+    }
+  }, [params.companyId]);
+
+  const path = isSpaceWorkMapEnabled ? Paths.spaceWorkMapPath(props.space.id!) : Paths.spaceGoalsPath(props.space.id!);
   const state = calculateState(props.goals, props.projects);
 
   return (

--- a/app/assets/js/routes/redirectIfFeatureEnabled.tsx
+++ b/app/assets/js/routes/redirectIfFeatureEnabled.tsx
@@ -26,6 +26,12 @@ export async function redirectIfFeatureNotEnabled(params: any, { feature, path }
   }
 }
 
+export async function hasFeatureEnabled(companyId: string, feature: string) {
+  const features = await getCachedEnabledFeatures(companyId);
+
+  return features?.includes(feature);
+}
+
 const ENABLED_FEATURES_CACHE: Record<string, string[]> = {};
 
 async function getCachedEnabledFeatures(companyId: string): Promise<string[]> {


### PR DESCRIPTION
If "space_work_map" feature is enabled, the "Goals & Projects" space tool redirects to the Space Work Map page.