### PR TITLE
feat: Add confirmation modal for folder deletion in Resource Hub

### DIFF
--- a/app/test/features/resource_hub_folder_test.exs
+++ b/app/test/features/resource_hub_folder_test.exs
@@ -100,7 +100,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_folder(name)
       |> Steps.assert_folder_created(%{name: name, index: 0})
-      |> delete_resource_from_nodes_list(name)
+      |> delete_resource_from_nodes_list(name, :with_confirmation)
       |> Steps.assert_folder_deleted_on_space_feed(name)
       |> Steps.assert_folder_deleted_on_company_feed(name)
     end
@@ -112,7 +112,7 @@ defmodule Operately.Features.ResourceHubFolderTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_folder(name)
       |> Steps.assert_folder_created(%{name: name, index: 0})
-      |> delete_resource_from_nodes_list(name)
+      |> delete_resource_from_nodes_list(name, :with_confirmation)
     end
   end
 

--- a/app/test/support/features/resource_hub/deletion.ex
+++ b/app/test/support/features/resource_hub/deletion.ex
@@ -14,6 +14,14 @@ defmodule Operately.Support.ResourceHub.Deletion do
     |> Steps.assert_resource_deleted(resource_name)
   end
 
+  def delete_resource_from_nodes_list(ctx, resource_name, :with_confirmation) do
+    ctx
+    |> Steps.visit_resource_hub_page()
+    |> Steps.delete_resource(resource_name)
+    |> Steps.confirm_deletion()
+    |> Steps.assert_resource_deleted(resource_name)
+  end
+
   def delete_resource_redirects_to_resource_hub(ctx, hub_name \\ "Resource hub") do
     ctx
     |> Steps.delete_resource()

--- a/app/test/support/features/resource_hub_steps.ex
+++ b/app/test/support/features/resource_hub_steps.ex
@@ -106,6 +106,11 @@ defmodule Operately.Support.Features.ResourceHubSteps do
     |> UI.click(testid: "delete-resource-link")
   end
 
+  step :confirm_deletion, ctx do
+    ctx
+    |> UI.click(testid: "submit")
+  end
+
   step :assert_resource_deleted, ctx, resource_name do
     ctx
     |> UI.refute_text(resource_name)


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2647.

Now, before deleting a folder, the user has to confirm the deletion.