### PR TITLE
fix: Profile tabs no longer overflows the page in small screen

### DIFF
--- a/turboui/src/Tabs/index.tsx
+++ b/turboui/src/Tabs/index.tsx
@@ -50,8 +50,8 @@ function useTabPath(tabId: string) {
 
 export function Tabs({ tabs }: { tabs: TabsState }) {
   return (
-    <div className="border-b shadow-b-xs pl-4 mt-2">
-      <nav className="flex gap-4 px-2 sm:px-0">
+    <div className="border-b shadow-b-xs pl-4 mt-2 overflow-x-auto">
+      <nav className="flex gap-4 px-2 sm:px-0 whitespace-nowrap">
         {tabs.tabs.map((tab) => (
           <TabItem key={tab.id} tab={tab} activeTab={tabs.active} />
         ))}


### PR DESCRIPTION
Now, tabs on the new profile page don't overflow the page in small screens.