### PR TITLE
fix: Introduce usePaths hook

### DIFF
--- a/app/assets/js/components/AvatarLink/index.tsx
+++ b/app/assets/js/components/AvatarLink/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { Avatar, AvatarProps, DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
 
 interface AvatarLinkProps extends AvatarProps {
   className?: string;
@@ -9,7 +9,7 @@ interface AvatarLinkProps extends AvatarProps {
 
 export function AvatarLink({ className, ...props }: AvatarLinkProps) {
   return (
-    <DivLink to={Paths.profilePath(props.person!.id!)} className={className}>
+    <DivLink to={DeprecatedPaths.profilePath(props.person!.id!)} className={className}>
       <Avatar {...props} />
     </DivLink>
   );

--- a/app/assets/js/components/ContributorAvatar/index.tsx
+++ b/app/assets/js/components/ContributorAvatar/index.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Projects from "@/models/projects";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { ProjectContributor } from "@/models/projects";
 import { Tooltip } from "@/components/Tooltip";
-import { Paths } from "@/routes/paths";
+import { ProjectContributor } from "@/models/projects";
+import { DeprecatedPaths } from "@/routes/paths";
 import { DivLink } from "turboui";
 
-import { Avatar } from "turboui";
-import classNames from "classnames";
-import { TestableElement } from "@/utils/testid";
 import { useColorMode } from "@/contexts/ThemeContext";
+import { TestableElement } from "@/utils/testid";
+import classNames from "classnames";
+import { Avatar } from "turboui";
 
 type Size = "xs" | "md" | "base" | "lg";
 const DefaultSize: Size = "base";
@@ -74,7 +74,7 @@ function Placeholder(props: PlaceholderProps) {
     </div>
   );
 
-  const path = Paths.projectContributorsPath(props.project.id!);
+  const path = DeprecatedPaths.projectContributorsPath(props.project.id!);
 
   return (
     <Tooltip content={tooltipContent}>

--- a/app/assets/js/components/ProjectPageNavigation/index.tsx
+++ b/app/assets/js/components/ProjectPageNavigation/index.tsx
@@ -1,19 +1,19 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function ProjectPageNavigation({ project }) {
-  return <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name }]} />;
 }
 
 export function ProjectMilestonesNavigation({ project }: { project: Projects.Project }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.projectPath(project.id!), label: project.name! },
-        { to: Paths.projectMilestonesPath(project.id!), label: "Milestones" },
+        { to: DeprecatedPaths.projectPath(project.id!), label: project.name! },
+        { to: DeprecatedPaths.projectMilestonesPath(project.id!), label: "Milestones" },
       ]}
     />
   );
@@ -23,8 +23,8 @@ export function ProjectContribsSubpageNavigation({ project }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.projectPath(project.id!), label: project.name },
-        { to: Paths.projectContributorsPath(project.id!), label: "Team & Access" },
+        { to: DeprecatedPaths.projectPath(project.id!), label: project.name },
+        { to: DeprecatedPaths.projectContributorsPath(project.id!), label: "Team & Access" },
       ]}
     />
   );
@@ -34,8 +34,8 @@ export function ProjectRetrospectiveNavigation({ project }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.projectPath(project.id!), label: project.name },
-        { to: Paths.projectRetrospectivePath(project.id!), label: "Retrospective" },
+        { to: DeprecatedPaths.projectPath(project.id!), label: project.name },
+        { to: DeprecatedPaths.projectRetrospectivePath(project.id!), label: "Retrospective" },
       ]}
     />
   );

--- a/app/assets/js/components/SpacePageNavigation/index.tsx
+++ b/app/assets/js/components/SpacePageNavigation/index.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import * as Spaces from "@/models/spaces";
 import * as Paper from "@/components/PaperContainer";
+import * as Spaces from "@/models/spaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function SpacePageNavigation({ space }: { space: Spaces.Space }) {
-  return <Paper.Navigation items={[{ to: Paths.spacePath(space.id!), label: space.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.spacePath(space.id!), label: space.name! }]} />;
 }

--- a/app/assets/js/contexts/CurrentCompanyContext.tsx
+++ b/app/assets/js/contexts/CurrentCompanyContext.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { useProfileUpdatedSignal } from "@/signals";
 import { assertPresent } from "@/utils/assertions";
 import { throttle } from "@/utils/throttle";
