### PR TITLE
chore: Trace feature test step durations

### DIFF
--- a/app/test/features/resource_hub_folder_test.exs
+++ b/app/test/features/resource_hub_folder_test.exs
@@ -15,6 +15,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
       |> Steps.assert_zero_state()
     end
 
+    @tag :trace
     feature "create folders at the root of resource hub", ctx do
       folder1 = "First Folder"
       folder2 = "Second Folder"
@@ -80,7 +81,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
     feature "folder can be renamed", ctx do
       attrs = %{
         current_name: "folder",
-        new_name: "edited folder",
+        new_name: "edited folder"
       }
 
       ctx
@@ -147,7 +148,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
     feature "copy folder in the same location", ctx do
       copied_folder = %{
         name: "Folder's Copy",
-        index: 1,
+        index: 1
       }
 
       ctx
@@ -163,7 +164,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
     feature "copy folder into another folder", ctx do
       copied_folder = %{
         name: "Folder's Copy",
-        index: 0,
+        index: 0
       }
 
       ctx
@@ -180,7 +181,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
     feature "copy folder into resource hub root", ctx do
       copied_folder = %{
         name: "Folder's Copy",
-        index: 0,
+        index: 0
       }
 
       ctx
@@ -198,7 +199,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
       copied_folder = %{
         original_name: "folder",
         name: "Folder's Copy",
-        index: 0,
+        index: 0
       }
 
       ctx

--- a/app/test/features/resource_hub_folder_test.exs
+++ b/app/test/features/resource_hub_folder_test.exs
@@ -15,7 +15,6 @@ defmodule Operately.Features.ResourceHubFolderTest do
       |> Steps.assert_zero_state()
     end
 
-    @tag :trace
     feature "create folders at the root of resource hub", ctx do
       folder1 = "First Folder"
       folder2 = "Second Folder"

--- a/app/test/support/custom_formatter.ex
+++ b/app/test/support/custom_formatter.ex
@@ -59,7 +59,7 @@ defmodule CustomFormatter do
   end
 
   defp display_test_started(%ExUnit.Test{name: _} = test, state) do
-    IO.write("\n  #{blue(test_type(test))}: #{test_name(test)} (#{file_and_line(test)})")
+    IO.write("  #{blue(test_type(test))}: #{test_name(test)} (#{file_and_line(test)})\n")
     {:noreply, state}
   end
 
@@ -88,7 +88,7 @@ defmodule CustomFormatter do
   end
 
   defp format_failure(test, failures) do
-    formatter_cb = fn key, value -> 
+    formatter_cb = fn key, value ->
       case key do
         :test_info -> "FAILED"
         :location_info -> ""
@@ -131,5 +131,4 @@ defmodule CustomFormatter do
     |> tl()
     |> Enum.join(" ")
   end
-
 end

--- a/app/test/support/feature_steps.ex
+++ b/app/test/support/feature_steps.ex
@@ -1,9 +1,8 @@
 defmodule Operately.FeatureSteps do
-
   defmacro step(name, do: block) do
     quote do
       def unquote(name)() do
-        IO.write("\n    #{unquote(name)}")
+        IO.write("    #{unquote(name)}\n")
 
         unquote(block)
       end
@@ -13,7 +12,7 @@ defmodule Operately.FeatureSteps do
   defmacro step(name, ctx, do: block) do
     quote do
       def unquote(name)(unquote(ctx)) do
-        IO.write("\n    #{unquote(name)}")
+        IO.write("    #{unquote(name)}\n")
 
         unquote(block)
       end
@@ -23,11 +22,10 @@ defmodule Operately.FeatureSteps do
   defmacro step(name, ctx, params, do: block) do
     quote do
       def unquote(name)(unquote(ctx), unquote(params)) do
-        IO.write("\n    #{unquote(name)}")
+        IO.write("    #{unquote(name)}\n")
 
         unquote(block)
       end
     end
   end
-
 end

--- a/app/test/support/features/resource_hub_folder_steps.ex
+++ b/app/test/support/features/resource_hub_folder_steps.ex
@@ -56,7 +56,7 @@ defmodule Operately.Support.Features.ResourceHubFolderSteps do
     |> UI.click(testid: "new-folder")
     |> UI.fill(testid: "new-folder-name", with: folder_name)
     |> UI.click(testid: "submit")
-    |> UI.refute_has(testid: "submit")
+    |> UI.refute_text("New folder")
   end
 
   step :rename_folder, ctx, attrs do

