### PR TITLE
feat: Add confirmation modal for document deletion in Resource Hub

### DIFF
--- a/app/assets/js/features/ResourceHub/components/FolderMenu.tsx
+++ b/app/assets/js/features/ResourceHub/components/FolderMenu.tsx
@@ -102,7 +102,7 @@ function DeleteFolderModal({ folder, isOpen, hideModal }: { folder: Hub.Resource
   return (
     <Modal isOpen={isOpen} hideModal={hideModal}>
       <Forms.Form form={form}>
-        <p className="mb-4">Are you sure you want to delete the folder "<b>{folder.name}</b>"?</p>
+        <p>Are you sure you want to delete the folder "<b>{folder.name}</b>"?</p>
         <Forms.Submit saveText="Delete" cancelText="Cancel" />
       </Forms.Form>
     </Modal>

--- a/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
@@ -1,20 +1,19 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 
+import { usePaths } from "@/routes/paths";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import { useDeleteResourceHubDocument } from "@/models/resourceHubs";
 import { assertPresent } from "@/utils/assertions";
 
 import { downloadMarkdown, exportToMarkdown } from "@/utils/markdown";
 import { IconCopy, IconEdit, IconFileExport, IconTrash } from "@tabler/icons-react";
 import { useLoadedData } from "./loader";
 
-import { usePaths } from "@/routes/paths";
 interface Props {
   showCopyModal: () => void;
+  showDeleteModal: () => void;
 }
 
-export function Options({ showCopyModal }: Props) {
+export function Options({ showCopyModal, showDeleteModal }: Props) {
   const paths = usePaths();
   const { document } = useLoadedData();
   assertPresent(document.permissions, "permissions must be present in document");
@@ -32,7 +31,7 @@ export function Options({ showCopyModal }: Props) {
       )}
       {document.permissions.canCreateDocument && <CopyLink showCopyModal={showCopyModal} />}
       {document.permissions.canView && <ExportMarkdownAction />}
-      {document.permissions.canDeleteDocument && <DeleteAction />}
+      {document.permissions.canDeleteDocument && <DeleteAction onClick={showDeleteModal} />}
     </PageOptions.Root>
   );
 }
@@ -41,26 +40,8 @@ function CopyLink({ showCopyModal }) {
   return <PageOptions.Action icon={IconCopy} title="Copy" onClick={showCopyModal} testId="copy-document-link" />;
 }
 
-function DeleteAction() {
-  const paths = usePaths();
-  const { document, folder, resourceHub } = useLoadedData();
-  const [remove] = useDeleteResourceHubDocument();
-  const navigate = useNavigate();
-
-  const redirect = () => {
-    if (folder) {
-      navigate(paths.resourceHubFolderPath(folder.id!));
-    } else {
-      navigate(paths.resourceHubPath(resourceHub.id!));
-    }
-  };
-
-  const handleDelete = async () => {
-    await remove({ documentId: document.id });
-    redirect();
-  };
-
-  return <PageOptions.Action icon={IconTrash} title="Delete" onClick={handleDelete} testId="delete-resource-link" />;
+function DeleteAction({ onClick }: { onClick: () => void }) {
+  return <PageOptions.Action icon={IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
 }
 
 function ExportMarkdownAction() {

--- a/app/test/features/resource_hub_document_test.exs
+++ b/app/test/features/resource_hub_document_test.exs
@@ -208,7 +208,7 @@ defmodule Operately.Features.ResourceHubDocumentTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_document(@document)
       |> Steps.assert_document_content(@document)
-      |> delete_resource_from_nodes_list(@document.name)
+      |> delete_resource_from_nodes_list(@document.name, :with_confirmation)
       |> Steps.assert_document_deleted_on_space_feed(@document.name)
       |> Steps.assert_document_deleted_on_company_feed(@document.name)
     end
@@ -218,7 +218,7 @@ defmodule Operately.Features.ResourceHubDocumentTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_document(@document)
       |> Steps.assert_document_content(@document)
-      |> delete_resource_from_nodes_list(@document.name)
+      |> delete_resource_from_nodes_list(@document.name, :with_confirmation)
       |> Steps.assert_document_deleted_notification_sent(@document.name)
       |> Steps.assert_document_deleted_email_sent(@document.name)
     end
@@ -228,21 +228,21 @@ defmodule Operately.Features.ResourceHubDocumentTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_document(@document)
       |> Steps.assert_document_content(@document)
-      |> delete_resource_from_nodes_list(@document.name)
+      |> delete_resource_from_nodes_list(@document.name, :with_confirmation)
     end
 
     feature "deleting document from document page redirects to resource hub", ctx do
       ctx
       |> Steps.given_document_within_resource_hub_root_exists()
       |> Steps.visit_document_page()
-      |> delete_resource_redirects_to_resource_hub()
+      |> delete_resource_redirects_to_resource_hub("Resource hub", :with_confirmation)
     end
 
     feature "deleting document within folder from document page redirects to folder", ctx do
       ctx
       |> Steps.given_document_within_folder_exists()
       |> Steps.visit_document_page()
-      |> delete_resource_redirects_to_folder()
+      |> delete_resource_redirects_to_folder(:with_confirmation)
     end
   end
 

--- a/app/test/support/features/resource_hub/deletion.ex
+++ b/app/test/support/features/resource_hub/deletion.ex
@@ -29,9 +29,25 @@ defmodule Operately.Support.ResourceHub.Deletion do
     |> Steps.assert_zero_state(hub_name)
   end
 
+  def delete_resource_redirects_to_resource_hub(ctx, hub_name, :with_confirmation) do
+    ctx
+    |> Steps.delete_resource()
+    |> Steps.confirm_deletion()
+    |> Steps.assert_page_is_resource_hub_root(name: hub_name)
+    |> Steps.assert_zero_state(hub_name)
+  end
+
   def delete_resource_redirects_to_folder(ctx) do
     ctx
     |> Steps.delete_resource()
+    |> Steps.assert_page_is_folder_root(folder_key: :folder)
+    |> Steps.assert_zero_folder_state()
+  end
+
+  def delete_resource_redirects_to_folder(ctx, :with_confirmation) do
+    ctx
+    |> Steps.delete_resource()
+    |> Steps.confirm_deletion()
     |> Steps.assert_page_is_folder_root(folder_key: :folder)
     |> Steps.assert_zero_folder_state()
   end


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2647.

Now both on the Resource Hub and the Document pages, before deleting a document, the user has to confirm the deletion.