### PR TITLE
fix: Query flat Work Map without including items' parents

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1736,6 +1736,19 @@ export interface GetDiscussionsResult {
   myDrafts?: Discussion[] | null;
 }
 
+export interface GetFlatWorkMapInput {
+  spaceId?: Id | null;
+  parentGoalId?: Id | null;
+  championId?: Id | null;
+  reviewerId?: Id | null;
+  contributorId?: Id | null;
+  includeAssignees?: boolean | null;
+}
+
+export interface GetFlatWorkMapResult {
+  workMap?: WorkMapItem[] | null;
+}
+
 export interface GetGoalInput {
   id?: Id | null;
   includeChampion?: boolean | null;
@@ -3278,6 +3291,10 @@ class ApiNamespaceRoot {
     return this.client.get("/get_discussions", input);
   }
 
+  async getFlatWorkMap(input: GetFlatWorkMapInput): Promise<GetFlatWorkMapResult> {
+    return this.client.get("/get_flat_work_map", input);
+  }
+
   async getGoal(input: GetGoalInput): Promise<GetGoalResult> {
     return this.client.get("/get_goal", input);
   }
@@ -3970,6 +3987,10 @@ export class ApiClient {
     return this.apiNamespaceRoot.getDiscussions(input);
   }
 
+  getFlatWorkMap(input: GetFlatWorkMapInput): Promise<GetFlatWorkMapResult> {
+    return this.apiNamespaceRoot.getFlatWorkMap(input);
+  }
+
   getGoal(input: GetGoalInput): Promise<GetGoalResult> {
     return this.apiNamespaceRoot.getGoal(input);
   }
@@ -4554,6 +4575,9 @@ export async function getDiscussion(input: GetDiscussionInput): Promise<GetDiscu
 export async function getDiscussions(input: GetDiscussionsInput): Promise<GetDiscussionsResult> {
   return defaultApiClient.getDiscussions(input);
 }
+export async function getFlatWorkMap(input: GetFlatWorkMapInput): Promise<GetFlatWorkMapResult> {
+  return defaultApiClient.getFlatWorkMap(input);
+}
 export async function getGoal(input: GetGoalInput): Promise<GetGoalResult> {
   return defaultApiClient.getGoal(input);
 }
@@ -5072,6 +5096,10 @@ export function useGetDiscussion(input: GetDiscussionInput): UseQueryHookResult<
 
 export function useGetDiscussions(input: GetDiscussionsInput): UseQueryHookResult<GetDiscussionsResult> {
   return useQuery<GetDiscussionsResult>(() => defaultApiClient.getDiscussions(input));
+}
+
+export function useGetFlatWorkMap(input: GetFlatWorkMapInput): UseQueryHookResult<GetFlatWorkMapResult> {
+  return useQuery<GetFlatWorkMapResult>(() => defaultApiClient.getFlatWorkMap(input));
 }
 
 export function useGetGoal(input: GetGoalInput): UseQueryHookResult<GetGoalResult> {
@@ -5923,6 +5951,8 @@ export default {
   useGetDiscussion,
   getDiscussions,
   useGetDiscussions,
+  getFlatWorkMap,
+  useGetFlatWorkMap,
   getGoal,
   useGetGoal,
   getGoalProgressUpdate,

--- a/app/assets/js/models/workMap/index.tsx
+++ b/app/assets/js/models/workMap/index.tsx
@@ -1,4 +1,4 @@
-import { WorkMapItem, getWorkMap } from "@/api";
+import { WorkMapItem, getWorkMap, getFlatWorkMap } from "@/api";
 import { WorkMap, TimeframeSelector } from "turboui";
 
 /**
@@ -24,5 +24,5 @@ export function convertToWorkMapItem(item: WorkMapItem): WorkMap.Item {
   };
 }
 
-export { getWorkMap };
+export { getWorkMap, getFlatWorkMap };
 export type { WorkMapItem };

--- a/app/assets/js/pages/ProfileV2Page/loader.tsx
+++ b/app/assets/js/pages/ProfileV2Page/loader.tsx
@@ -72,7 +72,7 @@ function fetchAssignedTab(championId: string, refreshCache: boolean) {
     fetchFn: async () =>
       fetchAll({
         person: fetchPerson(championId),
-        workMap: WorkMap.getWorkMap({
+        workMap: WorkMap.getFlatWorkMap({
           championId,
           contributorId: championId,
         }).then((d) => d.workMap?.map(convertToWorkMapItem) ?? []),
@@ -87,7 +87,7 @@ function fetchRaviewingTab(reviewerId: string, refreshCache: boolean) {
     fetchFn: async () =>
       fetchAll({
         person: fetchPerson(reviewerId),
-        workMap: WorkMap.getWorkMap({
+        workMap: WorkMap.getFlatWorkMap({
           reviewerId,
         }).then((d) => d.workMap?.map(convertToWorkMapItem) ?? []),
       }),

--- a/app/lib/operately/work_maps/work_map.ex
+++ b/app/lib/operately/work_maps/work_map.ex
@@ -66,12 +66,12 @@ defmodule Operately.WorkMaps.WorkMap do
 
   Returns a flat list of filtered items with empty children lists.
   """
-  def filter_direct_matches(flat_items, filters) when filters == %{}, do: flat_items
+  def filter_direct_matches(flat_items, filters) when filters == %{} do
+    Enum.map(flat_items, &%{&1 | children: []})
+  end
 
   def filter_direct_matches(flat_items, filters) when is_list(flat_items) and is_map(filters) do
-    # Simply filter items by all criteria directly without preserving hierarchy
     find_direct_matches(flat_items, filters)
-    # Clear the children field for consistency
     |> Enum.map(&%{&1 | children: []})
   end
 

--- a/app/lib/operately/work_maps/work_map.ex
+++ b/app/lib/operately/work_maps/work_map.ex
@@ -1,34 +1,13 @@
 defmodule Operately.WorkMaps.WorkMap do
-  @moduledoc """
-  Functions for working with work maps (hierarchical structures of goals and projects)
-  """
-
   alias Operately.WorkMaps.WorkMapItem
 
   @doc """
   Builds a hierarchical structure from a flat list of WorkMapItem structs.
 
   This function:
-  1. Identifies all items whose parent_id is nil or not present in the list (root items)
+  1. Identifies all items whose parent_id is nil or not in the list (root items)
   2. For each item with a parent in the list, adds it as a child of that parent
   3. Returns a list of root items with their children properly nested
-
-  ## Examples
-
-      iex> items = [
-      ...>   %WorkMapItem{id: 1, parent_id: nil, name: "Root 1", children: []},
-      ...>   %WorkMapItem{id: 2, parent_id: 1, name: "Child 1", children: []},
-      ...>   %WorkMapItem{id: 3, parent_id: 1, name: "Child 2", children: []},
-      ...>   %WorkMapItem{id: 4, parent_id: nil, name: "Root 2", children: []}
-      ...> ]
-      iex> build_hierarchy(items)
-      [
-        %WorkMapItem{id: 1, parent_id: nil, name: "Root 1", children: [
-          %WorkMapItem{id: 2, parent_id: 1, name: "Child 1", children: []},
-          %WorkMapItem{id: 3, parent_id: 1, name: "Child 2", children: []}
-        ]},
-        %WorkMapItem{id: 4, parent_id: nil, name: "Root 2", children: []}
-      ]
   """
   @spec build_hierarchy(list(WorkMapItem.t())) :: list(WorkMapItem.t())
   def build_hierarchy(items) when is_list(items) do
@@ -75,7 +54,29 @@ defmodule Operately.WorkMaps.WorkMap do
   end
 
   @doc """
-  Filters a flat list of WorkMapItem structs based on provided filters.
+  Filters items directly, only keeping items that match the filter criteria.
+  Does NOT preserve parent hierarchy - only direct matches are kept.
+
+  Supported filters:
+  - :space_id - Filters items by space ID
+  - :parent_goal_id - Filters items by parent goal ID
+  - :champion_id - Filters items by champion ID
+  - :reviewer_id - Filters items by reviewer ID
+  - :contributor_id - Filters items by contributor ID
+
+  Returns a flat list of filtered items with empty children lists.
+  """
+  def filter_direct_matches(flat_items, filters) when filters == %{}, do: flat_items
+
+  def filter_direct_matches(flat_items, filters) when is_list(flat_items) and is_map(filters) do
+    # Simply filter items by all criteria directly without preserving hierarchy
+    find_direct_matches(flat_items, filters)
+    # Clear the children field for consistency
+    |> Enum.map(&%{&1 | children: []})
+  end
+
+  @doc """
+  Filters a flat list of work map items based on filters, preserving parent hierarchy.
 
   Supported filters:
   - :space_id - Filters items by space ID
@@ -84,9 +85,8 @@ defmodule Operately.WorkMaps.WorkMap do
   - :reviewer_id - Filters items by reviewer ID
   - :contributor_id - Filters items by contributor ID
 
-  If a parent item is filtered out but its children would remain, the children will be
-  reparented to the nearest ancestor that passes the filter, or become root items
-  if no suitable ancestor exists.
+  If a parent item is filtered out but its children would remain, the hierarchy is preserved
+  by including all parent items needed to maintain the relationships.
 
   Returns a flat list of filtered items that can be passed to build_hierarchy.
   """

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -78,6 +78,7 @@ defmodule OperatelyWeb.Api do
   query(:search_potential_space_members, Q.SearchPotentialSpaceMembers)
   query(:search_project_contributor_candidates, Q.SearchProjectContributorCandidates)
   query(:get_work_map, Q.GetWorkMap)
+  query(:get_flat_work_map, Q.GetFlatWorkMap)
   query(:run_ai_prompt, Q.RunAiPrompt)
 
   mutation(:archive_message, M.ArchiveMessage)

--- a/app/lib/operately_web/api/queries/get_flat_work_map.ex
+++ b/app/lib/operately_web/api/queries/get_flat_work_map.ex
@@ -1,0 +1,37 @@
+defmodule OperatelyWeb.Api.Queries.GetFlatWorkMap do
+  use TurboConnect.Query
+  use OperatelyWeb.Api.Helpers
+
+  alias Operately.WorkMaps.GetWorkMapQuery
+
+  inputs do
+    field :space_id, :id
+    field :parent_goal_id, :id
+    field :champion_id, :id
+    field :reviewer_id, :id
+    field :contributor_id, :id
+    field :include_assignees, :boolean
+  end
+
+  outputs do
+    field :work_map, list_of(:work_map_item)
+  end
+
+  def call(conn, inputs) do
+    person = me(conn)
+    company = company(conn)
+
+    {:ok, flat_work_map} =
+      GetWorkMapQuery.execute(person, %{
+        company_id: company.id,
+        space_id: inputs[:space_id],
+        parent_goal_id: inputs[:parent_goal_id],
+        champion_id: inputs[:champion_id],
+        reviewer_id: inputs[:reviewer_id],
+        contributor_id: inputs[:contributor_id],
+        include_assignees: inputs[:include_assignees] || false
+      }, :flat)
+
+    {:ok, %{work_map: Serializer.serialize(flat_work_map)}}
+  end
+end

--- a/app/test/operately/work_maps/get_work_map_query_test.exs
+++ b/app/test/operately/work_maps/get_work_map_query_test.exs
@@ -308,20 +308,20 @@ defmodule Operately.WorkMaps.GetWorkMapQueryTest do
       |> Factory.setup()
       |> Factory.add_space(:space)
       |> Factory.add_company_member(:member)
-      |> Factory.add_company_member(:reviewer1)
-      |> Factory.add_company_member(:reviewer2)
+      |> Factory.add_company_member(:reviewer)
+      |> Factory.add_company_member(:person)
 
       # Create goals with different reviewers
-      |> Factory.add_goal(:goal1, :space, reviewer: :reviewer1)
-      |> Factory.add_goal(:goal2, :space, reviewer: :reviewer2)
+      |> Factory.add_goal(:goal1, :space, reviewer: :reviewer, champion: :person)
+      |> Factory.add_goal(:goal2, :space, reviewer: :person, champion: :reviewer)
 
       # Create projects with different reviewers
-      |> Factory.add_project(:project1, :space, reviewer: :reviewer1)
-      |> Factory.add_project(:project2, :space, reviewer: :reviewer2)
+      |> Factory.add_project(:project1, :space, reviewer: :reviewer)
+      |> Factory.add_project(:project2, :space, reviewer: :person)
     end
 
     test "returns only goals and projects with the specified reviewer", ctx do
-      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer1.id})
+      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer.id})
 
       assert_work_map_structure(work_map, ctx, %{
         goal1: [],
@@ -332,12 +332,12 @@ defmodule Operately.WorkMaps.GetWorkMapQueryTest do
     test "given parent and greatgrandchild have the same reviewer, but child and grandchild have another reviewer, returns full hierarchy", ctx do
       ctx =
         ctx
-        |> Factory.add_goal(:child, :space, parent_goal: :goal1, reviewer: :reviewer2)
-        |> Factory.add_goal(:grand_child, :space, parent_goal: :child, reviewer: :reviewer2)
-        |> Factory.add_goal(:great_grand_child, :space, parent_goal: :grand_child, reviewer: :reviewer1)
-        |> Factory.add_project(:grand_child_project, :space, goal: :child, reviewer: :reviewer1)
+        |> Factory.add_goal(:child, :space, parent_goal: :goal1, reviewer: :person, champion: :reviewer)
+        |> Factory.add_goal(:grand_child, :space, parent_goal: :child, reviewer: :person, champion: :reviewer)
+        |> Factory.add_goal(:great_grand_child, :space, parent_goal: :grand_child, reviewer: :reviewer, champion: :person)
+        |> Factory.add_project(:grand_child_project, :space, goal: :child, reviewer: :reviewer, champion: :person)
 
-      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer1.id})
+      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer.id})
 
       assert_work_map_structure(work_map, ctx, %{
         project1: [],
@@ -353,9 +353,9 @@ defmodule Operately.WorkMaps.GetWorkMapQueryTest do
     end
 
     test "given parent and child have different reviewer, returns full hierarchy including parent", ctx do
-      ctx = Factory.add_goal(ctx, :child, :space, parent_goal: :goal2, reviewer: :reviewer1)
+      ctx = Factory.add_goal(ctx, :child, :space, parent_goal: :goal2, reviewer: :reviewer)
 
-      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer1.id})
+      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, reviewer_id: ctx.reviewer.id})
 
       assert_work_map_structure(work_map, ctx, %{
         goal1: [],

--- a/app/test/operately_web/api/queries/get_flat_work_map_test.exs
+++ b/app/test/operately_web/api/queries/get_flat_work_map_test.exs
@@ -1,0 +1,242 @@
+defmodule OperatelyWeb.Api.Queries.GetFlatWorkMapTest do
+  use OperatelyWeb.TurboCase
+
+  alias OperatelyWeb.Paths
+  alias Operately.Access.Binding
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, :get_flat_work_map, %{})
+    end
+  end
+
+  describe "permissions - flat list access" do
+    @table [
+      %{person: :company_member,  count: 1,   expected_items: [:public_project]},
+      %{person: :space_member,    count: 3,   expected_items: [:public_project, :project1, :project2]},
+      %{person: :creator,         count: 4,   expected_items: [:public_project, :project1, :project2, :secret_project]},
+      %{person: :champion,        count: 4,   expected_items: [:public_project, :project1, :project2, :secret_project]},
+    ]
+
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_company_member(:company_member)
+      |> Factory.add_space_member(:space_member, :space)
+      |> Factory.add_space_member(:champion, :space)
+
+      # Project hierarchy:
+      # ├── public_project  (accessible to everyone)
+      # ├── project1        (accessible to space members only)
+      # ├── project2        (accessible to space members only)
+      # └── secret_project  (accessible to admin and champion only)
+      |> Factory.add_project(:public_project, :space)
+      |> Factory.add_project(:project1, :space, company_access_level: Binding.no_access())
+      |> Factory.add_project(:project2, :space, company_access_level: Binding.no_access())
+      |> Factory.add_project(:secret_project, :space, [
+        champion: :champion,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.no_access(),
+      ])
+    end
+
+    tabletest @table do
+      test "#{@test.person} has access to #{Enum.map_join(@test.expected_items, ", ", &Atom.to_string/1)}", ctx do
+        ctx = Factory.log_in_person(ctx, @test.person)
+        expected_items = Enum.map(@test.expected_items, &Paths.goal_id(ctx[&1]))
+
+        assert {200, res} = query(ctx.conn, :get_flat_work_map, %{})
+
+        # In flat list, items have no children field
+        assert length(res.work_map) == @test.count
+
+        # Verify all expected items are present
+        item_ids = Enum.map(res.work_map, & &1.id)
+        Enum.each(expected_items, fn id ->
+          assert id in item_ids
+        end)
+      end
+    end
+  end
+
+  describe "permissions - nested items in flat list" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_company_member(:company_member)
+      |> Factory.add_space_member(:space_member, :space)
+      |> Factory.add_space_member(:champion, :space)
+      |> Factory.add_goal(:parent_goal, :space)
+      |> Factory.add_goal(:child_goal, :space, parent_goal: :parent_goal)
+
+      # Project hierarchy:
+      # parent_goal
+      # └── child_goal
+      #     ├── public_project  (accessible to everyone)
+      #     ├── project1        (accessible to space members only)
+      #     ├── project2        (accessible to space members only)
+      #     └── secret_project  (accessible to champion only)
+      |> Factory.add_project(:public_project, :space, goal: :child_goal)
+      |> Factory.add_project(:project1, :space, goal: :child_goal, company_access_level: Binding.no_access())
+      |> Factory.add_project(:project2, :space, goal: :child_goal, company_access_level: Binding.no_access())
+      |> Factory.add_project(:secret_project, :space, [
+        goal: :child_goal,
+        champion: :champion,
+        company_access_level: Binding.no_access(),
+        space_access_level: Binding.no_access(),
+      ])
+    end
+
+    @table [
+      %{person: :company_member,  expected_items: 3,   projects_count: 1},
+      %{person: :space_member,    expected_items: 5,   projects_count: 3},
+      %{person: :creator,         expected_items: 6,   projects_count: 4},
+      %{person: :champion,        expected_items: 6,   projects_count: 4},
+    ]
+
+    tabletest @table do
+      test "#{@test.person} sees the correct items in flat list", ctx do
+        ctx = Factory.log_in_person(ctx, @test.person)
+
+        assert {200, res} = query(ctx.conn, :get_flat_work_map, %{})
+
+        # For flat list, we see all accessible items
+        assert length(res.work_map) == @test.expected_items
+
+        # Verify that the projects have the correct parent_id
+        projects = Enum.filter(res.work_map, &(&1.type == "project"))
+        assert length(projects) == @test.projects_count
+
+        # All projects should have child_goal as parent
+        Enum.each(projects, fn project ->
+          assert project.parent_id == ctx.child_goal.id
+        end)
+      end
+    end
+  end
+
+  describe "functionality" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space1)
+      |> Factory.add_space(:space2)
+      |> Factory.add_space(:space3)
+      |> Factory.add_goal(:goal1, :space1)
+      |> Factory.add_goal(:goal2, :space1)
+      |> Factory.add_project(:project1, :space1)
+      |> Factory.add_project(:project2, :space2)
+    end
+
+    test "returns empty list when no matching items exist", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      # Query with a non-existent space_id
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{space_id: Paths.space_id(ctx.space3)})
+      assert res.work_map == []
+    end
+
+    test "filters by space_id", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      # Query for space1
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{space_id: Paths.space_id(ctx.space1)})
+
+      # Should return 3 items from space1
+      assert length(res.work_map) == 3
+      item_ids = Enum.map(res.work_map, & &1.id)
+      assert Paths.goal_id(ctx.goal1) in item_ids
+      assert Paths.goal_id(ctx.goal2) in item_ids
+      assert Paths.project_id(ctx.project1) in item_ids
+
+      # Query for space2
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{space_id: Paths.space_id(ctx.space2)})
+
+      # Should return 1 item from space2
+      assert length(res.work_map) == 1
+      assert Enum.at(res.work_map, 0).id == Paths.project_id(ctx.project2)
+    end
+
+    test "filters by parent_goal_id", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:child_goal, :space1, parent_goal: :goal1)
+        |> Factory.log_in_person(:creator)
+
+      # Query for children of goal1
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{parent_goal_id: Paths.goal_id(ctx.goal1)})
+
+      # Should return only the child goal
+      assert length(res.work_map) == 1
+      assert Enum.at(res.work_map, 0).id == Paths.goal_id(ctx.child_goal)
+    end
+
+    test "filters by owner_id", ctx do
+      ctx =
+        ctx
+        |> Factory.add_company_member(:other_member)
+        |> Factory.add_goal(:owned_goal, :space1, champion: :other_member)
+        |> Factory.log_in_person(:creator)
+
+      # Query for items owned by other_member
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{champion_id: Paths.person_id(ctx.other_member)})
+
+      # Should return only the owned goal
+      assert length(res.work_map) == 1
+      assert Enum.at(res.work_map, 0).id == Paths.goal_id(ctx.owned_goal)
+    end
+
+    test "returns flat list with parent relationships preserved", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:parent_goal, :space1)
+        |> Factory.add_goal(:child_goal, :space1, parent_goal: :parent_goal)
+        |> Factory.add_project(:child_project, :space1, goal: :child_goal)
+        |> Factory.log_in_person(:creator)
+
+      assert {200, res} = query(ctx.conn, :get_flat_work_map, %{})
+
+      # In a flat list, we should have all items
+      assert length(res.work_map) >= 3
+
+      # Find our test items
+      parent_goal = Enum.find(res.work_map, &(&1.id == Paths.goal_id(ctx.parent_goal)))
+      child_goal = Enum.find(res.work_map, &(&1.id == Paths.goal_id(ctx.child_goal)))
+      child_project = Enum.find(res.work_map, &(&1.id == Paths.project_id(ctx.child_project)))
+
+      # Verify parent relationships
+      assert child_goal.parent_id == ctx.parent_goal.id
+      assert child_project.parent_id == ctx.child_goal.id
+
+      # Items in flat list should not have children
+      assert parent_goal.children == []
+      assert child_goal.children == []
+      assert child_project.children == []
+    end
+
+    test "successfully returns item without owner", ctx do
+      ctx =
+        ctx
+        |> Factory.log_in_person(:creator)
+        |> Factory.add_company_member(:champion)
+        |> Factory.add_space(:space4)
+        |> Factory.add_project(:project3, :space4, champion: :champion)
+
+      assert {200, %{work_map: [item]}} = query(ctx.conn, :get_flat_work_map, %{space_id: Paths.space_id(ctx.space4)})
+
+      assert item.id == Paths.project_id(ctx.project3)
+      assert item.owner.id == Paths.person_id(ctx.champion)
+      assert item.owner_path == Paths.person_path(ctx.company, ctx.champion)
+
+      Factory.suspend_company_member(ctx, :champion)
+
+      assert {200, %{work_map: [item]}} = query(ctx.conn, :get_flat_work_map, %{space_id: Paths.space_id(ctx.space4)})
+
+      assert item.id == Paths.project_id(ctx.project3)
+      refute item.owner
+      refute item.owner_path
+    end
+  end
+end

--- a/turboui/src/ProfilePage/index.tsx
+++ b/turboui/src/ProfilePage/index.tsx
@@ -48,7 +48,7 @@ export function ProfilePage(props: ProfilePage.Props) {
   const items = React.useMemo(() => {
     const data = processPersonalItems(props.workMap);
     return sortItemsByDueDate(data.ongoingItems);
-  }, [props.workMap]);
+  }, [props.workMap, tabs.active]);
 
   return (
     <Page title={props.title} size="fullwidth">


### PR DESCRIPTION
I've added a new query which filters Work Map items without including their parents. This new query is necessary to get the required result for the "My Work" page (https://github.com/operately/operately/issues/2518).