### PR TITLE
fix: Tabs border-b looks good in both light and  dark theme

### DIFF
--- a/turboui/src/Tabs/index.tsx
+++ b/turboui/src/Tabs/index.tsx
@@ -50,7 +50,7 @@ function useTabPath(tabId: string) {
 
 export function Tabs({ tabs }: { tabs: TabsState }) {
   return (
-    <div className="border-b shadow-b-xs pl-4 mt-2 overflow-x-auto">
+    <div className="border-stroke-dimmed border-b shadow-b-xs pl-4 mt-2 overflow-x-auto">
       <nav className="flex gap-4 px-2 sm:px-0 whitespace-nowrap">
         {tabs.tabs.map((tab) => (
           <TabItem key={tab.id} tab={tab} activeTab={tabs.active} />


### PR DESCRIPTION
Now, the border-b in the Tabs component looks good in both the light and dark themes.