### PR TITLE
fix: Don't include reviewer as contributor in Work Map query

### DIFF
--- a/app/lib/operately/work_maps/work_map.ex
+++ b/app/lib/operately/work_maps/work_map.ex
@@ -217,7 +217,8 @@ defmodule Operately.WorkMaps.WorkMap do
           :reviewer_id ->
             item.reviewer && item.reviewer.id == filter_value
           :contributor_id ->
-            item.contributor && item.contributor.id == filter_value
+            reviewer_id = get_project_reviewer_id(item.resource)
+            item.contributor && item.contributor.id == filter_value && reviewer_id != filter_value
         end
       end)
     end
@@ -264,4 +265,12 @@ defmodule Operately.WorkMaps.WorkMap do
       children ++ descendants
     end
   end
+
+  defp get_project_reviewer_id(%{ contributors: contributors }) do
+    Enum.find_value(contributors, fn
+      %{ role: :reviewer, person_id: person_id } -> person_id
+      _ -> nil
+    end)
+  end
+  defp get_project_reviewer_id(_), do: nil
 end

--- a/app/test/operately/work_maps/get_work_map_query_test.exs
+++ b/app/test/operately/work_maps/get_work_map_query_test.exs
@@ -427,6 +427,15 @@ defmodule Operately.WorkMaps.GetWorkMapQueryTest do
         }
       })
     end
+
+    test "does not return projects in which the contributor is the reviewer", ctx do
+      ctx = Factory.add_project(ctx, :project3, :space, reviewer: :contributor1)
+
+      {:ok, work_map} = GetWorkMapQuery.execute(:system, %{company_id: ctx.company.id, contributor_id: ctx.contributor1.id})
+      assert_work_map_structure(work_map, ctx, %{
+        project1: []
+      })
+    end
   end
 
   describe "functionality - execute/1 with deeply nested structure" do


### PR DESCRIPTION
When you included contributor in the Work Map query, project reviewers were being treated as contributors. This PR fixes this issue.