### PR TITLE
chore: Fix invalid session problems

### DIFF
--- a/app/test/support/feature_case.ex
+++ b/app/test/support/feature_case.ex
@@ -23,11 +23,10 @@ defmodule Operately.FeatureCase do
 
         screenshots_before = Path.wildcard("/tmp/screenshots/*")
 
-        on_exit fn ->
+        on_exit(fn ->
           screenshots_after = Path.wildcard("/tmp/screenshots/*")
-
           list_screenshots(screenshots_before, screenshots_after)
-        end
+        end)
 
         :ok
       end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   app:
     image: operately/operately-dev:latest
     user: ${USER_ID}:${GROUP_ID}
+    shm_size: 1g
     working_dir: /home/dev/app
     volumes:
       - ./:/home/dev/app

--- a/docker/dev/Dockerfile.dev
+++ b/docker/dev/Dockerfile.dev
@@ -3,6 +3,6 @@ FROM elixir:1.17.2-alpine
 RUN apk update && apk add --no-cache \
   bash git openssh nodejs npm inotify-tools \
   chromium chromium-chromedriver postgresql-client \
-  make gcc musl-dev build-base
+  make gcc musl-dev build-base htop
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
The key was: `shm_size: 1g`. After that change I had no problems with invalid session id.
fixes https://github.com/operately/operately/issues/2720