### PR TITLE
feat: Sort items on the mini work map

### DIFF
--- a/turboui/src/MiniWorkMap/MiniWorkMap.stories.tsx
+++ b/turboui/src/MiniWorkMap/MiniWorkMap.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   decorators: [
     (Story) => (
       <div className="sm:mt-12">
-        <Page title="Mini Work Map" size="small">
+        <Page title="Mini Work Map" size="medium">
           <div className="p-12">
             <Story />
           </div>
@@ -75,12 +75,38 @@ export const Default: Story = {
           },
         ],
       },
+      {
+        id: "project-a",
+        name: "Project Alp",
+        type: "project",
+        itemPath: "#",
+        state: "active",
+        progress: 50,
+        assignees: genPeople(3, { random: true }),
+        children: [],
+        status: "on_track",
+      },
+      {
+        id: "project-a",
+        name: "Project Bug",
+        type: "project",
+        itemPath: "#",
+        state: "closed",
+        progress: 50,
+        assignees: genPeople(3, { random: true }),
+        children: [],
+        status: "on_track",
+      },
     ],
   },
   decorators: [
     (Story) => (
-      <div className="w-[500px]">
+      <div className="">
         <Story />
+
+        <div className="text-sm mt-8">
+          Note: Items are sorted by their state (active, paused, closed) and then by their type (projects, goals).
+        </div>
       </div>
     ),
   ],

--- a/turboui/src/MiniWorkMap/index.tsx
+++ b/turboui/src/MiniWorkMap/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { match } from "ts-pattern";
 import { AvatarList } from "../Avatar";
 import { IconGoal, IconProject } from "../icons";
@@ -6,9 +6,12 @@ import { BlackLink } from "../Link";
 import { StatusBadge } from "../StatusBadge";
 
 export function MiniWorkMap(props: MiniWorkMap.Props) {
+  // Memoize the sorted items to avoid unnecessary recalculations
+  const sortedItems = useMemo(() => sortItems(props.items), [props.items]);
+
   return (
     <div className="flex flex-col">
-      {props.items.map((item) => (
+      {sortedItems.map((item) => (
         <ItemView key={item.id} item={item} depth={0} />
       ))}
     </div>
@@ -72,9 +75,12 @@ function ItemView({ item, depth }: { item: MiniWorkMap.WorkItem; depth: number }
 }
 
 function Subitems({ items, depth }: { items: MiniWorkMap.WorkItem[]; depth: number }) {
+  // Memoize the sorted items to avoid unnecessary recalculations
+  const sortedItems = useMemo(() => sortItems(items), [items]);
+
   return (
     <>
-      {items.map((subitem) => (
+      {sortedItems.map((subitem) => (
         <ItemView key={subitem.id} item={subitem} depth={depth} />
       ))}
     </>
@@ -110,4 +116,19 @@ function ItemName({ item }: { item: MiniWorkMap.WorkItem }) {
   } else {
     return nameElement;
   }
+}
+
+// Helper function to sort items by state and type
+function sortItems(items: MiniWorkMap.WorkItem[]): MiniWorkMap.WorkItem[] {
+  return [...items].sort((a, b) => {
+    // First sort by state: active -> paused -> closed
+    const stateOrder = { active: 0, paused: 1, closed: 2 };
+    if (stateOrder[a.state] !== stateOrder[b.state]) {
+      return stateOrder[a.state] - stateOrder[b.state];
+    }
+
+    // Then sort by type: projects -> goals
+    const typeOrder = { project: 0, goal: 1 };
+    return typeOrder[a.type] - typeOrder[b.type];
+  });
 }


### PR DESCRIPTION
The logic is:

- Sort by state in this order: `active`, `paused`, `closed`
- Then, sort by type: `project`, `goal`