--- a/app/test/support/features/ui.ex
+++ b/app/test/support/features/ui.ex
@@ -37,7 +37,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def new_session(state) do
-    execute(state, fn _ ->
+    execute("new_session", state, fn _ ->
       metadata = Phoenix.Ecto.SQL.Sandbox.metadata_for(Operately.Repo, self())
       {:ok, session} = Wallaby.start_session(metadata: metadata, window_size: [width: 1920, height: 2000])
       session
@@ -54,7 +54,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def click(state, %Wallaby.Query{} = query) do
-    execute(state, fn session ->
+    execute("click", state, fn session ->
       session |> Browser.click(query)
     end)
   end
@@ -63,7 +63,7 @@ defmodule Operately.Support.Features.UI do
     {_, opts} = Keyword.pop(opts, :in)
     css_query = compose_css_query(opts)
 
-    execute(state, fn session ->
+    execute("click", state, fn session ->
       session |> Browser.click(Query.css(css_query))
     end)
   rescue
@@ -96,13 +96,13 @@ defmodule Operately.Support.Features.UI do
     {_, opts} = Keyword.pop(opts, :in)
     css_query = compose_css_query(opts)
 
-    execute(state, fn session ->
+    execute("hover", state, fn session ->
       session |> Browser.hover(Query.css(css_query))
     end)
   end
 
   def send_keys(state, keys) do
-    execute(state, fn session ->
+    execute("send_keys", state, fn session ->
       session |> Browser.send_keys(keys)
     end)
   end
@@ -127,7 +127,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def assert_has(state, %Wallaby.Query{} = query) do
-    execute(state, fn session ->
+    execute("assert_has", state, fn session ->
       case Browser.execute_query(session, query) do
         {:ok, _query_result} ->
           session
@@ -146,13 +146,13 @@ defmodule Operately.Support.Features.UI do
   end
 
   def click_button(state, text) do
-    execute(state, fn session ->
+    execute("click_button", state, fn session ->
       session |> Browser.click(Query.button(text))
     end)
   end
 
   def click_link(state, text) do
-    execute(state, fn session ->
+    execute("click_link", state, fn session ->
       session |> Browser.click(Query.link(text))
     end)
   end
@@ -170,7 +170,7 @@ defmodule Operately.Support.Features.UI do
     # to update the value, but not too long to slow down the tests. We've tried
     # 10ms, but that was too short.
     #
-    execute(ctx, fn session ->
+    execute("fill", ctx, fn session ->
       session
       |> sleep(50)
       |> Browser.clear(query)
@@ -193,7 +193,7 @@ defmodule Operately.Support.Features.UI do
   def fill_rich_text(state, message) when is_binary(message) do
     query = Query.css(".ProseMirror[contenteditable=true]")
 
-    execute(state, fn session ->
+    execute("fill_rich_text", state, fn session ->
       session
       |> Browser.clear(query)
       |> Browser.find(query, fn element ->
@@ -205,7 +205,7 @@ defmodule Operately.Support.Features.UI do
   def fill_rich_text(state, testid: id, with: message) when is_binary(message) do
     query = Query.css("[data-test-id=\"#{id}\"] .ProseMirror[contenteditable=true]")
 
-    execute(state, fn session ->
+    execute("fill_rich_text", state, fn session ->
       session
       |> Browser.clear(query)
       |> Browser.find(query, fn element ->
@@ -215,7 +215,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def select_person_in(state, id: id, name: name) do
-    execute(state, fn session ->
+    execute("select_person_in", state, fn session ->
       Browser.fill_in(session, Query.css("#" <> id), with: name)
     end)
     |> assert_has(testid: testid(["person-option", name]))
@@ -228,7 +228,7 @@ defmodule Operately.Support.Features.UI do
     input_query = Query.css("input")
     option_query = Query.css("[data-test-id=\"#{testid(["person-option", name])}\"]")
 
-    execute(state, fn session ->
+    execute("select_person_in", state, fn session ->
       Browser.find(session, root_query, fn element ->
         element
         |> Browser.fill_in(input_query, with: name)
@@ -238,13 +238,13 @@ defmodule Operately.Support.Features.UI do
   end
 
   def press_enter(state) do
-    execute(state, fn session ->
+    execute("press_enter", state, fn session ->
       session |> Browser.send_keys([:enter])
     end)
   end
 
   def select(state, testid: id, option: option_name) do
-    execute(state, fn session ->
+    execute("select", state, fn session ->
       session
       |> Browser.click(query(testid: id))
       |> Browser.click(Query.text(option_name))
@@ -252,13 +252,13 @@ defmodule Operately.Support.Features.UI do
   end
 
   def assert_text(state, text) do
-    execute(state, fn session ->
+    execute("assert_text", state, fn session ->
       session |> Browser.assert_text(text)
     end)
   end
 
   def assert_text(state, text, testid: id) do
-    execute(state, fn session ->
+    execute("assert_text", state, fn session ->
       session
       |> Browser.find(query(testid: id), fn element ->
         element |> Browser.assert_text(text)
@@ -267,7 +267,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def refute_has(state, %Wallaby.Query{} = query) do
-    execute(state, fn session ->
+    execute("refute_has", state, fn session ->
       case Browser.execute_query(session, query) do
         {:error, :invalid_selector} -> raise Wallaby.QueryError, Query.ErrorMessage.message(query, :invalid_selector)
         {:error, _not_found} -> session
@@ -280,11 +280,11 @@ defmodule Operately.Support.Features.UI do
     {_, opts} = Keyword.pop(opts, :in)
     css_query = compose_css_query(opts)
 
-    refute_has(state, Query.css(css_query), attempts: [50, 150, 250, 400, 1000])
+    refute_has(state, Query.css(css_query), attempts: [1, 50, 150, 250, 400, 1000])
   end
 
   defp refute_has(state, query, attempts: [delay | attempts]) do
-    execute(state, fn session ->
+    execute("refute_has", state, fn session ->
       :timer.sleep(delay)
 
       has_element = session |> Browser.has?(query)
@@ -306,7 +306,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def refute_text(state, text, testid: id, attempts: [delay | attempts]) do
-    execute(state, fn session ->
+    execute("refute_has", state, fn session ->
       :timer.sleep(delay)
 
       session
@@ -324,7 +324,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def refute_text(state, text, attempts: [delay | attempts]) do
-    execute(state, fn session ->
+    execute("refute_has", state, fn session ->
       :timer.sleep(delay)
 
       visible_text = session |> Browser.text()
@@ -339,7 +339,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def assert_page(state, path) do
-    execute(state, fn session ->
+    execute("assert_page", state, fn session ->
       require ExUnit.Assertions
 
       wait_for_page_to_load(state, path)
@@ -351,31 +351,31 @@ defmodule Operately.Support.Features.UI do
   end
 
   def visit(state, path) do
-    execute(state, fn session ->
+    execute("visit", state, fn session ->
       session |> Browser.visit(path)
     end)
   end
 
   def scroll_to(state, testid: id) do
-    execute(state, fn session ->
+    execute("scrollto", state, fn session ->
       session |> Browser.execute_script("document.querySelector('[data-test-id=#{id}]').scrollIntoView()")
     end)
   end
 
   def find(state, testid: id) do
-    execute(state, fn session ->
+    execute("find", state, fn session ->
       session |> Browser.find(query(testid: id))
     end)
   end
 
   def find(state, %Wallaby.Query{} = query) do
-    execute(state, fn session ->
+    execute("find", state, fn session ->
       session |> Browser.find(query)
     end)
   end
 
   def find(state, %Wallaby.Query{} = query, callback) do
-    execute(state, fn session ->
+    execute("find", state, fn session ->
       session
       |> Browser.find(query, fn element ->
         callback.(%{state | session: element})
@@ -388,7 +388,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def wait_for_page_to_load(state, path) do
-    execute(state, fn session ->
+    execute("wait_for_page_load", state, fn session ->
       Wallaby.Browser.retry(fn ->
         if Wallaby.Browser.current_path(session) == path do
           {:ok, session}
@@ -420,13 +420,24 @@ defmodule Operately.Support.Features.UI do
   def upload_file(state, testid: id, path: path) do
     query = Query.css("[data-test-id=\"#{id}\"]", visible: false)
 
-    execute(state, fn session ->
+    execute("upload_file", state, fn session ->
       session |> Browser.attach_file(query, path: path)
     end)
   end
 
-  defp execute(state, callback) do
-    Map.update!(state, :session, callback)
+  defp execute(action, state, callback) do
+    if state[:trace] do
+      start_time = System.monotonic_time(:microsecond)
+      result = Map.update!(state, :session, callback)
+      end_time = System.monotonic_time(:microsecond)
+
+      diff = ((end_time - start_time) / 1000) |> round()
+      duration = String.pad_leading(to_string(diff), 6, " ") <> " ms"
+      IO.puts("      -> #{duration} - #{action}")
+      result
+    else
+      Map.update!(state, :session, callback)
+    end
   end
 
   defp compose_css_query([]), do: ""
@@ -442,7 +453,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def take_screenshot(state) do
-    execute(state, fn session ->
+    execute("take_screenshot", state, fn session ->
       session |> Browser.take_screenshot()
     end)
   end

--- a/app/test/support/features/ui.ex
+++ b/app/test/support/features/ui.ex
@@ -306,7 +306,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def refute_text(state, text, testid: id, attempts: [delay | attempts]) do
-    execute("refute_has", state, fn session ->
+    execute("refute_text", state, fn session ->
       :timer.sleep(delay)
 
       session
@@ -324,7 +324,7 @@ defmodule Operately.Support.Features.UI do
   end
 
   def refute_text(state, text, attempts: [delay | attempts]) do
-    execute("refute_has", state, fn session ->
+    execute("refute_text", state, fn session ->
       :timer.sleep(delay)
 
       visible_text = session |> Browser.text()


### PR DESCRIPTION
Example output when you put `@tag :trace` on top of your test.

```
  Feature: folders create folders at the root of resource hub (test/features/resource_hub_folder_test.exs:19)
    setup
      ->   1075 ms - visit
      ->    546 ms - assert_has
    visit_resource_hub_page
      ->    824 ms - visit
    create_folder
      ->    444 ms - click
      ->     75 ms - click
      ->    167 ms - fill
      ->     48 ms - click
      ->     94 ms - refute_text
    assert_folder_created
      ->     20 ms - assert_text
      ->     41 ms - assert_text
      ->    228 ms - find
    create_folder
      ->    161 ms - click
      ->    120 ms - click
      ->    279 ms - fill
      ->     45 ms - click
      ->     85 ms - refute_text
    assert_folder_created
      ->      9 ms - assert_text
      ->      9 ms - assert_text
      ->     33 ms - find
```