### PR TITLE
fix: Reset page state when navigating away

### DIFF
--- a/app/assets/js/pages/GoalV3Page/index.tsx
+++ b/app/assets/js/pages/GoalV3Page/index.tsx
@@ -259,7 +259,7 @@ function Page() {
     activityFeed: <GoalFeedItems goalId={goal.id!} />,
   };
 
-  return <GoalPage {...props} />;
+  return <GoalPage key={goal.id!} {...props} />;
 }
 
 function preparePerson(person: People.Person | null | undefined) {


### PR DESCRIPTION
e.g. if you click on "see parent goal", it will close the popup window from the previous page