### PR TITLE
fix: Links can now be created without a description

### DIFF
--- a/app/assets/js/pages/ResourceHubNewLinkPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubNewLinkPage/form.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useCreateResourceHubLink } from "@/models/resourceHubs";
+import { emptyContent } from "turboui/RichContent";
 
 import Forms from "@/components/Forms";
 import { useFieldValue } from "@/components/Forms/FormContext";
@@ -30,7 +31,7 @@ export function Form() {
       title: "",
       link: "",
       type: linkType,
-      description: null,
+      description: emptyContent(),
     },
     validate: (addError) => {
       if (!isValidURL(form.values.link)) {

--- a/app/test/features/resource_hub_link_test.exs
+++ b/app/test/features/resource_hub_link_test.exs
@@ -13,6 +13,15 @@ defmodule Operately.Features.ResourceHubLinkTest do
   setup ctx, do: Steps.setup(ctx)
 
   describe "Create links" do
+    feature "create link with empty description", ctx do
+      data = %{ title: "Link", url: "http://localhost:4000" }
+
+      ctx
+      |> Steps.visit_resource_hub_page()
+      |> Steps.create_link(data)
+      |> Steps.assert_link_content(data)
+    end
+
     feature "general link", ctx do
       ctx
       |> Steps.visit_resource_hub_page()

--- a/app/test/support/features/resource_hub_link_steps.ex
+++ b/app/test/support/features/resource_hub_link_steps.ex
@@ -53,13 +53,18 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     |> UI.fill(testid: "link", with: attrs.url)
     |> then(fn ctx ->
       if type_testid do
-        ctx
-        |> UI.click(testid: type_testid)
+        UI.click(ctx, testid: type_testid)
       else
         ctx
       end
     end)
-    |> UI.fill_rich_text(attrs.notes)
+    |> then(fn ctx ->
+      if attrs[:notes] do
+        UI.fill_rich_text(ctx, attrs.notes)
+      else
+        ctx
+      end
+    end)
     |> UI.click(testid: "submit")
     |> UI.refute_has(testid: "submit")
     |> then(fn ctx ->
@@ -147,7 +152,13 @@ defmodule Operately.Support.Features.ResourceHubLinkSteps do
     ctx
     |> UI.assert_page(Paths.link_path(ctx.company, node.link))
     |> UI.assert_text(attrs.title)
-    |> UI.assert_text(attrs.notes)
+    |> then(fn ctx ->
+      if attrs[:notes] do
+        UI.assert_text(ctx, attrs.notes)
+      else
+        ctx
+      end
+    end)
   end
 
   defp assert_link_type(link_name, type) do


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/2752.