-import { Paths } from "../routes/paths";
+import { DeprecatedPaths } from "../routes/paths";
 
 interface CurrentCompanyContextProps {
   me: People.Person | null;
@@ -61,7 +61,7 @@ export function useMentionedPersonLookupFn(): (
   return async (id: string) => {
     const person = ctx.people?.find((p) => p.id === id);
     if (person) {
-      return { ...person, profileLink: Paths.profilePath(person.id) };
+      return { ...person, profileLink: DeprecatedPaths.profilePath(person.id) };
     }
     ctx.peopleRefetch();
     return null;

--- a/app/assets/js/features/DiscussionForm/useForm.tsx
+++ b/app/assets/js/features/DiscussionForm/useForm.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import * as TipTapEditor from "@/components/Editor";
 import * as Discussions from "@/models/discussions";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
-import { useNavigate } from "react-router-dom";
-import { Paths } from "@/routes/paths";
-import { Subscriber } from "@/models/notifications";
 import { Options, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
+import { Subscriber } from "@/models/notifications";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigate } from "react-router-dom";
 
 interface UseFormOptions {
   mode: "create" | "edit";
@@ -77,7 +77,8 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
   const [saveChanges, saveChangesSubmitting] = useSaveChanges({ discussion, title, editor, validate });
   const [publishDraft, publishDraftSubmitting] = usePublishDraft({ discussion, title, editor, validate });
 
-  const cancelPath = mode === "edit" ? Paths.discussionPath(discussion?.id!) : Paths.spaceDiscussionsPath(space.id!);
+  const cancelPath =
+    mode === "edit" ? DeprecatedPaths.discussionPath(discussion?.id!) : DeprecatedPaths.spaceDiscussionsPath(space.id!);
 
   return {
     title,
@@ -125,7 +126,7 @@ function usePostMessage({ space, title, editor, subscriptionsState, validate }):
 
     setSubmitting(false);
 
-    navigate(Paths.discussionPath(res.discussion.id));
+    navigate(DeprecatedPaths.discussionPath(res.discussion.id));
 
     return true;
   };
@@ -155,7 +156,7 @@ function usePostAsDraft({ space, title, editor, subscriptionsState, validate }):
 
     setSubmitting(false);
 
-    navigate(Paths.discussionPath(res.discussion.id));
+    navigate(DeprecatedPaths.discussionPath(res.discussion.id));
 
     return true;
   };
@@ -181,7 +182,7 @@ function useSaveChanges({ discussion, title, editor, validate }): [() => Promise
 
     setSubmitting(false);
 
-    navigate(Paths.discussionPath(res.discussion.id));
+    navigate(DeprecatedPaths.discussionPath(res.discussion.id));
 
     return true;
   };
@@ -208,7 +209,7 @@ function usePublishDraft({ discussion, title, editor, validate }): [() => Promis
 
     setSubmitting(false);
 
-    navigate(Paths.discussionPath(res.discussion.id));
+    navigate(DeprecatedPaths.discussionPath(res.discussion.id));
 
     return true;
   };

--- a/app/assets/js/features/Feed/index.tsx
+++ b/app/assets/js/features/Feed/index.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
-import * as Time from "@/utils/time";
 import * as Activities from "@/models/activities";
+import * as Time from "@/utils/time";
+import * as React from "react";
 
 import { Activity } from "@/api";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { DeprecatedPaths } from "@/routes/paths";
 import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
 
-import { Avatar } from "turboui";
-import classNames from "classnames";
-import ActivityHandler, { DISPLAYED_IN_FEED } from "@/features/activities";
-import FormattedTime from "@/components/FormattedTime";
 import Api from "@/api";
+import FormattedTime from "@/components/FormattedTime";
+import ActivityHandler, { DISPLAYED_IN_FEED } from "@/features/activities";
+import classNames from "classnames";
+import { Avatar } from "turboui";
 
 type Page = "company" | "project" | "goal" | "space" | "profile";
 type ScopeType = "company" | "project" | "goal" | "space" | "person";
@@ -104,7 +104,7 @@ function ActivityItem({ activity, page }: { activity: Activities.Activity; page:
   const title = <ActivityHandler.FeedItemTitle activity={activity} page={page} />;
   const content = <ActivityHandler.FeedItemContent activity={activity} page={page} />;
   const alignement = ActivityHandler.feedItemAlignment(activity);
-  const profilePath = Paths.profilePath(author.id!);
+  const profilePath = DeprecatedPaths.profilePath(author.id!);
 
   return (
     <div className={classNames("flex flex-1 gap-3", alignement)}>

--- a/app/assets/js/features/Profile/PageHeader.tsx
+++ b/app/assets/js/features/Profile/PageHeader.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
 import * as Tabs from "@/components/Tabs";
+import * as React from "react";
 
 import { Person } from "@/models/people";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 import { Avatar } from "turboui";
 
@@ -26,8 +26,8 @@ export function PageHeader(props: PageHeaderProps) {
       </div>
 
       <Tabs.Root activeTab={props.activeTab}>
-        <Tabs.Tab id="about" title="About" linkTo={Paths.profilePath(props.person.id!)} />
-        <Tabs.Tab id="goals" title="Goals" linkTo={Paths.profileGoalsPath(props.person.id!)} />
+        <Tabs.Tab id="about" title="About" linkTo={DeprecatedPaths.profilePath(props.person.id!)} />
+        <Tabs.Tab id="goals" title="Goals" linkTo={DeprecatedPaths.profileGoalsPath(props.person.id!)} />
       </Tabs.Root>
     </div>
   );

--- a/app/assets/js/features/Profile/PageNavigation.tsx
+++ b/app/assets/js/features/Profile/PageNavigation.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function PageNavigation() {
-  return <Paper.Navigation items={[{ to: Paths.peoplePath(), label: "People" }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.peoplePath(), label: "People" }]} />;
 }

--- a/app/assets/js/features/ProjectListItem/index.tsx
+++ b/app/assets/js/features/ProjectListItem/index.tsx
@@ -1,17 +1,16 @@
-import * as React from "react";
 import * as Milestones from "@/models/milestones";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { Avatar } from "turboui";
-import classNames from "classnames";
 import FormattedTime from "@/components/FormattedTime";
+import classNames from "classnames";
+import { Avatar } from "turboui";
 
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
-import { PieChart } from "turboui";
 import { MilestoneIcon } from "@/components/MilestoneIcon";
-import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { PrivacyIndicator } from "@/features/Permissions";
+import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link, PieChart } from "turboui";
 
 interface ProjectListItemProps {
   project: Projects.Project;
@@ -40,7 +39,7 @@ export function ProjectListItem({ project, avatarPosition = "bottom", showSpace 
 }
 
 function ProjectNameLine({ project }) {
-  const path = Paths.projectPath(project.id);
+  const path = DeprecatedPaths.projectPath(project.id);
 
   return (
     <div className="font-extrabold flex items-center gap-2">
@@ -53,7 +52,6 @@ function ProjectNameLine({ project }) {
   );
 }
 
-
 function ProjectStatusLine({ project }: { project: Projects.Project }) {
   if (project.status === "closed") {
     return (
@@ -63,7 +61,7 @@ function ProjectStatusLine({ project }: { project: Projects.Project }) {
             Closed on <FormattedTime time={project.closedAt!} format="short-date" /> &middot;{" "}
           </>
         )}
-        <Link to={Paths.projectRetrospectivePath(project.id!)}>Read the retrospective</Link>
+        <Link to={DeprecatedPaths.projectRetrospectivePath(project.id!)}>Read the retrospective</Link>
       </div>
     );
   } else {
@@ -87,7 +85,7 @@ function MilestoneCompletion({ project }) {
 
   return (
     <div className="flex items-center gap-2 shrink-0">
-      <PieChart slices={[{percentage: percentage, color: "var(--color-accent-1)" }]} size={16} />
+      <PieChart slices={[{ percentage: percentage, color: "var(--color-accent-1)" }]} size={16} />
       {done.length}/{totalCount} completed
     </div>
   );

--- a/app/assets/js/features/ProjectRetrospective/useForm.tsx
+++ b/app/assets/js/features/ProjectRetrospective/useForm.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
-import * as Projects from "@/models/projects";
 import * as TipTapEditor from "@/components/Editor";
+import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { useNavigateTo } from "@/routes/useNavigateTo";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
-import { Paths } from "@/routes/paths";
-import { Subscriber } from "@/models/notifications";
 import { Options, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
+import { Subscriber } from "@/models/notifications";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigateTo } from "@/routes/useNavigateTo";
 
 interface Error {
   field: string;
@@ -47,8 +47,8 @@ export function useForm(options: FormOptions): FormState {
 
   const redirect = useNavigateTo(
     options.mode === "create"
-      ? Paths.projectPath(options.project.id!)
-      : Paths.projectRetrospectivePath(options.project.id!),
+      ? DeprecatedPaths.projectPath(options.project.id!)
+      : DeprecatedPaths.projectRetrospectivePath(options.project.id!),
   );
 
   const [post, { loading: posting }] = Projects.useCloseProject();

--- a/app/assets/js/features/ResourceHub/Drafts/ContinueEditingDrafts.tsx
+++ b/app/assets/js/features/ResourceHub/Drafts/ContinueEditingDrafts.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { ResourceHubNode } from "@/models/resourceHubs";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
 
 interface Props {
@@ -13,7 +13,7 @@ export function ContinueEditingDrafts({ resourceHubId, drafts }: Props) {
   if (drafts.length < 1) {
     return null;
   } else if (drafts.length === 1) {
-    const path = Paths.resourceHubEditDocumentPath(drafts[0]?.document?.id!);
+    const path = DeprecatedPaths.resourceHubEditDocumentPath(drafts[0]?.document?.id!);
 
     return (
       <div className="flex justify-center">
@@ -23,7 +23,7 @@ export function ContinueEditingDrafts({ resourceHubId, drafts }: Props) {
       </div>
     );
   } else {
-    const path = Paths.resourceHubDraftsPath(resourceHubId);
+    const path = DeprecatedPaths.resourceHubDraftsPath(resourceHubId);
 
     return (
       <div className="flex justify-center">

--- a/app/assets/js/features/ResourceHub/Navigation/NewResourcePageNavigation.tsx
+++ b/app/assets/js/features/ResourceHub/Navigation/NewResourcePageNavigation.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import * as Paper from "@/components/PaperContainer";
-import { Paths } from "@/routes/paths";
 import { ResourceHub, ResourceHubFolder } from "@/models/resourceHubs";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 
 interface Props {
@@ -14,8 +14,8 @@ export function NewResourcePageNavigation({ resourceHub, folder }: Props) {
   assertPresent(resourceHub.space, "space must be present in resourceHub");
 
   let items = [
-    { to: Paths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! },
-    { to: Paths.resourceHubPath(resourceHub.id!), label: resourceHub.name! },
+    { to: DeprecatedPaths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! },
+    { to: DeprecatedPaths.resourceHubPath(resourceHub.id!), label: resourceHub.name! },
   ];
 
   if (folder) {
@@ -29,7 +29,7 @@ function folderNavItems(folder: ResourceHubFolder) {
   assertPresent(folder.pathToFolder, "pathToFolder must be present in folder");
 
   return folder.pathToFolder.map((folder) => ({
-    to: Paths.resourceHubFolderPath(folder.id!),
+    to: DeprecatedPaths.resourceHubFolderPath(folder.id!),
     label: folder.name!,
   }));
 }

--- a/app/assets/js/features/ResourceHub/Navigation/ResourcePageNavigation.tsx
+++ b/app/assets/js/features/ResourceHub/Navigation/ResourcePageNavigation.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { assertPresent } from "@/utils/assertions";
 import { Resource } from "@/models/resourceHubs";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 
 export function ResourcePageNavigation({ resource }: { resource: Resource }) {
   assertPresent(resource.resourceHub, "resourceHub must be present in document");
@@ -11,13 +11,13 @@ export function ResourcePageNavigation({ resource }: { resource: Resource }) {
   const path = getPathToResource(resource);
 
   let items = [
-    { to: Paths.spacePath(resource.resourceHub.space.id!), label: resource.resourceHub.space.name! },
-    { to: Paths.resourceHubPath(resource.resourceHub.id!), label: resource.resourceHub.name! },
+    { to: DeprecatedPaths.spacePath(resource.resourceHub.space.id!), label: resource.resourceHub.space.name! },
+    { to: DeprecatedPaths.resourceHubPath(resource.resourceHub.id!), label: resource.resourceHub.name! },
   ];
 
   items = items.concat(
     path.map((folder) => ({
-      to: Paths.resourceHubFolderPath(folder.id!),
+      to: DeprecatedPaths.resourceHubFolderPath(folder.id!),
       label: folder.name!,
     })),
   );

--- a/app/assets/js/features/ResourceHub/components/CopyDocumentModal.tsx
+++ b/app/assets/js/features/ResourceHub/components/CopyDocumentModal.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import * as Hub from "@/models/resourceHubs";
 import Forms from "@/components/Forms";
-import { useNavigate } from "react-router-dom";
-import { assertPresent } from "@/utils/assertions";
 import { useSubscriptions } from "@/features/Subscriptions";
-import { Paths } from "@/routes/paths";
+import * as Hub from "@/models/resourceHubs";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { useNavigate } from "react-router-dom";
 import { CopyResourceModal } from "./CopyResource";
 
 interface FormProps {
@@ -46,7 +46,7 @@ export function CopyDocumentModal(props: FormProps) {
         copiedDocumentId: resource.id,
       });
 
-      navigate(Paths.resourceHubDocumentPath(res.document.id));
+      navigate(DeprecatedPaths.resourceHubDocumentPath(res.document.id));
     },
   });
 

--- a/app/assets/js/features/ResourceHub/components/CopyFolder.tsx
+++ b/app/assets/js/features/ResourceHub/components/CopyFolder.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { ResourceHubFolder, useCopyResourceHubFolder } from "@/models/resourceHubs";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 
 import { useNodesContext } from "../contexts/NodesContext";
@@ -42,7 +42,7 @@ export function CopyFolderModal(props: FormProps) {
         destParentFolderId: form.values.location.type == "folder" ? form.values.location.id : undefined,
       });
 
-      navigate(Paths.resourceHubFolderPath(res.folderId));
+      navigate(DeprecatedPaths.resourceHubFolderPath(res.folderId));
     },
   });
 

--- a/app/assets/js/features/ResourceHub/components/DocumentMenu.tsx
+++ b/app/assets/js/features/ResourceHub/components/DocumentMenu.tsx
@@ -2,15 +2,15 @@ import React from "react";
 
 import * as Hub from "@/models/resourceHubs";
 
-import { useBoolState } from "@/hooks/useBoolState";
-import { Menu, MenuLinkItem, MenuActionItem } from "turboui";
-import { Paths } from "@/routes/paths";
-import { createTestId } from "@/utils/testid";
 import { useNodesContext } from "@/features/ResourceHub";
-import { MoveResourceMenuItem, MoveResourceModal } from "./MoveResource";
-import { CopyResourceMenuItem } from "./CopyResource";
-import { CopyDocumentModal } from "./CopyDocumentModal";
+import { useBoolState } from "@/hooks/useBoolState";
+import { DeprecatedPaths } from "@/routes/paths";
 import { downloadMarkdown, exportToMarkdown } from "@/utils/markdown";
+import { createTestId } from "@/utils/testid";
+import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
+import { CopyDocumentModal } from "./CopyDocumentModal";
+import { CopyResourceMenuItem } from "./CopyResource";
+import { MoveResourceMenuItem, MoveResourceModal } from "./MoveResource";
 
 interface Props {
   document: Hub.ResourceHubDocument;
@@ -49,7 +49,7 @@ export function DocumentMenu({ document }: Props) {
 }
 
 function EditDocumentMenuItem({ document }: Props) {
-  const editPath = Paths.resourceHubEditDocumentPath(document.id!);
+  const editPath = DeprecatedPaths.resourceHubEditDocumentPath(document.id!);
   const editId = createTestId("edit", document.id!);
 
   return (

--- a/app/assets/js/features/ResourceHub/components/FileMenu.tsx
+++ b/app/assets/js/features/ResourceHub/components/FileMenu.tsx
@@ -4,13 +4,13 @@ import * as Hub from "@/models/resourceHubs";
 
 import { MoveResourceMenuItem, MoveResourceModal } from "./MoveResource";
 
-import { useBoolState } from "@/hooks/useBoolState";
-import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
-import { createTestId } from "@/utils/testid";
-import { assertPresent } from "@/utils/assertions";
-import { useDownloadFile } from "@/models/blobs";
 import { useNodesContext } from "@/features/ResourceHub";
-import { Paths } from "@/routes/paths";
+import { useBoolState } from "@/hooks/useBoolState";
+import { useDownloadFile } from "@/models/blobs";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { createTestId } from "@/utils/testid";
+import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
 
 interface Props {
   file: Hub.ResourceHubFile;
@@ -49,7 +49,7 @@ function DownloadFileMenuItem({ file }: Props) {
 }
 
 function EditFileMenuItem({ file }: Props) {
-  const editPath = Paths.resourceHubEditFilePath(file.id!);
+  const editPath = DeprecatedPaths.resourceHubEditFilePath(file.id!);
   const editId = createTestId("edit", file.id!);
 
   return (

--- a/app/assets/js/features/ResourceHub/components/LinkMenu.tsx
+++ b/app/assets/js/features/ResourceHub/components/LinkMenu.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 import * as Hub from "@/models/resourceHubs";
 
-import { useBoolState } from "@/hooks/useBoolState";
 import { useNodesContext } from "@/features/ResourceHub";
-import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
+import { useBoolState } from "@/hooks/useBoolState";
+import { DeprecatedPaths } from "@/routes/paths";
 import { createTestId } from "@/utils/testid";
-import { Paths } from "@/routes/paths";
+import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
 import { MoveResourceMenuItem, MoveResourceModal } from "./MoveResource";
 
 interface Props {
@@ -36,7 +36,7 @@ export function LinkMenu({ link }: Props) {
 }
 
 function EditLinkMenuItem({ link }: Props) {
-  const editPath = Paths.resourceHubEditLinkPath(link.id!);
+  const editPath = DeprecatedPaths.resourceHubEditLinkPath(link.id!);
   const editId = createTestId("edit", link.id!);
 
   return (

--- a/app/assets/js/features/ResourceHub/contexts/NewFileModalsContext.tsx
+++ b/app/assets/js/features/ResourceHub/contexts/NewFileModalsContext.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ResourceHub, ResourceHubFolder } from "@/models/resourceHubs";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 import { LinkOptions } from "@/features/ResourceHub";
-import { useAddFile, AddFileProps } from "../useAddFile";
+import { AddFileProps, useAddFile } from "../useAddFile";
 
 interface Props {
   children: NonNullable<React.ReactNode>;
@@ -29,11 +29,11 @@ export function NewFileModalsProvider({ children, resourceHub, folder }: Props) 
 
   const toggleShowAddFolder = () => setShowAddFolder(!showAddFolder);
   const navigateToNewDocument = () =>
-    navigate(Paths.resourceHubNewDocumentPath(resourceHub.id!, folder?.id || undefined));
+    navigate(DeprecatedPaths.resourceHubNewDocumentPath(resourceHub.id!, folder?.id || undefined));
 
   const navigateToNewLink = (type?: LinkOptions) => {
     navigate(
-      Paths.resourceHubNewLinkPath(resourceHub.id!, {
+      DeprecatedPaths.resourceHubNewLinkPath(resourceHub.id!, {
         folderId: folder?.id || undefined,
         type: type,
       }),

--- a/app/assets/js/features/ResourceHub/utils.tsx
+++ b/app/assets/js/features/ResourceHub/utils.tsx
@@ -1,6 +1,6 @@
 import { ResourceHubNode } from "@/models/resourceHubs";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 
 export type NodeType = "document" | "folder" | "file" | "link";
@@ -9,16 +9,16 @@ export function findPath(nodeType: NodeType, node: ResourceHubNode) {
   switch (nodeType) {
     case "document":
       assertPresent(node.document?.id, "document must be present in node");
-      return Paths.resourceHubDocumentPath(node.document.id);
+      return DeprecatedPaths.resourceHubDocumentPath(node.document.id);
     case "folder":
       assertPresent(node.folder?.id, "folder must be present in node");
-      return Paths.resourceHubFolderPath(node.folder.id);
+      return DeprecatedPaths.resourceHubFolderPath(node.folder.id);
     case "link":
       assertPresent(node.link?.id, "link must be present in node");
-      return Paths.resourceHubLinkPath(node.link.id);
+      return DeprecatedPaths.resourceHubLinkPath(node.link.id);
     case "file":
       assertPresent(node.file?.id, "file must be present in node");
-      return Paths.resourceHubFilePath(node.file.id);
+      return DeprecatedPaths.resourceHubFilePath(node.file.id);
   }
 }
 

--- a/app/assets/js/features/SpaceTools/Discussions.tsx
+++ b/app/assets/js/features/SpaceTools/Discussions.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { Space } from "@/models/spaces";
 import { Discussion } from "@/models/discussions";
-import { Paths } from "@/routes/paths";
+import { Space } from "@/models/spaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Container } from "./components";
-import { ZeroState } from "./Discussions/ZeroState";
 import { RegularState } from "./Discussions/RegularState";
+import { ZeroState } from "./Discussions/ZeroState";
 
 interface Props {
   space: Space;
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function Discussions(props: Props) {
-  const path = Paths.discussionsPath(props.space.id!);
+  const path = DeprecatedPaths.discussionsPath(props.space.id!);
   const isZeroState = props.discussions.length < 1;
 
   return (

--- a/app/assets/js/features/SpaceTools/GoalsAndProjects.tsx
+++ b/app/assets/js/features/SpaceTools/GoalsAndProjects.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-import { Space } from "@/models/spaces";
 import { Goal } from "@/models/goals";
 import { Project } from "@/models/projects";
-import { Paths } from "@/routes/paths";
+import { Space } from "@/models/spaces";
+import { DeprecatedPaths } from "@/routes/paths";
+import { match } from "ts-pattern";
 import { Container } from "./components";
-import { ZeroState } from "./GoalsAndProjects/ZeroState";
 import { AllDoneState } from "./GoalsAndProjects/AllDoneState";
 import { RegularState } from "./GoalsAndProjects/RegularState";
-import { match } from "ts-pattern";
+import { ZeroState } from "./GoalsAndProjects/ZeroState";
 
 interface Props {
   title: string;
@@ -21,7 +21,7 @@ export function GoalsAndProjects(props: Props) {
   const state = calculateState(props.goals, props.projects);
 
   return (
-    <Container path={Paths.spaceGoalsPath(props.space.id!)} testId="goals-and-projects">
+    <Container path={DeprecatedPaths.spaceGoalsPath(props.space.id!)} testId="goals-and-projects">
       {match(state)
         .with("zero", () => <ZeroState />)
         .with("all-done", () => <AllDoneState {...props} />)

--- a/app/assets/js/features/SpaceTools/ResourceHub.tsx
+++ b/app/assets/js/features/SpaceTools/ResourceHub.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as ResourceHubs from "@/models/resourceHubs";
+import * as React from "react";
 
 import { assertPresent } from "@/utils/assertions";
 import { createTestId } from "@/utils/testid";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Container } from "./components";
-import { ZeroState } from "./ResourceHubs/ZeroState";
 import { RegularState } from "./ResourceHubs/RegularState";
+import { ZeroState } from "./ResourceHubs/ZeroState";
 
 interface Props {
   resourceHub: ResourceHubs.ResourceHub;
@@ -17,7 +17,7 @@ export function ResourceHub(props: Props) {
   assertPresent(props.resourceHub.nodes, "nodes must be present in resourceHub");
 
   const testid = createTestId(props.resourceHub.name!);
-  const path = Paths.resourceHubPath(props.resourceHub.id!);
+  const path = DeprecatedPaths.resourceHubPath(props.resourceHub.id!);
   const isZeroState = props.resourceHub.nodes.length < 1;
 
   return (

--- a/app/assets/js/features/Tasks/TaskBoard.tsx
+++ b/app/assets/js/features/Tasks/TaskBoard.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import * as Tasks from "@/models/tasks";
+import * as React from "react";
 
 import { useIsDarkMode } from "@/contexts/ThemeContext";
-import { DivLink, AvatarList } from "turboui";
+import { DragAndDropProvider, useDraggable, useDraggingAnimation, useDropZone } from "@/features/DragAndDrop";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 import { insertAt } from "@/utils/array";
-import { DragAndDropProvider, useDraggable, useDropZone, useDraggingAnimation } from "@/features/DragAndDrop";
-import { Paths, compareIds } from "@/routes/paths";
 import { match } from "ts-pattern";
+import { AvatarList, DivLink } from "turboui";
 
 interface TaskBoardState {
   todoTasks: Tasks.Task[];
@@ -151,7 +151,7 @@ function TaskItem({
       <div className="my-1" style={isDragging ? {} : style} data-test-id={testId}>
         <DivLink
           className="text-sm bg-surface-base rounded p-2 border border-stroke-base flex items-start justify-between cursor-pointer"
-          to={Paths.taskPath(task.id!)}
+          to={DeprecatedPaths.taskPath(task.id!)}
         >
           <div className="font-medium">{task.name}</div>
           <AvatarList people={task.assignees!} size="tiny" stacked maxElements={5} />

--- a/app/assets/js/features/accounts/PageNavigation.tsx
+++ b/app/assets/js/features/accounts/PageNavigation.tsx
@@ -1,8 +1,8 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function PageNavigation() {
-  return <Paper.Navigation items={[{ to: Paths.accountPath(), label: "Account" }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.accountPath(), label: "Account" }]} />;
 }

--- a/app/assets/js/features/activities/CommentAdded/index.tsx
+++ b/app/assets/js/features/activities/CommentAdded/index.tsx
@@ -1,20 +1,20 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { ActivityHandler } from "../interfaces";
 import type {
   Activity,
   ActivityContentCommentAdded,
   ActivityContentGoalClosing,
   ActivityContentGoalDiscussionCreation,
-  ActivityContentGoalTimeframeEditing,
   ActivityContentGoalReopening,
+  ActivityContentGoalTimeframeEditing,
 } from "@/api";
+import type { ActivityHandler } from "../interfaces";
 
-import { match } from "ts-pattern";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { match } from "ts-pattern";
+import { Link } from "turboui";
 import { feedTitle, goalLink } from "../feedItemLinks";
 
 const CommentAdded: ActivityHandler = {
@@ -26,10 +26,10 @@ const CommentAdded: ActivityHandler = {
     const commentedActivity = content(activity).activity!;
 
     return match(commentedActivity.action)
-      .with("goal_timeframe_editing", () => Paths.goalActivityPath(commentedActivity.id!))
-      .with("goal_closing", () => Paths.goalActivityPath(commentedActivity.id!))
-      .with("goal_discussion_creation", () => Paths.goalActivityPath(commentedActivity.id!))
-      .with("goal_reopening", () => Paths.goalActivityPath(commentedActivity.id!))
+      .with("goal_timeframe_editing", () => DeprecatedPaths.goalActivityPath(commentedActivity.id!))
+      .with("goal_closing", () => DeprecatedPaths.goalActivityPath(commentedActivity.id!))
+      .with("goal_discussion_creation", () => DeprecatedPaths.goalActivityPath(commentedActivity.id!))
+      .with("goal_reopening", () => DeprecatedPaths.goalActivityPath(commentedActivity.id!))
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -54,7 +54,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_timeframe_editing", () => {
         const c = commentedActivity.content as ActivityContentGoalTimeframeEditing;
         const goal = c.goal!;
-        const path = Paths.goalActivityPath(commentedActivity.id!);
+        const path = DeprecatedPaths.goalActivityPath(commentedActivity.id!);
         const activityLink = <Link to={path}>timeframe change</Link>;
 
         if (page === "goal") {
@@ -66,7 +66,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_closing", () => {
         const c = commentedActivity.content as ActivityContentGoalClosing;
         const goal = c.goal!;
-        const path = Paths.goalActivityPath(commentedActivity.id!);
+        const path = DeprecatedPaths.goalActivityPath(commentedActivity.id!);
         const activityLink = <Link to={path}>goal closing</Link>;
 
         if (page === "goal") {
@@ -78,7 +78,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_discussion_creation", () => {
         const c = commentedActivity.content as ActivityContentGoalDiscussionCreation;
         const goal = c.goal!;
-        const path = Paths.goalActivityPath(commentedActivity.id!);
+        const path = DeprecatedPaths.goalActivityPath(commentedActivity.id!);
         const activityLink = <Link to={path}>{commentedActivity.commentThread!.title}</Link>;
 
         if (page === "goal") {
@@ -90,7 +90,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_reopening", () => {
         const c = commentedActivity.content as ActivityContentGoalReopening;
         const goal = c.goal!;
-        const path = Paths.goalActivityPath(commentedActivity.id!);
+        const path = DeprecatedPaths.goalActivityPath(commentedActivity.id!);
         const activityLink = <Link to={path}>goal reopening</Link>;
 
         if (page === "goal") {

--- a/app/assets/js/features/activities/CompanyAdminAdded/index.tsx
+++ b/app/assets/js/features/activities/CompanyAdminAdded/index.tsx
@@ -1,8 +1,8 @@
 import { Activity, ActivityContentCompanyAdminAdded } from "@/api";
-import { ActivityHandler } from "../interfaces";
-import { feedTitle } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 import { firstName, namesListToString } from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const CompanyAdminAdded: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -10,7 +10,7 @@ const CompanyAdminAdded: ActivityHandler = {
   },
 
   pagePath(): string {
-    return Paths.companyAdminPath();
+    return DeprecatedPaths.companyAdminPath();
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/CompanyAdminRemoved/index.tsx
+++ b/app/assets/js/features/activities/CompanyAdminRemoved/index.tsx
@@ -1,8 +1,8 @@
 import { Activity, ActivityContentCompanyAdminRemoved } from "@/api";
-import { ActivityHandler } from "../interfaces";
-import { feedTitle } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 import { firstName } from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const CompanyAdminRemoved: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -10,7 +10,7 @@ const CompanyAdminRemoved: ActivityHandler = {
   },
 
   pagePath(_activity: Activity) {
-    return Paths.companyAdminPath();
+    return DeprecatedPaths.companyAdminPath();
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/CompanyMemberRestoring/index.tsx
+++ b/app/assets/js/features/activities/CompanyMemberRestoring/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 import { feedTitle } from "../feedItemLinks";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentCompanyMemberRestoring } from "@/api";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
 
 const CompanyMemberRestoring: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const CompanyMemberRestoring: ActivityHandler = {
   },
 
   pagePath(_activity: Activity) {
-    return Paths.homePath();
+    return DeprecatedPaths.homePath();
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/CompanyOwnerRemoving/index.tsx
+++ b/app/assets/js/features/activities/CompanyOwnerRemoving/index.tsx
@@ -1,10 +1,10 @@
-import type { Activity } from "@/models/activities";
 import type { ActivityContentCompanyOwnerRemoving } from "@/api";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
 
-import { feedTitle } from "../feedItemLinks";
 import { firstName } from "@/models/people";
+import { feedTitle } from "../feedItemLinks";
 
 const CompanyOwnerRemoving: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const CompanyOwnerRemoving: ActivityHandler = {
   },
 
   pagePath(_activity: Activity) {
-    return Paths.companyAdminPath();
+    return DeprecatedPaths.companyAdminPath();
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/CompanyOwnersAdding/index.tsx
+++ b/app/assets/js/features/activities/CompanyOwnersAdding/index.tsx
@@ -1,10 +1,10 @@
 import { firstName, namesListToString } from "@/models/people";
 import { feedTitle } from "../feedItemLinks";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentCompanyOwnersAdding } from "@/api";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
 
 const CompanyOwnersAdding: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const CompanyOwnersAdding: ActivityHandler = {
   },
 
   pagePath(_activity: Activity) {
-    return Paths.companyAdminPath();
+    return DeprecatedPaths.companyAdminPath();
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/DiscussionCommentSubmitted/index.tsx
+++ b/app/assets/js/features/activities/DiscussionCommentSubmitted/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentDiscussionCommentSubmitted } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
 import React from "react";
 import { Link } from "turboui";
 import { feedTitle } from "../feedItemLinks";
@@ -16,7 +16,7 @@ const DiscussionCommentSubmitted: ActivityHandler = {
   },
 
   pagePath(_activity: Activity): string {
-    return Paths.discussionPath(content(_activity).discussion!.id!);
+    return DeprecatedPaths.discussionPath(content(_activity).discussion!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -35,7 +35,7 @@ const DiscussionCommentSubmitted: ActivityHandler = {
     const discussion = content(activity).discussion!;
     const space = content(activity).space!;
 
-    const path = Paths.discussionPath(discussion.id!);
+    const path = DeprecatedPaths.discussionPath(discussion.id!);
     const activityLink = <Link to={path}>{discussion.title}</Link>;
 
     if (page === "space") {

--- a/app/assets/js/features/activities/DiscussionPosting/index.tsx
+++ b/app/assets/js/features/activities/DiscussionPosting/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentDiscussionPosting } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
 import { feedTitle, spaceLink } from "./../feedItemLinks";
 
 const DiscussionPosting: ActivityHandler = {
@@ -16,7 +16,7 @@ const DiscussionPosting: ActivityHandler = {
   },
 
   pagePath(_activity: Activity): string {
-    return Paths.discussionPath(content(_activity).discussion!.id!);
+    return DeprecatedPaths.discussionPath(content(_activity).discussion!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -34,7 +34,7 @@ const DiscussionPosting: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const discussion = content(activity).discussion!;
 
-    const path = Paths.discussionPath(discussion.id!);
+    const path = DeprecatedPaths.discussionPath(discussion.id!);
     const link = <Link to={path}>{discussion.title!}</Link>;
 
     if (page === "space") {

--- a/app/assets/js/features/activities/GoalArchived/index.tsx
+++ b/app/assets/js/features/activities/GoalArchived/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentGoalArchived } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, goalLink } from "../feedItemLinks";
 
 const GoalArchived: ActivityHandler = {
@@ -13,7 +13,7 @@ const GoalArchived: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalPath(content(activity).goal!.id!);
+    return DeprecatedPaths.goalPath(content(activity).goal!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/GoalCheckIn/index.tsx
+++ b/app/assets/js/features/activities/GoalCheckIn/index.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import type { Activity } from "@/models/activities";
 import type { ActivityContentGoalCheckIn } from "@/api";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 
 import { ActivityHandler } from "../interfaces";
 
-import { Link } from "turboui";
-import { feedTitle, goalLink } from "../feedItemLinks";
 import { richContentToString } from "@/components/RichContent";
 import { truncateString } from "@/utils/strings";
 import { match } from "ts-pattern";
+import { Link } from "turboui";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 const GoalCheckIn: ActivityHandler = {
   pagePath(activity: Activity): string {
-    return Paths.goalCheckInPath(content(activity).update!.id!);
+    return DeprecatedPaths.goalCheckInPath(content(activity).update!.id!);
   },
 
   pageHtmlTitle(_activity: Activity): string {
@@ -55,7 +55,7 @@ const GoalCheckIn: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }) {
-    const path = Paths.goalCheckInPath(content(activity).update!.id!);
+    const path = DeprecatedPaths.goalCheckInPath(content(activity).update!.id!);
     const link = <Link to={path}>submitted a check-in</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalCheckInAcknowledgement/index.tsx
+++ b/app/assets/js/features/activities/GoalCheckInAcknowledgement/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentGoalCheckInAcknowledgement } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, goalLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 const GoalCheckInAcknowledgement: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const GoalCheckInAcknowledgement: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalCheckInPath(content(activity).update!.id!);
+    return DeprecatedPaths.goalCheckInPath(content(activity).update!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -34,7 +34,7 @@ const GoalCheckInAcknowledgement: ActivityHandler = {
     const goal = content(activity).goal!;
     const update = content(activity).update!;
 
-    const path = Paths.goalCheckInPath(update.id!);
+    const path = DeprecatedPaths.goalCheckInPath(update.id!);
     const link = <Link to={path}>Check-In</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalCheckInCommented/index.tsx
+++ b/app/assets/js/features/activities/GoalCheckInCommented/index.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentGoalCheckInCommented } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, goalLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { Link } from "turboui";
+import { feedTitle, goalLink } from "./../feedItemLinks";
 
 const GoalUpdateCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -17,7 +17,7 @@ const GoalUpdateCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalCheckInPath(content(activity).update?.id!);
+    return DeprecatedPaths.goalCheckInPath(content(activity).update?.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -39,7 +39,7 @@ const GoalUpdateCommented: ActivityHandler = {
     assertPresent(data.update, "Update must be present in activity content");
     assertPresent(data.update.id, "Update ID must be present in activity content");
 
-    const checkInPath = Paths.goalCheckInPath(data.update.id);
+    const checkInPath = DeprecatedPaths.goalCheckInPath(data.update.id);
     const checkInLink = <Link to={checkInPath}>Check-In</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalClosing/index.tsx
+++ b/app/assets/js/features/activities/GoalClosing/index.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import * as Icons from "@tabler/icons-react";
 
-import { Activity } from "@/models/activities";
 import { ActivityContentGoalClosing } from "@/api";
 import RichContent, { Summary } from "@/components/RichContent";
-import { Paths } from "@/routes/paths";
+import { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 
-import { ActivityHandler } from "../interfaces";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
-import { feedTitle, goalLink } from "../feedItemLinks";
 import { Link } from "turboui";
+import { feedTitle, goalLink } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const GoalClosing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -19,7 +19,7 @@ const GoalClosing: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalActivityPath(activity.id!);
+    return DeprecatedPaths.goalActivityPath(activity.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -65,7 +65,7 @@ const GoalClosing: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; content: any; page: any }) {
-    const path = Paths.goalActivityPath(activity.id!);
+    const path = DeprecatedPaths.goalActivityPath(activity.id!);
     const link = <Link to={path}>closed</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalCreated/index.tsx
+++ b/app/assets/js/features/activities/GoalCreated/index.tsx
@@ -1,12 +1,12 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentGoalCreated } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, goalLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { match } from "ts-pattern";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 const GoalCreated: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -14,7 +14,7 @@ const GoalCreated: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalPath(content(activity).goal!.id!);
+    return DeprecatedPaths.goalPath(content(activity).goal!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/GoalDiscussionCreation/index.tsx
+++ b/app/assets/js/features/activities/GoalDiscussionCreation/index.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-import * as People from "@/models/people";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as People from "@/models/people";
 import * as Icons from "@tabler/icons-react";
 
 import { Activity, ActivityContentGoalDiscussionCreation } from "@/api";
-import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import RichContent, { Summary } from "@/components/RichContent";
-import { Paths } from "@/routes/paths";
+import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
+import { DeprecatedPaths } from "@/routes/paths";
 
-import { ActivityHandler } from "../interfaces";
-import { Link } from "turboui";
 import { useMe } from "@/contexts/CurrentCompanyContext";
+import { Link } from "turboui";
+import { ActivityHandler } from "../interfaces";
 import { feedTitle, goalLink } from "./../feedItemLinks";
 
 const GoalDiscussionCreation: ActivityHandler = {
@@ -20,7 +20,7 @@ const GoalDiscussionCreation: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalActivityPath(activity.id!);
+    return DeprecatedPaths.goalActivityPath(activity.id!);
   },
 
   PageTitle({ activity }: { activity: Activity }) {
@@ -46,7 +46,7 @@ const GoalDiscussionCreation: ActivityHandler = {
           <PageOptions.Link
             icon={Icons.IconEdit}
             title="Edit"
-            to={Paths.goalDiscussionEditPath(activity.id!)}
+            to={DeprecatedPaths.goalDiscussionEditPath(activity.id!)}
             testId="edit"
           />
         )}
@@ -65,7 +65,7 @@ const GoalDiscussionCreation: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
-    const path = Paths.goalActivityPath(activity.id!);
+    const path = DeprecatedPaths.goalActivityPath(activity.id!);
     const link = <Link to={path}>{activity.commentThread!.title}</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalEditing/index.tsx
+++ b/app/assets/js/features/activities/GoalEditing/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
-import * as Timeframes from "@/utils/timeframes";
 import * as People from "@/models/people";
+import * as Timeframes from "@/utils/timeframes";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentGoalEditing } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths, compareIds } from "@/routes/paths";
-import { goalLink, feedTitle } from "../feedItemLinks";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 const GoalEditing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const GoalEditing: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalPath(content(activity).goal!.id!);
+    return DeprecatedPaths.goalPath(content(activity).goal!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/GoalReopening/index.tsx
+++ b/app/assets/js/features/activities/GoalReopening/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import { Activity, ActivityContentGoalClosing } from "@/api";
-import { Paths } from "@/routes/paths";
-import { ActivityHandler } from "../interfaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
+import { ActivityHandler } from "../interfaces";
 
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
-import { goalLink, feedTitle } from "../feedItemLinks";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 import RichContent, { Summary } from "@/components/RichContent";
 
@@ -17,7 +17,7 @@ const GoalClosing: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.goalActivityPath(activity.id!);
+    return DeprecatedPaths.goalActivityPath(activity.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -39,7 +39,7 @@ const GoalClosing: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; content: any; page: any }) {
-    const path = Paths.goalActivityPath(activity.id!);
+    const path = DeprecatedPaths.goalActivityPath(activity.id!);
     const link = <Link to={path}>reopened</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/GoalReparent/index.tsx
+++ b/app/assets/js/features/activities/GoalReparent/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
 import { Activity, ActivityContentGoalReparent } from "@/api";
-import { Paths } from "@/routes/paths";
-import { ActivityHandler } from "../interfaces";
-import { goalLink, feedTitle } from "../feedItemLinks";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { feedTitle, goalLink } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const GoalReparent: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const GoalReparent: ActivityHandler = {
     const data = content(activity);
     assertPresent(data.goal?.id, "goal.id must be present in activity");
 
-    return Paths.goalPath(data.goal.id);
+    return DeprecatedPaths.goalPath(data.goal.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/GoalTimeframeEditing/index.tsx
+++ b/app/assets/js/features/activities/GoalTimeframeEditing/index.tsx
@@ -1,19 +1,19 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import * as Timeframes from "@/utils/timeframes";
 import * as Icons from "@tabler/icons-react";
 
-import { goalLink, feedTitle } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Activity, ActivityContentGoalTimeframeEditing } from "@/api";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
+import { feedTitle, goalLink } from "../feedItemLinks";
 
 import RichContent from "@/components/RichContent";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
+import { assertPresent } from "@/utils/assertions";
 import { ActivityHandler } from "../interfaces";
 import { TimeframeEdited } from "./TimeframeEdited";
-import { assertPresent } from "@/utils/assertions";
 
 const GoalTimeframeEditing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -21,7 +21,7 @@ const GoalTimeframeEditing: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.goalActivityPath(activity.id!);
+    return DeprecatedPaths.goalActivityPath(activity.id!);
   },
 
   PageTitle({ activity }) {
@@ -68,7 +68,7 @@ const GoalTimeframeEditing: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }) {
-    const path = Paths.goalActivityPath(activity.id!);
+    const path = DeprecatedPaths.goalActivityPath(activity.id!);
     const activityLink = <Link to={path}>{extendedOrShortened(activity)} the timeframe</Link>;
 
     if (page === "goal") {

--- a/app/assets/js/features/activities/MessageArchiving/index.tsx
+++ b/app/assets/js/features/activities/MessageArchiving/index.tsx
@@ -1,10 +1,10 @@
-import type { Activity } from "@/models/activities";
 import type { ActivityContentMessageArchiving } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import React from "react";
 import { Link } from "react-router-dom";
 import { feedTitle } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const MessageArchiving: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -30,7 +30,7 @@ const MessageArchiving: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const title = content(activity).title!;
     const space = content(activity).space!;
-    const spaceLink = <Link to={Paths.spacePath(space.id!)}>{space.name!}</Link>;
+    const spaceLink = <Link to={DeprecatedPaths.spacePath(space.id!)}>{space.name!}</Link>;
 
     if (page === "space") {
       return feedTitle(activity, "deleted:", title);

--- a/app/assets/js/features/activities/ProjectArchived/index.tsx
+++ b/app/assets/js/features/activities/ProjectArchived/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectArchived } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { projectLink, feedTitle } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, projectLink } from "../feedItemLinks";
 
 const ProjectArchived: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectArchived: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectCheckInAcknowledged/index.tsx
+++ b/app/assets/js/features/activities/ProjectCheckInAcknowledged/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectCheckInAcknowledged } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
 
 const ProjectCheckInAcknowledged: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ProjectCheckInAcknowledged: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectCheckInPath(content(activity).checkIn!.id!);
+    return DeprecatedPaths.projectCheckInPath(content(activity).checkIn!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -34,7 +34,7 @@ const ProjectCheckInAcknowledged: ActivityHandler = {
     const project = content(activity).project!;
     const checkIn = content(activity).checkIn!;
 
-    const checkInPath = Paths.projectCheckInPath(checkIn.id!);
+    const checkInPath = DeprecatedPaths.projectCheckInPath(checkIn.id!);
     const checkInLink = <Link to={checkInPath}>Check-In</Link>;
 
     if (page === "project") {

--- a/app/assets/js/features/activities/ProjectCheckInCommented/index.tsx
+++ b/app/assets/js/features/activities/ProjectCheckInCommented/index.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectCheckInCommented } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
 
 const ProjectCheckInCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -16,7 +16,7 @@ const ProjectCheckInCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectCheckInPath(content(activity).checkIn!.id!);
+    return DeprecatedPaths.projectCheckInPath(content(activity).checkIn!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -35,7 +35,7 @@ const ProjectCheckInCommented: ActivityHandler = {
     const project = content(activity).project!;
     const checkIn = content(activity).checkIn!;
 
-    const checkInPath = Paths.projectCheckInPath(checkIn.id!);
+    const checkInPath = DeprecatedPaths.projectCheckInPath(checkIn.id!);
     const checkInLink = <Link to={checkInPath}>Check-In</Link>;
 
     if (page === "project") {

--- a/app/assets/js/features/activities/ProjectCheckInSubmitted/index.tsx
+++ b/app/assets/js/features/activities/ProjectCheckInSubmitted/index.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectCheckInSubmitted } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
 import { SmallStatusIndicator } from "@/components/status";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
 
 const ProjectCheckInSubmitted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -17,7 +17,7 @@ const ProjectCheckInSubmitted: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectCheckInPath(content(activity).checkIn!.id!);
+    return DeprecatedPaths.projectCheckInPath(content(activity).checkIn!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -36,7 +36,7 @@ const ProjectCheckInSubmitted: ActivityHandler = {
     const project = content(activity).project!;
     const checkIn = content(activity).checkIn!;
 
-    const checkInPath = Paths.projectCheckInPath(checkIn.id!);
+    const checkInPath = DeprecatedPaths.projectCheckInPath(checkIn.id!);
     const checkInLink = <Link to={checkInPath}>Check-In</Link>;
 
     if (page === "project") {

--- a/app/assets/js/features/activities/ProjectClosed/index.tsx
+++ b/app/assets/js/features/activities/ProjectClosed/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectClosed } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { projectLink, feedTitle } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
+import { feedTitle, projectLink } from "../feedItemLinks";
 
 const ProjectClosed: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ProjectClosed: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectRetrospectivePath(content(activity).project!.id!);
+    return DeprecatedPaths.projectRetrospectivePath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -32,7 +32,7 @@ const ProjectClosed: ActivityHandler = {
 
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const retroId = content(activity).project!.id!;
-    const retroPath = Paths.projectRetrospectivePath(retroId!);
+    const retroPath = DeprecatedPaths.projectRetrospectivePath(retroId!);
     const retroLink = <Link to={retroPath}>retrospective</Link>;
     const project = projectLink(content(activity).project!);
 

--- a/app/assets/js/features/activities/ProjectContributorAddition/index.tsx
+++ b/app/assets/js/features/activities/ProjectContributorAddition/index.tsx
@@ -4,8 +4,8 @@ import type { ActivityContentProjectContributorAddition } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectContributorAddition: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectContributorAddition: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectContributorEdited/index.tsx
+++ b/app/assets/js/features/activities/ProjectContributorEdited/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectContributorEdited } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths, compareIds } from "@/routes/paths";
 import { accessLevelAsString } from "@/features/Permissions";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
+import { feedTitle, projectLink } from "../feedItemLinks";
 
 const ProjectContributorEdited: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ProjectContributorEdited: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectContributorRemoved/index.tsx
+++ b/app/assets/js/features/activities/ProjectContributorRemoved/index.tsx
@@ -4,8 +4,8 @@ import type { ActivityContentProjectContributorRemoved } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectContributorRemoved: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectContributorRemoved: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectContributorsAddition/index.tsx
+++ b/app/assets/js/features/activities/ProjectContributorsAddition/index.tsx
@@ -1,13 +1,13 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
 import type { ActivityContentProjectContributorsAddition } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Avatar } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
 
 const ProjectContributorsAddition: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ProjectContributorsAddition: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectCreated/index.tsx
+++ b/app/assets/js/features/activities/ProjectCreated/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectCreated } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectCreated: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectCreated: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectGoalConnection/index.tsx
+++ b/app/assets/js/features/activities/ProjectGoalConnection/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectGoalConnection } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink, goalLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, goalLink, projectLink } from "../feedItemLinks";
 
 const ProjectGoalConnection: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectGoalConnection: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectGoalDisconnection/index.tsx
+++ b/app/assets/js/features/activities/ProjectGoalDisconnection/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectGoalDisconnection } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink, goalLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, goalLink, projectLink } from "../feedItemLinks";
 
 const ProjectGoalDisconnection: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectGoalDisconnection: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectKeyResourceAdded/index.tsx
+++ b/app/assets/js/features/activities/ProjectKeyResourceAdded/index.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import * as People from "@/models/people";
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectKeyResourceAdded } from "@/api";
+import type { Activity } from "@/models/activities";
+import * as People from "@/models/people";
+import React from "react";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectKeyResourceAdded: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectKeyResourceAdded: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectKeyResourceDeleted/index.tsx
+++ b/app/assets/js/features/activities/ProjectKeyResourceDeleted/index.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import * as People from "@/models/people";
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectKeyResourceDeleted } from "@/api";
+import type { Activity } from "@/models/activities";
+import * as People from "@/models/people";
+import React from "react";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectKeyResourceAdded: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ProjectKeyResourceAdded: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectMilestoneCommented/index.tsx
+++ b/app/assets/js/features/activities/ProjectMilestoneCommented/index.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectMilestoneCommented } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectMilestoneCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -16,7 +16,7 @@ const ProjectMilestoneCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectMilestonePath(content(activity).milestone!.id!);
+    return DeprecatedPaths.projectMilestonePath(content(activity).milestone!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -34,7 +34,7 @@ const ProjectMilestoneCommented: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const project = content(activity).project!;
     const milestone = content(activity).milestone!;
-    const path = Paths.projectMilestonePath(milestone.id!);
+    const path = DeprecatedPaths.projectMilestonePath(milestone.id!);
     const link = <Link to={path}>{milestone!.title!}</Link>;
     const what = didWhat(content(activity).commentAction!);
 

--- a/app/assets/js/features/activities/ProjectMoved/index.tsx
+++ b/app/assets/js/features/activities/ProjectMoved/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectMoved } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "../feedItemLinks";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
+import { feedTitle, projectLink } from "../feedItemLinks";
 
 const ProjectMoved: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ProjectMoved: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -42,8 +42,8 @@ const ProjectMoved: ActivityHandler = {
     const oldSpace = content(activity).oldSpace!;
     const newSpace = content(activity).newSpace!;
 
-    const oldSpacePath = Paths.spacePath(oldSpace.id!);
-    const newSpacePath = Paths.spacePath(newSpace.id!);
+    const oldSpacePath = DeprecatedPaths.spacePath(oldSpace.id!);
+    const newSpacePath = DeprecatedPaths.spacePath(newSpace.id!);
 
     const oldLink = <Link to={oldSpacePath}>{oldSpace.name}</Link>;
     const newLink = <Link to={newSpacePath}>{newSpace.name}</Link>;

--- a/app/assets/js/features/activities/ProjectPausing/index.tsx
+++ b/app/assets/js/features/activities/ProjectPausing/index.tsx
@@ -1,10 +1,10 @@
-import * as People from "@/models/people";
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectPausing } from "@/api";
+import type { Activity } from "@/models/activities";
+import * as People from "@/models/people";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectPausing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ProjectPausing: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectRenamed/index.tsx
+++ b/app/assets/js/features/activities/ProjectRenamed/index.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectRenamed } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
 const ProjectRenamed: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -14,7 +14,7 @@ const ProjectRenamed: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectResuming/index.tsx
+++ b/app/assets/js/features/activities/ProjectResuming/index.tsx
@@ -1,9 +1,9 @@
 import * as People from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, projectLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectResuming } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
 const ProjectResuming: ActivityHandler = {
@@ -12,7 +12,7 @@ const ProjectResuming: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectRetrospectiveCommented/index.tsx
+++ b/app/assets/js/features/activities/ProjectRetrospectiveCommented/index.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
 import type { ActivityContentProjectRetrospectiveCommented } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { feedTitle, projectLink } from "./../feedItemLinks";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
 
 const ProjectRetrospectiveCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -16,7 +16,7 @@ const ProjectRetrospectiveCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectRetrospectivePath(content(activity).projectId!);
+    return DeprecatedPaths.projectRetrospectivePath(content(activity).projectId!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -34,7 +34,7 @@ const ProjectRetrospectiveCommented: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
     const project = content(activity).project!;
 
-    const retrospectivePath = Paths.projectRetrospectivePath(project.id!);
+    const retrospectivePath = DeprecatedPaths.projectRetrospectivePath(project.id!);
     const retrospectiveLink = <Link to={retrospectivePath}>Retrospective</Link>;
 
     if (page === "project") {

--- a/app/assets/js/features/activities/ProjectTimelineEdited/index.tsx
+++ b/app/assets/js/features/activities/ProjectTimelineEdited/index.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
-import * as Time from "@/utils/time";
 import * as Milestones from "@/models/milestones";
-import * as Icons from "@tabler/icons-react";
 import * as People from "@/models/people";
+import * as Time from "@/utils/time";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
 import { feedTitle, projectLink } from "../feedItemLinks";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentProjectTimelineEdited } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
 const ProjectTimelineEdited: ActivityHandler = {
@@ -20,7 +20,7 @@ const ProjectTimelineEdited: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.projectPath(content(activity).project!.id!);
+    return DeprecatedPaths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {
@@ -159,7 +159,7 @@ function UpdatedMilestones({ content }: { content: Content }) {
 }
 
 function MilestoneLink({ milestone }: { milestone: Milestones.Milestone }) {
-  const path = Paths.projectMilestonePath(milestone.id!);
+  const path = DeprecatedPaths.projectMilestonePath(milestone.id!);
   const title = milestone.title;
 
   return (

--- a/app/assets/js/features/activities/ResourceHubDocumentCommented/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubDocumentCommented/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubDocumentCommented } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
 import React from "react";
 import { documentLink, feedTitle, spaceLink } from "../feedItemLinks";
 
@@ -15,7 +15,7 @@ const ResourceHubDocumentCommented: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.resourceHubDocumentPath(content(activity).document!.id!);
+    return DeprecatedPaths.resourceHubDocumentPath(content(activity).document!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubDocumentCreated/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubDocumentCreated/index.tsx
@@ -1,11 +1,11 @@
-import React from "react";
-import * as People from "@/models/people";
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubDocumentCreated } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
-import { documentLink, feedTitle, spaceLink } from "../feedItemLinks";
 import { Summary } from "@/components/RichContent";
+import type { Activity } from "@/models/activities";
+import * as People from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
+import React from "react";
+import { documentLink, feedTitle, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubDocumentCreating: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ResourceHubDocumentCreating: ActivityHandler = {
   },
 
   pagePath(_activity: Activity): string {
-    return Paths.resourceHubDocumentPath(content(_activity).document!.id!);
+    return DeprecatedPaths.resourceHubDocumentPath(content(_activity).document!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubDocumentDeleted/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubDocumentDeleted/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubDocumentDeleted } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubDocumentDeleted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ResourceHubDocumentDeleted: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+    return DeprecatedPaths.resourceHubPath(content(activity).resourceHub!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubDocumentEdited/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubDocumentEdited/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubDocumentEdited } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { documentLink, feedTitle, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubDocumentEdited: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ResourceHubDocumentEdited: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubDocumentPath(content(activity).document!.id!);
+    return DeprecatedPaths.resourceHubDocumentPath(content(activity).document!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFileCommented/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFileCommented/index.tsx
@@ -1,14 +1,14 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFileCommented } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 import React from "react";
 import { feedTitle, fileLink, spaceLink } from "../feedItemLinks";
-import { assertPresent } from "@/utils/assertions";
 
 const ResourceHubFileCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -19,7 +19,7 @@ const ResourceHubFileCommented: ActivityHandler = {
     const data = content(activity);
     assertPresent(data.file?.id, "file must be present in activity");
 
-    return Paths.resourceHubFilePath(data.file.id);
+    return DeprecatedPaths.resourceHubFilePath(data.file.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFileCreated/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFileCreated/index.tsx
@@ -1,13 +1,13 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFileCreated } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 import { Link } from "turboui";
 import { feedTitle, fileLink, resourceHubLink, spaceLink } from "../feedItemLinks";
-import { assertPresent } from "@/utils/assertions";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubFileCreated: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -21,9 +21,9 @@ const ResourceHubFileCreated: ActivityHandler = {
     assertPresent(data.resourceHub?.id, "resourceHub must be present in FileCreated activity");
 
     if (data.files.length === 1 && data.files[0]) {
-      return Paths.resourceHubFilePath(data.files[0].id!);
+      return DeprecatedPaths.resourceHubFilePath(data.files[0].id!);
     } else {
-      return Paths.resourceHubPath(data.resourceHub.id);
+      return DeprecatedPaths.resourceHubPath(data.resourceHub.id);
     }
   },
 
@@ -76,7 +76,7 @@ const ResourceHubFileCreated: ActivityHandler = {
             assertPresent(file.id, "id must be present in file");
             assertPresent(file.name, "name must be present in file");
 
-            const path = Paths.resourceHubFilePath(file.id);
+            const path = DeprecatedPaths.resourceHubFilePath(file.id);
             const name = file.name;
 
             return (

--- a/app/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFileDeleted/index.tsx
@@ -1,11 +1,11 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFileDeleted } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
-import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubFileDeleted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -16,7 +16,7 @@ const ResourceHubFileDeleted: ActivityHandler = {
     const data = content(activity);
     assertPresent(data.resourceHub?.id, "resourceHub must be present in activity");
 
-    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+    return DeprecatedPaths.resourceHubPath(content(activity).resourceHub!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFileEdited/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFileEdited/index.tsx
@@ -1,12 +1,12 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFileEdited } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
-import { feedTitle, fileLink, spaceLink } from "../feedItemLinks";
 import { Summary } from "@/components/RichContent";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, fileLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubFileEdited: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -15,7 +15,7 @@ const ResourceHubFileEdited: ActivityHandler = {
 
   pagePath(activity: Activity) {
     const file = content(activity).file!;
-    return Paths.resourceHubFilePath(file.id!);
+    return DeprecatedPaths.resourceHubFilePath(file.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFolderCopied/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFolderCopied/index.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFolderCopied } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { feedTitle, folderLink, spaceLink } from "../feedItemLinks";
 
@@ -18,7 +18,7 @@ const ResourceHubFolderCopied: ActivityHandler = {
     const folder = content(activity).folder;
     assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderCreated activity content");
 
-    return Paths.resourceHubFolderPath(folder.id);
+    return DeprecatedPaths.resourceHubFolderPath(folder.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFolderCreated/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFolderCreated/index.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFolderCreated } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { feedTitle, folderLink, spaceLink } from "../feedItemLinks";
 
@@ -18,7 +18,7 @@ const ResourceHubFolderCreated: ActivityHandler = {
     const folder = content(activity).folder;
     assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderCreated activity content");
 
-    return Paths.resourceHubFolderPath(folder.id);
+    return DeprecatedPaths.resourceHubFolderPath(folder.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFolderDeleted/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFolderDeleted/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFolderDeleted } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubFolderDeleted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ResourceHubFolderDeleted: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+    return DeprecatedPaths.resourceHubPath(content(activity).resourceHub!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubFolderRenamed/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubFolderRenamed/index.tsx
@@ -1,12 +1,12 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubFolderRenamed } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { feedTitle, folderLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubFolderRenamed: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -17,7 +17,7 @@ const ResourceHubFolderRenamed: ActivityHandler = {
     const folder = content(activity).folder;
     assertPresent(folder?.id, "folder.id must be present in ResourceHubFolderRenamed activity content");
 
-    return Paths.resourceHubFolderPath(folder.id);
+    return DeprecatedPaths.resourceHubFolderPath(folder.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubLinkCommented/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubLinkCommented/index.tsx
@@ -1,14 +1,14 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubLinkCommented } from "@/api";
+import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
-import { feedTitle, linkLink, spaceLink } from "../feedItemLinks";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { feedTitle, linkLink, spaceLink } from "../feedItemLinks";
 
 const ResourceHubLinkCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -19,7 +19,7 @@ const ResourceHubLinkCommented: ActivityHandler = {
     const data = content(activity);
     assertPresent(data.link?.id, "link.id must be present in activity");
 
-    return Paths.resourceHubLinkPath(data.link.id);
+    return DeprecatedPaths.resourceHubLinkPath(data.link.id);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubLinkCreated/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubLinkCreated/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubLinkCreated } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, linkLink, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubLinkCreated: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ResourceHubLinkCreated: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubLinkPath(content(activity).link?.id!);
+    return DeprecatedPaths.resourceHubLinkPath(content(activity).link?.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubLinkDeleted/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubLinkDeleted/index.tsx
@@ -1,10 +1,10 @@
 import * as People from "@/models/people";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubLinkDeleted } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, resourceHubLink, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubLinkDeleted: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -12,7 +12,7 @@ const ResourceHubLinkDeleted: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubPath(content(activity).resourceHub!.id!);
+    return DeprecatedPaths.resourceHubPath(content(activity).resourceHub!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ResourceHubLinkEdited/index.tsx
+++ b/app/assets/js/features/activities/ResourceHubLinkEdited/index.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import * as People from "@/models/people";
+import React from "react";
 
-import type { Activity } from "@/models/activities";
 import type { ActivityContentResourceHubLinkEdited } from "@/api";
-import type { ActivityHandler } from "../interfaces";
-import { Paths } from "@/routes/paths";
+import type { Activity } from "@/models/activities";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, spaceLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
 
 const ResourceHubLinkEdited: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -13,7 +13,7 @@ const ResourceHubLinkEdited: ActivityHandler = {
   },
 
   pagePath(activity: Activity) {
-    return Paths.resourceHubLinkPath(content(activity).link!.id!);
+    return DeprecatedPaths.resourceHubLinkPath(content(activity).link!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/SpaceAdded/index.tsx
+++ b/app/assets/js/features/activities/SpaceAdded/index.tsx
@@ -1,7 +1,7 @@
 import { Activity, ActivityContentSpaceAdded } from "@/api";
-import { ActivityHandler } from "../interfaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, spaceLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { ActivityHandler } from "../interfaces";
 
 const SpaceAdded: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -9,7 +9,7 @@ const SpaceAdded: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.spacePath(content(activity).space!.id!);
+    return DeprecatedPaths.spacePath(content(activity).space!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/SpaceJoining/index.tsx
+++ b/app/assets/js/features/activities/SpaceJoining/index.tsx
@@ -1,7 +1,7 @@
 import { Activity, ActivityContentSpaceJoining } from "@/api";
-import { ActivityHandler } from "../interfaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { feedTitle, spaceLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
+import { ActivityHandler } from "../interfaces";
 
 const SpaceJoining: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -9,7 +9,7 @@ const SpaceJoining: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.spacePath(content(activity).space!.id!);
+    return DeprecatedPaths.spacePath(content(activity).space!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/SpaceMemberRemoved/index.tsx
+++ b/app/assets/js/features/activities/SpaceMemberRemoved/index.tsx
@@ -1,8 +1,8 @@
 import { Activity, ActivityContentSpaceMemberRemoved } from "@/api";
-import { ActivityHandler } from "../interfaces";
-import { feedTitle, spaceLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 import { shortName } from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const SpaceMemberRemoved: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -10,7 +10,7 @@ const SpaceMemberRemoved: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.spacePath(content(activity).space!.id!);
+    return DeprecatedPaths.spacePath(content(activity).space!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/SpaceMembersAdded/index.tsx
+++ b/app/assets/js/features/activities/SpaceMembersAdded/index.tsx
@@ -1,8 +1,8 @@
 import { Activity, ActivityContentSpaceMembersAdded } from "@/api";
-import { ActivityHandler } from "../interfaces";
-import { feedTitle, spaceLink } from "../feedItemLinks";
-import { Paths } from "@/routes/paths";
 import { firstName, namesListToString } from "@/models/people";
+import { DeprecatedPaths } from "@/routes/paths";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+import { ActivityHandler } from "../interfaces";
 
 const SpaceMembersAdded: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -10,7 +10,7 @@ const SpaceMembersAdded: ActivityHandler = {
   },
 
   pagePath(activity: Activity): string {
-    return Paths.spacePath(content(activity).space!.id!);
+    return DeprecatedPaths.spacePath(content(activity).space!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/feedItemLinks.tsx
+++ b/app/assets/js/features/activities/feedItemLinks.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Link } from "turboui";
 
 import * as api from "@/api";
@@ -18,56 +18,56 @@ export const feedTitle = (activity: api.Activity, ...rest: (string | JSX.Element
 };
 
 export const projectLink = (project: api.Project) => {
-  const path = Paths.projectPath(project!.id!);
+  const path = DeprecatedPaths.projectPath(project!.id!);
   const name = project!.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const goalLink = (goal: api.Goal) => {
-  const path = Paths.goalPath(goal!.id!);
+  const path = DeprecatedPaths.goalPath(goal!.id!);
   const name = goal!.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const spaceLink = (space: api.Space) => {
-  const path = Paths.spacePath(space!.id!);
+  const path = DeprecatedPaths.spacePath(space!.id!);
   const name = space!.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const resourceHubLink = (hub: api.ResourceHub) => {
-  const path = Paths.resourceHubPath(hub.id!);
+  const path = DeprecatedPaths.resourceHubPath(hub.id!);
   const name = hub.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const documentLink = (document: api.ResourceHubDocument) => {
-  const path = Paths.resourceHubDocumentPath(document.id!);
+  const path = DeprecatedPaths.resourceHubDocumentPath(document.id!);
   const name = document.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const fileLink = (file: api.ResourceHubFile) => {
-  const path = Paths.resourceHubFilePath(file.id!);
+  const path = DeprecatedPaths.resourceHubFilePath(file.id!);
   const name = file.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const folderLink = (folder: api.ResourceHubFolder) => {
-  const path = Paths.resourceHubFolderPath(folder.id!);
+  const path = DeprecatedPaths.resourceHubFolderPath(folder.id!);
   const name = folder.name!;
 
   return <Link to={path}>{name}</Link>;
 };
 
 export const linkLink = (link: api.ResourceHubLink) => {
-  const path = Paths.resourceHubLinkPath(link.id!);
+  const path = DeprecatedPaths.resourceHubLinkPath(link.id!);
   const name = link.name!;
 
   return <Link to={path}>{name}</Link>;

--- a/app/assets/js/features/goals/GoalCheckIn/LastCheckInMessage.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/LastCheckInMessage.tsx
@@ -1,19 +1,19 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Goals from "@/models/goals";
 import * as Reactions from "@/models/reactions";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Avatar } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
 import RichContent from "@/components/RichContent";
+import { Avatar } from "turboui";
 
-import { SecondaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { SecondaryButton } from "turboui";
 
+import { assertPresent } from "@/utils/assertions";
 import plurarize from "@/utils/plurarize";
 import { DivLink } from "turboui";
-import { assertPresent } from "@/utils/assertions";
 
 export function LastCheckInMessage({ goal }: { goal: Goals.Goal }) {
   if (!goal.lastCheckIn) return null;
@@ -21,8 +21,8 @@ export function LastCheckInMessage({ goal }: { goal: Goals.Goal }) {
   assertPresent(goal.lastCheckIn.author, "author must be present in lastCheckIn");
 
   const { author, message } = goal.lastCheckIn;
-  const path = Paths.goalCheckInPath(goal.lastCheckIn.id!);
-  const championProfilePath = Paths.profilePath(author.id!);
+  const path = DeprecatedPaths.goalCheckInPath(goal.lastCheckIn.id!);
+  const championProfilePath = DeprecatedPaths.profilePath(author.id!);
 
   return (
     <div className="flex items-start gap-4">
@@ -53,7 +53,7 @@ export function LastCheckInMessage({ goal }: { goal: Goals.Goal }) {
 function LastMessageComments({ goal }: { goal: Goals.Goal }) {
   if (!goal.lastCheckIn) return null;
 
-  const path = Paths.goalCheckInPath(goal.lastCheckIn!.id!);
+  const path = DeprecatedPaths.goalCheckInPath(goal.lastCheckIn!.id!);
 
   return (
     <div className="flex items-center gap-1 text-sm leading-none text-content-dimmed">

--- a/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
@@ -8,7 +8,7 @@ import * as Time from "@/utils/time";
 import Forms from "@/components/Forms";
 import { emptyContent } from "@/components/RichContent";
 import { Options, SubscriptionsState } from "@/features/Subscriptions";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { validateTargets } from "../GoalTargetsV2/targetErrors";
 
@@ -43,7 +43,7 @@ export function useForm(props: EditProps | NewProps) {
     },
     cancel: () => {
       if (mode === "new") {
-        navigate(Paths.goalPath(goal.id!));
+        navigate(DeprecatedPaths.goalPath(goal.id!));
       } else {
         setPageMode("view");
       }
@@ -70,7 +70,7 @@ export function useForm(props: EditProps | NewProps) {
 
         const res = await post(payload);
 
-        navigate(Paths.goalCheckInPath(res.update!.id));
+        navigate(DeprecatedPaths.goalCheckInPath(res.update!.id));
       } else {
         const payload = { ...commonAttrs, id: props.update.id! };
         await edit(payload);

--- a/app/assets/js/features/goals/GoalForm/useForm.tsx
+++ b/app/assets/js/features/goals/GoalForm/useForm.tsx
@@ -1,17 +1,16 @@
-import * as React from "react";
+import * as TipTapEditor from "@/components/Editor";
 import * as Companies from "@/models/companies";
 import * as Goals from "@/models/goals";
 import * as People from "@/models/people";
-import * as TipTapEditor from "@/components/Editor";
 import * as Spaces from "@/models/spaces";
 import * as Timeframes from "@/utils/timeframes";
+import * as React from "react";
 
+import { PermissionsState, usePermissionsState } from "@/features/Permissions/usePermissionsState";
+import { useListState } from "@/hooks/useListState";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { useNavigate } from "react-router-dom";
-import { useListState } from "@/hooks/useListState";
-import { Paths } from "@/routes/paths";
-import { PermissionsState } from "@/features/Permissions/usePermissionsState";
-import { usePermissionsState } from "@/features/Permissions/usePermissionsState";
 
 export interface FormState {
   config: FormConfig;
@@ -283,7 +282,7 @@ function useSubmit(fields: Fields, config: FormConfig): [() => Promise<boolean>,
         spaceAccessLevel: fields.permissions.permissions.space,
       });
 
-      navigate(Paths.goalPath(res.goal.id!));
+      navigate(DeprecatedPaths.goalPath(res.goal.id!));
       return true;
     } else {
       const res = await edit({
@@ -320,7 +319,7 @@ function useSubmit(fields: Fields, config: FormConfig): [() => Promise<boolean>,
         spaceAccessLevel: fields.permissions.permissions.space,
       });
 
-      navigate(Paths.goalPath(res.goal.id!));
+      navigate(DeprecatedPaths.goalPath(res.goal.id!));
       return true;
     }
   };
@@ -387,10 +386,10 @@ function prepareDescriptionForSave(fields: Fields): string | null {
 
 function createCancelPath(config: FormConfig): string {
   if (config.mode === "edit") {
-    return Paths.goalPath(config.goal!.id!);
+    return DeprecatedPaths.goalPath(config.goal!.id!);
   } else if (config.allowSpaceSelection) {
-    return Paths.goalsPath();
+    return DeprecatedPaths.goalsPath();
   } else {
-    return Paths.spacePath(config.space!.id!);
+    return DeprecatedPaths.spacePath(config.space!.id!);
   }
 }

--- a/app/assets/js/features/goals/GoalPageHeader/index.tsx
+++ b/app/assets/js/features/goals/GoalPageHeader/index.tsx
@@ -1,13 +1,12 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
-import * as Goals from "@/models/goals";
-import * as Tabs from "@/components/Tabs";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Tabs from "@/components/Tabs";
+import * as Goals from "@/models/goals";
 import * as Timeframes from "@/utils/timeframes";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { GhostLink } from "turboui";
-import { Paths } from "@/routes/paths";
-import { PrimaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
+import { GhostLink, PrimaryButton } from "turboui";
 
 import FormattedTime from "@/components/FormattedTime";
 
@@ -59,10 +58,10 @@ function GoalIcon() {
 function GoalTabs({ activeTab, goal }: { activeTab: HeaderProps["activeTab"]; goal: Goals.Goal }) {
   return (
     <Tabs.Root activeTab={activeTab}>
-      <Tabs.Tab id="status" title="Current Status" linkTo={Paths.goalPath(goal.id!)} />
-      <Tabs.Tab id="subgoals" title="Sub-Goals and Projects" linkTo={Paths.goalSubgoalsPath(goal.id!)} />
-      <Tabs.Tab id="discussions" title="Discussions" linkTo={Paths.goalDiscussionsPath(goal.id!)} />
-      <Tabs.Tab id="about" title="About" linkTo={Paths.goalAboutPath(goal.id!)} />
+      <Tabs.Tab id="status" title="Current Status" linkTo={DeprecatedPaths.goalPath(goal.id!)} />
+      <Tabs.Tab id="subgoals" title="Sub-Goals and Projects" linkTo={DeprecatedPaths.goalSubgoalsPath(goal.id!)} />
+      <Tabs.Tab id="discussions" title="Discussions" linkTo={DeprecatedPaths.goalDiscussionsPath(goal.id!)} />
+      <Tabs.Tab id="about" title="About" linkTo={DeprecatedPaths.goalAboutPath(goal.id!)} />
     </Tabs.Root>
   );
 }
@@ -74,14 +73,26 @@ function ParentGoal({ goal }: { goal: Goals.Goal | null | undefined }) {
     content = (
       <div className="flex items-center gap-1">
         <Icons.IconTarget size={14} className="text-red-500" />
-        <GhostLink to={Paths.goalPath(goal.id!)} text={goal.name!} testId="project-goal-link" dimmed size="sm" />
+        <GhostLink
+          to={DeprecatedPaths.goalPath(goal.id!)}
+          text={goal.name!}
+          testId="project-goal-link"
+          dimmed
+          size="sm"
+        />
       </div>
     );
   } else {
     content = (
       <div className="flex items-center gap-1">
         <Icons.IconBuildingEstate size={14} />
-        <GhostLink to={Paths.goalsPath()} text="Company-wide goal" testId="company-goals-link" dimmed size="sm" />
+        <GhostLink
+          to={DeprecatedPaths.goalsPath()}
+          text="Company-wide goal"
+          testId="company-goals-link"
+          dimmed
+          size="sm"
+        />
       </div>
     );
   }
@@ -101,7 +112,7 @@ function Options({ goal }) {
         <PageOptions.Link
           icon={Icons.IconEdit}
           title="Edit Goal Definition"
-          to={Paths.goalEditPath(goal.id)}
+          to={DeprecatedPaths.goalEditPath(goal.id)}
           testId="edit-goal-definition"
         />
       )}
@@ -110,7 +121,7 @@ function Options({ goal }) {
         <PageOptions.Link
           icon={Icons.IconCalendar}
           title="Edit Timeframe"
-          to={Paths.goalEditTimeframePath(goal.id)}
+          to={DeprecatedPaths.goalEditTimeframePath(goal.id)}
           testId="edit-goal-timeframe"
         />
       )}
@@ -119,7 +130,7 @@ function Options({ goal }) {
         <PageOptions.Link
           icon={Icons.IconExchange}
           title="Change Parent"
-          to={Paths.goalEditParentPath(goal.id)}
+          to={DeprecatedPaths.goalEditParentPath(goal.id)}
           testId="change-parent-goal"
         />
       )}
@@ -128,7 +139,7 @@ function Options({ goal }) {
         <PageOptions.Link
           icon={Icons.IconCircleCheck}
           title="Close Goal"
-          to={Paths.goalClosePath(goal.id)}
+          to={DeprecatedPaths.goalClosePath(goal.id)}
           testId="close-goal"
         />
       )}
@@ -137,7 +148,7 @@ function Options({ goal }) {
         <PageOptions.Link
           icon={Icons.IconRotateDot}
           title="Reopen Goal"
-          to={Paths.goalReopenPath(goal.id)}
+          to={DeprecatedPaths.goalReopenPath(goal.id)}
           testId="reopen-goal"
         />
       )}
@@ -201,7 +212,7 @@ function CheckInButton({ goal }) {
   if (!goal.permissions.canCheckIn) return null;
   if (goal.isClosed || goal.isArchived) return null;
 
-  const path = Paths.goalCheckInNewPath(goal.id!);
+  const path = DeprecatedPaths.goalCheckInNewPath(goal.id!);
 
   return (
     <div className="mt-1">

--- a/app/assets/js/features/goals/GoalPageNavigation/index.tsx
+++ b/app/assets/js/features/goals/GoalPageNavigation/index.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function Navigation({ space }: { space: Spaces.Space }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(space.id!), label: space.name! },
-        { to: Paths.spaceGoalsPath(space.id!), label: "Goals & Projects" },
+        { to: DeprecatedPaths.spacePath(space.id!), label: space.name! },
+        { to: DeprecatedPaths.spaceGoalsPath(space.id!), label: "Goals & Projects" },
       ]}
     />
   );

--- a/app/assets/js/features/goals/GoalSubpageNavigation/index.tsx
+++ b/app/assets/js/features/goals/GoalSubpageNavigation/index.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function GoalSubpageNavigation({ goal }: { goal: Goals.Goal }) {
-  return <Paper.Navigation items={[{ to: Paths.goalPath(goal.id!), label: goal.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! }]} />;
 }

--- a/app/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
+++ b/app/assets/js/features/goals/GoalTree/components/GoalDetails.tsx
@@ -8,7 +8,7 @@ import { useWindowSizeBreakpoints } from "@/components/Pages";
 
 import { AvatarLink } from "@/components/AvatarLink";
 import { DescriptionSection, StatusSection, TargetsSection } from "@/features/goals/GoalCheckIn";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import classNames from "classnames";
 import { match } from "ts-pattern";
@@ -56,8 +56,8 @@ export function GoalActions({ hovered, node }: { hovered: boolean; node: GoalNod
     flex: size !== "xs",
   });
 
-  const newGoalPath = Paths.goalNewPath({ parentGoalId: node.goal.id! });
-  const newProjectPath = Paths.newProjectPath({
+  const newGoalPath = DeprecatedPaths.goalNewPath({ parentGoalId: node.goal.id! });
+  const newProjectPath = DeprecatedPaths.newProjectPath({
     goalId: node.goal.id!,
     spaceId: node.goal.space!.id!,
     backPathName: "Back to Goal Map",
@@ -132,7 +132,7 @@ function ChampionAndSpace({ goal }: { goal: Goals.Goal }) {
   assertPresent(goal.champion, "champion must be present in goal");
   assertPresent(goal.space, "space must be present in goal");
 
-  const path = Paths.spacePath(goal.space.id!);
+  const path = DeprecatedPaths.spacePath(goal.space.id!);
 
   return (
     <div className="flex items-center gap-1">

--- a/app/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
+++ b/app/assets/js/features/goals/GoalTree/components/ProjectDetails.tsx
@@ -3,21 +3,21 @@ import React from "react";
 import FormattedTime from "@/components/FormattedTime";
 import { useWindowSizeBreakpoints } from "@/components/Pages";
 
-import classNames from "classnames";
-import { match } from "ts-pattern";
-import { Project, sortContributorsByRole } from "@/models/projects";
-import { StatusSection } from "@/features/projectCheckIns/StatusSection";
-import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
 import { MilestoneIcon } from "@/components/MilestoneIcon";
-import { DivLink, AvatarList } from "turboui";
+import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
+import { StatusSection } from "@/features/projectCheckIns/StatusSection";
+import { RetrospectiveContent } from "@/features/ProjectRetrospective";
+import { Project, sortContributorsByRole } from "@/models/projects";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { truncateString } from "@/utils/strings";
-import { Paths } from "@/routes/paths";
-import { RetrospectiveContent } from "@/features/ProjectRetrospective";
+import classNames from "classnames";
+import { match } from "ts-pattern";
+import { AvatarList, DivLink } from "turboui";
 
-import { Status } from "./Status";
 import { ProjectNode } from "../tree";
 import { useTreeContext } from "../treeContext";
+import { Status } from "./Status";
 
 export function ProjectDetails({ node }: { node: ProjectNode }) {
   const { density } = useTreeContext();
@@ -68,7 +68,7 @@ function NextMilestone({ project }: { project: Project }) {
   if (!project.nextMilestone) return <></>;
 
   const name = truncateString(project.nextMilestone.title!, size !== "xs" ? 30 : 20);
-  const path = Paths.projectMilestonePath(project.nextMilestone.id!);
+  const path = DeprecatedPaths.projectMilestonePath(project.nextMilestone.id!);
 
   return (
     <DivLink to={path} className="flex items-center gap-2">
@@ -83,7 +83,7 @@ function NextMilestone({ project }: { project: Project }) {
 function SpaceName({ project }: { project: Project }) {
   assertPresent(project.space, "space must be present in project");
 
-  const path = Paths.spacePath(project.space.id!);
+  const path = DeprecatedPaths.spacePath(project.space.id!);
 
   return (
     <DivLink to={path} className="text-xs text-content-dimmed hover:underline underline-offset-2">

--- a/app/assets/js/features/goals/GoalTree/components/Status.tsx
+++ b/app/assets/js/features/goals/GoalTree/components/Status.tsx
@@ -3,11 +3,11 @@ import { useNavigate } from "react-router-dom";
 
 import * as Popover from "@radix-ui/react-popover";
 
-import { createTestId } from "@/utils/testid";
-import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
 import { SmallStatusIndicator } from "@/components/status";
+import { StatusIndicator } from "@/features/ProjectListItem/StatusIndicator";
+import { DeprecatedPaths } from "@/routes/paths";
+import { createTestId } from "@/utils/testid";
 import { IconArrowUpRight } from "@tabler/icons-react";
-import { Paths } from "@/routes/paths";
 import { Node } from "../tree";
 
 export function Status({ node, children }: { node: Node; children: ReactNode }) {
@@ -64,17 +64,17 @@ function useClickHandler(node: Node) {
   return () => {
     if (node.type === "goal") {
       if (node.isClosed) {
-        return navigate(Paths.goalPath(node.id!));
+        return navigate(DeprecatedPaths.goalPath(node.id!));
       } else {
-        return navigate(Paths.goalCheckInPath(node.asGoalNode()!.lastCheckIn!.id!));
+        return navigate(DeprecatedPaths.goalCheckInPath(node.asGoalNode()!.lastCheckIn!.id!));
       }
     }
 
     if (node.type === "project") {
       if (node.isClosed) {
-        return navigate(Paths.projectRetrospectivePath(node.id!));
+        return navigate(DeprecatedPaths.projectRetrospectivePath(node.id!));
       } else {
-        return navigate(Paths.projectCheckInPath(node.asProjectNode()!.lastCheckIn!.id!));
+        return navigate(DeprecatedPaths.projectCheckInPath(node.asProjectNode()!.lastCheckIn!.id!));
       }
     }
 

--- a/app/assets/js/features/goals/GoalTree/tree/goalNode.tsx
+++ b/app/assets/js/features/goals/GoalTree/tree/goalNode.tsx
@@ -2,7 +2,7 @@ import plurarize from "@/utils/plurarize";
 
 import { GoalProgressUpdate } from "@/api";
 import { Goal } from "@/models/goals";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Node } from "./node";
 
 import * as Spaces from "@/models/spaces";
@@ -80,7 +80,7 @@ export class GoalNode extends Node {
   }
 
   linkTo(): string {
-    return Paths.goalPath(this.goal.id!);
+    return DeprecatedPaths.goalPath(this.goal.id!);
   }
 
   childrenInfoLabel(): string {

--- a/app/assets/js/features/goals/GoalTree/tree/projectNode.tsx
+++ b/app/assets/js/features/goals/GoalTree/tree/projectNode.tsx
@@ -1,13 +1,12 @@
-import * as Time from "@/utils/time";
 import * as Spaces from "@/models/spaces";
+import * as Time from "@/utils/time";
 import * as Timeframes from "@/utils/timeframes";
 
-import { Project } from "@/models/projects";
-import { Paths } from "@/routes/paths";
-import { Node } from "./node";
-import { assertPresent } from "@/utils/assertions";
 import { ProjectCheckIn } from "@/api";
-import { ProjectRetrospective } from "@/models/projects";
+import { Project, ProjectRetrospective } from "@/models/projects";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { Node } from "./node";
 
 export class ProjectNode extends Node {
   public project: Project;
@@ -64,7 +63,7 @@ export class ProjectNode extends Node {
   }
 
   linkTo(): string {
-    return Paths.projectPath(this.project!.id!);
+    return DeprecatedPaths.projectPath(this.project!.id!);
   }
 
   childrenInfoLabel(): string | null {

--- a/app/assets/js/features/spaces/SpaceCards/SpaceCardLink.tsx
+++ b/app/assets/js/features/spaces/SpaceCards/SpaceCardLink.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { SpaceCard, SpaceCardProps } from "./SpaceCard";
-import { Paths } from "@/routes/paths";
 
 export function SpaceCardLink(props: SpaceCardProps) {
-  return <SpaceCard {...props} linkTo={Paths.spacePath(props.space.id!)} />;
+  return <SpaceCard {...props} linkTo={DeprecatedPaths.spacePath(props.space.id!)} />;
 }

--- a/app/assets/js/layouts/CompanyLayout/Bell.tsx
+++ b/app/assets/js/layouts/CompanyLayout/Bell.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
 import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
 
 import * as Notifications from "@/models/notifications";
 import classNames from "classnames";
 
 export function Bell() {
   const count = Notifications.useUnreadCount();
-  const path = Paths.notificationsPath();
+  const path = DeprecatedPaths.notificationsPath();
   const style = { height: "32px", width: "32px" };
 
   const className = classNames(

--- a/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Companies from "@/models/companies";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { DropdownMenu, DropdownLinkItem, DropdownSeparator } from "./DropdownMenu";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DropdownLinkItem, DropdownMenu, DropdownSeparator } from "./DropdownMenu";
 
 export function CompanyDropdown({ company }: { company: Companies.Company }) {
   return (
@@ -15,19 +15,19 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
       showDropdownIcon
     >
       <DropdownLinkItem
-        path={Paths.feedPath()}
+        path={DeprecatedPaths.feedPath()}
         icon={Icons.IconRss}
         title="The Feed"
         testId="company-dropdown-company-feed"
       />
       <DropdownLinkItem
-        path={Paths.peoplePath()}
+        path={DeprecatedPaths.peoplePath()}
         icon={Icons.IconUserCircle}
         title="People"
         testId="company-dropdown-people"
       />
       <DropdownLinkItem
-        path={Paths.orgChartPath()}
+        path={DeprecatedPaths.orgChartPath()}
         icon={Icons.IconBinaryTree2}
         title="Org Chart"
         testId="company-dropdown-org-chart"
@@ -36,13 +36,13 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
       <DropdownSeparator />
 
       <DropdownLinkItem
-        path={Paths.companyAdminPath()}
+        path={DeprecatedPaths.companyAdminPath()}
         icon={Icons.IconCircleKey}
         title="Company Admin"
         testId="company-dropdown-company-admin"
       />
       <DropdownLinkItem
-        path={Paths.lobbyPath()}
+        path={DeprecatedPaths.lobbyPath()}
         icon={Icons.IconSwitch}
         title="Switch Company"
         testId="company-dropdown-switch"

--- a/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
@@ -2,10 +2,12 @@ import * as Companies from "@/models/companies";
 import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
-import { DeprecatedPaths } from "@/routes/paths";
+import { Paths, usePaths } from "@/routes/paths";
 import { DropdownLinkItem, DropdownMenu, DropdownSeparator } from "./DropdownMenu";
 
 export function CompanyDropdown({ company }: { company: Companies.Company }) {
+  const paths = usePaths();
+
   return (
     <DropdownMenu
       testId="company-dropdown"
@@ -15,19 +17,19 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
       showDropdownIcon
     >
       <DropdownLinkItem
-        path={DeprecatedPaths.feedPath()}
+        path={paths.feedPath()}
         icon={Icons.IconRss}
         title="The Feed"
         testId="company-dropdown-company-feed"
       />
       <DropdownLinkItem
-        path={DeprecatedPaths.peoplePath()}
+        path={paths.peoplePath()}
         icon={Icons.IconUserCircle}
         title="People"
         testId="company-dropdown-people"
       />
       <DropdownLinkItem
-        path={DeprecatedPaths.orgChartPath()}
+        path={paths.orgChartPath()}
         icon={Icons.IconBinaryTree2}
         title="Org Chart"
         testId="company-dropdown-org-chart"
@@ -36,13 +38,13 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
       <DropdownSeparator />
 
       <DropdownLinkItem
-        path={DeprecatedPaths.companyAdminPath()}
+        path={paths.companyAdminPath()}
         icon={Icons.IconCircleKey}
         title="Company Admin"
         testId="company-dropdown-company-admin"
       />
       <DropdownLinkItem
-        path={DeprecatedPaths.lobbyPath()}
+        path={Paths.lobbyPath()}
         icon={Icons.IconSwitch}
         title="Switch Company"
         testId="company-dropdown-switch"

--- a/app/assets/js/layouts/CompanyLayout/NewDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/NewDropdown.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
 import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { DropdownMenu, DropdownLinkItem, DropdownSeparator } from "./DropdownMenu";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DropdownLinkItem, DropdownMenu, DropdownSeparator } from "./DropdownMenu";
 
 export function NewDropdown() {
   return (
     <DropdownMenu testId="new-dropdown" name="New" icon={Icons.IconPlus} align="end">
       <DropdownLinkItem
-        path={Paths.newGoalPath()}
+        path={DeprecatedPaths.newGoalPath()}
         icon={Icons.IconTargetArrow}
         title="New goal"
         testId="new-dropdown-new-goal"
       />
 
       <DropdownLinkItem
-        path={Paths.newProjectPath()}
+        path={DeprecatedPaths.newProjectPath()}
         icon={Icons.IconTable}
         title="New project"
         testId="new-dropdown-new-project"
@@ -24,7 +24,7 @@ export function NewDropdown() {
       <DropdownSeparator />
 
       <DropdownLinkItem
-        path={Paths.newSpacePath()}
+        path={DeprecatedPaths.newSpacePath()}
         icon={Icons.IconTent}
         title="New space"
         testId="new-dropdown-new-space"
@@ -33,7 +33,7 @@ export function NewDropdown() {
       <DropdownSeparator />
 
       <DropdownLinkItem
-        path={Paths.companyManagePeopleAddPeoplePath()}
+        path={DeprecatedPaths.companyManagePeopleAddPeoplePath()}
         icon={Icons.IconUser}
         title="New team member"
         testId="new-dropdown-new-team-member"

--- a/app/assets/js/layouts/CompanyLayout/Review.tsx
+++ b/app/assets/js/layouts/CompanyLayout/Review.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { useAssignmentsCount, useReviewRefreshSignal } from "@/models/assignments";
 
-import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { IconCoffee } from "@tabler/icons-react";
+import { DivLink } from "turboui";
 
 export function Review() {
   const [count, refetch] = useAssignmentsCount();
@@ -12,7 +12,7 @@ export function Review() {
 
   return (
     <DivLink
-      to={Paths.reviewPath()}
+      to={DeprecatedPaths.reviewPath()}
       className="font-semibold flex items-center gap-1 cursor-pointer group hover:bg-surface-bg-highlight px-1.5 py-0.5 rounded relative"
       testId="review-link"
     >

--- a/app/assets/js/layouts/CompanyLayout/User.tsx
+++ b/app/assets/js/layouts/CompanyLayout/User.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-import { Avatar } from "turboui";
-import { Link } from "react-router-dom";
 import { useMe } from "@/contexts/CurrentCompanyContext";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "react-router-dom";
+import { Avatar } from "turboui";
 
 export function User() {
   const me = useMe();
@@ -12,7 +12,7 @@ export function User() {
 
   return (
     <Link
-      to={Paths.accountPath()}
+      to={DeprecatedPaths.accountPath()}
       className="flex items-center cursor-pointer border border-stroke-base rounded-full"
       style={{ height: "32px", width: "32px" }}
       data-test-id="account-menu"

--- a/app/assets/js/layouts/CompanyLayout/index.tsx
+++ b/app/assets/js/layouts/CompanyLayout/index.tsx
@@ -1,26 +1,26 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Api from "@/api";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { useLoaderData } from "react-router-dom";
 import { logOut } from "@/routes/auth";
+import { useLoaderData } from "react-router-dom";
 
-import { DivLink } from "turboui";
-import { Outlet } from "react-router-dom";
-import { User } from "./User";
-import { Bell } from "./Bell";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
-import { Review } from "./Review";
+import { Outlet } from "react-router-dom";
+import { DivLink } from "turboui";
+import { Bell } from "./Bell";
 import { CompanyDropdown } from "./CompanyDropdown";
-import { NewDropdown } from "./NewDropdown";
 import { HelpDropdown } from "./HelpDropdown";
+import { NewDropdown } from "./NewDropdown";
+import { Review } from "./Review";
+import { User } from "./User";
 
-import { DevBar } from "@/features/DevBar";
-import { Paths } from "@/routes/paths";
-import { useScrollToTopOnNavigationChange } from "@/hooks/useScrollToTopOnNavigationChange";
 import { useWindowSizeBreakpoints } from "@/components/Pages";
-import { hasFeature } from "@/models/companies";
 import { useMe } from "@/contexts/CurrentCompanyContext";
+import { DevBar } from "@/features/DevBar";
+import { useScrollToTopOnNavigationChange } from "@/hooks/useScrollToTopOnNavigationChange";
+import { hasFeature } from "@/models/companies";
+import { DeprecatedPaths } from "@/routes/paths";
 
 function Navigation({ company }: { company: Api.Company }) {
   const size = useWindowSizeBreakpoints();
@@ -48,10 +48,10 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     if (hasFeature(company, "new_navigation")) {
       return (
         <>
-          <MobileSectionLink to={Paths.goalsPath()} icon={Icons.IconBuildingEstate}>
+          <MobileSectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconBuildingEstate}>
             Company
           </MobileSectionLink>
-          <MobileSectionLink to={Paths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
+          <MobileSectionLink to={DeprecatedPaths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
             My work
           </MobileSectionLink>
         </>
@@ -59,10 +59,10 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     } else {
       return (
         <>
-          <MobileSectionLink to={Paths.goalsPath()} icon={Icons.IconTargetArrow}>
+          <MobileSectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconTargetArrow}>
             Goals
           </MobileSectionLink>
-          <MobileSectionLink to={Paths.projectsPath()} icon={Icons.IconTable}>
+          <MobileSectionLink to={DeprecatedPaths.projectsPath()} icon={Icons.IconTable}>
             Projects
           </MobileSectionLink>
         </>
@@ -74,7 +74,7 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     <div className="transition-all z-50 py-2 bg-base border-b border-surface-outline">
       <div className="flex items-center justify-between px-4">
         <div className="flex items-center gap-3">
-          <DivLink className="flex items-center gap-2 cursor-pointer" to={Paths.homePath()}>
+          <DivLink className="flex items-center gap-2 cursor-pointer" to={DeprecatedPaths.homePath()}>
             <OperatelyLogo />
           </DivLink>
           <div className="font-bold">{company.name}</div>
@@ -90,33 +90,33 @@ function MobileNavigation({ company }: { company: Api.Company }) {
           className="flex flex-col bg-base absolute inset-0 top-10 bg-surface-bg border-t border-surface-outline"
           onClick={() => setOpen(false)}
         >
-          <MobileSectionLink to={Paths.homePath()} icon={Icons.IconHome2}>
+          <MobileSectionLink to={DeprecatedPaths.homePath()} icon={Icons.IconHome2}>
             Home
           </MobileSectionLink>
 
           {navLinks}
 
-          <MobileSectionLink to={Paths.reviewPath()} icon={Icons.IconCoffee}>
+          <MobileSectionLink to={DeprecatedPaths.reviewPath()} icon={Icons.IconCoffee}>
             Review
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.peoplePath()} icon={Icons.IconUserCircle}>
+          <MobileSectionLink to={DeprecatedPaths.peoplePath()} icon={Icons.IconUserCircle}>
             People
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.notificationsPath()} icon={Icons.IconBell}>
+          <MobileSectionLink to={DeprecatedPaths.notificationsPath()} icon={Icons.IconBell}>
             Notifications
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.accountPath()} icon={Icons.IconUser}>
+          <MobileSectionLink to={DeprecatedPaths.accountPath()} icon={Icons.IconUser}>
             Account
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.companyAdminPath()} icon={Icons.IconCircleKey}>
+          <MobileSectionLink to={DeprecatedPaths.companyAdminPath()} icon={Icons.IconCircleKey}>
             Company Admin
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.lobbyPath()} icon={Icons.IconSwitch}>
+          <MobileSectionLink to={DeprecatedPaths.lobbyPath()} icon={Icons.IconSwitch}>
             Switch Company
           </MobileSectionLink>
 
@@ -160,10 +160,10 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
     if (hasFeature(company, "new_navigation")) {
       return (
         <>
-          <SectionLink to={Paths.goalsPath()} icon={Icons.IconBuildingEstate}>
+          <SectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconBuildingEstate}>
             Company
           </SectionLink>
-          <SectionLink to={Paths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
+          <SectionLink to={DeprecatedPaths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
             My work
           </SectionLink>
         </>
@@ -171,10 +171,10 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
     } else {
       return (
         <>
-          <SectionLink to={Paths.goalsPath()} icon={Icons.IconTargetArrow}>
+          <SectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconTargetArrow}>
             Goals
           </SectionLink>
-          <SectionLink to={Paths.projectsPath()} icon={Icons.IconTable}>
+          <SectionLink to={DeprecatedPaths.projectsPath()} icon={Icons.IconTable}>
             Projects
           </SectionLink>
         </>
@@ -186,7 +186,7 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
     <div className="transition-all z-50 py-1.5 bg-base border-b border-surface-outline">
       <div className="flex items-center justify-between px-4">
         <div className="flex items-center">
-          <DivLink className="flex items-center gap-2 cursor-pointer" to={Paths.homePath()}>
+          <DivLink className="flex items-center gap-2 cursor-pointer" to={DeprecatedPaths.homePath()}>
             <OperatelyLogo />
           </DivLink>
 
@@ -195,7 +195,7 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
           </div>
 
           <div className="flex items-center gap-2.5 border-l border-surface-outline px-4">
-            <SectionLink to={Paths.homePath()} icon={Icons.IconHome2}>
+            <SectionLink to={DeprecatedPaths.homePath()} icon={Icons.IconHome2}>
               Home
             </SectionLink>
 

--- a/app/assets/js/layouts/CompanyLayout/index.tsx
+++ b/app/assets/js/layouts/CompanyLayout/index.tsx
@@ -20,7 +20,7 @@ import { useMe } from "@/contexts/CurrentCompanyContext";
 import { DevBar } from "@/features/DevBar";
 import { useScrollToTopOnNavigationChange } from "@/hooks/useScrollToTopOnNavigationChange";
 import { hasFeature } from "@/models/companies";
-import { DeprecatedPaths } from "@/routes/paths";
+import { Paths, usePaths } from "@/routes/paths";
 
 function Navigation({ company }: { company: Api.Company }) {
   const size = useWindowSizeBreakpoints();
@@ -34,6 +34,7 @@ function Navigation({ company }: { company: Api.Company }) {
 
 function MobileNavigation({ company }: { company: Api.Company }) {
   const me = useMe()!;
+  const paths = usePaths();
   const [open, setOpen] = React.useState(false);
 
   const handleLogOut = async () => {
@@ -48,10 +49,10 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     if (hasFeature(company, "new_navigation")) {
       return (
         <>
-          <MobileSectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconBuildingEstate}>
+          <MobileSectionLink to={paths.goalsPath()} icon={Icons.IconBuildingEstate}>
             Company
           </MobileSectionLink>
-          <MobileSectionLink to={DeprecatedPaths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
+          <MobileSectionLink to={paths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
             My work
           </MobileSectionLink>
         </>
@@ -59,10 +60,10 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     } else {
       return (
         <>
-          <MobileSectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconTargetArrow}>
+          <MobileSectionLink to={paths.goalsPath()} icon={Icons.IconTargetArrow}>
             Goals
           </MobileSectionLink>
-          <MobileSectionLink to={DeprecatedPaths.projectsPath()} icon={Icons.IconTable}>
+          <MobileSectionLink to={paths.projectsPath()} icon={Icons.IconTable}>
             Projects
           </MobileSectionLink>
         </>
@@ -74,7 +75,7 @@ function MobileNavigation({ company }: { company: Api.Company }) {
     <div className="transition-all z-50 py-2 bg-base border-b border-surface-outline">
       <div className="flex items-center justify-between px-4">
         <div className="flex items-center gap-3">
-          <DivLink className="flex items-center gap-2 cursor-pointer" to={DeprecatedPaths.homePath()}>
+          <DivLink className="flex items-center gap-2 cursor-pointer" to={paths.homePath()}>
             <OperatelyLogo />
           </DivLink>
           <div className="font-bold">{company.name}</div>
@@ -90,33 +91,33 @@ function MobileNavigation({ company }: { company: Api.Company }) {
           className="flex flex-col bg-base absolute inset-0 top-10 bg-surface-bg border-t border-surface-outline"
           onClick={() => setOpen(false)}
         >
-          <MobileSectionLink to={DeprecatedPaths.homePath()} icon={Icons.IconHome2}>
+          <MobileSectionLink to={paths.homePath()} icon={Icons.IconHome2}>
             Home
           </MobileSectionLink>
 
           {navLinks}
 
-          <MobileSectionLink to={DeprecatedPaths.reviewPath()} icon={Icons.IconCoffee}>
+          <MobileSectionLink to={paths.reviewPath()} icon={Icons.IconCoffee}>
             Review
           </MobileSectionLink>
 
-          <MobileSectionLink to={DeprecatedPaths.peoplePath()} icon={Icons.IconUserCircle}>
+          <MobileSectionLink to={paths.peoplePath()} icon={Icons.IconUserCircle}>
             People
           </MobileSectionLink>
 
-          <MobileSectionLink to={DeprecatedPaths.notificationsPath()} icon={Icons.IconBell}>
+          <MobileSectionLink to={paths.notificationsPath()} icon={Icons.IconBell}>
             Notifications
           </MobileSectionLink>
 
-          <MobileSectionLink to={DeprecatedPaths.accountPath()} icon={Icons.IconUser}>
+          <MobileSectionLink to={paths.accountPath()} icon={Icons.IconUser}>
             Account
           </MobileSectionLink>
 
-          <MobileSectionLink to={DeprecatedPaths.companyAdminPath()} icon={Icons.IconCircleKey}>
+          <MobileSectionLink to={paths.companyAdminPath()} icon={Icons.IconCircleKey}>
             Company Admin
           </MobileSectionLink>
 
-          <MobileSectionLink to={DeprecatedPaths.lobbyPath()} icon={Icons.IconSwitch}>
+          <MobileSectionLink to={Paths.lobbyPath()} icon={Icons.IconSwitch}>
             Switch Company
           </MobileSectionLink>
 
@@ -155,15 +156,16 @@ function MobileSectionAction({ onClick, children, icon }) {
 
 function DesktopNavigation({ company }: { company: Api.Company }) {
   const me = useMe()!;
+  const paths = usePaths();
 
   const navLinks = React.useMemo(() => {
     if (hasFeature(company, "new_navigation")) {
       return (
         <>
-          <SectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconBuildingEstate}>
+          <SectionLink to={paths.goalsPath()} icon={Icons.IconBuildingEstate}>
             Company
           </SectionLink>
-          <SectionLink to={DeprecatedPaths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
+          <SectionLink to={paths.profileV2Path(me.id)} icon={Icons.IconBriefcase}>
             My work
           </SectionLink>
         </>
@@ -171,10 +173,10 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
     } else {
       return (
         <>
-          <SectionLink to={DeprecatedPaths.goalsPath()} icon={Icons.IconTargetArrow}>
+          <SectionLink to={paths.goalsPath()} icon={Icons.IconTargetArrow}>
             Goals
           </SectionLink>
-          <SectionLink to={DeprecatedPaths.projectsPath()} icon={Icons.IconTable}>
+          <SectionLink to={paths.projectsPath()} icon={Icons.IconTable}>
             Projects
           </SectionLink>
         </>
@@ -186,7 +188,7 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
     <div className="transition-all z-50 py-1.5 bg-base border-b border-surface-outline">
       <div className="flex items-center justify-between px-4">
         <div className="flex items-center">
-          <DivLink className="flex items-center gap-2 cursor-pointer" to={DeprecatedPaths.homePath()}>
+          <DivLink className="flex items-center gap-2 cursor-pointer" to={paths.homePath()}>
             <OperatelyLogo />
           </DivLink>
 
@@ -195,7 +197,7 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
           </div>
 
           <div className="flex items-center gap-2.5 border-l border-surface-outline px-4">
-            <SectionLink to={DeprecatedPaths.homePath()} icon={Icons.IconHome2}>
+            <SectionLink to={paths.homePath()} icon={Icons.IconHome2}>
               Home
             </SectionLink>
 

--- a/app/assets/js/models/people/index.tsx
+++ b/app/assets/js/models/people/index.tsx
@@ -2,11 +2,11 @@ import * as api from "@/api";
 import * as Time from "@/utils/time";
 
 import Api from "@/api";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export type Person = api.Person;
 
-export { useGetMe, getPerson, getPeople, updateProfile, useGetPeople } from "@/api";
+export { getPeople, getPerson, updateProfile, useGetMe, useGetPeople } from "@/api";
 
 export type SearchScope =
   | { type: "company"; id?: undefined }
@@ -147,6 +147,6 @@ export function toPersonWithLink(personOrPeople: Person | Person[], useV2 = fals
 
   return {
     ...person,
-    link: useV2 ? Paths.profileV2Path(person.id!) : Paths.profilePath(person.id!),
+    link: useV2 ? DeprecatedPaths.profileV2Path(person.id!) : DeprecatedPaths.profilePath(person.id!),
   };
 }

--- a/app/assets/js/pages/AccountAppearancePage/index.tsx
+++ b/app/assets/js/pages/AccountAppearancePage/index.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
+import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import classnames from "classnames";
 import Forms from "@/components/Forms";
+import classnames from "classnames";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
-import { Paths } from "@/routes/paths";
-import { useNavigate } from "react-router-dom";
-import { useTheme, useSetTheme } from "@/contexts/ThemeContext";
+import { useSetTheme, useTheme } from "@/contexts/ThemeContext";
 import { PageNavigation } from "@/features/accounts/PageNavigation";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigate } from "react-router-dom";
 
 export default { name: "AccountAppearancePage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -40,7 +40,7 @@ function Form() {
     },
     submit: async () => {
       await People.updateProfile({ id: me.id, theme: form.values.theme });
-      navigate(Paths.accountPath());
+      navigate(DeprecatedPaths.accountPath());
     },
   });
 

--- a/app/assets/js/pages/AccountChangePasswordPage/index.tsx
+++ b/app/assets/js/pages/AccountChangePasswordPage/index.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Accounts from "@/models/accounts";
+import * as React from "react";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
-import { useNavigate } from "react-router-dom";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigate } from "react-router-dom";
 
 export default { name: "AccountChangePasswordPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -31,9 +31,9 @@ function Page() {
         newPasswordConfirmation: form.values.confirmPassword,
       });
 
-      navigate(Paths.accountSecurityPath());
+      navigate(DeprecatedPaths.accountSecurityPath());
     },
-    cancel: () => navigate(Paths.accountSecurityPath()),
+    cancel: () => navigate(DeprecatedPaths.accountSecurityPath()),
   });
 
   return (

--- a/app/assets/js/pages/AccountPage/index.tsx
+++ b/app/assets/js/pages/AccountPage/index.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-import * as Icons from "@tabler/icons-react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Icons from "@tabler/icons-react";
 
-import { logOut } from "@/routes/auth";
-import { Paths } from "@/routes/paths";
-import { BurgerActionsGroup, BurgerLink, BurgerButton } from "./BurgerActions";
 import { useMe } from "@/contexts/CurrentCompanyContext";
+import { logOut } from "@/routes/auth";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { BurgerActionsGroup, BurgerButton, BurgerLink } from "./BurgerActions";
 
 export default { name: "AccountPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -40,7 +40,7 @@ function ProfileLink() {
   const me = useMe()!;
 
   return (
-    <BurgerLink icon={Icons.IconUserCircle} to={Paths.profileEditPath(me.id!)} testId="profile-link">
+    <BurgerLink icon={Icons.IconUserCircle} to={DeprecatedPaths.profileEditPath(me.id!)} testId="profile-link">
       Profile
     </BurgerLink>
   );
@@ -48,7 +48,7 @@ function ProfileLink() {
 
 function AppearanceLink() {
   return (
-    <BurgerLink icon={Icons.IconPalette} to={Paths.accountAppearancePath()} testId="appearance-link">
+    <BurgerLink icon={Icons.IconPalette} to={DeprecatedPaths.accountAppearancePath()} testId="appearance-link">
       Appearance
     </BurgerLink>
   );
@@ -56,7 +56,7 @@ function AppearanceLink() {
 
 function PasswordLink() {
   return (
-    <BurgerLink icon={Icons.IconLockPassword} to={Paths.accountSecurityPath()} testId="password-link">
+    <BurgerLink icon={Icons.IconLockPassword} to={DeprecatedPaths.accountSecurityPath()} testId="password-link">
       Password &amp; Security
     </BurgerLink>
   );

--- a/app/assets/js/pages/AccountSecurityPage/index.tsx
+++ b/app/assets/js/pages/AccountSecurityPage/index.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
 import { PageNavigation } from "@/features/accounts/PageNavigation";
 import { Link } from "turboui";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 
 export default { name: "AccountSecurityPage", loader: Pages.emptyLoader, Page } as PageModule;
@@ -19,7 +19,7 @@ function Page() {
           <Paper.Header title="Password & Security" />
 
           <div>You are using your email and password to sign in to your account.</div>
-          <Link to={Paths.accountChangePasswordPath()} testId="change-password">
+          <Link to={DeprecatedPaths.accountChangePasswordPath()} testId="change-password">
             Change your password
           </Link>
         </Paper.Body>

--- a/app/assets/js/pages/AiPlaygroundPage/index.tsx
+++ b/app/assets/js/pages/AiPlaygroundPage/index.tsx
@@ -3,9 +3,9 @@ import * as Companies from "@/models/companies";
 import * as React from "react";
 import * as Turboui from "turboui";
 
-import { Paths } from "@/routes/paths";
-import { redirect } from "react-router-dom";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { redirect } from "react-router-dom";
 
 export default { name: "AiPlaygroundPage", loader, Page } as PageModule;
 
@@ -20,7 +20,7 @@ async function loader({ params }): Promise<LoaderResult> {
   if (Companies.hasFeature(company, "ai_playground")) {
     return {};
   } else {
-    throw redirect(Paths.homePath());
+    throw redirect(DeprecatedPaths.homePath());
   }
 }
 

--- a/app/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminAddPeoplePage/index.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
+import * as React from "react";
 
-import { useNavigate } from "react-router-dom";
-import { Paths } from "@/routes/paths";
 import { CopyToClipboard } from "@/components/CopyToClipboard";
-import { PrimaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigate } from "react-router-dom";
+import { PrimaryButton } from "turboui";
 
 import Forms from "@/components/Forms";
 import { match } from "ts-pattern";
@@ -90,7 +90,7 @@ function InviteForm({ setPageState }: { setPageState: SetPageStateFn }) {
       }
     },
     cancel: () => {
-      navigate(Paths.companyManagePeoplePath());
+      navigate(DeprecatedPaths.companyManagePeoplePath());
     },
   });
 
@@ -173,8 +173,8 @@ function Navigation() {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.companyAdminPath(), label: "Company Administration" },
-        { to: Paths.companyManagePeoplePath(), label: "Manage People" },
+        { to: DeprecatedPaths.companyAdminPath(), label: "Company Administration" },
+        { to: DeprecatedPaths.companyManagePeoplePath(), label: "Manage People" },
       ]}
     />
   );

--- a/app/assets/js/pages/CompanyAdminManageAdminsPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminManageAdminsPage/page.tsx
@@ -1,20 +1,18 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as People from "@/models/people";
+import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
+import * as People from "@/models/people";
+import * as React from "react";
 
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
+import { AddAdminsModal } from "./AddAdminsModal";
+import { AddOwnersModal } from "./AddOwnersModal";
 import { useLoadedData } from "./loader";
 import { useFrom } from "./useForm";
-import { Paths, compareIds } from "@/routes/paths";
-import { AddOwnersModal } from "./AddOwnersModal";
-import { AddAdminsModal } from "./AddAdminsModal";
 
-import { Avatar } from "turboui";
-import { BlackLink } from "turboui";
-import { SecondaryButton } from "turboui";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { createTestId } from "@/utils/testid";
+import { Avatar, BlackLink, SecondaryButton } from "turboui";
 
 export function Page() {
   const form = useFrom();
@@ -24,7 +22,7 @@ export function Page() {
   return (
     <Pages.Page title={"Manage admins and owners"} testId="manage-admins-page">
       <Paper.Root>
-        <Paper.Navigation items={[{ to: Paths.companyAdminPath(), label: "Company Administration" }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.companyAdminPath(), label: "Company Administration" }]} />
 
         <Paper.Body>
           <Paper.Header
@@ -79,7 +77,7 @@ function PersonRow({ person, type }: { person: People.Person; type: "admins" | "
 function PersonInfo({ person }: { person: People.Person }) {
   return (
     <div>
-      <BlackLink to={Paths.profilePath(person.id!)} className="font-bold" underline="hover">
+      <BlackLink to={DeprecatedPaths.profilePath(person.id!)} className="font-bold" underline="hover">
         {person.fullName}
       </BlackLink>
 

--- a/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
@@ -1,25 +1,23 @@
 import { PageModule } from "@/routes/types";
 
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as People from "@/models/people";
-import * as Icons from "@tabler/icons-react";
+import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
 import * as Invitations from "@/models/invitations";
+import * as People from "@/models/people";
 import * as Time from "@/utils/time";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { PrimaryButton, SecondaryButton } from "turboui";
-import { BlackLink } from "turboui";
-import { Menu, MenuLinkItem, MenuActionItem } from "turboui";
 import { CopyToClipboard } from "@/components/CopyToClipboard";
+import { DeprecatedPaths } from "@/routes/paths";
+import { BlackLink, Menu, MenuActionItem, MenuLinkItem, PrimaryButton, SecondaryButton } from "turboui";
 
-import { Avatar } from "turboui";
 import Modal, { ModalState, useModalState } from "@/components/Modal";
-import { createTestId } from "@/utils/testid";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import plurarize from "@/utils/plurarize";
+import { createTestId } from "@/utils/testid";
+import { Avatar } from "turboui";
 
 export default { name: "CompanyAdminManagePeoplePage", loader, Page } as PageModule;
 
@@ -64,12 +62,12 @@ function Page() {
 }
 
 function Navigation() {
-  return <Paper.Navigation items={[{ to: Paths.companyAdminPath(), label: "Company Administration" }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.companyAdminPath(), label: "Company Administration" }]} />;
 }
 
 function AddMemberButton() {
   return (
-    <PrimaryButton linkTo={Paths.companyManagePeopleAddPeoplePath()} testId="add-person">
+    <PrimaryButton linkTo={DeprecatedPaths.companyManagePeopleAddPeoplePath()} testId="add-person">
       Add Team Member
     </PrimaryButton>
   );
@@ -128,7 +126,7 @@ function PersonRow({ person }: { person: People.Person }) {
 function PersonInfo({ person }: { person: People.Person }) {
   return (
     <div>
-      <BlackLink to={Paths.profilePath(person.id!)} className="font-bold" underline="hover">
+      <BlackLink to={DeprecatedPaths.profilePath(person.id!)} className="font-bold" underline="hover">
         {person.fullName}
       </BlackLink>
 
@@ -176,7 +174,7 @@ function EditProfileButton({ person }: { person: People.Person }) {
   return (
     <SecondaryButton
       size="xs"
-      linkTo={Paths.profileEditPath(person.id!, { from: "admin-manage-people" })}
+      linkTo={DeprecatedPaths.profileEditPath(person.id!, { from: "admin-manage-people" })}
       testId={createTestId("edit", person.id!)}
     >
       Edit Profile
@@ -207,7 +205,7 @@ function PersonOptions({ person }: { person: People.Person }) {
 
 function PersonOptionViewProfile({ person }: { person: People.Person }) {
   return (
-    <MenuLinkItem icon={Icons.IconId} testId="view-profile" to={Paths.profilePath(person.id!)}>
+    <MenuLinkItem icon={Icons.IconId} testId="view-profile" to={DeprecatedPaths.profilePath(person.id!)}>
       View Profile
     </MenuLinkItem>
   );

--- a/app/assets/js/pages/CompanyAdminPage/NavigationBackToLobby.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/NavigationBackToLobby.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import * as React from "react";
 
 export function NavigationBackToLobby() {
-  return <Paper.Navigation items={[{ to: Paths.homePath(), label: "Home" }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.homePath(), label: "Home" }]} />;
 }

--- a/app/assets/js/pages/CompanyAdminPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/page.tsx
@@ -4,7 +4,7 @@ import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
-import { Paths, includesId } from "@/routes/paths";
+import { DeprecatedPaths, includesId } from "@/routes/paths";
 import { Link } from "turboui";
 import { CompanyAdmins, CompanyOwners } from "./CompanyAdmins";
 import { useLoadedData } from "./loader";
@@ -31,7 +31,7 @@ export function Page() {
             </p>
 
             <p className="mt-2">
-              <Link to={Paths.companyPermissionsPath()}>View permission breakdown</Link>
+              <Link to={DeprecatedPaths.companyPermissionsPath()}>View permission breakdown</Link>
             </p>
           </Paper.Section>
 
@@ -58,9 +58,9 @@ function AdminsMenu() {
     return null;
   }
 
-  const managePeople = Paths.companyManagePeoplePath();
-  const renameCompanyPath = Paths.companyRenamePath();
-  const restorePath = Paths.companyAdminRestoreSuspendedPeoplePath();
+  const managePeople = DeprecatedPaths.companyManagePeoplePath();
+  const renameCompanyPath = DeprecatedPaths.companyRenamePath();
+  const restorePath = DeprecatedPaths.companyAdminRestoreSuspendedPeoplePath();
 
   return (
     <Paper.Section title="As an admin or owner, you can:">
@@ -90,8 +90,8 @@ function OwnersMenu() {
     return null;
   }
 
-  const manageTrustedDomains = Paths.companyAdminManageTrustedDomainsPath();
-  const manageAdmins = Paths.companyManageAdminsPath();
+  const manageTrustedDomains = DeprecatedPaths.companyAdminManageTrustedDomainsPath();
+  const manageAdmins = DeprecatedPaths.companyManageAdminsPath();
 
   return (
     <Paper.Section title="As an owner, you can:">

--- a/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
@@ -1,17 +1,16 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as People from "@/models/people";
+import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
+import * as People from "@/models/people";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
-import { BlackLink, Link } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
+import { BlackLink, Link, SecondaryButton } from "turboui";
 
-import { Avatar } from "turboui";
-import { createTestId } from "@/utils/testid";
 import { InfoCallout } from "@/components/Callouts";
 import { PageModule } from "@/routes/types";
+import { createTestId } from "@/utils/testid";
+import { Avatar } from "turboui";
 
 export default { name: "CompanyAdminRestoreSuspendedPeoplePage", loader, Page } as PageModule;
 
@@ -49,7 +48,7 @@ function Page() {
 }
 
 function Navigation() {
-  return <Paper.Navigation items={[{ to: Paths.companyAdminPath(), label: "Company Administration" }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.companyAdminPath(), label: "Company Administration" }]} />;
 }
 
 function NoSuspenedPeopleMessage() {
@@ -62,7 +61,7 @@ function NoSuspenedPeopleMessage() {
         description={
           <p>
             There are no deactivated people in {company.name}. To remove access for departing team members, visit the{" "}
-            <Link to={Paths.companyManagePeoplePath()}>Manage People</Link> page.
+            <Link to={DeprecatedPaths.companyManagePeoplePath()}>Manage People</Link> page.
           </p>
         }
       />
@@ -100,7 +99,7 @@ function PersonRow({ person }: { person: People.Person }) {
 function PersonInfo({ person }: { person: People.Person }) {
   return (
     <div>
-      <BlackLink to={Paths.profilePath(person.id!)} className="font-bold" underline="hover">
+      <BlackLink to={DeprecatedPaths.profilePath(person.id!)} className="font-bold" underline="hover">
         {person.fullName}
       </BlackLink>
 

--- a/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
 import * as Forms from "@/components/Form";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
-import { useForm, FormState } from "./useForm";
-import { GhostButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
 import { createTestId } from "@/utils/testid";
-import { Paths } from "@/routes/paths";
+import { GhostButton } from "turboui";
+import { useLoadedData } from "./loader";
+import { FormState, useForm } from "./useForm";
 
 export function Page() {
   const { company } = useLoadedData();
@@ -17,7 +17,7 @@ export function Page() {
   return (
     <Pages.Page title={["Trusted Email Domains", company.name!]}>
       <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: Paths.companyAdminPath(), label: "Company Administration" }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.companyAdminPath(), label: "Company Administration" }]} />
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-3xl font-extrabold">Trusted Email Domains</div>

--- a/app/assets/js/pages/CompanyPermissionsPage/index.tsx
+++ b/app/assets/js/pages/CompanyPermissionsPage/index.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import { PageModule } from "@/routes/types";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export default { name: "CompanyPermissionsPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -12,7 +12,7 @@ function Page() {
   return (
     <Pages.Page title="Permissions">
       <Paper.Root size="small">
-        <Paper.NavigateBack to={Paths.companyAdminPath()} title="Back to Company Admin" />
+        <Paper.NavigateBack to={DeprecatedPaths.companyAdminPath()} title="Back to Company Admin" />
         <div className="font-extrabold text-2xl mb-4 text-center">Permission Breakdown</div>
         <Paper.Body>
           <Header />

--- a/app/assets/js/pages/CompanyRenamePage/index.tsx
+++ b/app/assets/js/pages/CompanyRenamePage/index.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
 import Forms from "@/components/Forms";
-import { useNavigate, useRevalidator } from "react-router-dom";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigate, useRevalidator } from "react-router-dom";
 
 export default { name: "CompanyRenamePage", loader, Page } as PageModule;
 
@@ -33,16 +33,16 @@ function Page() {
     submit: async () => {
       await edit({ name: form.values.name });
 
-      navigate(Paths.companyAdminPath());
+      navigate(DeprecatedPaths.companyAdminPath());
       revalidate();
     },
-    cancel: () => navigate(Paths.companyAdminPath()),
+    cancel: () => navigate(DeprecatedPaths.companyAdminPath()),
   });
 
   return (
     <Pages.Page title={"Rename Company"} testId="company-rename-page">
       <Paper.Root size="small">
-        <Paper.NavigateBack to={Paths.companyAdminPath()} title="Back to Company Admin" />
+        <Paper.NavigateBack to={DeprecatedPaths.companyAdminPath()} title="Back to Company Admin" />
 
         <Paper.Body>
           <Forms.Form form={form}>

--- a/app/assets/js/pages/CompanyWorkMapPage/loader.tsx
+++ b/app/assets/js/pages/CompanyWorkMapPage/loader.tsx
@@ -1,7 +1,7 @@
 import { Company, getCompany } from "@/models/companies";
 import { convertToWorkMapItem, getWorkMap } from "@/models/workMap";
 import { PageCache } from "@/routes/PageCache";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoaderResult {
@@ -15,7 +15,7 @@ interface LoaderResult {
 export async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
   await redirectIfFeatureNotEnabled(params, {
     feature: "work_map_page",
-    path: Paths.goalsPath(),
+    path: DeprecatedPaths.goalsPath(),
   });
 
   return await PageCache.fetch({

--- a/app/assets/js/pages/DiscussionDraftsPage/index.tsx
+++ b/app/assets/js/pages/DiscussionDraftsPage/index.tsx
@@ -1,23 +1,22 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Spaces from "@/models/spaces";
 import * as Discussions from "@/models/discussions";
-import * as Time from "@/utils/time";
+import * as Spaces from "@/models/spaces";
 import { PageModule } from "@/routes/types";
+import * as Time from "@/utils/time";
+import * as React from "react";
 
-import { Discussion } from "@/models/discussions";
-import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
-import { PrimaryButton } from "turboui";
-import { createTestId } from "@/utils/testid";
-import { truncateString } from "@/utils/strings";
-import { assertPresent } from "@/utils/assertions";
 import { richContentToString } from "@/components/RichContent";
+import { Discussion } from "@/models/discussions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { truncateString } from "@/utils/strings";
+import { createTestId } from "@/utils/testid";
+import { DivLink, PrimaryButton } from "turboui";
 
-import { Avatar } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
 import classNames from "classnames";
+import { Avatar } from "turboui";
 
 export default { name: "DiscussionDraftsPage", loader, Page } as PageModule;
 
@@ -63,8 +62,8 @@ function Navigation() {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(space.id!), label: space.name! },
-        { to: Paths.spaceDiscussionsPath(space.id!), label: "Discussions" },
+        { to: DeprecatedPaths.spacePath(space.id!), label: space.name! },
+        { to: DeprecatedPaths.spaceDiscussionsPath(space.id!), label: "Discussions" },
       ]}
     />
   );
@@ -80,7 +79,7 @@ function NewDiscussionButton() {
   const { space } = Pages.useLoadedData<LoadedData>();
 
   return (
-    <PrimaryButton linkTo={Paths.discussionNewPath(space.id!)} size="sm" testId="new-discussion">
+    <PrimaryButton linkTo={DeprecatedPaths.discussionNewPath(space.id!)} size="sm" testId="new-discussion">
       New Discussion
     </PrimaryButton>
   );
@@ -118,7 +117,7 @@ function DiscussionList() {
 function DiscussionListItem({ discussion }: { discussion: Discussion }) {
   assertPresent(discussion.author, "author must be present in discussion");
 
-  const path = Paths.discussionEditPath(discussion.id!);
+  const path = DeprecatedPaths.discussionEditPath(discussion.id!);
 
   const className = classNames(
     "flex items-start gap-4",

--- a/app/assets/js/pages/DiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/DiscussionEditPage/index.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Discussions from "@/models/discussions";
 
-import { PrimaryButton, GhostButton } from "turboui";
 import { Form, FormState, useForm } from "@/features/DiscussionForm";
-import { Paths } from "@/routes/paths";
-import { Link } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { GhostButton, Link, PrimaryButton } from "turboui";
 
 export default { name: "DiscussionEditPage", loader, Page } as PageModule;
 
@@ -99,8 +98,8 @@ function Navigation({ space }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(space.id), label: space.name },
-        { to: Paths.spaceDiscussionsPath(space.id), label: "Discussions" },
+        { to: DeprecatedPaths.spacePath(space.id), label: space.name },
+        { to: DeprecatedPaths.spaceDiscussionsPath(space.id), label: "Discussions" },
       ]}
     />
   );

--- a/app/assets/js/pages/DiscussionNewPage/index.tsx
+++ b/app/assets/js/pages/DiscussionNewPage/index.tsx
@@ -1,15 +1,14 @@
 import React from "react";
 
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
 
-import { PrimaryButton, GhostButton } from "turboui";
-import { Form, useForm, FormState } from "@/features/DiscussionForm";
-import { Paths } from "@/routes/paths";
+import { Form, FormState, useForm } from "@/features/DiscussionForm";
 import { SubscribersSelector } from "@/features/Subscriptions";
-import { Link } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { GhostButton, Link, PrimaryButton } from "turboui";
 
 export default { name: "DiscussionNewPage", loader, Page } as PageModule;
 
@@ -90,5 +89,5 @@ function DiscardLink({ form }) {
 }
 
 function Navigation({ space }) {
-  return <Paper.Navigation items={[{ to: Paths.spaceDiscussionsPath(space.id), label: space.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.spaceDiscussionsPath(space.id), label: space.name! }]} />;
 }

--- a/app/assets/js/pages/DiscussionPage/page.tsx
+++ b/app/assets/js/pages/DiscussionPage/page.tsx
@@ -1,27 +1,27 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import * as Reactions from "@/models/reactions";
 import * as Discussions from "@/models/discussions";
+import * as Reactions from "@/models/reactions";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
 import RichContent from "@/components/RichContent";
 
 import { Spacer } from "@/components/Spacer";
-import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useComments } from "@/features/CommentSection";
+import { ReactionList, useReactionsForm } from "@/features/Reactions";
 
-import { Paths, compareIds } from "@/routes/paths";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { DocumentTitle } from "@/features/documents/DocumentTitle";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
-import { useNavigate } from "react-router-dom";
-import { assertPresent } from "@/utils/assertions";
-import { useLoadedData } from "./loader";
-import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { OngoingDraftActions } from "@/features/drafts";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { assertPresent } from "@/utils/assertions";
+import { useNavigate } from "react-router-dom";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { discussion } = useLoadedData();
@@ -116,8 +116,8 @@ function Navigation({ space }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(space.id), label: space.name },
-        { to: Paths.spaceDiscussionsPath(space.id), label: "Discussions" },
+        { to: DeprecatedPaths.spacePath(space.id), label: space.name },
+        { to: DeprecatedPaths.spaceDiscussionsPath(space.id), label: "Discussions" },
       ]}
     />
   );
@@ -131,7 +131,7 @@ function Options() {
 
   const handleArchive = async () => {
     await archive({ messageId: discussion.id! });
-    navigate(Paths.spaceDiscussionsPath(discussion.space!.id!));
+    navigate(DeprecatedPaths.spaceDiscussionsPath(discussion.space!.id!));
   };
 
   if (!compareIds(me.id, discussion.author!.id)) return null;
@@ -141,7 +141,7 @@ function Options() {
       <PageOptions.Link
         icon={Icons.IconEdit}
         title="Edit"
-        to={Paths.discussionEditPath(discussion.id!)}
+        to={DeprecatedPaths.discussionEditPath(discussion.id!)}
         testId="edit-discussion"
         keepOutsideOnBigScreen
       />
@@ -177,7 +177,7 @@ function ContinueEditingDraft() {
 
   const [publish] = Discussions.usePublishDiscussion();
   const refresh = Pages.useRefresh();
-  const editPath = Paths.discussionEditPath(discussion.id!);
+  const editPath = DeprecatedPaths.discussionEditPath(discussion.id!);
 
   const publishHandler = async () => {
     await publish({ id: discussion.id! });

--- a/app/assets/js/pages/GoalAboutPage/page.tsx
+++ b/app/assets/js/pages/GoalAboutPage/page.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Navigation } from "@/features/goals/GoalPageNavigation";
 import { Header } from "@/features/goals/GoalPageHeader";
+import { Navigation } from "@/features/goals/GoalPageNavigation";
 
-import { Avatar } from "turboui";
 import RichContent from "@/components/RichContent";
+import { Avatar } from "turboui";
 
-import { useLoadedData } from "./loader";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { DivLink } from "turboui";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { goal } = useLoadedData();
@@ -38,7 +38,7 @@ const DimmedLabel = ({ children }) => (
 );
 
 const AvatarAndName = ({ person }) => {
-  const profilePath = Paths.profilePath(person.id);
+  const profilePath = DeprecatedPaths.profilePath(person.id);
 
   return (
     <DivLink to={profilePath}>

--- a/app/assets/js/pages/GoalAddPage/page.tsx
+++ b/app/assets/js/pages/GoalAddPage/page.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 
+import { useMe } from "@/contexts/CurrentCompanyContext";
+import { Form, FormState, useForm } from "@/features/goals/GoalForm";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PrimaryButton } from "turboui";
 import { useLoadedData } from "./loader";
-import { FormState, useForm, Form } from "@/features/goals/GoalForm";
-import { useMe } from "@/contexts/CurrentCompanyContext";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const me = useMe()!;
@@ -34,7 +34,7 @@ function NewGoalForSpacePage({ form }: { form: FormState }) {
   return (
     <Pages.Page title="New Goal" testId="goal-add-page">
       <Paper.Root size="large">
-        <Paper.NavigateBack to={Paths.goalsPath()} title={`Back to ${space!.name} Space`} />
+        <Paper.NavigateBack to={DeprecatedPaths.goalsPath()} title={`Back to ${space!.name} Space`} />
 
         <h1 className="mb-4 font-bold text-3xl text-center">Adding a new subgoal for {space!.name}</h1>
 
@@ -54,7 +54,7 @@ function NewGoalPage({ form }: { form: FormState }) {
   return (
     <Pages.Page title="New Goal" testId="goal-add-page">
       <Paper.Root size="large">
-        <Paper.NavigateBack to={Paths.goalsPath()} title="Back to Goals" />
+        <Paper.NavigateBack to={DeprecatedPaths.goalsPath()} title="Back to Goals" />
 
         <h1 className="mb-4 font-bold text-3xl text-center">
           Adding a new {isCompanyWide ? "company-wide" : " "} goal

--- a/app/assets/js/pages/GoalArchivePage/page.tsx
+++ b/app/assets/js/pages/GoalArchivePage/page.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
 import { useNavigateTo } from "@/routes/useNavigateTo";
+import { useLoadedData } from "./loader";
 
-import { PrimaryButton } from "turboui";
-import { DimmedLink } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DimmedLink, PrimaryButton } from "turboui";
 
 export function Page() {
   const { goal } = useLoadedData();
@@ -16,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Archiving ", goal.name!]}>
       <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: Paths.goalPath(goal.id!), label: goal.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! }]} />
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-3xl font-extrabold">Archive this goal?</div>
@@ -26,7 +25,7 @@ export function Page() {
 
           <div className="flex items-center gap-6 mt-8">
             <ArchiveButton goal={goal} />
-            <DimmedLink to={Paths.goalPath(goal.id!)}>Cancel</DimmedLink>
+            <DimmedLink to={DeprecatedPaths.goalPath(goal.id!)}>Cancel</DimmedLink>
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -35,7 +34,7 @@ export function Page() {
 }
 
 function ArchiveButton({ goal }) {
-  const navigateToGoal = useNavigateTo(Paths.goalPath(goal.id!));
+  const navigateToGoal = useNavigateTo(DeprecatedPaths.goalPath(goal.id!));
 
   const [archive, { loading: loading }] = Goals.useArchiveGoal();
 

--- a/app/assets/js/pages/GoalCheckInNewPage/index.tsx
+++ b/app/assets/js/pages/GoalCheckInNewPage/index.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { useSubscriptions } from "@/features/Subscriptions";
-import { assertPresent } from "@/utils/assertions";
-import { useForm, Form as CheckInForm } from "@/features/goals/GoalCheckIn";
+import { Form as CheckInForm, useForm } from "@/features/goals/GoalCheckIn";
 import { banner } from "@/features/goals/GoalPageHeader/Banner";
+import { useSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { assertPresent } from "@/utils/assertions";
 
 import FormattedTime from "@/components/FormattedTime";
 
@@ -63,9 +63,9 @@ function Navigation({ goal }: { goal: Goals.Goal }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(goal.space.id!), label: goal.space.name! },
-        { to: Paths.spaceGoalsPath(goal.space.id!), label: "Goals & Projects" },
-        { to: Paths.goalPath(goal.id!), label: goal.name! },
+        { to: DeprecatedPaths.spacePath(goal.space.id!), label: goal.space.name! },
+        { to: DeprecatedPaths.spaceGoalsPath(goal.space.id!), label: "Goals & Projects" },
+        { to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! },
       ]}
     />
   );

--- a/app/assets/js/pages/GoalCheckInPage/Navigation.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Navigation.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { useLoadedData } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { useLoadedData } from "./loader";
 
 export function Navigation() {
   const { goal } = useLoadedData();
@@ -13,9 +13,9 @@ export function Navigation() {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(goal.space.id!), label: goal.space.name! },
-        { to: Paths.spaceGoalsPath(goal.space.id!), label: "Goals & Projects" },
-        { to: Paths.goalPath(goal.id!), label: goal.name! },
+        { to: DeprecatedPaths.spacePath(goal.space.id!), label: goal.space.name! },
+        { to: DeprecatedPaths.spaceGoalsPath(goal.space.id!), label: "Goals & Projects" },
+        { to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! },
       ]}
     />
   );

--- a/app/assets/js/pages/GoalClosingPage/Form.tsx
+++ b/app/assets/js/pages/GoalClosingPage/Form.tsx
@@ -1,20 +1,20 @@
 import React from "react";
 
-import * as Goals from "@/models/goals";
 import Forms from "@/components/Forms";
 import { emptyContent } from "@/components/RichContent";
+import * as Goals from "@/models/goals";
 
+import { Options, SubscribersSelector, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { assertPresent } from "@/utils/assertions";
-import { Options, SubscribersSelector, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
 import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
 
 export function Form() {
   const { goal } = useLoadedData();
 
   const [close] = Goals.useCloseGoal();
-  const navigateToGoal = useNavigateTo(Paths.goalPath(goal.id!));
+  const navigateToGoal = useNavigateTo(DeprecatedPaths.goalPath(goal.id!));
 
   assertPresent(goal.potentialSubscribers, "potentialSubscribers must be present in goal");
 

--- a/app/assets/js/pages/GoalClosingPage/loader.tsx
+++ b/app/assets/js/pages/GoalClosingPage/loader.tsx
@@ -1,7 +1,7 @@
 import * as Pages from "@/components/Pages";
 import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
-import { Paths, compareIds } from "@/routes/paths";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 
 interface LoaderResult {
   goal: Goals.Goal;
@@ -17,12 +17,12 @@ export interface ActiveSubitem {
 
 export async function loader({ params }): Promise<LoaderResult> {
   const [goal, goals, projects] = await Promise.all([
-    Goals.getGoal({ 
+    Goals.getGoal({
       id: params.goalId,
       includeChampion: true,
       includeReviewer: true,
       includePotentialSubscribers: true,
-  }).then((data) => data.goal!),
+    }).then((data) => data.goal!),
     Goals.getGoals({}).then((data) => data.goals!),
     Projects.getProjects({}).then((data) => data.projects!),
   ]);
@@ -48,7 +48,7 @@ function findActiveSubitems(goal: Goals.Goal, goals: Goals.Goal[], projects: Pro
       id: goal.id!,
       name: goal.name!,
       type: "goal",
-      link: Paths.goalPath(goal.id!),
+      link: DeprecatedPaths.goalPath(goal.id!),
     });
   });
 
@@ -57,7 +57,7 @@ function findActiveSubitems(goal: Goals.Goal, goals: Goals.Goal[], projects: Pro
       id: project.id!,
       name: project.name!,
       type: "project",
-      link: Paths.projectPath(project.id!),
+      link: DeprecatedPaths.projectPath(project.id!),
     });
   });
 

--- a/app/assets/js/pages/GoalClosingPage/page.tsx
+++ b/app/assets/js/pages/GoalClosingPage/page.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { ActiveSubitemsWarning } from "./ActiveSubitemsWarning";
 
-import { useLoadedData } from "./loader";
 import { Form } from "./Form";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { goal } = useLoadedData();
@@ -29,7 +29,7 @@ export function Page() {
 function Navigation() {
   const { goal } = useLoadedData();
 
-  return <Paper.Navigation items={[{ to: Paths.goalPath(goal.id!), label: goal.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! }]} />;
 }
 
 function PageTitle() {

--- a/app/assets/js/pages/GoalDiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/GoalDiscussionEditPage/index.tsx
@@ -1,20 +1,19 @@
-import * as React from "react";
+import * as Api from "@/api";
+import * as TipTapEditor from "@/components/Editor";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Goals from "@/models/goals";
-import * as TipTapEditor from "@/components/Editor";
 import * as Activities from "@/models/activities";
-import * as Api from "@/api";
+import * as Goals from "@/models/goals";
 import { PageModule } from "@/routes/types";
+import * as React from "react";
 
 import { FormTitleInput } from "@/components/FormTitleInput";
-import { PrimaryButton } from "turboui";
-import { DimmedLink } from "turboui";
-import { Paths } from "@/routes/paths";
 import { GoalSubpageNavigation } from "@/features/goals/GoalSubpageNavigation";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Validators } from "@/utils/validators";
+import { DimmedLink, PrimaryButton } from "turboui";
 
-import { useFormState, formValidator, useFormMutationAction } from "@/components/Form/useFormState";
+import { formValidator, useFormMutationAction, useFormState } from "@/components/Form/useFormState";
 import { match } from "ts-pattern";
 
 export default { name: "GoalDiscussionEditPage", loader, Page } as PageModule;
@@ -56,7 +55,7 @@ function Page() {
               Save
             </PrimaryButton>
 
-            <DimmedLink to={Paths.goalActivityPath(activity.id!)}>Cancel</DimmedLink>
+            <DimmedLink to={DeprecatedPaths.goalActivityPath(activity.id!)}>Cancel</DimmedLink>
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -98,7 +97,7 @@ function useForm({ activity }: { activity: Activities.Activity }) {
         title: fields.title,
         message: JSON.stringify(fields.editor.editor.getJSON()),
       }),
-      onCompleted: (_data, navigate) => navigate(Paths.goalActivityPath(activity.id!)),
+      onCompleted: (_data, navigate) => navigate(DeprecatedPaths.goalActivityPath(activity.id!)),
     }),
   });
 }

--- a/app/assets/js/pages/GoalDiscussionNewPage/Form.tsx
+++ b/app/assets/js/pages/GoalDiscussionNewPage/Form.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-import { PrimaryButton, DimmedLink } from "turboui";
+import { DimmedLink, PrimaryButton } from "turboui";
 
-import * as Goals from "@/models/goals";
 import * as TipTapEditor from "@/components/Editor";
 import { FormTitleInput } from "@/components/FormTitleInput";
+import * as Goals from "@/models/goals";
 
-import { Paths } from "@/routes/paths";
-import { assertPresent } from "@/utils/assertions";
 import { SubscribersSelector, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 
 import { useForm } from "./useForm";
 
@@ -41,7 +41,7 @@ export function Form({ goal }: { goal: Goals.Goal }) {
           Post Discussion
         </PrimaryButton>
 
-        <DimmedLink to={Paths.goalDiscussionsPath(goal.id!)}>Cancel</DimmedLink>
+        <DimmedLink to={DeprecatedPaths.goalDiscussionsPath(goal.id!)}>Cancel</DimmedLink>
       </div>
     </>
   );

--- a/app/assets/js/pages/GoalDiscussionNewPage/useForm.tsx
+++ b/app/assets/js/pages/GoalDiscussionNewPage/useForm.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
-import * as Goals from "@/models/goals";
 import * as TipTapEditor from "@/components/Editor";
-import { Paths } from "@/routes/paths";
-import { Validators } from "@/utils/validators";
-import { useFormState, formValidator } from "@/components/Form/useFormState";
+import { formValidator, useFormState } from "@/components/Form/useFormState";
 import { Options, SubscriptionsState } from "@/features/Subscriptions";
+import * as Goals from "@/models/goals";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Validators } from "@/utils/validators";
 
 type FormFields = {
   title: string;
@@ -48,7 +48,7 @@ export function useForm({ goal, subscriptionsState }: { goal: Goals.Goal; subscr
           sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
           subscriberIds: subscriptionsState.currentSubscribersList,
         })
-          .then((data) => navigate(Paths.goalActivityPath(data.id!)))
+          .then((data) => navigate(DeprecatedPaths.goalActivityPath(data.id!)))
           .finally(() => setSubmitting(false));
       },
       submitting,

--- a/app/assets/js/pages/GoalDiscussionsPage/index.tsx
+++ b/app/assets/js/pages/GoalDiscussionsPage/index.tsx
@@ -1,19 +1,18 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Goals from "@/models/goals";
+import * as Paper from "@/components/PaperContainer";
 import * as Activities from "@/models/activities";
+import * as Goals from "@/models/goals";
 import { PageModule } from "@/routes/types";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { Navigation } from "@/features/goals/GoalPageNavigation";
 import { Header } from "@/features/goals/GoalPageHeader";
+import { Navigation } from "@/features/goals/GoalPageNavigation";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PrimaryButton, SecondaryButton } from "turboui";
 
 import FormattedTime from "@/components/FormattedTime";
-import { Avatar } from "turboui";
-import { DivLink } from "turboui";
 import ActivityHandler from "@/features/activities";
+import { Avatar, DivLink } from "turboui";
 
 export default { name: "GoalDiscussionsPage", loader, Page } as PageModule;
 
@@ -39,7 +38,7 @@ async function loader({ params }): Promise<LoaderResult> {
     goal: await goalPromise,
     activities: await activitiesPromise,
   };
-};
+}
 
 function Page() {
   const { goal } = Pages.useLoadedData<LoaderResult>();
@@ -54,7 +53,7 @@ function Page() {
 
           <div className="flex items-center my-6">
             <div className="flex-1 font-bold text-xs uppercase">Discussions</div>
-            <PrimaryButton size="sm" linkTo={Paths.newGoalDiscussionPath(goal.id!)} testId="start-discussion">
+            <PrimaryButton size="sm" linkTo={DeprecatedPaths.newGoalDiscussionPath(goal.id!)} testId="start-discussion">
               Start a new discussion
             </PrimaryButton>
           </div>
@@ -64,7 +63,7 @@ function Page() {
       </Paper.Root>
     </Pages.Page>
   );
-};
+}
 
 function ActivityList() {
   const { activities } = Pages.useLoadedData<LoaderResult>();
@@ -80,7 +79,7 @@ function ActivityList() {
 
 function ActivityItem({ activity }: { activity: Activities.Activity }) {
   const path = ActivityHandler.pagePath(activity);
-  const authorProfilePath = Paths.profilePath(activity.author!.id!);
+  const authorProfilePath = DeprecatedPaths.profilePath(activity.author!.id!);
 
   return (
     <div className="flex items-start border-t border-stroke-base py-6">

--- a/app/assets/js/pages/GoalEditParentPage/page.tsx
+++ b/app/assets/js/pages/GoalEditParentPage/page.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
-import { useNavigate } from "react-router-dom";
 import { GoalSelector } from "@/features/goals/GoalTree/GoalSelector";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigate } from "react-router-dom";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { goal } = useLoadedData();
@@ -14,7 +14,7 @@ export function Page() {
   return (
     <Pages.Page title={["Changing Parent", goal.name!]}>
       <Paper.Root>
-        <Paper.Navigation items={[{ to: Paths.goalPath(goal.id!), label: goal.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! }]} />
 
         <Paper.Body>
           <div className="text-content-accent text-2xl font-extrabold mb-8">Choose a new parent for the goal</div>
@@ -30,7 +30,7 @@ function GoalList() {
   const { goal, goals } = useLoadedData();
 
   const navigate = useNavigate();
-  const goalPath = Paths.goalPath(goal.id!);
+  const goalPath = DeprecatedPaths.goalPath(goal.id!);
 
   const [select] = Goals.useChangeGoalParent();
 

--- a/app/assets/js/pages/GoalEditTimeframePage/index.tsx
+++ b/app/assets/js/pages/GoalEditTimeframePage/index.tsx
@@ -1,19 +1,18 @@
-import * as React from "react";
-import * as Pages from "@/components/Pages";
-import * as Goals from "@/models/goals";
-import * as Paper from "@/components/PaperContainer";
-import * as Timeframes from "@/utils/timeframes";
 import * as TipTapEditor from "@/components/Editor";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Goals from "@/models/goals";
 import * as Time from "@/utils/time";
+import * as Timeframes from "@/utils/timeframes";
+import * as React from "react";
 
-import { GoalSubpageNavigation } from "@/features/goals/GoalSubpageNavigation";
-import { PrimaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
-import { DimmedLink } from "turboui";
 import { Datepicker } from "@/components/Datepicker";
-import { PageModule } from "@/routes/types";
+import { GoalSubpageNavigation } from "@/features/goals/GoalSubpageNavigation";
 import { SubscribersSelector, SubscriptionsState } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
+import { DimmedLink, PrimaryButton } from "turboui";
 import { Form, useForm } from "./useForm";
 
 export default { name: "GoalEditTimeframePage", loader, Page } as PageModule;
@@ -199,7 +198,7 @@ function Submit({ goal, form }: { goal: Goals.Goal; form: Form }) {
           Submit
         </PrimaryButton>
 
-        <DimmedLink to={Paths.goalPath(goal.id!)}>Cancel</DimmedLink>
+        <DimmedLink to={DeprecatedPaths.goalPath(goal.id!)}>Cancel</DimmedLink>
       </div>
     </div>
   );

--- a/app/assets/js/pages/GoalEditTimeframePage/useForm.tsx
+++ b/app/assets/js/pages/GoalEditTimeframePage/useForm.tsx
@@ -1,11 +1,11 @@
-import React from "react";
+import * as TipTapEditor from "@/components/Editor";
 import * as Goals from "@/models/goals";
 import * as Timeframes from "@/utils/timeframes";
-import * as TipTapEditor from "@/components/Editor";
+import React from "react";
 
-import { useNavigateTo } from "@/routes/useNavigateTo";
-import { Paths } from "@/routes/paths";
 import { Options, SubscriptionsState, useSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigateTo } from "@/routes/useNavigateTo";
 import { assertPresent } from "@/utils/assertions";
 
 interface Error {
@@ -30,7 +30,7 @@ export function useForm({ goal }: { goal: Goals.Goal }): Form {
   const originalTimeframe = Timeframes.parse(goal.timeframe);
   const [timeframe, setTimeframe] = React.useState<Timeframes.Timeframe>(originalTimeframe);
 
-  const navigateToGoalPage = useNavigateTo(Paths.goalPath(goal.id));
+  const navigateToGoalPage = useNavigateTo(DeprecatedPaths.goalPath(goal.id));
   const [editTimeframe, { loading: submitting }] = Goals.useEditGoalTimeframe();
 
   const subscriptionsState = useSubscriptions(goal.potentialSubscribers, {

--- a/app/assets/js/pages/GoalPage/index.tsx
+++ b/app/assets/js/pages/GoalPage/index.tsx
@@ -10,10 +10,10 @@ import { banner } from "@/features/goals/GoalPageHeader/Banner";
 import { Navigation } from "@/features/goals/GoalPageNavigation";
 import { GoalTargets } from "@/features/goals/GoalTargets";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
-import { assertPresent } from "@/utils/assertions";
 import { PageModule } from "@/routes/types";
+import { assertPresent } from "@/utils/assertions";
 
 export default { name: "GoalPage", loader, Page } as PageModule;
 
@@ -24,12 +24,12 @@ interface LoaderResult {
 async function loader({ params }): Promise<LoaderResult> {
   await redirectIfFeatureEnabled(params, {
     feature: "goal_page_v3",
-    path: Paths.goalV3Path(params.id),
+    path: DeprecatedPaths.goalV3Path(params.id),
   });
 
   await redirectIfFeatureEnabled(params, {
     feature: "new_goal_page",
-    path: Paths.goalV2Path(params.id),
+    path: DeprecatedPaths.goalV2Path(params.id),
   });
 
   return {

--- a/app/assets/js/pages/GoalReopenPage/index.tsx
+++ b/app/assets/js/pages/GoalReopenPage/index.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
 import { PageModule } from "@/routes/types";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Form } from "./Form";
 
 export default { name: "GoalReopenPage", loader, Page } as PageModule;
@@ -30,7 +30,7 @@ function Page() {
   return (
     <Pages.Page title={"Reopen " + goal.name}>
       <Paper.Root>
-        <Paper.Navigation items={[{ to: Paths.goalPath(goal.id!), label: goal.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.goalPath(goal.id!), label: goal.name! }]} />
 
         <Paper.Body>
           <Title />

--- a/app/assets/js/pages/GoalReopenPage/useForm.tsx
+++ b/app/assets/js/pages/GoalReopenPage/useForm.tsx
@@ -1,8 +1,8 @@
-import * as Goals from "@/models/goals";
 import * as Editor from "@/components/Editor";
-import { useNavigate } from "react-router-dom";
 import { Options, SubscriptionsState } from "@/features/Subscriptions";
-import { Paths } from "@/routes/paths";
+import * as Goals from "@/models/goals";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigate } from "react-router-dom";
 
 export interface FormState {
   messageEditor: Editor.EditorState;
@@ -19,7 +19,7 @@ export function useForm(goal: Goals.Goal, subscriptionsState: SubscriptionsState
     mentionSearchScope: { type: "goal", id: goal.id! },
   });
 
-  const goalPath = Paths.goalPath(goal.id!);
+  const goalPath = DeprecatedPaths.goalPath(goal.id!);
 
   const [reopen] = Goals.useReopenGoal();
 

--- a/app/assets/js/pages/GoalV2Page/DeleteGoalModal.tsx
+++ b/app/assets/js/pages/GoalV2Page/DeleteGoalModal.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 import { MiniWorkMap } from "turboui";
 
-import { useNavigate } from "react-router-dom";
 import { findGoalChildren, useDeleteGoal } from "@/models/goals";
+import { useNavigate } from "react-router-dom";
 import { useWorkItems } from "./useWorkItems";
 
-import Modal from "@/components/Modal";
-import { PrimaryButton, SecondaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
-import { useLoadedData } from "./loader";
 import { WarningCallout } from "@/components/Callouts";
+import Modal from "@/components/Modal";
+import { DeprecatedPaths } from "@/routes/paths";
+import { PrimaryButton, SecondaryButton } from "turboui";
+import { useLoadedData } from "./loader";
 
 interface Props {
   showDeleteGoal: boolean;
@@ -45,7 +45,7 @@ function DeleteGoal({ toggleShowDeleteGoal }: { toggleShowDeleteGoal: () => void
     if (loading) return;
     await deleteGoal({ goalId: goal.id });
     toggleShowDeleteGoal();
-    navigate(Paths.goalsPath());
+    navigate(DeprecatedPaths.goalsPath());
   };
 
   return (

--- a/app/assets/js/pages/GoalV2Page/Messages.tsx
+++ b/app/assets/js/pages/GoalV2Page/Messages.tsx
@@ -1,25 +1,24 @@
 import * as React from "react";
 
-import * as People from "@/models/people";
+import ActivityHandler from "@/features/activities";
 import * as Activities from "@/models/activities";
 import { GoalActivities } from "@/models/goals";
-import ActivityHandler from "@/features/activities";
+import * as People from "@/models/people";
 import * as Timeframes from "@/utils/timeframes";
 
 import { match } from "ts-pattern";
 
-import FormattedTime from "@/components/FormattedTime";
 import { AvatarLink } from "@/components/AvatarLink";
-import { SecondaryButton } from "turboui";
+import FormattedTime from "@/components/FormattedTime";
 import { richContentToString } from "@/components/RichContent";
-import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { truncateString } from "@/utils/strings";
+import { DivLink, SecondaryButton } from "turboui";
 
+import { StatusBadge } from "turboui";
 import { DisableInEditMode, Title } from "./components";
 import { useLoadedData } from "./loader";
-import { StatusBadge } from "turboui";
 
 interface Props {
   activity: Activities.Activity;
@@ -27,7 +26,7 @@ interface Props {
 
 export function Messages() {
   const { goal } = useLoadedData();
-  const writeMessagePath = Paths.newGoalDiscussionPath(goal.id!);
+  const writeMessagePath = DeprecatedPaths.newGoalDiscussionPath(goal.id!);
 
   return (
     <DisableInEditMode>

--- a/app/assets/js/pages/GoalV2Page/NextCheckIn.tsx
+++ b/app/assets/js/pages/GoalV2Page/NextCheckIn.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-import { Paths } from "@/routes/paths";
+import FormattedTime from "@/components/FormattedTime";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { assertPresent } from "@/utils/assertions";
 import { SecondaryButton } from "turboui";
-import FormattedTime from "@/components/FormattedTime";
 
 import { DisableInEditMode, Title } from "./components";
 import { useLoadedData } from "./loader";
 
 export function NextCheckIn() {
   const { goal } = useLoadedData();
-  const navigate = useNavigateTo(Paths.goalCheckInNewPath(goal.id!));
+  const navigate = useNavigateTo(DeprecatedPaths.goalCheckInNewPath(goal.id!));
 
   assertPresent(goal.nextUpdateScheduledAt, "nextUpdateScheduledAt must be present in goal");
 

--- a/app/assets/js/pages/GoalV2Page/Options.tsx
+++ b/app/assets/js/pages/GoalV2Page/Options.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
 import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
-import { Paths } from "@/routes/paths";
+import * as Icons from "@tabler/icons-react";
 
 import { useLoadedData } from "./loader";
 
@@ -36,7 +36,7 @@ export function Options({ toggleShowDeleteGoal }: Props) {
         <PageOptions.Link
           icon={Icons.IconCircleCheck}
           title="Close Goal"
-          to={Paths.goalClosePath(goal.id!)}
+          to={DeprecatedPaths.goalClosePath(goal.id!)}
           testId="close-goal"
         />
       )}
@@ -45,7 +45,7 @@ export function Options({ toggleShowDeleteGoal }: Props) {
         <PageOptions.Link
           icon={Icons.IconRotateDot}
           title="Reopen Goal"
-          to={Paths.goalReopenPath(goal.id!)}
+          to={DeprecatedPaths.goalReopenPath(goal.id!)}
           testId="reopen-goal"
         />
       )}

--- a/app/assets/js/pages/GoalV2Page/ParentGoal.tsx
+++ b/app/assets/js/pages/GoalV2Page/ParentGoal.tsx
@@ -3,16 +3,15 @@ import React from "react";
 import { filterPossibleParentGoals, Goal } from "@/models/goals";
 import { IconBuildingEstate, IconTarget } from "@tabler/icons-react";
 
-import classNames from "classnames";
-import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import Forms from "@/components/Forms";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import classNames from "classnames";
 
-import { GhostLink } from "turboui";
 import { useIsViewMode } from "@/components/Pages";
-import { Paths } from "@/routes/paths";
-import { useLoadedData } from "./loader";
-import { SecondaryButton } from "turboui";
 import { GoalSelector } from "@/features/goals/GoalTree/GoalSelector";
+import { DeprecatedPaths } from "@/routes/paths";
+import { GhostLink, SecondaryButton } from "turboui";
+import { useLoadedData } from "./loader";
 
 export function ParentGoal() {
   const isViewMode = useIsViewMode();
@@ -90,5 +89,5 @@ function GoalName({ link }: { link?: boolean }) {
   if (!link) {
     return <div className="font-medium text-sm text-content-dimmed">{parentGoal.name}</div>;
   }
-  return <GhostLink to={Paths.goalPath(parentGoal.id!)} text={parentGoal.name!} dimmed size="sm" />;
+  return <GhostLink to={DeprecatedPaths.goalPath(parentGoal.id!)} text={parentGoal.name!} dimmed size="sm" />;
 }

--- a/app/assets/js/pages/GoalV2Page/RelatedWork.tsx
+++ b/app/assets/js/pages/GoalV2Page/RelatedWork.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import { MiniWorkMap } from "turboui";
 
 import { Spacer } from "@/components/Spacer";
+import { DeprecatedPaths } from "@/routes/paths";
 import { SecondaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
 
+import { assertPresent } from "@/utils/assertions";
 import { DisableInEditMode, Title } from "./components";
 import { useLoadedData } from "./loader";
-import { assertPresent } from "@/utils/assertions";
 import { useWorkItems } from "./useWorkItems";
 
 export function RelatedWork() {
@@ -17,8 +17,8 @@ export function RelatedWork() {
 
   assertPresent(goal.space, "space must be present in goal");
 
-  const newGoalPath = Paths.goalNewPath({ parentGoalId: goal.id! });
-  const newProjectPath = Paths.newProjectPath({ goalId: goal.id!, spaceId: goal.space.id! });
+  const newGoalPath = DeprecatedPaths.goalNewPath({ parentGoalId: goal.id! });
+  const newProjectPath = DeprecatedPaths.newProjectPath({ goalId: goal.id!, spaceId: goal.space.id! });
 
   return (
     <DisableInEditMode>
@@ -37,4 +37,3 @@ export function RelatedWork() {
     </DisableInEditMode>
   );
 }
-

--- a/app/assets/js/pages/GoalV2Page/useWorkItems.tsx
+++ b/app/assets/js/pages/GoalV2Page/useWorkItems.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
 
-import { compareIds, Paths } from "@/routes/paths";
+import { compareIds, DeprecatedPaths } from "@/routes/paths";
 
 import { assertPresent } from "@/utils/assertions";
 import { MiniWorkMap } from "turboui";
@@ -23,7 +23,7 @@ export function useWorkItems(): MiniWorkMap.WorkItem[] {
         state: project.closedAt ? "closed" : project.status === "paused" ? "paused" : "active",
         status: project.lastCheckIn?.status || "pending",
         name: project.name,
-        itemPath: Paths.projectPath(project.id),
+        itemPath: DeprecatedPaths.projectPath(project.id),
         progress: Projects.getProgress(project),
         completed: Projects.isClosed(project),
         assignees: Projects.getPeople(project),
@@ -43,7 +43,7 @@ export function useWorkItems(): MiniWorkMap.WorkItem[] {
         state: goal.closedAt ? "closed" : "active",
         status: goal.lastCheckIn?.status || "pending",
         name: goal.name,
-        itemPath: Paths.goalPath(goal.id),
+        itemPath: DeprecatedPaths.goalPath(goal.id),
         progress: goal.progressPercentage,
         completed: goal.isClosed,
         assignees: Goals.getPeople(goal),

--- a/app/assets/js/pages/GoalV3Page/index.tsx
+++ b/app/assets/js/pages/GoalV3Page/index.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from "react-router-dom";
 import { GoalPage, showErrorToast } from "turboui";
 import { useMentionedPersonLookupFn } from "../../contexts/CurrentCompanyContext";
 import { getWorkMap, WorkMapItem } from "../../models/workMap";
-import { Paths } from "../../routes/paths";
+import { DeprecatedPaths } from "../../routes/paths";
 import { assertPresent } from "../../utils/assertions";
 import { fetchAll } from "../../utils/async";
 
@@ -116,7 +116,7 @@ function Page() {
     try {
       await Api.deleteGoal({ goalId: goal.id! });
       PageCache.invalidate(pageCacheKey(goal.id!));
-      navigate(Paths.spaceWorkMapPath(goal.space!.id, "goals"));
+      navigate(DeprecatedPaths.spaceWorkMapPath(goal.space!.id, "goals"));
     } catch (error) {
       console.error("Failed to delete goal:", error);
       showErrorToast("Something went wrong", "Failed to delete the goal. Please try again.");
@@ -125,14 +125,14 @@ function Page() {
 
   const props: GoalPage.Props = {
     goalName: goal.name,
-    workmapLink: Paths.spaceWorkMapPath(goal.space.id, "goals"),
-    closeLink: Paths.goalClosePath(goal.id),
-    reopenLink: Paths.goalReopenPath(goal.id),
-    editGoalLink: Paths.goalEditPath(goal.id),
-    newCheckInLink: Paths.goalCheckInNewPath(goal.id),
-    newDiscussionLink: Paths.newGoalDiscussionPath(goal.id),
-    addSubprojectLink: Paths.newProjectPath({ goalId: goal.id!, spaceId: goal.space!.id! }),
-    addSubgoalLink: Paths.newGoalPath({ parentGoalId: goal.id!, spaceId: goal.space!.id! }),
+    workmapLink: DeprecatedPaths.spaceWorkMapPath(goal.space.id, "goals"),
+    closeLink: DeprecatedPaths.goalClosePath(goal.id),
+    reopenLink: DeprecatedPaths.goalReopenPath(goal.id),
+    editGoalLink: DeprecatedPaths.goalEditPath(goal.id),
+    newCheckInLink: DeprecatedPaths.goalCheckInNewPath(goal.id),
+    newDiscussionLink: DeprecatedPaths.newGoalDiscussionPath(goal.id),
+    addSubprojectLink: DeprecatedPaths.newProjectPath({ goalId: goal.id!, spaceId: goal.space!.id! }),
+    addSubgoalLink: DeprecatedPaths.newGoalPath({ parentGoalId: goal.id!, spaceId: goal.space!.id! }),
     closedAt: Time.parse(goal.closedAt),
     retrospective: prepareRetrospective(goal.retrospective),
     neglectedGoal: false,
@@ -279,7 +279,7 @@ function preparePerson(person: People.Person | null | undefined) {
       fullName: person.fullName!,
       title: person.title || "",
       avatarUrl: person.avatarUrl || "",
-      profileLink: Paths.profilePath(person.id!),
+      profileLink: DeprecatedPaths.profilePath(person.id!),
     };
   }
 }
@@ -292,7 +292,7 @@ function prepareCheckIns(checkIns: GoalProgressUpdate[]): GoalPage.Props["checkI
       id: checkIn.id!,
       author: preparePerson(checkIn.author)!,
       date: Time.parse(checkIn.insertedAt!)!,
-      link: Paths.goalCheckInPath(checkIn.id!),
+      link: DeprecatedPaths.goalCheckInPath(checkIn.id!),
       content: JSON.parse(checkIn.message!),
       commentCount: checkIn.commentsCount!,
       status: checkIn.status!,
@@ -304,7 +304,7 @@ function prepareParentGoal(g: Goal | null | undefined): GoalPage.Props["parentGo
   if (!g) {
     return null;
   } else {
-    return { id: g!.id!, link: Paths.goalPath(g!.id!), name: g!.name! };
+    return { id: g!.id!, link: DeprecatedPaths.goalPath(g!.id!), name: g!.name! };
   }
 }
 
@@ -442,7 +442,7 @@ function prepareDiscussions(discussions: GoalDiscussion[]): GoalPage.Props["disc
       date: Time.parse(discussion.insertedAt)!,
       title: discussion.title,
       author: preparePerson(discussion.author)!,
-      link: Paths.goalDiscussionPath(discussion.id),
+      link: DeprecatedPaths.goalDiscussionPath(discussion.id),
       content: JSON.parse(discussion.content),
       commentCount: discussion.commentCount,
     };
@@ -455,7 +455,7 @@ function prepareRetrospective(retrospective: GoalRetrospective | null | undefine
   }
 
   return {
-    link: Paths.goalRetrospectivePath(retrospective.id),
+    link: DeprecatedPaths.goalRetrospectivePath(retrospective.id),
     date: Time.parse(retrospective.insertedAt)!,
     content: JSON.parse(retrospective.content),
     author: preparePerson(retrospective.author)!,
@@ -475,7 +475,7 @@ function prepareSpace(space: Space): GoalPage.Space {
   return {
     id: space.id!,
     name: space.name!,
-    link: Paths.spacePath(space.id!),
+    link: DeprecatedPaths.spacePath(space.id!),
   };
 }
 
@@ -486,7 +486,7 @@ function useSpaceSearch(): GoalPage.Props["spaceSearch"] {
     return data.spaces.map((space) => ({
       id: space.id!,
       name: space.name!,
-      link: Paths.spacePath(space.id!),
+      link: DeprecatedPaths.spacePath(space.id!),
     }));
   };
 }

--- a/app/assets/js/pages/GoalsAndProjectsPage/loader.tsx
+++ b/app/assets/js/pages/GoalsAndProjectsPage/loader.tsx
@@ -1,7 +1,7 @@
 import * as Pages from "@/components/Pages";
 import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoaderResult {
@@ -12,7 +12,7 @@ interface LoaderResult {
 export async function loader({ params }): Promise<LoaderResult> {
   await redirectIfFeatureEnabled(params, {
     feature: "work_map_page",
-    path: Paths.workMapPath(),
+    path: DeprecatedPaths.workMapPath(),
   });
 
   const [goals, projects] = await Promise.all([

--- a/app/assets/js/pages/GoalsAndProjectsPage/page.tsx
+++ b/app/assets/js/pages/GoalsAndProjectsPage/page.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import { GoalTree } from "@/features/goals/GoalTree";
-import { Paths } from "@/routes/paths";
-import { useLoadedData } from "./loader";
 import { AddGoalOrProjectButton } from "@/features/goals/AddGoalOrProjectButton";
+import { GoalTree } from "@/features/goals/GoalTree";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useLoadedData } from "./loader";
 
 import classNames from "classnames";
 
@@ -32,9 +32,9 @@ export function Page() {
 }
 
 function Header() {
-  const newGoalPath = Paths.newGoalPath({ companyWide: true });
-  const newProjectPath = Paths.newProjectPath({
-    backPath: Paths.goalsPath(),
+  const newGoalPath = DeprecatedPaths.newGoalPath({ companyWide: true });
+  const newProjectPath = DeprecatedPaths.newProjectPath({
+    backPath: DeprecatedPaths.goalsPath(),
     backPathName: "Back to Goal Map",
   });
 

--- a/app/assets/js/pages/HomePage/page.tsx
+++ b/app/assets/js/pages/HomePage/page.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Spaces from "@/models/spaces";
+import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
+import * as Spaces from "@/models/spaces";
 
-import { SpaceCardLink, SpaceCardGrid } from "@/features/spaces/SpaceCards";
+import { SpaceCardGrid, SpaceCardLink } from "@/features/spaces/SpaceCards";
 
-import { useLoadedData } from "./loader";
-import { Feed, useItemsQuery } from "@/features/Feed";
 import { useMe } from "@/contexts/CurrentCompanyContext";
+import { Feed, useItemsQuery } from "@/features/Feed";
+import { DeprecatedPaths } from "@/routes/paths";
 import { GhostButton } from "turboui";
-import { Paths } from "@/routes/paths";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   return (
@@ -65,7 +65,7 @@ function ActivityFeed() {
 
 function AddSpaceButton() {
   return (
-    <GhostButton linkTo={Paths.newSpacePath()} testId="add-space" size="sm">
+    <GhostButton linkTo={DeprecatedPaths.newSpacePath()} testId="add-space" size="sm">
       Add Space
     </GhostButton>
   );

--- a/app/assets/js/pages/HomePage/page.tsx
+++ b/app/assets/js/pages/HomePage/page.tsx
@@ -9,7 +9,7 @@ import { SpaceCardGrid, SpaceCardLink } from "@/features/spaces/SpaceCards";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { Feed, useItemsQuery } from "@/features/Feed";
-import { DeprecatedPaths } from "@/routes/paths";
+import { usePaths } from "@/routes/paths";
 import { GhostButton } from "turboui";
 import { useLoadedData } from "./loader";
 
@@ -64,8 +64,10 @@ function ActivityFeed() {
 }
 
 function AddSpaceButton() {
+  const paths = usePaths();
+
   return (
-    <GhostButton linkTo={DeprecatedPaths.newSpacePath()} testId="add-space" size="sm">
+    <GhostButton linkTo={paths.newSpacePath()} testId="add-space" size="sm">
       Add Space
     </GhostButton>
   );

--- a/app/assets/js/pages/LobbyPage/index.tsx
+++ b/app/assets/js/pages/LobbyPage/index.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
 import { DivLink, Link } from "turboui";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
 import plurarize from "@/utils/plurarize";
@@ -86,7 +86,7 @@ function CompanyCard({ company }: { company: Api.Company }) {
   );
 
   return (
-    <DivLink to={Paths.companyHomePath(company.id!)} className={className}>
+    <DivLink to={DeprecatedPaths.companyHomePath(company.id!)} className={className}>
       <Icons.IconBuildingEstate size={40} className="text-cyan-500" strokeWidth={1} />
       <div className="font-medium mt-2">{company.name}</div>
       <div className="text-xs">{plurarize(company.memberCount!, "member", "members")}</div>
@@ -107,7 +107,7 @@ function AddCompanyCard() {
   );
 
   return (
-    <DivLink to={Paths.newCompanyPath()} className={className} testId="add-company-card">
+    <DivLink to={DeprecatedPaths.newCompanyPath()} className={className} testId="add-company-card">
       <div className="font-bold sm:text-lg">+ Create new</div>
       <div className="text-xs sm:text-sm font-medium">Add new organization</div>
       <div className="flex justify-end mt-3">

--- a/app/assets/js/pages/LobbyPage/index.tsx
+++ b/app/assets/js/pages/LobbyPage/index.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
 import { DivLink, Link } from "turboui";
 
-import { DeprecatedPaths } from "@/routes/paths";
+import { Paths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
 import plurarize from "@/utils/plurarize";
@@ -86,7 +86,7 @@ function CompanyCard({ company }: { company: Api.Company }) {
   );
 
   return (
-    <DivLink to={DeprecatedPaths.companyHomePath(company.id!)} className={className}>
+    <DivLink to={Paths.companyHomePath(company.id!)} className={className}>
       <Icons.IconBuildingEstate size={40} className="text-cyan-500" strokeWidth={1} />
       <div className="font-medium mt-2">{company.name}</div>
       <div className="text-xs">{plurarize(company.memberCount!, "member", "members")}</div>
@@ -107,7 +107,7 @@ function AddCompanyCard() {
   );
 
   return (
-    <DivLink to={DeprecatedPaths.newCompanyPath()} className={className} testId="add-company-card">
+    <DivLink to={Paths.newCompanyPath()} className={className} testId="add-company-card">
       <div className="font-bold sm:text-lg">+ Create new</div>
       <div className="text-xs sm:text-sm font-medium">Add new organization</div>
       <div className="flex justify-end mt-3">

--- a/app/assets/js/pages/LoginPage/index.tsx
+++ b/app/assets/js/pages/LoginPage/index.tsx
@@ -7,7 +7,7 @@ import { OperatelyLogo } from "@/components/OperatelyLogo";
 
 import { SignInWithGoogleButton } from "@/features/auth/Buttons";
 import { logIn } from "@/routes/auth";
-import { DeprecatedPaths } from "@/routes/paths";
+import { Paths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 import classNames from "classnames";
 import { DimmedLink, Link } from "turboui";
@@ -98,7 +98,7 @@ function PasswordInput() {
 
 function ForgotPasswordLink() {
   return (
-    <DimmedLink to={DeprecatedPaths.forgotPasswordPath()} className="text-sm font-normal" testId="forgot-password-link">
+    <DimmedLink to={Paths.forgotPasswordPath()} className="text-sm font-normal" testId="forgot-password-link">
       Forgot password?
     </DimmedLink>
   );

--- a/app/assets/js/pages/LoginPage/index.tsx
+++ b/app/assets/js/pages/LoginPage/index.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
 import Forms from "@/components/Forms";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
 
-import classNames from "classnames";
-import { logIn } from "@/routes/auth";
-import { Link, DimmedLink } from "turboui";
 import { SignInWithGoogleButton } from "@/features/auth/Buttons";
-import { Paths } from "@/routes/paths";
+import { logIn } from "@/routes/auth";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import classNames from "classnames";
+import { DimmedLink, Link } from "turboui";
 
 export default { name: "LoginPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -98,7 +98,7 @@ function PasswordInput() {
 
 function ForgotPasswordLink() {
   return (
-    <DimmedLink to={Paths.forgotPasswordPath()} className="text-sm font-normal" testId="forgot-password-link">
+    <DimmedLink to={DeprecatedPaths.forgotPasswordPath()} className="text-sm font-normal" testId="forgot-password-link">
       Forgot password?
     </DimmedLink>
   );

--- a/app/assets/js/pages/NewCompanyPage/index.tsx
+++ b/app/assets/js/pages/NewCompanyPage/index.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
+import * as Api from "@/api";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Api from "@/api";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
 
 import Forms from "@/components/Forms";
@@ -29,14 +29,14 @@ function Page() {
         isDemo: form.values.isDemo == "true",
       });
 
-      navigate(Paths.companyHomePath(res.company.id));
+      navigate(DeprecatedPaths.companyHomePath(res.company.id));
     },
   });
 
   return (
     <Pages.Page title={"New Company"}>
       <Paper.Root size="small" className="mt-24">
-        <Paper.NavigateBack to={Paths.lobbyPath()} title="Back to the Lobby" />
+        <Paper.NavigateBack to={DeprecatedPaths.lobbyPath()} title="Back to the Lobby" />
         <Paper.Body>
           <PageTitle />
 

--- a/app/assets/js/pages/NewCompanyPage/index.tsx
+++ b/app/assets/js/pages/NewCompanyPage/index.tsx
@@ -4,7 +4,7 @@ import * as Paper from "@/components/PaperContainer";
 import * as React from "react";
 
 import { OperatelyLogo } from "@/components/OperatelyLogo";
-import { DeprecatedPaths } from "@/routes/paths";
+import { Paths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
 
 import Forms from "@/components/Forms";
@@ -29,14 +29,14 @@ function Page() {
         isDemo: form.values.isDemo == "true",
       });
 
-      navigate(DeprecatedPaths.companyHomePath(res.company.id));
+      navigate(Paths.companyHomePath(res.company.id));
     },
   });
 
   return (
     <Pages.Page title={"New Company"}>
       <Paper.Root size="small" className="mt-24">
-        <Paper.NavigateBack to={DeprecatedPaths.lobbyPath()} title="Back to the Lobby" />
+        <Paper.NavigateBack to={Paths.lobbyPath()} title="Back to the Lobby" />
         <Paper.Body>
           <PageTitle />
 

--- a/app/assets/js/pages/NotFoundPage/index.tsx
+++ b/app/assets/js/pages/NotFoundPage/index.tsx
@@ -1,8 +1,8 @@
-import React from "react";
 import * as Pages from "@/components/Pages";
-import { GhostButton } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import React from "react";
+import { GhostButton } from "turboui";
 
 export default { name: "NotFoundPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -17,7 +17,7 @@ function Page() {
         <div className="text-lg font-medium my-4">Sorry, we couldn't find that page you were looking for.</div>
 
         <div className="flex w-full justify-center mt-4">
-          <GhostButton linkTo={Paths.homePath()} testId="back-to-lobby">
+          <GhostButton linkTo={DeprecatedPaths.homePath()} testId="back-to-lobby">
             Go back to Home
           </GhostButton>
         </div>

--- a/app/assets/js/pages/PeopleOrgChartPage/page.tsx
+++ b/app/assets/js/pages/PeopleOrgChartPage/page.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
-import { Avatar } from "turboui";
-import { Link } from "turboui";
 import * as Icons from "@tabler/icons-react";
+import { Avatar, Link } from "turboui";
+import { useLoadedData } from "./loader";
 
-import { useOrgChart, OrgChart, OrgChartNode } from "./useOrgChart";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 import classNames from "classnames";
-import { Paths, compareIds } from "@/routes/paths";
+import { OrgChart, OrgChartNode, useOrgChart } from "./useOrgChart";
 
 export function Page() {
   const { people } = useLoadedData();
@@ -78,7 +77,7 @@ function Subtree({ node, chart }: { node: OrgChartNode; chart: OrgChart }) {
 
 function PersonCard({ node, chart }: { node: OrgChartNode; chart: OrgChart }) {
   const person = node.person;
-  const path = Paths.profilePath(person.id!);
+  const path = DeprecatedPaths.profilePath(person.id!);
 
   return (
     <div className="">

--- a/app/assets/js/pages/PeoplePage/page.tsx
+++ b/app/assets/js/pages/PeoplePage/page.tsx
@@ -1,11 +1,10 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
 import { Person } from "@/models/people";
-import { Avatar } from "turboui";
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Avatar, Link } from "turboui";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { company, people } = useLoadedData();
@@ -41,7 +40,7 @@ function PersonCard({ person }: { person: Person }) {
 
         <div className="flex flex-col">
           <div className="font-bold leading-tight">
-            <Link to={Paths.profilePath(person.id!!)} underline="never" testId={testId}>
+            <Link to={DeprecatedPaths.profilePath(person.id!!)} underline="never" testId={testId}>
               {person.fullName}
             </Link>
           </div>

--- a/app/assets/js/pages/ProfileEditPage/index.tsx
+++ b/app/assets/js/pages/ProfileEditPage/index.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
+import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
-import * as Pages from "@/components/Pages";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
-import { Paths } from "@/routes/paths";
 import { Timezones } from "./timezones";
 
-import { Avatar } from "turboui";
 import Forms from "@/components/Forms";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { PageModule } from "@/routes/types";
+import { Avatar } from "turboui";
 
 export default { name: "ProfileEditPage", loader, Page } as PageModule;
 
@@ -50,13 +50,13 @@ function Navigation() {
     return (
       <Paper.Navigation
         items={[
-          { label: "Company Administration", to: Paths.companyAdminPath() },
-          { label: "Manage Team Members", to: Paths.companyManagePeoplePath() },
+          { label: "Company Administration", to: DeprecatedPaths.companyAdminPath() },
+          { label: "Manage Team Members", to: DeprecatedPaths.companyManagePeoplePath() },
         ]}
       />
     );
   } else {
-    return <Paper.Navigation items={[{ label: "Account", to: Paths.accountPath() }]} />;
+    return <Paper.Navigation items={[{ label: "Account", to: DeprecatedPaths.accountPath() }]} />;
   }
 }
 
@@ -92,9 +92,9 @@ function ProfileForm({ person }: { person: People.Person }) {
       });
 
       if (me.id === person.id) {
-        navigate(Paths.accountPath());
+        navigate(DeprecatedPaths.accountPath());
       } else {
-        navigate(Paths.companyManagePeoplePath());
+        navigate(DeprecatedPaths.companyManagePeoplePath());
       }
     },
   });

--- a/app/assets/js/pages/ProfilePage/Colleagues.tsx
+++ b/app/assets/js/pages/ProfilePage/Colleagues.tsx
@@ -1,12 +1,11 @@
-import * as React from "react";
 import * as People from "@/models/people";
+import * as React from "react";
 
-import { DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DivLink, SecondaryButton } from "turboui";
 
-import { Avatar } from "turboui";
 import classNames from "classnames";
+import { Avatar } from "turboui";
 
 export function Colleagues({ person }: { person: People.Person }) {
   const [allPeersVisible, setAllPeersVisible] = React.useState(false);
@@ -128,7 +127,9 @@ function PersonCard(props: PersonCardProps) {
   const testid = `person-card-${person.id}`;
 
   if (link) {
-    return <DivLink to={Paths.profilePath(person.id!)} className={className} children={content} testId={testid} />;
+    return (
+      <DivLink to={DeprecatedPaths.profilePath(person.id!)} className={className} children={content} testId={testid} />
+    );
   } else {
     return <div className={className} children={content} data-test-id={testid} />;
   }

--- a/app/assets/js/pages/ProfilePage/loader.tsx
+++ b/app/assets/js/pages/ProfilePage/loader.tsx
@@ -1,6 +1,6 @@
 import * as Pages from "@/components/Pages";
 import * as People from "@/models/people";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoaderResult {
@@ -10,7 +10,7 @@ interface LoaderResult {
 export async function loader({ params }): Promise<LoaderResult> {
   await redirectIfFeatureEnabled(params, {
     feature: "new_profile_page",
-    path: Paths.profileV2Path(params.id),
+    path: DeprecatedPaths.profileV2Path(params.id),
   });
 
   return {

--- a/app/assets/js/pages/ProfileV2Page/index.tsx
+++ b/app/assets/js/pages/ProfileV2Page/index.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import * as People from "@/models/people";
 import { toPersonWithLink } from "@/models/people";
 
-import { PageModule } from "@/routes/types";
-import { ProfilePage } from "turboui";
 import { Feed, useItemsQuery } from "@/features/Feed";
+import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
+import { ProfilePage } from "turboui";
 
-import { loader, useLoadedData } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { IconPencil } from "@tabler/icons-react";
-import { Paths } from "@/routes/paths";
+import { loader, useLoadedData } from "./loader";
 
 export default { name: "ProfileV2Page", loader, Page } as PageModule;
 
@@ -36,7 +36,7 @@ function Page() {
         type: "link" as const,
         icon: IconPencil,
         label: "Edit",
-        link: Paths.profileEditPath(person.id!),
+        link: DeprecatedPaths.profileEditPath(person.id!),
         hidden: !person.permissions.canEditProfile,
       },
     ],

--- a/app/assets/js/pages/ProfileV2Page/loader.tsx
+++ b/app/assets/js/pages/ProfileV2Page/loader.tsx
@@ -3,7 +3,7 @@ import * as WorkMap from "@/models/workMap";
 import { convertToWorkMapItem } from "@/models/workMap";
 
 import { PageCache } from "@/routes/PageCache";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
 import { fetchAll } from "@/utils/async";
 
@@ -19,7 +19,7 @@ interface LoaderResult {
 export async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
   await redirectIfFeatureNotEnabled(params, {
     feature: "new_profile_page",
-    path: Paths.profilePath(params.id),
+    path: DeprecatedPaths.profilePath(params.id),
   });
 
   return fetchData(params.id, refreshCache);

--- a/app/assets/js/pages/ProjectAddPage/page.tsx
+++ b/app/assets/js/pages/ProjectAddPage/page.tsx
@@ -1,21 +1,21 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Projects from "@/models/projects";
+import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
+import * as Projects from "@/models/projects";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
-import { Paths, compareIds } from "@/routes/paths";
 import { useMe } from "@/contexts/CurrentCompanyContext";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
+import { useLoadedData } from "./loader";
 
 import Forms from "@/components/Forms";
-import { SecondaryButton } from "turboui";
-import { AccessLevel } from "@/features/projects/AccessLevel";
 import { PermissionLevels } from "@/features/Permissions";
-import { AccessSelectors } from "@/features/projects/AccessSelectors";
 import { applyAccessLevelConstraints, initialAccessLevels } from "@/features/Permissions/AccessFields";
+import { AccessLevel } from "@/features/projects/AccessLevel";
+import { AccessSelectors } from "@/features/projects/AccessSelectors";
+import { SecondaryButton } from "turboui";
 
 export function Page() {
   return (
@@ -95,7 +95,7 @@ function Form() {
         spaceAccessLevel: form.values.access.spaceMembers,
       });
 
-      navigate(Paths.projectPath(res.project.id!));
+      navigate(DeprecatedPaths.projectPath(res.project.id!));
     },
   });
 

--- a/app/assets/js/pages/ProjectAddResourcePage/page.tsx
+++ b/app/assets/js/pages/ProjectAddResourcePage/page.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
 import * as Forms from "@/components/Form";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as KeyResources from "@/models/keyResources";
+import * as React from "react";
 
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { ResourceIcon } from "@/components/KeyResourceIcon";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useLoadedData, useResourceTypeParam } from "./loader";
 import { useForm } from "./useForm";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -38,7 +38,7 @@ export function Page() {
 }
 
 function Form({ project, form }) {
-  const onCancel = useNavigateTo(Paths.projectEditResourcesPath(project.id));
+  const onCancel = useNavigateTo(DeprecatedPaths.projectEditResourcesPath(project.id));
   const namePlaceholder = KeyResources.placeholderName(form.resourceType);
 
   return (

--- a/app/assets/js/pages/ProjectAddResourcePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectAddResourcePage/useForm.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-import * as Projects from "@/models/projects";
 import * as KeyResources from "@/models/keyResources";
+import * as Projects from "@/models/projects";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
-import { Paths } from "@/routes/paths";
 
 interface FormState {
   projectId: string;
@@ -21,7 +21,7 @@ interface FormState {
 }
 
 export function useForm(project: Projects.Project, resourceType: string): FormState {
-  const gotoResourceList = useNavigateTo(Paths.projectEditResourcesPath(project.id!));
+  const gotoResourceList = useNavigateTo(DeprecatedPaths.projectEditResourcesPath(project.id!));
 
   const [name, setName] = React.useState("");
   const [url, setUrl] = React.useState("");

--- a/app/assets/js/pages/ProjectArchivationPage/page.tsx
+++ b/app/assets/js/pages/ProjectArchivationPage/page.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
 import { useNavigateTo } from "@/routes/useNavigateTo";
+import { useLoadedData } from "./loader";
 
-import { DimmedLink } from "turboui";
-import { Paths } from "@/routes/paths";
-import { PrimaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DimmedLink, PrimaryButton } from "turboui";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -16,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Archiving ", project.name!]}>
       <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-3xl font-extrabold">Archive this project?</div>
@@ -26,7 +25,7 @@ export function Page() {
 
           <div className="flex items-center gap-6 mt-8">
             <ArchiveButton project={project} />
-            <DimmedLink to={Paths.projectPath(project.id!)}>Cancel</DimmedLink>
+            <DimmedLink to={DeprecatedPaths.projectPath(project.id!)}>Cancel</DimmedLink>
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -35,7 +34,7 @@ export function Page() {
 }
 
 function ArchiveButton({ project }) {
-  const navigateToProjectArchive = useNavigateTo(Paths.projectPath(project.id!));
+  const navigateToProjectArchive = useNavigateTo(DeprecatedPaths.projectPath(project.id!));
 
   const [archive, { loading }] = Projects.useArchiveProject();
 

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-import { useNavigate } from "react-router-dom";
-import { ProjectCheckIn, useEditProjectCheckIn } from "@/models/projectCheckIns";
 import { Person } from "@/models/people";
+import { ProjectCheckIn, useEditProjectCheckIn } from "@/models/projectCheckIns";
+import { useNavigate } from "react-router-dom";
 
+import FormattedTime from "@/components/FormattedTime";
 import Forms from "@/components/Forms";
 import { Spacer } from "@/components/Spacer";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
-import FormattedTime from "@/components/FormattedTime";
 
 export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
   const [edit] = useEditProjectCheckIn();
@@ -28,7 +28,7 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
       }
     },
     cancel: () => {
-      navigate(Paths.projectCheckInPath(checkIn.id!));
+      navigate(DeprecatedPaths.projectCheckInPath(checkIn.id!));
     },
     submit: async () => {
       const res = await edit({
@@ -37,7 +37,7 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
         description: JSON.stringify(form.values.description),
       });
 
-      navigate(Paths.projectCheckInPath(res.checkIn.id));
+      navigate(DeprecatedPaths.projectCheckInPath(res.checkIn.id));
     },
   });
 

--- a/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-import { useNavigate } from "react-router-dom";
+import { Person } from "@/models/people";
 import { usePostProjectCheckIn } from "@/models/projectCheckIns";
 import { Project } from "@/models/projects";
-import { Person } from "@/models/people";
+import { useNavigate } from "react-router-dom";
 
 import Forms from "@/components/Forms";
 import { Spacer } from "@/components/Spacer";
 import { Options, SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
-import { Paths } from "@/routes/paths";
 
 export function Form({ project }: { project: Project }) {
   assertPresent(project.potentialSubscribers, "potentialSubscribers must be present in project");
@@ -36,7 +36,7 @@ export function Form({ project }: { project: Project }) {
       }
     },
     cancel: () => {
-      navigate(Paths.projectCheckInsPath(project.id!));
+      navigate(DeprecatedPaths.projectCheckInsPath(project.id!));
     },
     submit: async () => {
       const res = await post({
@@ -47,7 +47,7 @@ export function Form({ project }: { project: Project }) {
         subscriberIds: subscriptionsState.currentSubscribersList,
       });
 
-      navigate(Paths.projectCheckInPath(res.checkIn.id));
+      navigate(DeprecatedPaths.projectCheckInPath(res.checkIn.id));
     },
   });
 

--- a/app/assets/js/pages/ProjectCheckInNewPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInNewPage/page.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import { Paths } from "@/routes/paths";
-import { useLoadedData } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { Form } from "./Form";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -27,8 +27,8 @@ function Navigation({ project }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.projectPath(project.id), label: project.name! },
-        { to: Paths.projectCheckInsPath(project.id), label: "Check-Ins" },
+        { to: DeprecatedPaths.projectPath(project.id), label: project.name! },
+        { to: DeprecatedPaths.projectCheckInsPath(project.id), label: "Check-Ins" },
       ]}
     />
   );

--- a/app/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -1,30 +1,30 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
+import * as Paper from "@/components/PaperContainer";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Reactions from "@/models/reactions";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Avatar } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
+import { Avatar } from "turboui";
 
 import { TextSeparator } from "@/components/TextSeparator";
-import { Paths, compareIds } from "@/routes/paths";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 import { AckCTA } from "./AckCTA";
 
 import { Spacer } from "@/components/Spacer";
-import { StatusSection } from "@/features/projectCheckIns/StatusSection";
 import { DescriptionSection } from "@/features/projectCheckIns/DescriptionSection";
+import { StatusSection } from "@/features/projectCheckIns/StatusSection";
 
-import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useForProjectCheckIn } from "@/features/CommentSection";
+import { ReactionList, useReactionsForm } from "@/features/Reactions";
 
-import { useLoadedData, useRefresh } from "./loader";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
 import { banner } from "../ProjectPage/Banner";
+import { useLoadedData, useRefresh } from "./loader";
 
 export function Page() {
   const { checkIn } = useLoadedData();
@@ -117,8 +117,8 @@ function Navigation({ project }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.projectPath(project.id), label: project.name! },
-        { to: Paths.projectCheckInsPath(project.id), label: "Check-Ins" },
+        { to: DeprecatedPaths.projectPath(project.id), label: project.name! },
+        { to: DeprecatedPaths.projectCheckInsPath(project.id), label: "Check-Ins" },
       ]}
     />
   );
@@ -150,7 +150,7 @@ function Options() {
       <PageOptions.Link
         icon={Icons.IconEdit}
         title="Edit check-in"
-        to={Paths.projectCheckInEditPath(checkIn.id!)}
+        to={DeprecatedPaths.projectCheckInEditPath(checkIn.id!)}
         testId="edit-check-in"
       />
     </PageOptions.Root>

--- a/app/assets/js/pages/ProjectCheckInsPage/CheckInButton.tsx
+++ b/app/assets/js/pages/ProjectCheckInsPage/CheckInButton.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { PrimaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
 
 export function CheckInButton({ project }: { project: Projects.Project }) {
   if (!project.permissions!.canCheckIn) return null;
 
-  const path = Paths.projectCheckInNewPath(project.id!);
+  const path = DeprecatedPaths.projectCheckInNewPath(project.id!);
 
   return <PrimaryButton linkTo={path}>Check-In Now</PrimaryButton>;
 }

--- a/app/assets/js/pages/ProjectCheckInsPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInsPage/page.tsx
@@ -1,17 +1,17 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as ProjectCheckIns from "@/models/projectCheckIns";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
-import { CheckInButton } from "./CheckInButton";
-import { Paths } from "@/routes/paths";
 import { Summary } from "@/components/RichContent";
+import { DeprecatedPaths } from "@/routes/paths";
 import { DivLink } from "turboui";
+import { CheckInButton } from "./CheckInButton";
+import { useLoadedData } from "./loader";
 
 import FormattedTime from "@/components/FormattedTime";
-import { Avatar } from "turboui";
 import { SmallStatusIndicator } from "@/components/status";
+import { Avatar } from "turboui";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -33,7 +33,7 @@ export function Page() {
 function Navigation() {
   const { project } = useLoadedData();
 
-  return <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />;
 }
 
 function Header() {
@@ -89,7 +89,7 @@ function isCurrentYear(year: number) {
 
 function CheckInCard({ checkIn }: { checkIn: ProjectCheckIns.ProjectCheckIn }) {
   const author = checkIn.author!;
-  const path = Paths.projectCheckInPath(checkIn.id!);
+  const path = DeprecatedPaths.projectCheckInPath(checkIn.id!);
 
   return (
     <DivLink className="flex items-start gap-2 rounded-lg cursor-pointer border border-stroke-base" to={path}>

--- a/app/assets/js/pages/ProjectContributorsAddPage/AddChampion.tsx
+++ b/app/assets/js/pages/ProjectContributorsAddPage/AddChampion.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { PermissionLevels } from "@/features/Permissions";
-import { ProjectContribsSubpageNavigation } from "@/components/ProjectPageNavigation";
 import { useAddProjectContributor } from "@/api";
+import { ProjectContribsSubpageNavigation } from "@/components/ProjectPageNavigation";
+import { PermissionLevels } from "@/features/Permissions";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { LoaderResult } from "./loader";
 
@@ -65,5 +65,5 @@ function useForm() {
 
 function useGoBack() {
   const { project } = Pages.useLoadedData() as LoaderResult;
-  return useNavigateTo(Paths.projectContributorsPath(project.id!));
+  return useNavigateTo(DeprecatedPaths.projectContributorsPath(project.id!));
 }

--- a/app/assets/js/pages/ProjectContributorsAddPage/AddContributors.tsx
+++ b/app/assets/js/pages/ProjectContributorsAddPage/AddContributors.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import * as Projects from "@/models/projects";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { PERMISSIONS_LIST, PermissionLevels } from "@/features/Permissions";
 import { useAddProjectContributors } from "@/api";
+import { PERMISSIONS_LIST, PermissionLevels } from "@/features/Permissions";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
-import { LoaderResult } from "./loader";
-import { SecondaryButton } from "turboui";
 import { createTestId } from "@/utils/testid";
+import { SecondaryButton } from "turboui";
+import { LoaderResult } from "./loader";
 
 interface ContributorFields {
   key: number;
@@ -39,7 +39,7 @@ function newContributor() {
 
 export function AddContributors() {
   const { project } = Pages.useLoadedData() as LoaderResult;
-  const gotoContribPage = useNavigateTo(Paths.projectContributorsPath(project.id!));
+  const gotoContribPage = useNavigateTo(DeprecatedPaths.projectContributorsPath(project.id!));
   const [add] = useAddProjectContributors();
 
   const form = Forms.useForm({
@@ -66,7 +66,7 @@ export function AddContributors() {
   return (
     <Pages.Page title={["Add contributors", project.name!]}>
       <Paper.Root size="small">
-        <Paper.NavigateBack to={Paths.projectContributorsPath(project.id!)} title="Back to Team & Access" />
+        <Paper.NavigateBack to={DeprecatedPaths.projectContributorsPath(project.id!)} title="Back to Team & Access" />
         <div className="text-2xl font-extrabold mb-4 text-center">Add contributors to {project.name}</div>
 
         <Forms.Form form={form}>

--- a/app/assets/js/pages/ProjectContributorsAddPage/AddReviewer.tsx
+++ b/app/assets/js/pages/ProjectContributorsAddPage/AddReviewer.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { PermissionLevels } from "@/features/Permissions";
-import { ProjectContribsSubpageNavigation } from "@/components/ProjectPageNavigation";
 import { useAddProjectContributor } from "@/api";
+import { ProjectContribsSubpageNavigation } from "@/components/ProjectPageNavigation";
+import { PermissionLevels } from "@/features/Permissions";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { LoaderResult } from "./loader";
 
@@ -69,5 +69,5 @@ function useForm() {
 
 function useGoBack() {
   const { project } = Pages.useLoadedData() as LoaderResult;
-  return useNavigateTo(Paths.projectContributorsPath(project.id!));
+  return useNavigateTo(DeprecatedPaths.projectContributorsPath(project.id!));
 }

--- a/app/assets/js/pages/ProjectContributorsEditPage/loader.tsx
+++ b/app/assets/js/pages/ProjectContributorsEditPage/loader.tsx
@@ -1,6 +1,6 @@
 import * as Pages from "@/components/Pages";
 import * as ProjectContributors from "@/models/projectContributors";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 
 export interface UrlParams {
@@ -25,5 +25,5 @@ export async function loader({ params, request }): Promise<LoaderResult> {
 
 export function useGotoProjectContributors() {
   const { contributor } = Pages.useLoadedData() as LoaderResult;
-  return useNavigateTo(Paths.projectContributorsPath(contributor.project!.id!));
+  return useNavigateTo(DeprecatedPaths.projectContributorsPath(contributor.project!.id!));
 }

--- a/app/assets/js/pages/ProjectContributorsPage/index.tsx
+++ b/app/assets/js/pages/ProjectContributorsPage/index.tsx
@@ -1,26 +1,26 @@
 import React from "react";
 
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
-import * as Projects from "@/models/projects";
+import * as Paper from "@/components/PaperContainer";
 import * as ProjectContributors from "@/models/projectContributors";
+import * as Projects from "@/models/projects";
 import { PageModule } from "@/routes/types";
 
-import { PrimaryButton, SecondaryButton } from "turboui";
 import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { ProjectContributor } from "@/models/projectContributors";
+import { PrimaryButton, SecondaryButton } from "turboui";
 
-import { ContributorAvatar, PlaceholderAvatar } from "@/components/ContributorAvatar";
-import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
-import { createTestId } from "@/utils/testid";
-import { Paths } from "@/routes/paths";
 import { ProjectAccessLevelBadge } from "@/components/Badges/AccessLevelBadges";
+import { ContributorAvatar, PlaceholderAvatar } from "@/components/ContributorAvatar";
 import { AccessLevel } from "@/features/projects/AccessLevel";
+import { DeprecatedPaths } from "@/routes/paths";
+import { createTestId } from "@/utils/testid";
 import { match } from "ts-pattern";
+import { Menu, MenuActionItem, MenuLinkItem } from "turboui";
 
-import { OtherPeople } from "./OtherPeople";
-import { useLoadedData, loader } from "./loader";
 import { BorderedRow } from "@/components/BorderedRow";
+import { OtherPeople } from "./OtherPeople";
+import { loader, useLoadedData } from "./loader";
 
 export default { name: "ProjectContributorsPage", loader, Page } as PageModule;
 
@@ -64,7 +64,7 @@ function AddContribsButton() {
   const { project } = useLoadedData();
 
   if (!project.permissions?.canEditContributors) return null;
-  const path = Paths.projectContributorsAddPath(project.id!, { type: "contributor" });
+  const path = DeprecatedPaths.projectContributorsAddPath(project.id!, { type: "contributor" });
 
   return (
     <PrimaryButton linkTo={path} testId="add-contributors-button" size="sm">
@@ -75,7 +75,7 @@ function AddContribsButton() {
 
 function GeneralAccess() {
   const { project } = useLoadedData();
-  const editPath = Paths.projectEditPermissionsPath(project.id!);
+  const editPath = DeprecatedPaths.projectEditPermissionsPath(project.id!);
 
   return (
     <Paper.Section title="General Access">
@@ -156,7 +156,7 @@ function ContributorNameAndResponsibility({ contributor }: { contributor: Projec
 
 function ReviewerPlaceholder() {
   const { project } = useLoadedData();
-  const path = Paths.projectContributorsAddPath(project.id!, { type: "reviewer" });
+  const path = DeprecatedPaths.projectContributorsAddPath(project.id!, { type: "reviewer" });
 
   return (
     <Paper.Section title="Reviewer">
@@ -190,7 +190,7 @@ function PlaceholderTitleAndDescription({ title, description }: { title: string;
 
 function ChampionPlaceholder() {
   const { project } = useLoadedData();
-  const path = Paths.projectContributorsAddPath(project.id!, { type: "champion" });
+  const path = DeprecatedPaths.projectContributorsAddPath(project.id!, { type: "champion" });
 
   return (
     <Paper.Section title="Champion">
@@ -279,7 +279,7 @@ function ContributotNameAndResponsibility({ contributor }: { contributor: Projec
 }
 
 function ReassignAsContributorMenuItem({ contributor }: { contributor: ProjectContributor }) {
-  const path = Paths.projectContributorsEditPath(contributor.id!, { action: "reassign-as-contributor" });
+  const path = DeprecatedPaths.projectContributorsEditPath(contributor.id!, { action: "reassign-as-contributor" });
 
   return (
     <MenuLinkItem to={path} testId="convert-to-contributor">
@@ -289,7 +289,7 @@ function ReassignAsContributorMenuItem({ contributor }: { contributor: ProjectCo
 }
 
 function ChangeProjectChampionMenuItem({ contributor }: { contributor: ProjectContributor }) {
-  const path = Paths.projectContributorsEditPath(contributor.id!, { action: "change-champion" });
+  const path = DeprecatedPaths.projectContributorsEditPath(contributor.id!, { action: "change-champion" });
 
   return (
     <MenuLinkItem to={path} testId="choose-new-champion">
@@ -299,7 +299,7 @@ function ChangeProjectChampionMenuItem({ contributor }: { contributor: ProjectCo
 }
 
 function ChangeProjectReviewerMenuItem({ contributor }: { contributor: ProjectContributor }) {
-  const path = Paths.projectContributorsEditPath(contributor.id!, { action: "change-reviewer" });
+  const path = DeprecatedPaths.projectContributorsEditPath(contributor.id!, { action: "change-reviewer" });
 
   return (
     <MenuLinkItem to={path} testId="choose-new-reviewer">
@@ -309,7 +309,7 @@ function ChangeProjectReviewerMenuItem({ contributor }: { contributor: ProjectCo
 }
 
 function EditMenuItem({ contributor }: { contributor: ProjectContributor }) {
-  const path = Paths.projectContributorsEditPath(contributor.id!, { action: "edit-contributor" });
+  const path = DeprecatedPaths.projectContributorsEditPath(contributor.id!, { action: "edit-contributor" });
 
   return (
     <MenuLinkItem to={path} testId="edit-contributor">

--- a/app/assets/js/pages/ProjectEditAccessLevelsPage/index.tsx
+++ b/app/assets/js/pages/ProjectEditAccessLevelsPage/index.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
 import Forms from "@/components/Forms";
 
 import { useEditProjectPermissions } from "@/api";
-import { Paths } from "@/routes/paths";
-import { useNavigateTo } from "@/routes/useNavigateTo";
 import { ProjectContribsSubpageNavigation } from "@/components/ProjectPageNavigation";
+import { applyAccessLevelConstraints, initialAccessLevels } from "@/features/Permissions/AccessFields";
 import { AccessSelectors } from "@/features/projects/AccessSelectors";
-import { initialAccessLevels, applyAccessLevelConstraints } from "@/features/Permissions/AccessFields";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigateTo } from "@/routes/useNavigateTo";
 
 export default { name: "ProjectEditAccessLevelsPage", loader, Page } as PageModule;
 
@@ -54,7 +54,7 @@ function Form() {
   const { project, space } = Pages.useLoadedData();
   const parentAccessLevel = space.accessLevels!;
 
-  const navigateToContributorsPath = useNavigateTo(Paths.projectContributorsPath(project.id!));
+  const navigateToContributorsPath = useNavigateTo(DeprecatedPaths.projectContributorsPath(project.id!));
   const [edit] = useEditProjectPermissions();
 
   const form = Forms.useForm({

--- a/app/assets/js/pages/ProjectEditDescriptionPage/page.tsx
+++ b/app/assets/js/pages/ProjectEditDescriptionPage/page.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
 import * as TipTapEditor from "@/components/Editor";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { PrimaryButton, SecondaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -15,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Overview Edit", project.name!]}>
       <Paper.Root>
-        <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body>
           <div className="text-content-accent text-sm font-medium">PROJECT OVERVIEW</div>
@@ -31,7 +31,7 @@ export function Page() {
 function Editor() {
   const { project } = useLoadedData();
 
-  const goToProjectPage = useNavigateTo(Paths.projectPath(project.id!));
+  const goToProjectPage = useNavigateTo(DeprecatedPaths.projectPath(project.id!));
 
   const [post, { loading }] = Projects.useUpdateProjectDescription();
 
@@ -65,7 +65,7 @@ function Editor() {
           <PrimaryButton onClick={submit} testId="save" loading={loading}>
             Save
           </PrimaryButton>
-          <SecondaryButton linkTo={Paths.projectPath(project.id!)}>Cancel</SecondaryButton>
+          <SecondaryButton linkTo={DeprecatedPaths.projectPath(project.id!)}>Cancel</SecondaryButton>
         </div>
       </TipTapEditor.Root>
     </div>

--- a/app/assets/js/pages/ProjectEditGoalPage/page.tsx
+++ b/app/assets/js/pages/ProjectEditGoalPage/page.tsx
@@ -1,13 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Goals from "@/models/goals";
+import * as React from "react";
 
 import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
 import { GoalSelector } from "@/features/goals/GoalTree/GoalSelector";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -31,7 +31,7 @@ function GoalList() {
   const { project, goals } = useLoadedData();
 
   const navigate = useNavigate();
-  const projectPath = Paths.projectPath(project.id!);
+  const projectPath = DeprecatedPaths.projectPath(project.id!);
 
   const [connect] = Goals.useConnectGoalToProject();
 

--- a/app/assets/js/pages/ProjectEditProjectNamePage/page.tsx
+++ b/app/assets/js/pages/ProjectEditProjectNamePage/page.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import * as Projects from "@/models/projects";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
 import * as Forms from "@/components/Form";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Projects from "@/models/projects";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -15,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Edit Project Name", project.name!]}>
       <Paper.Root>
-        <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body>
           <h1 className="mb-8 font-extrabold text-content-accent text-3xl">Editing the project's name</h1>
@@ -27,7 +27,7 @@ export function Page() {
 }
 
 function Form({ project }: { project: Projects.Project }) {
-  const navigateToProject = useNavigateTo(Paths.projectPath(project.id!));
+  const navigateToProject = useNavigateTo(DeprecatedPaths.projectPath(project.id!));
   const [projectName, setProjectName] = React.useState(project.name);
 
   const [edit, { loading }] = Projects.useEditProjectName();

--- a/app/assets/js/pages/ProjectEditResourcePage/page.tsx
+++ b/app/assets/js/pages/ProjectEditResourcePage/page.tsx
@@ -1,16 +1,16 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
 import * as Forms from "@/components/Form";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as KeyResources from "@/models/keyResources";
+import * as React from "react";
 
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { ResourceIcon } from "@/components/KeyResourceIcon";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useLoadedData } from "./loader";
 import { useForm } from "./useForm";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const { project, keyResource } = useLoadedData();
@@ -35,7 +35,7 @@ export function Page() {
 }
 
 function Form({ project, form }) {
-  const onCancel = useNavigateTo(Paths.projectEditResourcesPath(project.id!));
+  const onCancel = useNavigateTo(DeprecatedPaths.projectEditResourcesPath(project.id!));
   const namePlaceholder = KeyResources.placeholderName(form.resourceType);
 
   return (

--- a/app/assets/js/pages/ProjectEditResourcePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectEditResourcePage/useForm.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-import * as Projects from "@/models/projects";
 import * as KeyResources from "@/models/keyResources";
+import * as Projects from "@/models/projects";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
-import { Paths } from "@/routes/paths";
 
 interface FormState {
   projectId: string;
@@ -21,7 +21,7 @@ interface FormState {
 }
 
 export function useForm(project: Projects.Project, keyResource: KeyResources.KeyResource): FormState {
-  const gotoResourceList = useNavigateTo(Paths.projectEditResourcesPath(project.id!));
+  const gotoResourceList = useNavigateTo(DeprecatedPaths.projectEditResourcesPath(project.id!));
 
   const [name, setName] = React.useState<string>(keyResource.title!);
   const [url, setUrl] = React.useState<string>(keyResource.link!);

--- a/app/assets/js/pages/ProjectEditResourcesPage/page.tsx
+++ b/app/assets/js/pages/ProjectEditResourcesPage/page.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import * as Projects from "@/models/projects";
 import * as KeyResources from "@/models/keyResources";
+import * as Projects from "@/models/projects";
 
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
 import { ResourceIcon } from "@/components/KeyResourceIcon";
-import { Link, ButtonLink, DivLink } from "turboui";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
+import { ButtonLink, DivLink, Link } from "turboui";
 
+import { DeprecatedPaths } from "@/routes/paths";
+import { useNavigateTo } from "@/routes/useNavigateTo";
 import { createTestId } from "@/utils/testid";
 import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
-import { useNavigateTo } from "@/routes/useNavigateTo";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -56,14 +56,14 @@ function ResourcesListWithData({ project }: { project: Projects.Project }) {
 
 function ResourceListItem({ resource }: { resource: KeyResources.KeyResource }) {
   const { project } = useLoadedData();
-  const gotoResourceList = useNavigateTo(Paths.projectEditResourcesPath(project.id!));
+  const gotoResourceList = useNavigateTo(DeprecatedPaths.projectEditResourcesPath(project.id!));
   const [remove] = KeyResources.useRemoveKeyResource();
 
   const title = resource!.title;
   const icon = <ResourceIcon resourceType={resource!.resourceType!} size={32} />;
   const removeId = createTestId("remove-resource", title!);
 
-  const editPath = Paths.projectEditResourcePath(resource!.id!);
+  const editPath = DeprecatedPaths.projectEditResourcePath(resource!.id!);
   const editId = createTestId("edit-resource", title!);
 
   const submit = React.useCallback(async () => {
@@ -124,7 +124,7 @@ function PotentialResourceListItem({ resourceType }: { resourceType: string }) {
   const icon = <ResourceIcon resourceType={resourceType} size={32} />;
 
   const id = createTestId("add-resource", title);
-  const path = Paths.projectNewResourcePath(project.id!, { resourceType });
+  const path = DeprecatedPaths.projectNewResourcePath(project.id!, { resourceType });
 
   return (
     <div className="rounded border border-stroke-base flex flex-col items-center justify-center text-center">

--- a/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
@@ -1,10 +1,10 @@
-import * as React from "react";
 import * as Projects from "@/models/projects";
 import * as Time from "@/utils/time";
+import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
-import { useMilestoneListState, MilestoneListState } from "./useMilestoneListState";
-import { Paths } from "@/routes/paths";
+import { MilestoneListState, useMilestoneListState } from "./useMilestoneListState";
 
 interface Error {
   field: string;
@@ -35,7 +35,7 @@ export interface FormState {
 
 export function useForm(project: Projects.Project): FormState {
   const navigate = useNavigate();
-  const milestonesPath = Paths.projectMilestonesPath(project.id!);
+  const milestonesPath = DeprecatedPaths.projectMilestonesPath(project.id!);
 
   const oldStart = Time.parseDate(project.startedAt);
   const oldDue = Time.parseDate(project.deadline);

--- a/app/assets/js/pages/ProjectMilestonePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectMilestonePage/useForm.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
+import * as TipTapEditor from "@/components/Editor";
 import * as Milestones from "@/models/milestones";
 import * as Projects from "@/models/projects";
-import * as TipTapEditor from "@/components/Editor";
 import * as Time from "@/utils/time";
+import * as React from "react";
 
-import { useRefresh } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
-import { Paths } from "@/routes/paths";
+import { useRefresh } from "./loader";
 
 export interface FormState {
   milestone: Milestones.Milestone;
@@ -67,7 +67,7 @@ const useReopenMilestone = (milestone: Milestones.Milestone) => {
 
 const useArchiveMilestone = (project: Projects.Project, milestone: Milestones.Milestone) => {
   const refresh = useRefresh();
-  const gotoProject = useNavigateTo(Paths.projectPath(project.id!));
+  const gotoProject = useNavigateTo(DeprecatedPaths.projectPath(project.id!));
 
   const [post] = Milestones.useRemoveProjectMilestone();
 

--- a/app/assets/js/pages/ProjectMilestonesPage/page.tsx
+++ b/app/assets/js/pages/ProjectMilestonesPage/page.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 
+import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Milestones from "@/models/milestones";
-import * as Pages from "@/components/Pages";
 import * as Time from "@/utils/time";
 
-import { GhostButton } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
+import { GhostButton } from "turboui";
 
-import { useLoadedData } from "./loader";
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { Link } from "turboui";
 import { MilestoneIcon } from "@/components/MilestoneIcon";
-import { Paths } from "@/routes/paths";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link } from "turboui";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -33,7 +33,7 @@ export function Page() {
 }
 
 function Title({ project }) {
-  const editTimeline = Paths.projectEditTimelinePath(project.id);
+  const editTimeline = DeprecatedPaths.projectEditTimelinePath(project.id);
 
   return (
     <div className="flex items-center justify-between mb-8">
@@ -118,7 +118,7 @@ function MilestoneList({ project }) {
 }
 
 function PendingItem({ milestone }) {
-  const path = Paths.projectMilestonePath(milestone.id);
+  const path = DeprecatedPaths.projectMilestonePath(milestone.id);
 
   return (
     <div className="flex flex-col border-b border-stroke-base first:border-t first:border-stroke-base py-1">
@@ -146,7 +146,7 @@ function PendingItem({ milestone }) {
 }
 
 function DoneItem({ milestone }) {
-  const path = Paths.projectMilestonePath(milestone.id);
+  const path = DeprecatedPaths.projectMilestonePath(milestone.id);
 
   return (
     <div className="flex flex-col border-b border-stroke-base first:border-t first:border-stroke-base py-1">

--- a/app/assets/js/pages/ProjectMovePage/page.tsx
+++ b/app/assets/js/pages/ProjectMovePage/page.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
 import * as Projects from "@/models/projects";
 
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
+import { SpaceCard, SpaceCardGrid } from "@/features/spaces/SpaceCards";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
 import { useNavigateTo } from "@/routes/useNavigateTo";
 import { useLoadedData } from "./loader";
-import { SpaceCardGrid, SpaceCard } from "@/features/spaces/SpaceCards";
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { Paths, compareIds } from "@/routes/paths";
 
 export function Page() {
   const { project, spaces } = useLoadedData();
@@ -44,7 +44,7 @@ function NoOtherSpaces() {
 }
 
 function MoveToSpace({ project, candidateSpaces }: { project: Projects.Project; candidateSpaces: Spaces.Space[] }) {
-  const gotoProject = useNavigateTo(Paths.projectPath(project.id!));
+  const gotoProject = useNavigateTo(DeprecatedPaths.projectPath(project.id!));
   const [move] = Projects.useMoveProjectToSpace();
 
   const moveProjectToSpace = async (project: Projects.Project, space: Spaces.Space) => {

--- a/app/assets/js/pages/ProjectPage/Banner.tsx
+++ b/app/assets/js/pages/ProjectPage/Banner.tsx
@@ -1,11 +1,10 @@
-import * as React from "react";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
-import { PrimaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
 import { match } from "ts-pattern";
+import { Link, PrimaryButton } from "turboui";
 
 import FormattedTime from "@/components/FormattedTime";
 
@@ -17,7 +16,7 @@ export function banner(project: Projects.Project) {
 }
 
 function ProjectClosedBanner({ project }: { project: Projects.Project }) {
-  const retroPath = Paths.projectRetrospectivePath(project.id!);
+  const retroPath = DeprecatedPaths.projectRetrospectivePath(project.id!);
 
   return (
     <Paper.Banner testId="project-closed-banner">
@@ -31,7 +30,7 @@ function ProjectClosedBanner({ project }: { project: Projects.Project }) {
 }
 
 function ProjectPausedBanner({ project }: { project: Projects.Project }) {
-  const resumePath = Paths.resumeProjectPath(project.id!);
+  const resumePath = DeprecatedPaths.resumeProjectPath(project.id!);
 
   return (
     <Paper.Banner testId="project-paused-banner">

--- a/app/assets/js/pages/ProjectPage/CheckInSection.tsx
+++ b/app/assets/js/pages/ProjectPage/CheckInSection.tsx
@@ -1,17 +1,16 @@
-import * as React from "react";
-import * as Projects from "@/models/projects";
-import * as People from "@/models/people";
 import * as Callouts from "@/components/Callouts";
+import * as People from "@/models/people";
+import * as Projects from "@/models/projects";
+import * as React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
 import { Avatar } from "turboui";
 
-import { DimmedLabel } from "./Label";
-import { SecondaryButton } from "turboui";
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
-import { SmallStatusIndicator } from "@/components/status";
 import { Summary } from "@/components/RichContent";
+import { SmallStatusIndicator } from "@/components/status";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link, SecondaryButton } from "turboui";
+import { DimmedLabel } from "./Label";
 
 export function CheckInSection({ project }: { project: Projects.Project }) {
   return (
@@ -21,7 +20,7 @@ export function CheckInSection({ project }: { project: Projects.Project }) {
           <div className="font-bold text-sm">Check-Ins</div>
           {project.lastCheckIn && (
             <div className="text-sm">
-              <Link to={Paths.projectCheckInsPath(project.id!)}>View all</Link>
+              <Link to={DeprecatedPaths.projectCheckInsPath(project.id!)}>View all</Link>
             </div>
           )}
         </div>
@@ -97,7 +96,7 @@ function LastCheckInContent({ project }: { project: Projects.Project }) {
 
 function LastCheckInLink({ project }: { project: Projects.Project }) {
   const time = project.lastCheckIn!.insertedAt!;
-  const path = Paths.projectCheckInPath(project.lastCheckIn!.id!);
+  const path = DeprecatedPaths.projectCheckInPath(project.lastCheckIn!.id!);
 
   return (
     <Link to={path} testId="last-check-in-link">
@@ -109,7 +108,7 @@ function LastCheckInLink({ project }: { project: Projects.Project }) {
 function CheckInNowButton({ project }: { project: Projects.Project }) {
   if (!project.permissions!.canCheckIn) return null;
 
-  const newCheckInPath = Paths.projectCheckInNewPath(project.id!);
+  const newCheckInPath = DeprecatedPaths.projectCheckInNewPath(project.id!);
 
   return (
     <div className="flex">
@@ -134,7 +133,7 @@ function CheckInZeroState({ project }: { project: Projects.Project }) {
 function NoReviewerCallout({ project }: { project: Projects.Project }) {
   if (project.reviewer) return null;
 
-  const path = Paths.projectContributorsAddPath(project.id!, { type: "reviewer" });
+  const path = DeprecatedPaths.projectContributorsAddPath(project.id!, { type: "reviewer" });
   const addReviewer = (
     <Link to={path} testId="add-reviewer">
       Add a Reviewer

--- a/app/assets/js/pages/ProjectPage/ContributorsSection.tsx
+++ b/app/assets/js/pages/ProjectPage/ContributorsSection.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
-import * as Projects from "@/models/projects";
 import * as ProjectContributors from "@/models/projectContributors";
+import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
-import { ContributorAvatar, ReviewerPlaceholder, ChampionPlaceholder } from "@/components/ContributorAvatar";
+import { ChampionPlaceholder, ContributorAvatar, ReviewerPlaceholder } from "@/components/ContributorAvatar";
 import { ProjectContributor } from "@/models/projectContributors";
+import { DeprecatedPaths } from "@/routes/paths";
+import { SecondaryButton } from "turboui";
 
 export function ContributorsSection({ project }: { project: Projects.Project }) {
   const { champion, reviewer, contributors } = ProjectContributors.splitByRole(project.contributors!);
@@ -35,7 +35,7 @@ function ContribList({ contributors }: { contributors: ProjectContributor[] }) {
 
 function ManageAccessButton({ project }: { project: Projects.Project }) {
   if (!project.permissions!.canEditContributors) return null;
-  const path = Paths.projectContributorsPath(project.id!);
+  const path = DeprecatedPaths.projectContributorsPath(project.id!);
 
   return (
     <SecondaryButton size="xs" testId="manage-team-button" linkTo={path}>

--- a/app/assets/js/pages/ProjectPage/Header.tsx
+++ b/app/assets/js/pages/ProjectPage/Header.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
-import * as Projects from "@/models/projects";
 import * as Goals from "@/models/goals";
+import * as Projects from "@/models/projects";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { DimmedLink, DivLink } from "turboui";
-import { Paths } from "@/routes/paths";
 import { PrivacyIndicator } from "@/features/Permissions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DimmedLink, DivLink } from "turboui";
 
 export function Header({ project }: { project: Projects.Project }) {
   return (
@@ -44,7 +44,7 @@ function ParentGoal({ project }: { project: Projects.Project }) {
 }
 
 function ParentGoalNotLinked({ project }: { project: Projects.Project }) {
-  const path = Paths.editProjectGoalPath(project.id!);
+  const path = DeprecatedPaths.editProjectGoalPath(project.id!);
 
   return (
     <div className="text-sm text-content-dimmed mx-1 font-medium">
@@ -58,7 +58,7 @@ function ParentGoalLinked({ goal }: { goal: Goals.Goal }) {
     <>
       <Icons.IconTarget size={14} className="text-red-500" />
       <DivLink
-        to={Paths.goalPath(goal.id!)}
+        to={DeprecatedPaths.goalPath(goal.id!)}
         className="text-sm text-content-dimmed mx-1 hover:underline font-medium"
         testId="project-goal-link"
       >

--- a/app/assets/js/pages/ProjectPage/Navigation.tsx
+++ b/app/assets/js/pages/ProjectPage/Navigation.tsx
@@ -2,14 +2,14 @@ import React from "react";
 
 import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function Navigation({ space }: { space: Spaces.Space }) {
   return (
     <Paper.Navigation
       items={[
-        { to: Paths.spacePath(space.id!), label: space.name! },
-        { to: Paths.spaceGoalsPath(space.id!), label: "Goals & Projects" },
+        { to: DeprecatedPaths.spacePath(space.id!), label: space.name! },
+        { to: DeprecatedPaths.spaceGoalsPath(space.id!), label: "Goals & Projects" },
       ]}
     />
   );

--- a/app/assets/js/pages/ProjectPage/ProjectDescriptionSection.tsx
+++ b/app/assets/js/pages/ProjectPage/ProjectDescriptionSection.tsx
@@ -1,9 +1,8 @@
-import * as React from "react";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link, SecondaryButton } from "turboui";
 
 import RichContent, { countCharacters, shortenContent } from "@/components/RichContent";
 
@@ -28,7 +27,7 @@ function EditLink({ project }: { project: Projects.Project }) {
   if (!project.permissions!.canEditDescription) return null;
   if (!project.description) return null;
 
-  const path = Paths.projectEditDescriptionPath(project.id!);
+  const path = DeprecatedPaths.projectEditDescriptionPath(project.id!);
 
   return (
     <div className="text-sm">
@@ -79,7 +78,7 @@ function ExpandCollapseButton({ showMore, setShowMore }) {
 }
 
 function DescriptionZeroState({ project }) {
-  const writePath = Paths.projectEditDescriptionPath(project.id!);
+  const writePath = DeprecatedPaths.projectEditDescriptionPath(project.id!);
 
   const editLink = (
     <SecondaryButton linkTo={writePath} testId="write-project-description-link" size="xs">

--- a/app/assets/js/pages/ProjectPage/ProjectOptions.tsx
+++ b/app/assets/js/pages/ProjectPage/ProjectOptions.tsx
@@ -1,9 +1,9 @@
-import * as React from "react";
-import * as Icons from "@tabler/icons-react";
-import * as Projects from "@/models/projects";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Projects from "@/models/projects";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function ProjectOptions({ project }) {
   return (
@@ -12,7 +12,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconPlayerPlayFilled}
           title="Resume the project"
-          to={Paths.resumeProjectPath(project.id)}
+          to={DeprecatedPaths.resumeProjectPath(project.id)}
           testId="resume-project-link"
         />
       )}
@@ -21,7 +21,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconEdit}
           title="Edit project name"
-          to={Paths.editProjectNamePath(project.id)}
+          to={DeprecatedPaths.editProjectNamePath(project.id)}
           testId="edit-project-name-button"
         />
       )}
@@ -30,7 +30,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconPlayerPauseFilled}
           title="Pause the project"
-          to={Paths.pauseProjectPath(project.id)}
+          to={DeprecatedPaths.pauseProjectPath(project.id)}
           testId="pause-project-link"
         />
       )}
@@ -39,7 +39,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconExchange}
           title="Change Parent Goal"
-          to={Paths.editProjectGoalPath(project.id)}
+          to={DeprecatedPaths.editProjectGoalPath(project.id)}
           testId="connect-project-to-goal-link"
         />
       )}
@@ -48,7 +48,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconReplace}
           title="Move project to another space"
-          to={Paths.moveProjectPath(project.id)}
+          to={DeprecatedPaths.moveProjectPath(project.id)}
           testId="move-project-link"
         />
       )}
@@ -57,7 +57,7 @@ export function ProjectOptions({ project }) {
         <PageOptions.Link
           icon={Icons.IconCircleCheck}
           title="Close the project"
-          to={Paths.projectClosePath(project.id)}
+          to={DeprecatedPaths.projectClosePath(project.id)}
           testId="close-project"
         />
       )}

--- a/app/assets/js/pages/ProjectPage/ResourcesSection.tsx
+++ b/app/assets/js/pages/ProjectPage/ResourcesSection.tsx
@@ -1,10 +1,9 @@
-import * as React from "react";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
 import { ResourceIcon } from "@/components/KeyResourceIcon";
-import { SecondaryButton } from "turboui";
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link, SecondaryButton } from "turboui";
 
 export function ResourcesSection({ project }: { project: Projects.Project }) {
   return (
@@ -29,7 +28,7 @@ function EditLink({ project }: { project: Projects.Project }) {
 
   return (
     <div className="text-sm">
-      <Link to={Paths.projectEditResourcesPath(project.id!)} testId="edit-resources-link">
+      <Link to={DeprecatedPaths.projectEditResourcesPath(project.id!)} testId="edit-resources-link">
         Edit
       </Link>
     </div>
@@ -45,7 +44,7 @@ function Content({ project }) {
 }
 
 function ResourcesZeroState({ project }) {
-  const editPath = Paths.projectEditResourcesPath(project.id!);
+  const editPath = DeprecatedPaths.projectEditResourcesPath(project.id!);
 
   const editLink = (
     <SecondaryButton linkTo={editPath} testId="add-resources-link" size="xs">

--- a/app/assets/js/pages/ProjectPage/TimelineSection.tsx
+++ b/app/assets/js/pages/ProjectPage/TimelineSection.tsx
@@ -1,13 +1,12 @@
-import * as Projects from "@/models/projects";
-import * as React from "react";
 import * as Milestones from "@/models/milestones";
+import * as Projects from "@/models/projects";
 import * as Time from "@/utils/time";
+import * as React from "react";
 
-import { Link } from "turboui";
-import { Paths } from "@/routes/paths";
-import { DimmedLabel } from "./Label";
-import { SecondaryButton } from "turboui";
 import { MilestoneIcon } from "@/components/MilestoneIcon";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Link, SecondaryButton } from "turboui";
+import { DimmedLabel } from "./Label";
 
 import FormattedTime from "@/components/FormattedTime";
 import { assertPresent } from "@/utils/assertions";
@@ -35,7 +34,7 @@ export function TimelineSection({ project }: { project: Projects.Project }) {
 
 function ViewTimelineLink({ project }: { project: Projects.Project }) {
   return (
-    <Link to={Paths.projectMilestonesPath(project.id!)} testId="manage-timeline">
+    <Link to={DeprecatedPaths.projectMilestonesPath(project.id!)} testId="manage-timeline">
       View
     </Link>
   );
@@ -164,7 +163,7 @@ function ProjectMilestones({ project }) {
 }
 
 function MilestonesZeroState({ project }) {
-  const editPath = Paths.projectEditTimelinePath(project.id!);
+  const editPath = DeprecatedPaths.projectEditTimelinePath(project.id!);
 
   const editLink = (
     <SecondaryButton linkTo={editPath} testId="add-milestones-link" size="xs">
@@ -182,7 +181,7 @@ function MilestonesZeroState({ project }) {
 
 function AllMilestonesCompleted({ project }) {
   const editLink = (
-    <Link to={Paths.projectEditTimelinePath(project.id!)} testId="add-milestones-link">
+    <Link to={DeprecatedPaths.projectEditTimelinePath(project.id!)} testId="add-milestones-link">
       Add more milestones
     </Link>
   );
@@ -208,7 +207,7 @@ function MilestonesList({ milestones }: { milestones: Projects.Milestone[] }) {
 }
 
 function MilestoneLink({ milestone }) {
-  const path = Paths.projectMilestonePath(milestone.id!);
+  const path = DeprecatedPaths.projectMilestonePath(milestone.id!);
   const title = milestone.title;
   const deadline = milestone.deadlineAt;
 

--- a/app/assets/js/pages/ProjectPausePage/page.tsx
+++ b/app/assets/js/pages/ProjectPausePage/page.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
 import { useNavigateTo } from "@/routes/useNavigateTo";
+import { useLoadedData } from "./loader";
 
-import { PrimaryButton } from "turboui";
-import { DimmedLink } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DimmedLink, PrimaryButton } from "turboui";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -16,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Pausing", project.name!]}>
       <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-3xl font-extrabold">Pause this project?</div>
@@ -32,7 +31,7 @@ export function Page() {
 
           <div className="flex items-center gap-6 mt-8">
             <PauseProject project={project} />
-            <DimmedLink to={Paths.projectPath(project.id!)}>Keep it active</DimmedLink>
+            <DimmedLink to={DeprecatedPaths.projectPath(project.id!)}>Keep it active</DimmedLink>
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -41,7 +40,7 @@ export function Page() {
 }
 
 function PauseProject({ project }) {
-  const path = Paths.projectPath(project.id);
+  const path = DeprecatedPaths.projectPath(project.id);
   const onSuccess = useNavigateTo(path);
 
   const [pause, { loading }] = Projects.usePauseProject();

--- a/app/assets/js/pages/ProjectResumePage/page.tsx
+++ b/app/assets/js/pages/ProjectResumePage/page.tsx
@@ -1,14 +1,13 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
+import * as React from "react";
 
-import { useLoadedData } from "./loader";
 import { useNavigateTo } from "@/routes/useNavigateTo";
+import { useLoadedData } from "./loader";
 
-import { PrimaryButton } from "turboui";
-import { DimmedLink } from "turboui";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DimmedLink, PrimaryButton } from "turboui";
 
 export function Page() {
   const { project } = useLoadedData();
@@ -16,7 +15,7 @@ export function Page() {
   return (
     <Pages.Page title={["Resume", project.name!]}>
       <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: Paths.projectPath(project.id!), label: project.name! }]} />
+        <Paper.Navigation items={[{ to: DeprecatedPaths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body minHeight="none">
           <div className="text-content-accent text-3xl font-extrabold">Ready to resume project?</div>
@@ -31,7 +30,7 @@ export function Page() {
 
           <div className="flex items-center gap-6 mt-8">
             <ResumeButton project={project} />
-            <DimmedLink to={Paths.projectPath(project.id!)}>Keep it paused</DimmedLink>
+            <DimmedLink to={DeprecatedPaths.projectPath(project.id!)}>Keep it paused</DimmedLink>
           </div>
         </Paper.Body>
       </Paper.Root>
@@ -40,7 +39,7 @@ export function Page() {
 }
 
 function ResumeButton({ project }) {
-  const path = Paths.projectPath(project.id);
+  const path = DeprecatedPaths.projectPath(project.id);
   const onSuccess = useNavigateTo(path);
 
   const [resume, { loading }] = Projects.useResumeProject();

--- a/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -1,23 +1,23 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Reactions from "@/models/reactions";
+import * as React from "react";
 
-import { Paths } from "@/routes/paths";
-import { IconEdit } from "@tabler/icons-react";
+import FormattedTime from "@/components/FormattedTime";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
+import { Spacer } from "@/components/Spacer";
 import { CommentSection, useComments } from "@/features/CommentSection";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { AvatarWithName } from "turboui";
-import { Spacer } from "@/components/Spacer";
-import FormattedTime from "@/components/FormattedTime";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { IconEdit } from "@tabler/icons-react";
+import { AvatarWithName } from "turboui";
 
-import { useLoadedData, useRefresh } from "./loader";
-import { assertPresent } from "@/utils/assertions";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { RetrospectiveContent } from "@/features/ProjectRetrospective";
+import { assertPresent } from "@/utils/assertions";
+import { useLoadedData, useRefresh } from "./loader";
 
 export function Page() {
   const { retrospective } = useLoadedData();
@@ -58,7 +58,7 @@ function Options() {
         <PageOptions.Link
           icon={IconEdit}
           title="Edit retrospective"
-          to={Paths.projectRetrospectiveEditPath(retrospective.project!.id!)}
+          to={DeprecatedPaths.projectRetrospectiveEditPath(retrospective.project!.id!)}
           testId="edit-retrospective"
         />
       )}

--- a/app/assets/js/pages/ProjectsPage/page.tsx
+++ b/app/assets/js/pages/ProjectsPage/page.tsx
@@ -1,19 +1,19 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { useLoadedData, useFilters } from "./loader";
-import { PrimaryButton } from "turboui";
 import { ProjectList } from "@/features/ProjectList";
+import { PrimaryButton } from "turboui";
+import { useFilters, useLoadedData } from "./loader";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import classNames from "classnames";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const { projects } = useLoadedData();
 
-  const newProjectPath = Paths.newProjectPath({
-    backPath: Paths.projectsPath(),
+  const newProjectPath = DeprecatedPaths.newProjectPath({
+    backPath: DeprecatedPaths.projectsPath(),
     backPathName: "Back to Projects",
   });
 

--- a/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
@@ -3,12 +3,12 @@ import { useNavigate } from "react-router-dom";
 
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import { useDeleteResourceHubDocument } from "@/models/resourceHubs";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 
-import { useLoadedData } from "./loader";
-import { IconCopy, IconEdit, IconTrash, IconFileExport } from "@tabler/icons-react";
 import { downloadMarkdown, exportToMarkdown } from "@/utils/markdown";
+import { IconCopy, IconEdit, IconFileExport, IconTrash } from "@tabler/icons-react";
+import { useLoadedData } from "./loader";
 
 interface Props {
   showCopyModal: () => void;
@@ -24,7 +24,7 @@ export function Options({ showCopyModal }: Props) {
         <PageOptions.Link
           icon={IconEdit}
           title="Edit"
-          to={Paths.resourceHubEditDocumentPath(document.id!)}
+          to={DeprecatedPaths.resourceHubEditDocumentPath(document.id!)}
           testId="edit-document-link"
           keepOutsideOnBigScreen
         />
@@ -47,9 +47,9 @@ function DeleteAction() {
 
   const redirect = () => {
     if (folder) {
-      navigate(Paths.resourceHubFolderPath(folder.id!));
+      navigate(DeprecatedPaths.resourceHubFolderPath(folder.id!));
     } else {
-      navigate(Paths.resourceHubPath(resourceHub.id!));
+      navigate(DeprecatedPaths.resourceHubPath(resourceHub.id!));
     }
   };
 

--- a/app/assets/js/pages/ResourceHubDocumentPage/page.tsx
+++ b/app/assets/js/pages/ResourceHubDocumentPage/page.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 
-import { usePublishResourceHubDocument } from "@/models/resourceHubs";
-import * as Reactions from "@/models/reactions";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
+import * as Reactions from "@/models/reactions";
+import { usePublishResourceHubDocument } from "@/models/resourceHubs";
 
 import RichContent from "@/components/RichContent";
 import { Spacer } from "@/components/Spacer";
-import { assertPresent } from "@/utils/assertions";
-import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CommentSection, useComments } from "@/features/CommentSection";
-import { CurrentSubscriptions } from "@/features/Subscriptions";
-import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { DocumentTitle } from "@/features/documents/DocumentTitle";
-import { ResourcePageNavigation, CopyDocumentModal } from "@/features/ResourceHub";
 import { OngoingDraftActions } from "@/features/drafts";
-import { Paths } from "@/routes/paths";
+import { useClearNotificationsOnLoad } from "@/features/notifications";
+import { ReactionList, useReactionsForm } from "@/features/Reactions";
+import { CopyDocumentModal, ResourcePageNavigation } from "@/features/ResourceHub";
+import { CurrentSubscriptions } from "@/features/Subscriptions";
 import { useBoolState } from "@/hooks/useBoolState";
+import { DeprecatedPaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
 
 import { useLoadedData } from "./loader";
 import { Options } from "./Options";
@@ -46,7 +46,12 @@ export function Page() {
           <DocumentComments />
           <DocumentSubscriptions />
 
-          <CopyDocumentModal parent={folder ?? resourceHub} resource={document} isOpen={isCopyFormOpen} hideModal={closeCopyForm} />
+          <CopyDocumentModal
+            parent={folder ?? resourceHub}
+            resource={document}
+            isOpen={isCopyFormOpen}
+            hideModal={closeCopyForm}
+          />
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>
@@ -141,7 +146,7 @@ function ContinueEditingDraft() {
 
   const [publish] = usePublishResourceHubDocument();
   const refresh = Pages.useRefresh();
-  const editPath = Paths.resourceHubEditDocumentPath(document.id!);
+  const editPath = DeprecatedPaths.resourceHubEditDocumentPath(document.id!);
 
   const publishHandler = async () => {
     await publish({ documentId: document.id });

--- a/app/assets/js/pages/ResourceHubDraftsPage/page.tsx
+++ b/app/assets/js/pages/ResourceHubDraftsPage/page.tsx
@@ -3,10 +3,10 @@ import React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Hub from "@/features/ResourceHub";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
-import { useLoadedData } from "./loader";
 import { assertPresent } from "@/utils/assertions";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { resourceHub, draftNodes } = useLoadedData();
@@ -34,8 +34,8 @@ function PageNavigation() {
     <Paper.Navigation
       testId="navigation"
       items={[
-        { to: Paths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! },
-        { to: Paths.resourceHubPath(resourceHub.id!), label: resourceHub.name! },
+        { to: DeprecatedPaths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! },
+        { to: DeprecatedPaths.resourceHubPath(resourceHub.id!), label: resourceHub.name! },
       ]}
     />
   );

--- a/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useEditResourceHubDocument, ResourceHubDocument, usePublishResourceHubDocument } from "@/models/resourceHubs";
+import { ResourceHubDocument, useEditResourceHubDocument, usePublishResourceHubDocument } from "@/models/resourceHubs";
 
 import Forms from "@/components/Forms";
 import { useFormContext } from "@/components/Forms/FormContext";
 import { areRichTextObjectsEqual } from "@/components/RichContent";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function Form({ document }: { document: ResourceHubDocument }) {
   const navigate = useNavigate();
@@ -26,7 +26,7 @@ export function Form({ document }: { document: ResourceHubDocument }) {
         addError("content", "Content is required");
       }
     },
-    cancel: () => navigate(Paths.resourceHubDocumentPath(document.id!)),
+    cancel: () => navigate(DeprecatedPaths.resourceHubDocumentPath(document.id!)),
     submit: async (type: "save" | "publish-draft") => {
       const { title, content } = form.values;
 
@@ -46,7 +46,7 @@ export function Form({ document }: { document: ResourceHubDocument }) {
         });
       }
 
-      navigate(Paths.resourceHubDocumentPath(document.id!));
+      navigate(DeprecatedPaths.resourceHubDocumentPath(document.id!));
     },
   });
 

--- a/app/assets/js/pages/ResourceHubEditFilePage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditFilePage/form.tsx
@@ -4,9 +4,9 @@ import { useNavigate } from "react-router-dom";
 import { ResourceHubFile, useEditResourceHubFile } from "@/models/resourceHubs";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
 import { areRichTextObjectsEqual } from "@/components/RichContent";
 import { findNameAndExtension } from "@/features/ResourceHub";
+import { DeprecatedPaths } from "@/routes/paths";
 
 export function Form({ file }: { file: ResourceHubFile }) {
   const navigate = useNavigate();
@@ -28,7 +28,7 @@ export function Form({ file }: { file: ResourceHubFile }) {
       }
     },
     cancel: () => {
-      navigate(Paths.resourceHubFilePath(file.id!));
+      navigate(DeprecatedPaths.resourceHubFilePath(file.id!));
     },
     submit: async () => {
       const { title, description } = form.values;
@@ -39,9 +39,9 @@ export function Form({ file }: { file: ResourceHubFile }) {
           name: !extension ? title : [title, extension].join("."),
           description: JSON.stringify(description),
         });
-        navigate(Paths.resourceHubFilePath(res.file.id));
+        navigate(DeprecatedPaths.resourceHubFilePath(res.file.id));
       } else {
-        navigate(Paths.resourceHubFilePath(file.id!));
+        navigate(DeprecatedPaths.resourceHubFilePath(file.id!));
       }
     },
   });

--- a/app/assets/js/pages/ResourceHubEditLinkPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditLinkPage/form.tsx
@@ -4,12 +4,12 @@ import { useNavigate } from "react-router-dom";
 import { ResourceHubLink, useEditResourceHubLink } from "@/models/resourceHubs";
 
 import Forms from "@/components/Forms";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { isValidURL } from "@/utils/validators";
 
-import { useLoadedData } from "./loader";
 import { areRichTextObjectsEqual } from "@/components/RichContent";
+import { useLoadedData } from "./loader";
 
 export function Form() {
   const { link } = useLoadedData();
@@ -38,7 +38,7 @@ export function Form() {
       }
     },
     cancel: () => {
-      navigate(Paths.resourceHubLinkPath(link.id!));
+      navigate(DeprecatedPaths.resourceHubLinkPath(link.id!));
     },
     submit: async () => {
       const { title, url, description } = form.values;
@@ -51,9 +51,9 @@ export function Form() {
           description: JSON.stringify(description),
           type: link.type,
         });
-        navigate(Paths.resourceHubLinkPath(link.id!));
+        navigate(DeprecatedPaths.resourceHubLinkPath(link.id!));
       } else {
-        navigate(Paths.resourceHubLinkPath(link.id!));
+        navigate(DeprecatedPaths.resourceHubLinkPath(link.id!));
       }
     },
   });

--- a/app/assets/js/pages/ResourceHubFilePage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubFilePage/Options.tsx
@@ -1,12 +1,12 @@
+import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Icons from "@tabler/icons-react";
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import * as Icons from "@tabler/icons-react";
-import * as PageOptions from "@/components/PaperContainer/PageOptions";
 
-import { useDeleteResourceHubFile } from "@/models/resourceHubs";
 import { useDownloadFile } from "@/models/blobs";
+import { useDeleteResourceHubFile } from "@/models/resourceHubs";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { useLoadedData } from "./loader";
 
@@ -22,7 +22,7 @@ export function Options() {
         <PageOptions.Link
           icon={Icons.IconEdit}
           title="Edit"
-          to={Paths.resourceHubEditFilePath(file.id!)}
+          to={DeprecatedPaths.resourceHubEditFilePath(file.id!)}
           testId="edit-file-link"
         />
       )}
@@ -51,10 +51,10 @@ function DeleteAction() {
 
   const redirect = () => {
     if (file.parentFolder) {
-      navigate(Paths.resourceHubFolderPath(file.parentFolder.id!));
+      navigate(DeprecatedPaths.resourceHubFolderPath(file.parentFolder.id!));
     } else {
       assertPresent(file.resourceHub, "resourceHub must be present in file");
-      navigate(Paths.resourceHubPath(file.resourceHub.id!));
+      navigate(DeprecatedPaths.resourceHubPath(file.resourceHub.id!));
     }
   };
 

--- a/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
@@ -1,11 +1,11 @@
+import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import * as Icons from "@tabler/icons-react";
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import * as Icons from "@tabler/icons-react";
-import * as PageOptions from "@/components/PaperContainer/PageOptions";
 
 import { useDeleteResourceHubLink } from "@/models/resourceHubs";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { useLoadedData } from "./loader";
 
@@ -19,7 +19,7 @@ export function Options() {
         <PageOptions.Link
           icon={Icons.IconEdit}
           title="Edit"
-          to={Paths.resourceHubEditLinkPath(link.id!)}
+          to={DeprecatedPaths.resourceHubEditLinkPath(link.id!)}
           testId="edit-link-link"
         />
       )}
@@ -35,10 +35,10 @@ function DeleteAction() {
 
   const redirect = () => {
     if (link.parentFolder) {
-      navigate(Paths.resourceHubFolderPath(link.parentFolder.id!));
+      navigate(DeprecatedPaths.resourceHubFolderPath(link.parentFolder.id!));
     } else {
       assertPresent(link.resourceHub, "resourceHub must be present in link");
-      navigate(Paths.resourceHubPath(link.resourceHub.id!));
+      navigate(DeprecatedPaths.resourceHubPath(link.resourceHub.id!));
     }
   };
 

--- a/app/assets/js/pages/ResourceHubNewDocumentPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubNewDocumentPage/form.tsx
@@ -5,12 +5,12 @@ import { ResourceHub, useCreateResourceHubDocument } from "@/models/resourceHubs
 
 import Forms from "@/components/Forms";
 import { useFormContext } from "@/components/Forms/FormContext";
-import { Link } from "turboui";
 import { DimmedSection } from "@/components/PaperContainer";
 import { Spacer } from "@/components/Spacer";
 import { Options, SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { Link } from "turboui";
 
 import { useLoadedData } from "./loader";
 
@@ -48,7 +48,7 @@ export function Form() {
         subscriberIds: subscriptionsState.currentSubscribersList,
         postAsDraft: isDraft,
       });
-      navigate(Paths.resourceHubDocumentPath(res.document.id));
+      navigate(DeprecatedPaths.resourceHubDocumentPath(res.document.id));
     },
   });
   form.actions.setState;
@@ -112,7 +112,7 @@ function FormActions({ resourceHub }: { resourceHub: ResourceHub }) {
 
 function DiscardLink({ resourceHubId }: { resourceHubId: string }) {
   return (
-    <Link to={Paths.resourceHubPath(resourceHubId)} testId="discard" className="font-medium">
+    <Link to={DeprecatedPaths.resourceHubPath(resourceHubId)} testId="discard" className="font-medium">
       Discard this document
     </Link>
   );

--- a/app/assets/js/pages/ResourceHubNewLinkPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubNewLinkPage/form.tsx
@@ -5,11 +5,11 @@ import { useCreateResourceHubLink } from "@/models/resourceHubs";
 
 import Forms from "@/components/Forms";
 import { useFieldValue } from "@/components/Forms/FormContext";
+import { LinkIcon, LinkOptions } from "@/features/ResourceHub";
 import { Options, SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { isValidURL } from "@/utils/validators";
-import { LinkOptions, LinkIcon } from "@/features/ResourceHub";
 
 import { useLoadedData } from "./loader";
 
@@ -37,7 +37,7 @@ export function Form() {
       }
     },
     cancel: () => {
-      navigate(Paths.resourceHubPath(resourceHub.id!));
+      navigate(DeprecatedPaths.resourceHubPath(resourceHub.id!));
     },
     submit: async () => {
       const res = await post({
@@ -50,7 +50,7 @@ export function Form() {
         sendNotificationsToEveryone: subscriptionsState.subscriptionType === Options.ALL,
         subscriberIds: subscriptionsState.currentSubscribersList,
       });
-      navigate(Paths.resourceHubLinkPath(res.link.id));
+      navigate(DeprecatedPaths.resourceHubLinkPath(res.link.id));
     },
   });
 

--- a/app/assets/js/pages/ResourceHubPage/page.tsx
+++ b/app/assets/js/pages/ResourceHubPage/page.tsx
@@ -4,9 +4,9 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Hub from "@/features/ResourceHub";
 
-import { Paths } from "@/routes/paths";
-import { useLoadedData, useRefresh } from "./loader";
+import { DeprecatedPaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
+import { useLoadedData, useRefresh } from "./loader";
 
 export function Page() {
   const { resourceHub, nodes, draftNodes } = useLoadedData();
@@ -43,7 +43,7 @@ function PageNavigation() {
   return (
     <Paper.Navigation
       testId="navigation"
-      items={[{ to: Paths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! }]}
+      items={[{ to: DeprecatedPaths.spacePath(resourceHub.space.id!), label: resourceHub.space.name! }]}
     />
   );
 }

--- a/app/assets/js/pages/SpaceAccessManagementPage/page.tsx
+++ b/app/assets/js/pages/SpaceAccessManagementPage/page.tsx
@@ -4,20 +4,19 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
 
-import { Paths } from "@/routes/paths";
-import { Space } from "@/models/spaces";
-import { AccessLevel } from "@/features/spaces";
-import { OtherPeople } from "./OtherPeople";
+import { SpaceAccessLevelBadge } from "@/components/Badges/AccessLevelBadges";
 import { BorderedRow } from "@/components/BorderedRow";
 import { PermissionLevels } from "@/features/Permissions";
-import { Menu, MenuActionItem, SubMenu } from "turboui";
-import { SpaceAccessLevelBadge } from "@/components/Badges/AccessLevelBadges";
-import { PrimaryButton, SecondaryButton } from "turboui";
+import { AccessLevel } from "@/features/spaces";
+import { Space } from "@/models/spaces";
+import { DeprecatedPaths } from "@/routes/paths";
+import { Menu, MenuActionItem, PrimaryButton, SecondaryButton, SubMenu } from "turboui";
+import { OtherPeople } from "./OtherPeople";
 
+import { useEditSpaceMembersPermissions, useRemoveGroupMember } from "@/models/spaces";
+import { assertPresent } from "@/utils/assertions";
 import { createTestId } from "@/utils/testid";
 import { useLoadedData } from "./loader";
-import { assertPresent } from "@/utils/assertions";
-import { useEditSpaceMembersPermissions, useRemoveGroupMember } from "@/models/spaces";
 
 import { Avatar } from "turboui";
 
@@ -43,7 +42,7 @@ export function Page() {
 
 function Title() {
   const { space } = useLoadedData();
-  const addMembersPath = Paths.spaceAddMembersPath(space.id!);
+  const addMembersPath = DeprecatedPaths.spaceAddMembersPath(space.id!);
 
   assertPresent(space.permissions, "Space permissions must be present");
 
@@ -66,12 +65,12 @@ function Title() {
 }
 
 function Navigation({ space }: { space: Space }) {
-  return <Paper.Navigation items={[{ to: Paths.spacePath(space.id!), label: space.name! }]} />;
+  return <Paper.Navigation items={[{ to: DeprecatedPaths.spacePath(space.id!), label: space.name! }]} />;
 }
 
 function GeneralAccess() {
   const { space } = useLoadedData();
-  const editPath = Paths.spaceEditGeneralAccessPath(space.id!);
+  const editPath = DeprecatedPaths.spaceEditGeneralAccessPath(space.id!);
 
   assertPresent(space.accessLevels, "Space access levels must be present");
   assertPresent(space.permissions, "Space permissions must be present");

--- a/app/assets/js/pages/SpaceAddMembersPage/index.tsx
+++ b/app/assets/js/pages/SpaceAddMembersPage/index.tsx
@@ -1,18 +1,18 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
-import * as Spaces from "@/models/spaces";
 import * as People from "@/models/people";
+import * as Spaces from "@/models/spaces";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
 import { PERMISSIONS_LIST, PermissionLevels } from "@/features/Permissions";
 
 import Forms from "@/components/Forms";
-import { Paths, compareIds } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
+import { DeprecatedPaths, compareIds } from "@/routes/paths";
+import { PageModule } from "@/routes/types";
 import { createTestId } from "@/utils/testid";
 import { useNavigate } from "react-router-dom";
-import { PageModule } from "@/routes/types";
+import { SecondaryButton } from "turboui";
 
 export default { name: "SpaceAddMembersPage", loader, Page } as PageModule;
 
@@ -41,7 +41,7 @@ function newMember() {
 
 function Page() {
   const { space } = Pages.useLoadedData() as LoaderResult;
-  const backPath = Paths.spaceAccessManagementPath(space.id!);
+  const backPath = DeprecatedPaths.spaceAccessManagementPath(space.id!);
   const navigate = useNavigate();
   const [add] = Spaces.useAddSpaceMembers();
 

--- a/app/assets/js/pages/SpaceAddPage/index.tsx
+++ b/app/assets/js/pages/SpaceAddPage/index.tsx
@@ -8,10 +8,10 @@ import * as Spaces from "@/models/spaces";
 
 import Forms from "@/components/Forms";
 
-import { Paths } from "@/routes/paths";
-import { SecondaryButton } from "turboui";
-import { AccessLevel, AccessSelectors, initialAccessLevels, applyAccessLevelConstraints } from "@/features/spaces";
+import { AccessLevel, AccessSelectors, applyAccessLevelConstraints, initialAccessLevels } from "@/features/spaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { SecondaryButton } from "turboui";
 
 export default { name: "SpaceAddPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -37,14 +37,14 @@ function Page() {
         companyPermissions: form.values.access.companyMembers,
       });
 
-      navigate(Paths.spacePath(res.group.id!));
+      navigate(DeprecatedPaths.spacePath(res.group.id!));
     },
   });
 
   return (
     <Pages.Page title="Create a new space">
       <Paper.Root size="small">
-        <Paper.NavigateBack to={Paths.homePath()} title="Back to Home" />
+        <Paper.NavigateBack to={DeprecatedPaths.homePath()} title="Back to Home" />
         <Title />
 
         <Forms.Form form={form}>

--- a/app/assets/js/pages/SpaceDiscussionsPage/page.tsx
+++ b/app/assets/js/pages/SpaceDiscussionsPage/page.tsx
@@ -1,21 +1,20 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
+import * as React from "react";
 
-import { Discussion } from "@/models/discussions";
-import { DivLink, Link } from "turboui";
 import { Summary } from "@/components/RichContent";
-import { PrimaryButton } from "turboui";
-import { Paths } from "@/routes/paths";
 import { SpacePageNavigation } from "@/components/SpacePageNavigation";
+import { Discussion } from "@/models/discussions";
+import { DeprecatedPaths } from "@/routes/paths";
+import { DivLink, Link, PrimaryButton } from "turboui";
 
-import { useLoadedData } from "./loader";
 import { assertPresent } from "@/utils/assertions";
+import { useLoadedData } from "./loader";
 
-import { Avatar } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
-import classNames from "classnames";
 import { CommentsCountIndicator } from "@/features/Comments";
+import classNames from "classnames";
+import { Avatar } from "turboui";
 
 export function Page() {
   const { space, discussions } = useLoadedData();
@@ -45,7 +44,7 @@ function NewDiscussionButton() {
   const { space } = useLoadedData();
 
   return (
-    <PrimaryButton linkTo={Paths.discussionNewPath(space.id!)} size="sm" testId="new-discussion">
+    <PrimaryButton linkTo={DeprecatedPaths.discussionNewPath(space.id!)} size="sm" testId="new-discussion">
       New Discussion
     </PrimaryButton>
   );
@@ -57,7 +56,7 @@ function ContinueEditingDrafts() {
   if (myDrafts.length < 1) {
     return null;
   } else if (myDrafts.length === 1) {
-    const path = Paths.discussionEditPath(myDrafts[0]!.id!);
+    const path = DeprecatedPaths.discussionEditPath(myDrafts[0]!.id!);
 
     return (
       <div className="flex justify-center">
@@ -67,7 +66,7 @@ function ContinueEditingDrafts() {
       </div>
     );
   } else {
-    const path = Paths.discussionDraftsPath(space.id!);
+    const path = DeprecatedPaths.discussionDraftsPath(space.id!);
 
     return (
       <div className="flex justify-center">
@@ -103,7 +102,7 @@ function DiscussionListItem({ discussion }: { discussion: Discussion }) {
   assertPresent(discussion.author, "author must be present in discussion");
   assertPresent(discussion.commentsCount, "commentsCount must be present in discussion");
 
-  const path = Paths.discussionPath(discussion.id!);
+  const path = DeprecatedPaths.discussionPath(discussion.id!);
 
   const className = classNames(
     "flex gap-4",

--- a/app/assets/js/pages/SpaceEditGeneralAccessPage/index.tsx
+++ b/app/assets/js/pages/SpaceEditGeneralAccessPage/index.tsx
@@ -1,14 +1,14 @@
-import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
 import Forms from "@/components/Forms";
 
-import { Paths } from "@/routes/paths";
-import { useNavigateTo } from "@/routes/useNavigateTo";
-import { initialAccessLevels, applyAccessLevelConstraints, AccessSelectors } from "@/features/spaces";
+import { AccessSelectors, applyAccessLevelConstraints, initialAccessLevels } from "@/features/spaces";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
+import { useNavigateTo } from "@/routes/useNavigateTo";
 
 export default { name: "SpaceEditGeneralAccessPage", loader, Page } as PageModule;
 
@@ -40,7 +40,7 @@ function Page() {
 function Form() {
   const { space } = Pages.useLoadedData();
 
-  const navigateBack = useNavigateTo(Paths.spaceAccessManagementPath(space.id!));
+  const navigateBack = useNavigateTo(DeprecatedPaths.spaceAccessManagementPath(space.id!));
   const [edit] = Spaces.useEditSpacePermissions();
 
   const form = Forms.useForm({

--- a/app/assets/js/pages/SpaceEditPage/index.tsx
+++ b/app/assets/js/pages/SpaceEditPage/index.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
 import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
+import * as React from "react";
 
-import { useNavigate } from "react-router-dom";
+import { DeprecatedPaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
-import { Paths } from "@/routes/paths";
+import { useNavigate } from "react-router-dom";
 
 import Forms from "@/components/Forms";
 
@@ -26,7 +26,7 @@ function Page() {
   const { space } = Pages.useLoadedData<LoaderResult>();
 
   const [edit] = Spaces.useEditSpace();
-  const backPath = Paths.spacePath(space.id!);
+  const backPath = DeprecatedPaths.spacePath(space.id!);
 
   const form = Forms.useForm({
     fields: {

--- a/app/assets/js/pages/SpaceGoalsPage/loader.tsx
+++ b/app/assets/js/pages/SpaceGoalsPage/loader.tsx
@@ -3,7 +3,7 @@ import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
 import * as Spaces from "@/models/spaces";
 
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoadedData {
@@ -15,7 +15,7 @@ interface LoadedData {
 export async function loader({ params }): Promise<LoadedData> {
   await redirectIfFeatureEnabled(params, {
     feature: "space_work_map",
-    path: Paths.spaceWorkMapPath(params.id),
+    path: DeprecatedPaths.spaceWorkMapPath(params.id),
   });
 
   const spacePromise = Spaces.getSpace({

--- a/app/assets/js/pages/SpaceGoalsPage/page.tsx
+++ b/app/assets/js/pages/SpaceGoalsPage/page.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import { useLoadedData } from "./loader";
-import { GoalTree } from "@/features/goals/GoalTree";
-import { Paths } from "@/routes/paths";
 import { SpacePageNavigation } from "@/components/SpacePageNavigation";
 import { AddGoalOrProjectButton } from "@/features/goals/AddGoalOrProjectButton";
+import { GoalTree } from "@/features/goals/GoalTree";
+import { DeprecatedPaths } from "@/routes/paths";
+import { useLoadedData } from "./loader";
 
 export function Page() {
   const { space, goals, projects } = useLoadedData();
@@ -34,10 +34,10 @@ export function Page() {
 function Header() {
   const { space } = useLoadedData();
 
-  const newGoalPath = Paths.spaceNewGoalPath(space.id!);
-  const newProjectPath = Paths.newProjectPath({
+  const newGoalPath = DeprecatedPaths.spaceNewGoalPath(space.id!);
+  const newProjectPath = DeprecatedPaths.newProjectPath({
     spaceId: space.id!,
-    backPath: Paths.spaceGoalsPath(space.id!),
+    backPath: DeprecatedPaths.spaceGoalsPath(space.id!),
     backPathName: `Back to ${space.name} Goal Map`,
   });
 

--- a/app/assets/js/pages/SpacePage/page.tsx
+++ b/app/assets/js/pages/SpacePage/page.tsx
@@ -7,15 +7,15 @@ import * as Spaces from "@/models/spaces";
 import { Feed, useItemsQuery } from "@/features/Feed";
 import { AvatarList, PrimaryButton, SecondaryButton } from "turboui";
 
-import { useJoinSpace } from "@/models/spaces";
-import { PrivacyIndicator } from "@/features/spaces/PrivacyIndicator";
 import { useClearNotificationsOnLoad } from "@/features/notifications";
-import { assertPresent } from "@/utils/assertions";
+import { PrivacyIndicator } from "@/features/spaces/PrivacyIndicator";
 import { ToolsSection } from "@/features/SpaceTools";
+import { useJoinSpace } from "@/models/spaces";
+import { assertPresent } from "@/utils/assertions";
 
-import { useLoadedData, useRefresh } from "./loader";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { match } from "ts-pattern";
+import { useLoadedData, useRefresh } from "./loader";
 
 export function Page() {
   const { space, tools } = useLoadedData();
@@ -46,7 +46,7 @@ function SpaceEdit() {
 
   return (
     <div className="absolute right-4 top-4">
-      <SecondaryButton size="xs" linkTo={Paths.spaceEditPath(space.id!)} testId="edit-space">
+      <SecondaryButton size="xs" linkTo={DeprecatedPaths.spaceEditPath(space.id!)} testId="edit-space">
         Edit
       </SecondaryButton>
     </div>
@@ -135,7 +135,7 @@ function JoinButton({ space }) {
 }
 
 function ManageAccessButton({ space }: { space: Spaces.Space }) {
-  const path = Paths.spaceAccessManagementPath(space.id!);
+  const path = DeprecatedPaths.spaceAccessManagementPath(space.id!);
 
   assertPresent(space.permissions, "permissions must be present in space");
   if (!space.permissions.canAddMembers) return null;

--- a/app/assets/js/pages/SpaceWorkMapPage/loader.tsx
+++ b/app/assets/js/pages/SpaceWorkMapPage/loader.tsx
@@ -1,7 +1,7 @@
 import { Space, getSpace } from "@/models/spaces";
 import { convertToWorkMapItem, getWorkMap } from "@/models/workMap";
 import { PageCache } from "@/routes/PageCache";
-import { Paths } from "@/routes/paths";
+import { DeprecatedPaths } from "@/routes/paths";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
 import { fetchAll } from "../../utils/async";
 
@@ -16,7 +16,7 @@ interface LoaderResult {
 export async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
   await redirectIfFeatureNotEnabled(params, {
     feature: "space_work_map",
-    path: Paths.spaceGoalsPath(params.id),
+    path: DeprecatedPaths.spaceGoalsPath(params.id),
   });
 
   return PageCache.fetch({

--- a/app/assets/js/pages/SpaceWorkMapPage/page.tsx
+++ b/app/assets/js/pages/SpaceWorkMapPage/page.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 
+import { DeprecatedPaths } from "@/routes/paths";
 import { WorkMapPage } from "turboui";
 import { useLoadedData } from "./loader";
-import { Paths } from "@/routes/paths";
 
 export function Page() {
   const { data } = useLoadedData();
@@ -14,7 +14,7 @@ export function Page() {
       title={title}
       items={workMap}
       columnOptions={{ hideSpace: true }}
-      navigation={[{ to: Paths.spacePath(space.id), label: space.name }]}
+      navigation={[{ to: DeprecatedPaths.spacePath(space.id), label: space.name }]}
     />
   );
 }

--- a/app/assets/js/pages/TaskPage/page.tsx
+++ b/app/assets/js/pages/TaskPage/page.tsx
@@ -1,21 +1,20 @@
-import * as React from "react";
-import * as Paper from "@/components/PaperContainer";
-import * as Pages from "@/components/Pages";
-import * as Tasks from "@/models/tasks";
-import * as Forms from "@/components/Form";
-import * as Icons from "@tabler/icons-react";
 import * as TipTapEditor from "@/components/Editor";
+import * as Forms from "@/components/Form";
+import * as Pages from "@/components/Pages";
+import * as Paper from "@/components/PaperContainer";
+import * as Tasks from "@/models/tasks";
+import * as Icons from "@tabler/icons-react";
+import * as React from "react";
 
 import RichContent from "@/components/RichContent";
-import { Avatar } from "turboui";
-import { PrimaryButton, SecondaryButton } from "turboui";
+import { Avatar, PrimaryButton, SecondaryButton } from "turboui";
 
-import { useLoadedData } from "./loader";
-import { useForm, FormState } from "./useForm";
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { MultiPeopleSearch } from "@/features/Tasks/NewTaskModal/MultiPeopleSearch";
+import { DeprecatedPaths } from "@/routes/paths";
 import { truncateString } from "@/utils/strings";
-import { Paths } from "@/routes/paths";
+import { useLoadedData } from "./loader";
+import { FormState, useForm } from "./useForm";
 
 export function Page() {
   const { task } = useLoadedData();
@@ -45,8 +44,8 @@ export function Page() {
 }
 
 function Navigation({ task }: { task: Tasks.Task }) {
-  const projectPath = Paths.projectPath(task.project!.id!);
-  const milestonePath = Paths.projectMilestonePath(task.milestone!.id!);
+  const projectPath = DeprecatedPaths.projectPath(task.project!.id!);
+  const milestonePath = DeprecatedPaths.projectMilestonePath(task.milestone!.id!);
 
   return (
     <Paper.Navigation

--- a/app/assets/js/routes/ErrorPage.tsx
+++ b/app/assets/js/routes/ErrorPage.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
 import NotFoundPage from "@/pages/NotFoundPage";
+import * as React from "react";
 
-import { GhostButton } from "turboui";
-import { Paths } from "./paths";
-import { useRouteError } from "react-router-dom";
-import { AxiosError } from "axios";
 import { captureException } from "@sentry/react";
+import { AxiosError } from "axios";
+import { useRouteError } from "react-router-dom";
+import { GhostButton } from "turboui";
+import { DeprecatedPaths } from "./paths";
 
 export default function ErrorPage() {
   const error = useRouteError() as AxiosError | null;
@@ -22,8 +22,8 @@ function ServerErrorPage() {
 
   React.useEffect(() => {
     console.error(error);
-    captureException(error, { level: 'fatal' })
-  }, [error])
+    captureException(error, { level: "fatal" });
+  }, [error]);
 
   return (
     <div className="absolute inset-0 flex justify-center items-center gap-16">
@@ -35,7 +35,7 @@ function ServerErrorPage() {
         <div className="text-lg font-medium my-4">An unexpected error has occurred.</div>
 
         <div className="flex w-full justify-center mt-4">
-          <GhostButton linkTo={Paths.homePath()} testId="back-to-lobby">
+          <GhostButton linkTo={DeprecatedPaths.homePath()} testId="back-to-lobby">
             Go back to Home
           </GhostButton>
         </div>

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -6,7 +6,7 @@ import * as ProjectContributorsAddPage from "@/pages/ProjectContributorsAddPage"
 import * as ProjectContributorsEditPage from "@/pages/ProjectContributorsEditPage";
 import { WorkMap } from "turboui";
 
-export class Paths {
+export class DeprecatedPaths {
   static lobbyPath() {
     return "/";
   }
@@ -40,7 +40,7 @@ export class Paths {
   }
 
   static isHomePath() {
-    return window.location.pathname === Paths.homePath();
+    return window.location.pathname === DeprecatedPaths.homePath();
   }
 
   static homePath() {

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -59,10 +59,6 @@ export class Paths {
     return this.createCompanyPath(["feed"]);
   }
 
-  isHomePath() {
-    return window.location.pathname === DeprecatedPaths.homePath();
-  }
-
   homePath() {
     return this.createCompanyPath([]);
   }

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -1,12 +1,32 @@
-import { LinkOptions } from "@/features/ResourceHub";
 import * as GoalAddPage from "@/pages/GoalAddPage";
 import * as ProfileEditPage from "@/pages/ProfileEditPage";
 import * as ProjectAddPage from "@/pages/ProjectAddPage";
 import * as ProjectContributorsAddPage from "@/pages/ProjectContributorsAddPage";
 import * as ProjectContributorsEditPage from "@/pages/ProjectContributorsEditPage";
-import { WorkMap } from "turboui";
+import * as React from "react";
 
-export class DeprecatedPaths {
+import { LinkOptions } from "@/features/ResourceHub";
+import { WorkMap } from "turboui";
+import { useLoadedData } from "../pages/GoalAddPage/loader";
+
+const UNACCEPTABLE_PATH_CHARACTERS = ["/", "?", "#", "[", "]"];
+
+class Paths {
+  //
+  // When deprecatedLookup is true, the paths will use the old lookup method
+  // which is based on the company ID in the window.location.pathname.
+  //
+  // We've deprecated this method and replaced it with a new one that uses
+  // a more robust way to get the company ID, based on the react-router context.
+  //
+  private deprecatedLookup: boolean;
+  private companyId?: string | null;
+
+  constructor(opts: { deprecatedLookup?: boolean; companyId: string | null }) {
+    this.companyId = opts.companyId || null;
+    this.deprecatedLookup = opts.deprecatedLookup || false;
+  }
+
   static lobbyPath() {
     return "/";
   }
@@ -16,63 +36,63 @@ export class DeprecatedPaths {
   }
 
   static newCompanyPath() {
-    return createPath(["new"]);
+    return "/new";
   }
 
   static companyHomePath(companyId: string) {
-    return createPath([companyId]);
+    return "/" + companyId;
   }
 
-  static companyPermissionsPath() {
-    return createCompanyPath(["admin", "permissions"]);
+  companyPermissionsPath() {
+    return this.createCompanyPath(["admin", "permissions"]);
   }
 
-  static companyRenamePath() {
-    return createCompanyPath(["admin", "rename"]);
+  companyRenamePath() {
+    return this.createCompanyPath(["admin", "rename"]);
   }
 
-  static companyAdminRestoreSuspendedPeoplePath() {
-    return createCompanyPath(["admin", "restore-suspended-people"]);
+  companyAdminRestoreSuspendedPeoplePath() {
+    return this.createCompanyPath(["admin", "restore-suspended-people"]);
   }
 
-  static feedPath() {
-    return createCompanyPath(["feed"]);
+  feedPath() {
+    return this.createCompanyPath(["feed"]);
   }
 
-  static isHomePath() {
+  isHomePath() {
     return window.location.pathname === DeprecatedPaths.homePath();
   }
 
-  static homePath() {
-    return createCompanyPath([]);
+  homePath() {
+    return this.createCompanyPath([]);
   }
 
-  static accountPath() {
-    return createCompanyPath(["account"]);
+  accountPath() {
+    return this.createCompanyPath(["account"]);
   }
 
-  static accountAppearancePath() {
-    return createCompanyPath(["account", "appearance"]);
+  accountAppearancePath() {
+    return this.createCompanyPath(["account", "appearance"]);
   }
 
-  static accountSecurityPath() {
-    return createCompanyPath(["account", "security"]);
+  accountSecurityPath() {
+    return this.createCompanyPath(["account", "security"]);
   }
 
-  static accountChangePasswordPath() {
-    return createCompanyPath(["account", "security", "change-password"]);
+  accountChangePasswordPath() {
+    return this.createCompanyPath(["account", "security", "change-password"]);
   }
 
-  static notificationsPath() {
-    return createCompanyPath(["notifications"]);
+  notificationsPath() {
+    return this.createCompanyPath(["notifications"]);
   }
 
-  static reviewPath() {
-    return createCompanyPath(["review"]);
+  reviewPath() {
+    return this.createCompanyPath(["review"]);
   }
 
-  static profileEditPath(personId: string, params?: { from: ProfileEditPage.FromLocation }) {
-    const path = createCompanyPath(["people", personId, "profile", "edit"]);
+  profileEditPath(personId: string, params?: { from: ProfileEditPage.FromLocation }) {
+    const path = this.createCompanyPath(["people", personId, "profile", "edit"]);
 
     if (params?.from) {
       return path + "?from=" + params.from;
@@ -81,414 +101,434 @@ export class DeprecatedPaths {
     }
   }
 
-  static companyAdminPath() {
-    return createCompanyPath(["admin"]);
+  companyAdminPath() {
+    return this.createCompanyPath(["admin"]);
   }
 
-  static companyManagePeoplePath() {
-    return createCompanyPath(["admin", "manage-people"]);
+  companyManagePeoplePath() {
+    return this.createCompanyPath(["admin", "manage-people"]);
   }
 
-  static companyManageAdminsPath() {
-    return createCompanyPath(["admin", "manage-admins"]);
+  companyManageAdminsPath() {
+    return this.createCompanyPath(["admin", "manage-admins"]);
   }
 
-  static companyManagePeopleAddPeoplePath() {
-    return createCompanyPath(["admin", "manage-people", "add"]);
+  companyManagePeopleAddPeoplePath() {
+    return this.createCompanyPath(["admin", "manage-people", "add"]);
   }
 
-  static companyAdminManageTrustedDomainsPath() {
-    return createCompanyPath(["admin", "manage-trusted-email-domains"]);
+  companyAdminManageTrustedDomainsPath() {
+    return this.createCompanyPath(["admin", "manage-trusted-email-domains"]);
   }
 
-  static peoplePath() {
-    return createCompanyPath(["people"]);
+  peoplePath() {
+    return this.createCompanyPath(["people"]);
   }
 
-  static discussionsPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "discussions"]);
+  discussionsPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "discussions"]);
   }
 
-  static discussionDraftsPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "discussions", "drafts"]);
+  discussionDraftsPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "discussions", "drafts"]);
   }
 
-  static discussionPath(discussionId: string) {
-    return createCompanyPath(["discussions", discussionId]);
+  discussionPath(discussionId: string) {
+    return this.createCompanyPath(["discussions", discussionId]);
   }
 
-  static discussionEditPath(discussionId: string) {
-    return createCompanyPath(["discussions", discussionId, "edit"]);
+  discussionEditPath(discussionId: string) {
+    return this.createCompanyPath(["discussions", discussionId, "edit"]);
   }
 
-  static discussionNewPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "discussions", "new"]);
+  discussionNewPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "discussions", "new"]);
   }
 
-  static projectPath(projectId: string) {
-    return createCompanyPath(["projects", projectId]);
+  projectPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId]);
   }
 
-  static projectCheckInNewPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "check-ins", "new"]);
+  projectCheckInNewPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "check-ins", "new"]);
   }
 
-  static projectNewPath({ goalId }: { goalId: string }) {
-    return createCompanyPath(["projects", "new"]) + "?goalId=" + goalId;
+  projectNewPath({ goalId }: { goalId: string }) {
+    return this.createCompanyPath(["projects", "new"]) + "?goalId=" + goalId;
   }
 
-  static projectCheckInPath(checkInId: string) {
-    return createCompanyPath(["project-check-ins", checkInId]);
+  projectCheckInPath(checkInId: string) {
+    return this.createCompanyPath(["project-check-ins", checkInId]);
   }
 
-  static projectCheckInEditPath(checkInId: string) {
-    return createCompanyPath(["project-check-ins", checkInId, "edit"]);
+  projectCheckInEditPath(checkInId: string) {
+    return this.createCompanyPath(["project-check-ins", checkInId, "edit"]);
   }
 
-  static projectCheckInsPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "check-ins"]);
+  projectCheckInsPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "check-ins"]);
   }
 
-  static projectRetrospectivePath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "retrospective"]);
+  projectRetrospectivePath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "retrospective"]);
   }
 
-  static projectRetrospectiveEditPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "retrospective", "edit"]);
-  }
-  static projectMilestonesPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "milestones"]);
+  projectRetrospectiveEditPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "retrospective", "edit"]);
   }
 
-  static projectMilestonePath(milestoneId: string) {
-    return createCompanyPath(["milestones", milestoneId]);
+  projectMilestonesPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "milestones"]);
   }
 
-  static projectContributorsPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "contributors"]);
+  projectMilestonePath(milestoneId: string) {
+    return this.createCompanyPath(["milestones", milestoneId]);
   }
 
-  static projectContributorsAddPath(projectId: string, params: ProjectContributorsAddPage.UrlParams) {
-    return createCompanyPath(["projects", projectId, "contributors", "add"]) + encodeUrlParams(params);
+  projectContributorsPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "contributors"]);
   }
 
-  static projectContributorsEditPath(contributorId: string, params?: ProjectContributorsEditPage.UrlParams) {
-    return createCompanyPath(["project-contribs", contributorId, "edit"]) + encodeUrlParams(params);
+  projectContributorsAddPath(projectId: string, params: ProjectContributorsAddPage.UrlParams) {
+    return this.createCompanyPath(["projects", projectId, "contributors", "add"]) + encodeUrlParams(params);
   }
 
-  static editProjectGoalPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "goal"]);
+  projectContributorsEditPath(contributorId: string, params?: ProjectContributorsEditPage.UrlParams) {
+    return this.createCompanyPath(["project-contribs", contributorId, "edit"]) + encodeUrlParams(params);
   }
 
-  static editProjectNamePath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "name"]);
+  editProjectGoalPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "goal"]);
   }
 
-  static editProjectAccessLevelsPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "permissions"]);
+  editProjectNamePath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "name"]);
   }
 
-  static moveProjectPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "move"]);
+  editProjectAccessLevelsPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "permissions"]);
   }
 
-  static pauseProjectPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "pause"]);
+  moveProjectPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "move"]);
   }
 
-  static resumeProjectPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "resume"]);
+  pauseProjectPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "pause"]);
   }
 
-  static orgChartPath() {
-    return createCompanyPath(["people", "org-chart"]);
+  resumeProjectPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "resume"]);
   }
 
-  static newSpacePath() {
-    return createCompanyPath(["spaces", "new"]);
+  orgChartPath() {
+    return this.createCompanyPath(["people", "org-chart"]);
   }
 
-  static resourceHubPath(resourceHubId: string) {
-    return createCompanyPath(["resource-hubs", resourceHubId]);
+  newSpacePath() {
+    return this.createCompanyPath(["spaces", "new"]);
   }
 
-  static resourceHubDraftsPath(resourceHubId: string) {
-    return createCompanyPath(["resource-hubs", resourceHubId, "drafts"]);
+  resourceHubPath(resourceHubId: string) {
+    return this.createCompanyPath(["resource-hubs", resourceHubId]);
   }
 
-  static resourceHubFolderPath(folderId: string) {
-    return createCompanyPath(["folders", folderId]);
+  resourceHubDraftsPath(resourceHubId: string) {
+    return this.createCompanyPath(["resource-hubs", resourceHubId, "drafts"]);
   }
 
-  static resourceHubFilePath(fileId: string) {
-    return createCompanyPath(["files", fileId]);
+  resourceHubFolderPath(folderId: string) {
+    return this.createCompanyPath(["folders", folderId]);
   }
 
-  static resourceHubEditFilePath(fileId: string) {
-    return createCompanyPath(["files", fileId, "edit"]);
+  resourceHubFilePath(fileId: string) {
+    return this.createCompanyPath(["files", fileId]);
   }
 
-  static resourceHubDocumentPath(documentId: string) {
-    return createCompanyPath(["documents", documentId]);
+  resourceHubEditFilePath(fileId: string) {
+    return this.createCompanyPath(["files", fileId, "edit"]);
   }
 
-  static resourceHubEditDocumentPath(documentId: string) {
-    return createCompanyPath(["documents", documentId, "edit"]);
+  resourceHubDocumentPath(documentId: string) {
+    return this.createCompanyPath(["documents", documentId]);
   }
 
-  static resourceHubNewDocumentPath(resourceHubId: string, folderId?: string) {
+  resourceHubEditDocumentPath(documentId: string) {
+    return this.createCompanyPath(["documents", documentId, "edit"]);
+  }
+
+  resourceHubNewDocumentPath(resourceHubId: string, folderId?: string) {
     if (folderId) {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-document"]) + "?folderId=" + folderId;
+      return this.createCompanyPath(["resource-hubs", resourceHubId, "new-document"]) + "?folderId=" + folderId;
     } else {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-document"]);
+      return this.createCompanyPath(["resource-hubs", resourceHubId, "new-document"]);
     }
   }
 
-  static resourceHubNewLinkPath(resourceHubId: string, attrs: { folderId?: string; type?: LinkOptions }) {
+  resourceHubNewLinkPath(resourceHubId: string, attrs: { folderId?: string; type?: LinkOptions }) {
     const { folderId, type } = attrs;
 
     if (folderId && type) {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + `?folderId=${folderId}&type=${type}`;
+      return (
+        this.createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + `?folderId=${folderId}&type=${type}`
+      );
     } else if (folderId) {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + "?folderId=" + folderId;
+      return this.createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + "?folderId=" + folderId;
     } else if (type) {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + "?type=" + type;
+      return this.createCompanyPath(["resource-hubs", resourceHubId, "new-link"]) + "?type=" + type;
     } else {
-      return createCompanyPath(["resource-hubs", resourceHubId, "new-link"]);
+      return this.createCompanyPath(["resource-hubs", resourceHubId, "new-link"]);
     }
   }
 
-  static resourceHubEditLinkPath(linkId: string) {
-    return createCompanyPath(["links", linkId, "edit"]);
+  resourceHubEditLinkPath(linkId: string) {
+    return this.createCompanyPath(["links", linkId, "edit"]);
   }
 
-  static resourceHubLinkPath(linkId: string) {
-    return createCompanyPath(["links", linkId]);
+  resourceHubLinkPath(linkId: string) {
+    return this.createCompanyPath(["links", linkId]);
   }
 
-  static spacePath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId]);
+  spacePath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId]);
   }
 
-  static spaceEditPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "edit"]);
+  spaceEditPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "edit"]);
   }
 
-  static spaceEditGeneralAccessPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "edit", "general-access"]);
+  spaceEditGeneralAccessPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "edit", "general-access"]);
   }
 
-  static spaceGoalsPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "goals"]);
+  spaceGoalsPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "goals"]);
   }
 
-  static spaceDiscussionsPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "discussions"]);
+  spaceDiscussionsPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "discussions"]);
   }
 
-  static spaceAppearancePath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "appearance"]);
+  spaceAppearancePath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "appearance"]);
   }
 
-  static spaceAccessManagementPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "access"]);
+  spaceAccessManagementPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "access"]);
   }
 
-  static spaceAddMembersPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "add-members"]);
+  spaceAddMembersPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "add-members"]);
   }
 
-  static workMapPath(tab?: WorkMap.Filter) {
-    return createCompanyPath(["work-map"]) + (tab ? `?tab=${tab}` : "");
+  workMapPath(tab?: WorkMap.Filter) {
+    return this.createCompanyPath(["work-map"]) + (tab ? `?tab=${tab}` : "");
   }
 
-  static spaceWorkMapPath(spaceId: string, tab?: WorkMap.Filter) {
-    return createCompanyPath(["spaces", spaceId, "work-map"]) + (tab ? `?tab=${tab}` : "");
+  spaceWorkMapPath(spaceId: string, tab?: WorkMap.Filter) {
+    return this.createCompanyPath(["spaces", spaceId, "work-map"]) + (tab ? `?tab=${tab}` : "");
   }
 
-  static goalClosePath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "complete"]);
+  goalClosePath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "complete"]);
   }
 
-  static goalPath(goalId: string) {
-    return createCompanyPath(["goals", goalId]);
+  goalPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId]);
   }
 
   // Temporary path
-  static goalV2Path(goalId: string) {
-    return createCompanyPath(["goals", goalId, "v2"]);
+  goalV2Path(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "v2"]);
   }
-  static goalV3Path(goalId: string) {
-    return createCompanyPath(["goals", goalId, "v3"]);
-  }
-
-  static newGoalPath(params?: GoalAddPage.UrlParams) {
-    return createCompanyPath(["goals", "new"]) + encodeUrlParams(params);
+  goalV3Path(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "v3"]);
   }
 
-  static spaceNewGoalPath(spaceId: string) {
-    return createCompanyPath(["spaces", spaceId, "goals", "new"]);
+  newGoalPath(params?: GoalAddPage.UrlParams) {
+    return this.createCompanyPath(["goals", "new"]) + encodeUrlParams(params);
   }
 
-  static newProjectPath(params?: ProjectAddPage.UrlParams) {
-    return createCompanyPath(["projects", "new"]) + encodeUrlParams(params);
+  spaceNewGoalPath(spaceId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "goals", "new"]);
   }
 
-  static projectsPath() {
-    return createCompanyPath(["projects"]);
+  newProjectPath(params?: ProjectAddPage.UrlParams) {
+    return this.createCompanyPath(["projects", "new"]) + encodeUrlParams(params);
   }
 
-  static goalsPath() {
-    return createCompanyPath(["goals"]);
+  projectsPath() {
+    return this.createCompanyPath(["projects"]);
   }
 
-  static goalAboutPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "about"]);
+  goalsPath() {
+    return this.createCompanyPath(["goals"]);
   }
 
-  static goalSubgoalsPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "subgoals"]);
+  goalAboutPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "about"]);
   }
 
-  static goalNewPath({ parentGoalId }: { parentGoalId: string }) {
-    return createCompanyPath(["goals", "new"]) + "?parentGoalId=" + parentGoalId;
+  goalSubgoalsPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "subgoals"]);
   }
 
-  static goalCheckInNewPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "check-ins", "new"]);
+  goalNewPath({ parentGoalId }: { parentGoalId: string }) {
+    return this.createCompanyPath(["goals", "new"]) + "?parentGoalId=" + parentGoalId;
   }
 
-  static goalCheckInPath(checkInId: string) {
-    return createCompanyPath(["goal-check-ins", checkInId]);
+  goalCheckInNewPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "check-ins", "new"]);
   }
 
-  static newGoalDiscussionPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "discussions", "new"]);
+  goalCheckInPath(checkInId: string) {
+    return this.createCompanyPath(["goal-check-ins", checkInId]);
   }
 
-  static goalDiscussionsPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "discussions"]);
+  newGoalDiscussionPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "discussions", "new"]);
   }
 
-  static goalDiscussionPath(id: string) {
-    return createCompanyPath(["goal-activities", id]);
+  goalDiscussionsPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "discussions"]);
   }
 
-  static goalRetrospectivePath(id: string) {
-    return createCompanyPath(["goal-activities", id]);
+  goalDiscussionPath(id: string) {
+    return this.createCompanyPath(["goal-activities", id]);
   }
 
-  static goalDiscussionEditPath(activityId: string) {
-    return createCompanyPath(["goal-activities", activityId, "edit"]);
+  goalRetrospectivePath(id: string) {
+    return this.createCompanyPath(["goal-activities", id]);
   }
 
-  static goalActivityPath(activityId: string) {
-    return createCompanyPath(["goal-activities", activityId]);
+  goalDiscussionEditPath(activityId: string) {
+    return this.createCompanyPath(["goal-activities", activityId, "edit"]);
   }
 
-  static createCompanyPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "complete"]);
+  goalActivityPath(activityId: string) {
+    return this.createCompanyPath(["goal-activities", activityId]);
   }
 
-  static goalReopenPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "reopen"]);
+  goalReopenPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "reopen"]);
   }
 
-  static goalArchivePath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "archive"]);
+  goalArchivePath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "archive"]);
   }
 
-  static goalEditParentPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "edit", "parent"]);
+  goalEditParentPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "edit", "parent"]);
   }
 
-  static goalEditTimeframePath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "edit", "timeframe"]);
+  goalEditTimeframePath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "edit", "timeframe"]);
   }
 
-  static goalEditPath(goalId: string) {
-    return createCompanyPath(["goals", goalId, "edit"]);
+  goalEditPath(goalId: string) {
+    return this.createCompanyPath(["goals", goalId, "edit"]);
   }
 
-  static profileV2Path(personId: string) {
-    return createCompanyPath(["people", personId, "v2"]);
+  profileV2Path(personId: string) {
+    return this.createCompanyPath(["people", personId, "v2"]);
   }
 
-  static profilePath(personId: string) {
-    return createCompanyPath(["people", personId]);
+  profilePath(personId: string) {
+    return this.createCompanyPath(["people", personId]);
   }
 
-  static profileGoalsPath(personId: string) {
-    return createCompanyPath(["people", personId, "goals"]);
+  profileGoalsPath(personId: string) {
+    return this.createCompanyPath(["people", personId, "goals"]);
   }
 
-  static projectEditTimelinePath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "timeline"]);
+  projectEditTimelinePath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "timeline"]);
   }
 
-  static projectEditDescriptionPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "description"]);
+  projectEditDescriptionPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "description"]);
   }
 
-  static projectEditResourcesPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "resources"]);
+  projectEditResourcesPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "resources"]);
   }
 
-  static projectEditResourcePath(resourceId: string) {
-    return createCompanyPath(["project-resources", resourceId, "edit"]);
+  projectEditResourcePath(resourceId: string) {
+    return this.createCompanyPath(["project-resources", resourceId, "edit"]);
   }
 
-  static projectEditPermissionsPath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "edit", "permissions"]);
+  projectEditPermissionsPath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "edit", "permissions"]);
   }
 
-  static projectNewResourcePath(projectId: string, { resourceType }: { resourceType: string }) {
-    return createCompanyPath(["projects", projectId, "resources", "new"]) + "?resourceType=" + resourceType;
+  projectNewResourcePath(projectId: string, { resourceType }: { resourceType: string }) {
+    return this.createCompanyPath(["projects", projectId, "resources", "new"]) + "?resourceType=" + resourceType;
   }
 
-  static projectClosePath(projectId: string) {
-    return createCompanyPath(["projects", projectId, "close"]);
+  projectClosePath(projectId: string) {
+    return this.createCompanyPath(["projects", projectId, "close"]);
   }
 
-  static taskPath(taskId: string) {
-    return createCompanyPath(["tasks", taskId]);
+  taskPath(taskId: string) {
+    return this.createCompanyPath(["tasks", taskId]);
   }
-}
 
-function getCompanyID(): string {
-  const parts = window.location.pathname.split("/") as string[];
+  //
+  // Private utility methods
+  //
 
-  if (parts.length >= 2) {
-    return parts[1]!;
-  } else {
-    throw new Error("Company ID not found in path");
+  private createCompanyPath(elements: string[]) {
+    return this.createPath([this.getCompanyID(), ...elements]);
   }
-}
 
-function createCompanyPath(elements: string[]) {
-  return createPath([getCompanyID(), ...elements]);
-}
+  private createPath(elements: string[]) {
+    Paths.validatePathElements(elements);
+    return "/" + elements.join("/");
+  }
 
-function createPath(elements: string[]) {
-  validatePathElements(elements);
+  private getCompanyID(): string {
+    if (this.deprecatedLookup) {
+      const parts = window.location.pathname.split("/") as string[];
 
-  return "/" + elements.join("/");
-}
-
-const UNACCEPTABLE_CHARACTERS = ["/", "?", "#", "[", "]"];
-
-function validatePathElements(elements: string[]) {
-  elements.forEach((element) => {
-    if (!element) {
-      throw new Error("Unsuported path elements: " + JSON.stringify(elements));
-    }
-
-    UNACCEPTABLE_CHARACTERS.forEach((char) => {
-      if (element.includes(char)) {
-        throw new Error(`Path elements cannot contain ${char}`);
+      if (parts.length >= 2) {
+        return parts[1]!;
+      } else {
+        throw new Error("Company ID not found in path");
       }
+    } else {
+      if (!this.companyId) {
+        throw new Error("Can't create company paths without a company ID");
+      }
+
+      return this.companyId;
+    }
+  }
+
+  static validatePathElements(elements: string[]) {
+    elements.forEach((element) => {
+      if (!element) {
+        throw new Error("Unsuported path elements: " + JSON.stringify(elements));
+      }
+
+      UNACCEPTABLE_PATH_CHARACTERS.forEach((char) => {
+        if (element.includes(char)) {
+          throw new Error(`Path elements cannot contain ${char}`);
+        }
+      });
     });
-  });
+  }
+}
+
+export const DeprecatedPaths = new Paths({ deprecatedLookup: true, companyId: null });
+
+export function usePaths() {
+  const { company } = useLoadedData();
+
+  const paths = React.useMemo(() => {
+    return new Paths({ deprecatedLookup: false, companyId: company?.id || null });
+  }, [company.id]);
+
+  return paths;
 }
 
 type ID = string | null | undefined;

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -11,7 +11,7 @@ import { useLoadedData } from "../pages/GoalAddPage/loader";
 
 const UNACCEPTABLE_PATH_CHARACTERS = ["/", "?", "#", "[", "]"];
 
-class Paths {
+export class Paths {
   //
   // When deprecatedLookup is true, the paths will use the old lookup method
   // which is based on the company ID in the window.location.pathname.


### PR DESCRIPTION
First step to resolving this https://github.com/operately/operately/issues/2591.

---

Fixing path building by migrating from window.location to router context. 
This was causing page transition issues and flaky tests.

I've renamed `Paths` → `DeprecatedPaths` as first step. 
When you see `DeprecatedPaths.someFunctionCall()` with `usePaths()` hook pattern. 

Too many files to update at once, so doing gradual migration.