### PR TITLE
feat: Add Profile V2 page behind feature flag

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -995,7 +995,7 @@ export interface Person {
   title: string;
   avatarUrl: string | null;
   timezone?: string | null;
-  email?: string | null;
+  email: string;
   sendDailySummary?: boolean | null;
   notifyOnMention?: boolean | null;
   notifyAboutAssignments?: boolean | null;

--- a/app/assets/js/models/people/index.tsx
+++ b/app/assets/js/models/people/index.tsx
@@ -2,6 +2,7 @@ import * as api from "@/api";
 import * as Time from "@/utils/time";
 
 import Api from "@/api";
+import { Paths } from "@/routes/paths";
 
 export type Person = api.Person;
 
@@ -122,4 +123,30 @@ export function hasInvitationExpired(person: Person): boolean {
   if (!time) return false;
 
   return time < Time.now();
+}
+
+export interface PersonWithLink extends Person {
+  link: string;
+}
+
+/**
+ * Converts a Person or array of Person objects to include profile links
+ *
+ * @param personOrPeople - A Person object or array of Person objects
+ * @param useV2 - Whether to use V2 profile paths (optional, defaults to false)
+ * @returns Person(s) with added link property
+ */
+export function toPersonWithLink(person: Person, useV2?: boolean): PersonWithLink;
+export function toPersonWithLink(people: Person[], useV2?: boolean): PersonWithLink[];
+export function toPersonWithLink(personOrPeople: Person | Person[], useV2 = false): PersonWithLink | PersonWithLink[] {
+  if (Array.isArray(personOrPeople)) {
+    return personOrPeople.map((person) => toPersonWithLink(person, useV2));
+  }
+
+  const person = personOrPeople;
+
+  return {
+    ...person,
+    link: useV2 ? Paths.profileV2Path(person.id!) : Paths.profilePath(person.id!),
+  };
 }

--- a/app/assets/js/pages/ProfilePage/loader.tsx
+++ b/app/assets/js/pages/ProfilePage/loader.tsx
@@ -1,11 +1,18 @@
 import * as Pages from "@/components/Pages";
 import * as People from "@/models/people";
+import { Paths } from "@/routes/paths";
+import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoaderResult {
   person: People.Person;
 }
 
 export async function loader({ params }): Promise<LoaderResult> {
+  await redirectIfFeatureEnabled(params, {
+    feature: "new_profile_page",
+    path: Paths.profileV2Path(params.id),
+  });
+
   return {
     person: await People.getPerson({
       id: params.id,

--- a/app/assets/js/pages/ProfileV2Page/index.tsx
+++ b/app/assets/js/pages/ProfileV2Page/index.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+import * as Pages from "@/components/Pages";
+import * as People from "@/models/people";
+import { toPersonWithLink } from "@/models/people";
+
+import { PageModule } from "@/routes/types";
+import { PageCache } from "@/routes/PageCache";
+import { ProfilePage } from "turboui";
+import { Feed, useItemsQuery } from "@/features/Feed";
+import { assertPresent } from "@/utils/assertions";
+import { Paths } from "@/routes/paths";
+import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
+
+interface LoaderResult {
+  person: People.PersonWithLink;
+}
+
+export default { name: "ProfileV2Page", loader, Page } as PageModule;
+
+async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
+  await redirectIfFeatureNotEnabled(params, {
+    feature: "new_profile_page",
+    path: Paths.profilePath(params.id),
+  });
+
+  return await PageCache.fetch({
+    cacheKey: `v1-PersonalWorkMap.person-${params.id}`,
+    refreshCache,
+    fetchFn: async () => {
+      const [person] = await Promise.all([
+        People.getPerson({
+          id: params.id,
+          includeManager: true,
+          includeReports: true,
+          includePeers: true,
+        }).then((data) => data.person!),
+      ]);
+
+      return { person };
+    },
+  });
+}
+
+function Page() {
+  const { person } = Pages.useLoadedData<LoaderResult>();
+
+  assertPresent(person.peers);
+  assertPresent(person.reports);
+ 
+  const props = {
+    title: [person.fullName!, "Profile"],
+
+    person: toPersonWithLink(person, true),
+    peers: toPersonWithLink(People.sortByName(person.peers), true),
+    reports: toPersonWithLink(People.sortByName(person.reports), true),
+    manager: person.manager ? toPersonWithLink(person.manager, true) : null,
+
+    activityFeed: <ActivityFeed personId={person.id!} />,
+  };
+
+  return <ProfilePage {...props} />;
+}
+
+function ActivityFeed({ personId }: { personId: string }) {
+  const { data, loading, error } = useItemsQuery("person", personId);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error</div>;
+
+  return <Feed items={data!.activities!} testId="profile-feed" page="profile" />;
+}

--- a/app/assets/js/pages/index.tsx
+++ b/app/assets/js/pages/index.tsx
@@ -54,6 +54,7 @@ import PeoplePage from "./PeoplePage";
 import ProfileEditPage from "./ProfileEditPage";
 import ProfileGoalsPage from "./ProfileGoalsPage";
 import ProfilePage from "./ProfilePage";
+import ProfileV2Page from "./ProfileV2Page";
 import ProjectAddPage from "./ProjectAddPage";
 import ProjectAddResourcePage from "./ProjectAddResourcePage";
 import ProjectArchivationPage from "./ProjectArchivationPage";
@@ -164,6 +165,7 @@ export default {
   ProfileEditPage,
   ProfileGoalsPage,
   ProfilePage,
+  ProfileV2Page,
   ProjectAddPage,
   ProjectAddResourcePage,
   ProjectArchivationPage,

--- a/app/assets/js/routes/index.tsx
+++ b/app/assets/js/routes/index.tsx
@@ -85,6 +85,7 @@ export function createAppRoutes() {
         pageRoute("people", pages.PeoplePage),
         pageRoute("people/org-chart", pages.PeopleOrgChartPage),
         pageRoute("people/:id", pages.ProfilePage),
+        pageRoute("people/:id/v2", pages.ProfileV2Page),
         pageRoute("people/:id/goals", pages.ProfileGoalsPage),
         pageRoute("people/:id/profile/edit", pages.ProfileEditPage),
 

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -402,6 +402,10 @@ export class Paths {
     return createCompanyPath(["goals", goalId, "edit"]);
   }
 
+  static profileV2Path(personId: string) {
+    return createCompanyPath(["people", personId, "v2"]);
+  }
+
   static profilePath(personId: string) {
     return createCompanyPath(["people", personId]);
   }

--- a/app/lib/operately_web/api/serializers/person.ex
+++ b/app/lib/operately_web/api/serializers/person.ex
@@ -3,6 +3,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     %{
       id: OperatelyWeb.Paths.person_id(data),
       full_name: data.full_name,
+      email: data.email,
       avatar_url: data.avatar_url,
       title: data.title,
       access_level: find_access_level(bindings),
@@ -13,6 +14,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     %{
       id: OperatelyWeb.Paths.person_id(data),
       full_name: data.full_name,
+      email: data.email,
       avatar_url: data.avatar_url,
       title: data.title,
       has_open_invitation: data.has_open_invitation,

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1102,7 +1102,7 @@ defmodule OperatelyWeb.Api.Types do
     field :title, :string, optional: false, nullable: false
     field :avatar_url, :string, optional: false, nullable: true
     field :timezone, :string
-    field :email, :string
+    field :email, :string, optional: false, nullable: false
     field :send_daily_summary, :boolean
     field :notify_on_mention, :boolean
     field :notify_about_assignments, :boolean

--- a/app/test/operately_web/api/queries/get_space_test.exs
+++ b/app/test/operately_web/api/queries/get_space_test.exs
@@ -147,7 +147,7 @@ defmodule OperatelyWeb.Api.Queries.GetSpaceTest do
       |> Enum.with_index()
       |> Enum.map(fn {m, i} -> {m, Enum.at(res.space.members, i)} end)
       |> Enum.each(fn {m, res} ->
-        assert res == %{id: Paths.person_id(m), full_name: m.full_name, avatar_url: m.avatar_url, title: m.title, has_open_invitation: false}
+        assert res == %{id: Paths.person_id(m), full_name: m.full_name, email: m.email, avatar_url: m.avatar_url, title: m.title, has_open_invitation: false}
       end)
     end
 

--- a/app/test/operately_web/api/queries/search_project_contributor_candidates_test.exs
+++ b/app/test/operately_web/api/queries/search_project_contributor_candidates_test.exs
@@ -182,6 +182,7 @@ defmodule OperatelyWeb.Api.Queries.SearchProjectContributorCandidatesTest do
       assert res.people == [%{
         id: Paths.person_id(person),
         full_name: person.full_name,
+        email: person.email,
         title: person.title,
         avatar_url: person.avatar_url,
         has_open_invitation: false

--- a/turboui/src/PersonCard/index.tsx
+++ b/turboui/src/PersonCard/index.tsx
@@ -91,7 +91,7 @@ function ConnectionLines(props: PersonCard.Props) {
       {props.connectUp && (
         <div
           className={classNames(
-            "absolute border-b-2 border-l-2 rounded-bl-lg botom-10",
+            "absolute border-b-2 border-l-2 rounded-bl-lg",
             "transform -translate-y-1/2",
             connectColor,
           )}

--- a/turboui/src/PersonCard/index.tsx
+++ b/turboui/src/PersonCard/index.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+import classNames from "../utils/classnames";
+import { Avatar } from "../Avatar";
+import { DivLink } from "../Link";
+
+export namespace PersonCard {
+  interface Person {
+    id: string;
+    fullName: string;
+    email: string;
+    avatarUrl: string | null;
+    title: string;
+    link: string;
+  }
+
+  export interface Props {
+    person: Person;
+    highlight?: boolean;
+    link?: boolean;
+
+    connectLeft?: boolean;
+    connectRight?: boolean;
+    connectUp?: boolean;
+    connectUpJoinLeft?: boolean;
+    connectColor?: string;
+  }
+}
+
+export function PersonCard(props: PersonCard.Props) {
+  const { person, highlight, link } = props;
+  const location = useLocation();
+
+  const className = classNames("flex items-center gap-2 text-sm rounded-xl px-4 py-3 bg-surface-dimmed", "relative", {
+    "border-2 border-accent-1": highlight,
+    "border-2 border-stroke-base": !highlight,
+    "cursor-pointer": !link,
+  });
+
+  const content = (
+    <>
+      <Avatar person={person} size={36} />
+      <div className="truncate">
+        <div className="font-semibold">{person.fullName}</div>
+        <div className="text-xs truncate">{person.title}</div>
+      </div>
+
+      <ConnectionLines {...props} />
+    </>
+  );
+
+  const testid = `person-card-${person.id}`;
+
+  // Preserve query parameters when navigating
+  const getLinkWithParams = () => {
+    if (typeof window === "undefined") return person.link; // Handle SSR
+
+    try {
+      const currentSearchParams = new URLSearchParams(location.search);
+
+      const url = new URL(person.link, window.location.origin);
+      const targetSearchParams = new URLSearchParams(url.search);
+
+      currentSearchParams.forEach((value, key) => {
+        if (!targetSearchParams.has(key)) {
+          targetSearchParams.append(key, value);
+        }
+      });
+
+      url.search = targetSearchParams.toString();
+
+      return url.pathname + url.search;
+    } catch (e) {
+      return person.link;
+    }
+  };
+
+  if (link) {
+    return <DivLink to={getLinkWithParams()} className={className} children={content} testId={testid} />;
+  } else {
+    return <div className={className} children={content} data-test-id={testid} />;
+  }
+}
+
+function ConnectionLines(props: PersonCard.Props) {
+  const connectColor = props.connectColor || "border-accent-1";
+
+  return (
+    <>
+      {props.connectUp && (
+        <div
+          className={classNames(
+            "absolute border-b-2 border-l-2 rounded-bl-lg botom-10",
+            "transform -translate-y-1/2",
+            connectColor,
+          )}
+          style={{
+            left: "-10px",
+            width: "10px",
+            height: props.connectUpJoinLeft ? "100%" : "calc(100% + 20px)",
+          }}
+        />
+      )}
+
+      {props.connectUp && props.connectUpJoinLeft && (
+        <div
+          className={classNames("absolute border-t-2 border-r-2 rounded-tr-lg", connectColor)}
+          style={{
+            width: "10px",
+            height: "20px",
+            left: "-18px",
+            top: "calc(-100% + 17px)",
+          }}
+        />
+      )}
+
+      {props.connectLeft && (
+        <div
+          className={classNames(
+            "absolute top-1/2 -left-5 w-5 border-t-2",
+            "transform -translate-y-1/2",
+            "z-[1]",
+            connectColor,
+          )}
+        />
+      )}
+
+      {props.connectRight && (
+        <div
+          className={classNames(
+            "absolute top-1/2 -right-5 w-5 border-t-2",
+            "transform -translate-y-1/2",
+            "z-[1]",
+            connectColor,
+          )}
+        />
+      )}
+    </>
+  );
+}

--- a/turboui/src/ProfilePage/components/Colleagues.tsx
+++ b/turboui/src/ProfilePage/components/Colleagues.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import { SecondaryButton } from "../../Button";
+import { PersonCard } from "../../PersonCard";
+
+import { ProfilePage } from "..";
+
+export function Colleagues(props: ProfilePage.Props) {
+  const [allPeersVisible, setAllPeersVisible] = React.useState(false);
+  const [allReportsVisible, setAllReportsVisible] = React.useState(false);
+
+  const visiblePeers = allPeersVisible ? props.peers : props.peers.slice(0, 4);
+  const visibleReports = allReportsVisible ? props.reports : props.reports.slice(0, 4);
+  const hasManager = !!props.manager;
+
+  return (
+    <div className="py-6">
+      <div className="text-xs mb-2 uppercase font-bold">Colleagues</div>
+
+      <div className="grid grid-cols-3 gap-4">
+        {props.manager && (
+          <div>
+            <div className="text-xs font-medium text-content-dimmed mb-2">Manager</div>
+            <PersonCard person={props.manager} link />
+          </div>
+        )}
+
+        <div>
+          <div className="text-xs font-medium text-content-dimmed mb-2">Peers</div>
+
+          <div className="flex flex-col gap-2">
+            <PersonCard
+              person={props.person}
+              highlight
+              connectLeft={hasManager}
+              connectRight={props.reports.length > 0}
+            />
+
+            {visiblePeers.map((peer, index) => (
+              <PersonCard
+                key={peer!.id}
+                person={peer!}
+                link
+                connectUp={hasManager}
+                connectUpJoinLeft={index === 0}
+                connectColor="border-surface-outline"
+              />
+            ))}
+          </div>
+
+          {!allPeersVisible && props.peers.length > visiblePeers.length && (
+            <div className="mt-2 flex items-center justify-center">
+              <SecondaryButton size="xxs" onClick={() => setAllPeersVisible(true)}>
+                Show all
+              </SecondaryButton>
+            </div>
+          )}
+        </div>
+
+        {visibleReports.length > 0 && (
+          <div>
+            <div className="text-xs font-medium text-content-dimmed mb-2">Reports</div>
+
+            <div className="flex flex-col gap-2">
+              {props.reports.map((person, index) => (
+                <PersonCard
+                  key={person.id}
+                  person={person}
+                  link
+                  connectUp={index > 0}
+                  connectUpJoinLeft={index === 1}
+                />
+              ))}
+            </div>
+
+            {!allReportsVisible && props.reports.length > visibleReports.length && (
+              <div className="mt-2 flex items-center justify-center">
+                <SecondaryButton size="xxs" onClick={() => setAllReportsVisible(true)}>
+                  Show all
+                </SecondaryButton>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/turboui/src/ProfilePage/components/Colleagues.tsx
+++ b/turboui/src/ProfilePage/components/Colleagues.tsx
@@ -62,7 +62,7 @@ export function Colleagues(props: ProfilePage.Props) {
             <div className="text-xs font-medium text-content-dimmed mb-2">Reports</div>
 
             <div className="flex flex-col gap-2">
-              {props.reports.map((person, index) => (
+              {visibleReports.map((person, index) => (
                 <PersonCard
                   key={person.id}
                   person={person}

--- a/turboui/src/ProfilePage/components/index.tsx
+++ b/turboui/src/ProfilePage/components/index.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+import { Avatar } from "../../Avatar";
+import { ProfilePage } from "../index";
+import { IconMail } from "@tabler/icons-react";
+
+export { Colleagues } from "./Colleagues";
+
+export function PageHeader({ person }: { person: ProfilePage.Person }) {
+  return (
+    <div className="mt-4 px-4 flex items-center gap-4">
+      <Avatar person={person} size={72} />
+      <div className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <div className="text-xl font-bold">{person.fullName}</div>
+        </div>
+        <div className="font-medium">{person.title}</div>
+      </div>
+    </div>
+  );
+}
+
+export function Contact({ person }: { person: ProfilePage.Person }) {
+  return (
+    <div className="pb-6">
+      <div className="text-xs mb-2 uppercase font-bold">Contact</div>
+      <div className="flex items-center gap-1 font-medium">
+        <IconMail size={20} className="text-content-dimmed" />
+        {person.email}
+      </div>
+    </div>
+  );
+}

--- a/turboui/src/ProfilePage/index.tsx
+++ b/turboui/src/ProfilePage/index.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+
+import { IconLogs, IconEye, IconClipboardCheck, IconUserCircle } from "@tabler/icons-react";
+
+import { Page } from "../Page";
+import { Tabs, useTabs } from "../Tabs";
+import { Colleagues, PageHeader, Contact } from "./components";
+
+export namespace ProfilePage {
+  export interface Person {
+    id: string;
+    fullName: string;
+    email: string;
+    avatarUrl: string | null;
+    title: string;
+    link: string;
+  }
+
+  export interface Props {
+    title: string | string[];
+
+    person: Person;
+    manager: Person | null;
+    peers: Person[];
+    reports: Person[];
+
+    activityFeed: React.ReactNode;
+  }
+}
+
+export function ProfilePage(props: ProfilePage.Props) {
+  const tabs = useTabs("overview", [
+    { id: "assigned", label: "Assigned", icon: <IconClipboardCheck size={14} /> },
+    { id: "reviewing", label: "Reviewing", icon: <IconEye size={14} /> },
+    { id: "activity", label: "Recent activity", icon: <IconLogs size={14} /> },
+    { id: "about", label: "About", icon: <IconUserCircle size={14} /> },
+  ]);
+
+  return (
+    <Page title={props.title} size="fullwidth">
+      <PageHeader person={props.person} />
+      <Tabs tabs={tabs} />
+
+      {tabs.active === "activity" && <ActivityFeed {...props} />}
+      {tabs.active === "about" && <About {...props} />}
+    </Page>
+  );
+}
+
+function ActivityFeed(props: ProfilePage.Props) {
+  return (
+    <div className="p-4 max-w-5xl mx-auto my-6">
+      <div className="font-bold text-lg mb-4">Recent activity</div>
+      {props.activityFeed}
+    </div>
+  );
+}
+
+function About(props: ProfilePage.Props) {
+  return (
+    <div className="p-4 max-w-5xl mx-auto my-6">
+      <div className="flex flex-col divide-y divide-stroke-base">
+        <Contact person={props.person} />
+        <Colleagues {...props} />
+      </div>
+    </div>
+  );
+}

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -15,3 +15,4 @@ export * from "./WorkMap";
 
 export { GoalPage } from "./GoalPage";
 export { MiniWorkMap } from "./MiniWorkMap";
+export { ProfilePage } from "./ProfilePage";


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2518. 

So far I added only the about and activity tabs. I'm going to add the Work Map tabs (Assigned and Reviewing) in the upcoming PRs. 

I'm calling it "ProfileV2Page", but we can change it to another name if the current name is not correct.