### PR TITLE
feat: Add confirmation modal for link deletion in Resource Hub

### DIFF
--- a/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
@@ -1,15 +1,16 @@
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Icons from "@tabler/icons-react";
 import React from "react";
-import { useNavigate } from "react-router-dom";
-
-import { useDeleteResourceHubLink } from "@/models/resourceHubs";
 
 import { usePaths } from "@/routes/paths";
 import { assertPresent } from "@/utils/assertions";
 import { useLoadedData } from "./loader";
 
-export function Options() {
+interface Props {
+  showDeleteModal: () => void;
+}
+
+export function Options({ showDeleteModal }: Props) {
   const { link } = useLoadedData();
   const paths = usePaths();
   assertPresent(link.permissions, "permissions must be present in link");
@@ -24,32 +25,15 @@ export function Options() {
           testId="edit-link-link"
         />
       )}
-      {link.permissions.canDeleteLink && <DeleteAction />}
+      {link.permissions.canDeleteLink && <DeleteAction onClick={showDeleteModal} />}
     </PageOptions.Root>
   );
 }
 
-function DeleteAction() {
-  const { link } = useLoadedData();
-  const [remove] = useDeleteResourceHubLink();
-  const navigate = useNavigate();
-  const paths = usePaths();
+interface DeleteActionProps {
+  onClick: () => void;
+}
 
-  const redirect = () => {
-    if (link.parentFolder) {
-      navigate(paths.resourceHubFolderPath(link.parentFolder.id!));
-    } else {
-      assertPresent(link.resourceHub, "resourceHub must be present in link");
-      navigate(paths.resourceHubPath(link.resourceHub.id!));
-    }
-  };
-
-  const handleDelete = async () => {
-    await remove({ linkId: link.id });
-    redirect();
-  };
-
-  return (
-    <PageOptions.Action icon={Icons.IconTrash} title="Delete" onClick={handleDelete} testId="delete-resource-link" />
-  );
+function DeleteAction({ onClick }: DeleteActionProps) {
+  return <PageOptions.Action icon={Icons.IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
 }

--- a/app/test/features/resource_hub_link_test.exs
+++ b/app/test/features/resource_hub_link_test.exs
@@ -161,7 +161,7 @@ defmodule Operately.Features.ResourceHubLinkTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_link(@link)
       |> Steps.visit_resource_hub_page()
-      |> delete_resource_from_nodes_list(@link.title)
+      |> delete_resource_from_nodes_list(@link.title, :with_confirmation)
       |> Steps.assert_link_deleted_on_space_feed()
       |> Steps.assert_link_deleted_on_company_feed()
     end
@@ -171,7 +171,7 @@ defmodule Operately.Features.ResourceHubLinkTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_link(@link)
       |> Steps.visit_resource_hub_page()
-      |> delete_resource_from_nodes_list(@link.title)
+      |> delete_resource_from_nodes_list(@link.title, :with_confirmation)
       |> Steps.assert_link_deleted_notification_sent()
       |> Steps.assert_link_deleted_email_sent()
     end
@@ -181,21 +181,21 @@ defmodule Operately.Features.ResourceHubLinkTest do
       |> Steps.visit_resource_hub_page()
       |> Steps.create_link(@link)
       |> Steps.visit_resource_hub_page()
-      |> delete_resource_from_nodes_list(@link.title)
+      |> delete_resource_from_nodes_list(@link.title, :with_confirmation)
     end
 
     feature "deleting link from link page redirects to resource hub", ctx do
       ctx
       |> Steps.given_link_exists()
       |> Steps.visit_link_page()
-      |> delete_resource_redirects_to_resource_hub()
+      |> delete_resource_redirects_to_resource_hub("Resource hub", :with_confirmation)
     end
 
     feature "deleting link within folder from link page redirects to folder", ctx do
       ctx
       |> Steps.given_link_within_folder_exists()
       |> Steps.visit_link_page()
-      |> delete_resource_redirects_to_folder()
+      |> delete_resource_redirects_to_folder(:with_confirmation)
     end
   end
 


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2647.

Now both on the Resource Hub and the Link pages, before deleting a link, the user has to confirm the deletion.