### PR TITLE
chore: Optimize tabler icons imports

### DIFF
--- a/app/assets/js/__tests__/mocks/tabler-icons-react.js
+++ b/app/assets/js/__tests__/mocks/tabler-icons-react.js
@@ -1,0 +1,26 @@
+// Mock for @tabler/icons-react
+const createMockIcon = (name) => {
+  const component = (props) => {
+    return {
+      type: 'svg',
+      props: {
+        ...props,
+        'data-testid': `mock-icon-${name}`,
+      },
+      key: null,
+      ref: null,
+    };
+  };
+  component.displayName = name;
+  return component;
+};
+
+// Create a proxy that returns a mock icon for any imported icon
+module.exports = new Proxy(
+  {},
+  {
+    get: function(target, prop) {
+      return createMockIcon(prop);
+    }
+  }
+);

--- a/app/assets/js/components/Callouts/index.tsx
+++ b/app/assets/js/components/Callouts/index.tsx
@@ -6,7 +6,7 @@ import {
   IconCircleCheckFilled,
   IconCircleXFilled,
   IconInfoCircleFilled,
-} from "@tabler/icons-react";
+} from "turboui";
 
 interface Props extends TestableElement {
   message: string | JSX.Element;

--- a/app/assets/js/components/ContributorAvatar/index.tsx
+++ b/app/assets/js/components/ContributorAvatar/index.tsx
@@ -1,5 +1,5 @@
 import * as Projects from "@/models/projects";
-import * as Icons from "@tabler/icons-react";
+import { IconQuestionMark } from "turboui";
 import * as React from "react";
 
 import { Tooltip } from "@/components/Tooltip";
@@ -120,7 +120,7 @@ export function PlaceholderAvatar({ size }: { size: Size }) {
 
   return (
     <div className={className} style={style}>
-      <Icons.IconQuestionMark size={DIMENSIONS[size].icon} className={iconColor} stroke={3} />
+      <IconQuestionMark size={DIMENSIONS[size].icon} className={iconColor} stroke={3} />
     </div>
   );
 }

--- a/app/assets/js/components/CopyToClipboard/index.tsx
+++ b/app/assets/js/components/CopyToClipboard/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { IconCopy, IconCheck, IconProps } from "@tabler/icons-react";
+import { IconCopy, IconCheck, TablerIconProps as IconProps } from "turboui";
 
 interface CopyToClipboardProps {
   text: string;

--- a/app/assets/js/components/Editor/Blob/BlobView.tsx
+++ b/app/assets/js/components/Editor/Blob/BlobView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { NodeViewWrapper, NodeViewContent } from "@tiptap/react";
-import * as Icons from "@tabler/icons-react";
+import { IconTrash, IconPdf, IconFileZip, IconFileFilled } from "turboui";
 import classnames from "classnames";
 
 import { LoadingProgressBar } from "@/components/LoadingProgressBar";
@@ -69,7 +69,7 @@ function VideoView({ node, deleteNode, view, updateAttributes }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -156,7 +156,7 @@ function ImageView({ node, deleteNode, updateAttributes, view }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -201,7 +201,7 @@ function FileView({ node, deleteNode, view }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -218,13 +218,13 @@ function HumanFilesize({ size }: { size: number }) {
 function FileIcon({ filetype }: { filetype: string }) {
   switch (filetype) {
     case "application/pdf":
-      return <Icons.IconPdf className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconPdf className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     case "application/zip":
-      return <Icons.IconFileZip className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileZip className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     case "text/plain":
-      return <Icons.IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     default:
-      return <Icons.IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
   }
 }
 

--- a/app/assets/js/components/Form/dateselector.tsx
+++ b/app/assets/js/components/Form/dateselector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classnames from "classnames";
-import * as Icons from "@tabler/icons-react";
+import { IconCalendar } from "turboui";
 
 import * as Popover from "@radix-ui/react-popover";
 import DatePicker from "react-datepicker";
@@ -46,7 +46,7 @@ export function DateSelector(props: DateSelectorProps) {
         <Popover.Root open={open} onOpenChange={setOpen}>
           <Popover.Trigger asChild>
             <div className={className}>
-              <Icons.IconCalendar size={20} />
+              <IconCalendar size={20} />
               <FormattedTime time={date} format="short-date-with-weekday" />
             </div>
           </Popover.Trigger>

--- a/app/assets/js/components/Forms/Elements/Input.tsx
+++ b/app/assets/js/components/Forms/Elements/Input.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import classNames from "classnames";
-import { IconCheck } from "@tabler/icons-react";
+import { IconCheck } from "turboui";
 
 interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   field?: string;

--- a/app/assets/js/components/Forms/NumberInput.tsx
+++ b/app/assets/js/components/Forms/NumberInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconCheck } from "turboui";
 
 import classNames from "classnames";
 import { InputField } from "./FieldGroup";
@@ -52,7 +52,7 @@ export function NumberInput(props: NumberInputProps) {
 
         {!error && props.okSign && (
           <div className="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-1">
-            <Icons.IconCheck size={20} />
+            <IconCheck size={20} />
           </div>
         )}
       </div>

--- a/app/assets/js/components/Forms/PasswordInput.tsx
+++ b/app/assets/js/components/Forms/PasswordInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconCheck } from "turboui";
 
 import classNames from "classnames";
 import { InputField } from "./FieldGroup";
@@ -50,7 +50,7 @@ export function PasswordInput(props: PasswordInputProps) {
 
         {!error && props.okSign && (
           <div className="absolute inset-y-0 right-0 flex items-center pr-4 text-accent-1">
-            <Icons.IconCheck size={20} />
+            <IconCheck size={20} />
           </div>
         )}
       </div>

--- a/app/assets/js/components/Forms/SelectStatus.tsx
+++ b/app/assets/js/components/Forms/SelectStatus.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { InputField } from "./FieldGroup";
 import classNames from "classnames";
 
-import * as Icons from "@tabler/icons-react";
+import { IconChevronDown } from "turboui";
 import * as Popover from "@radix-ui/react-popover";
 import * as People from "@/models/people";
 
@@ -56,7 +56,7 @@ export function SelectStatus({ field, options, reviewer, label }: Props) {
             <StatusOrPlaceholder status={value} reviewer={reviewer} />
 
             <div className="p-4">
-              <Icons.IconChevronDown size={24} />
+              <IconChevronDown size={24} />
             </div>
           </div>
         </Popover.Trigger>

--- a/app/assets/js/components/KeyResourceIcon/index.tsx
+++ b/app/assets/js/components/KeyResourceIcon/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Brands from "@/components/Brands";
-import * as Icons from "@tabler/icons-react";
+import { IconLink } from "turboui";
 
 export function ResourceIcon({ resourceType, size }: { resourceType: string; size: number }) {
   switch (resourceType) {
@@ -16,6 +16,6 @@ export function ResourceIcon({ resourceType, size }: { resourceType: string; siz
       return <Brands.Slack size={size} />;
     case "generic":
     default:
-      return <Icons.IconLink size={size} />;
+      return <IconLink size={size} />;
   }
 }

--- a/app/assets/js/components/MilestoneIcon/index.tsx
+++ b/app/assets/js/components/MilestoneIcon/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import classNames from "classnames";
 
-import * as Icons from "@tabler/icons-react";
+import { IconFlag3Filled } from "turboui";
 import * as Projects from "@/models/projects";
 
 interface MilestoneIconProps {
@@ -28,5 +28,5 @@ export function MilestoneIcon({ milestone, className, size = 16 }: MilestoneIcon
     return classNames(color, className);
   }, [milestone.status, milestone.deadlineAt, className]);
 
-  return <Icons.IconFlag3Filled size={size} className={classNameFinal} />;
+  return <IconFlag3Filled size={size} className={classNameFinal} />;
 }

--- a/app/assets/js/components/Modal/index.tsx
+++ b/app/assets/js/components/Modal/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactModal from "react-modal";
-import * as Icons from "@tabler/icons-react";
+import { IconX } from "turboui";
 
 import { useColorMode } from "@/contexts/ThemeContext";
 
@@ -69,7 +69,7 @@ function CloseButton({ hideModal }) {
       className="hover:cursor-pointer text-content-dimmed hover:text-content-accent transition-colors"
       onClick={hideModal}
     >
-      <Icons.IconX size={20} />
+      <IconX size={20} />
     </div>
   );
 }

--- a/app/assets/js/components/PaperContainer/Navigation.tsx
+++ b/app/assets/js/components/PaperContainer/Navigation.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconArrowLeft, IconDots, IconSlash } from "turboui";
 import * as Pages from "@/components/Pages";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 
@@ -11,7 +11,7 @@ export function NavigateBack({ to, title }) {
   return (
     <div className="flex items-center justify-center mb-4">
       <Link to={to}>
-        <Icons.IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
+        <IconArrowLeft className="text-content-dimmed inline mr-2" size={16} />
         {title}
       </Link>
     </div>
@@ -60,7 +60,7 @@ function HiddenItems({ items, hiddenCount }: { items: Item[]; hiddenCount: numbe
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger className="border border-surface-outline px-1 rounded">
-        <Icons.IconDots className="cursor-pointer shrink-0" size={18} />
+        <IconDots className="cursor-pointer shrink-0" size={18} />
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
@@ -101,7 +101,7 @@ function NavSeparator() {
 
   return (
     <div className="shrink-0">
-      <Icons.IconSlash size={iconSize} />
+      <IconSlash size={iconSize} />
     </div>
   );
 }

--- a/app/assets/js/components/PaperContainer/PageOptions.tsx
+++ b/app/assets/js/components/PaperContainer/PageOptions.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Pages from "@/components/Pages";
 
-import { DivLink } from "turboui";
+import { DivLink, IconDots, IconX } from "turboui";
 import classNames from "classnames";
 import { TestableElement } from "@/utils/testid";
 import { SecondaryButton } from "turboui";
@@ -152,7 +151,7 @@ function Trigger({ testId }) {
 
   return (
     <div className={className} onClick={open} data-test-id={testId}>
-      <Icons.IconDots size={20} />
+      <IconDots size={20} />
     </div>
   );
 }
@@ -165,7 +164,7 @@ function Close({ onClick }) {
         onClick={onClick}
         data-test-id="project-options-button"
       >
-        <Icons.IconX size={20} />
+        <IconX size={20} />
       </div>
     </div>
   );

--- a/app/assets/js/features/CommentSection/CommentSection.tsx
+++ b/app/assets/js/features/CommentSection/CommentSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import * as Icons from "@tabler/icons-react";
+import { IconSquareCheckFilled, IconSquareChevronsLeftFilled, IconEdit } from "turboui";
 import * as TipTapEditor from "@/components/Editor";
 import * as Reactions from "@/models/reactions";
 
@@ -127,7 +127,7 @@ function MilestoneCompleted({ comment }) {
       <div className="flex-1">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <Icons.IconSquareCheckFilled size={20} className="text-accent-1" />
+            <IconSquareCheckFilled size={20} className="text-accent-1" />
             <div className="flex-1 pr-2 font-semibold text-content-accent">Completed the Milestone</div>
           </div>
 
@@ -152,7 +152,7 @@ function MilestoneReopened({ comment }) {
       <div className="flex-1">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
-            <Icons.IconSquareChevronsLeftFilled size={20} className="text-yellow-500" />
+            <IconSquareChevronsLeftFilled size={20} className="text-yellow-500" />
             <div className="flex-1 pr-2 font-semibold text-content-accent">Re-Opened the Milestone</div>
           </div>
 
@@ -219,7 +219,7 @@ function CommentDropdownMenu({ comment, onEdit }) {
 
   return (
     <Menu size="small" testId="comment-options">
-      <MenuActionItem onClick={onEdit} testId="edit-comment" icon={Icons.IconEdit}>
+      <MenuActionItem onClick={onEdit} testId="edit-comment" icon={IconEdit}>
         Edit
       </MenuActionItem>
     </Menu>
@@ -236,7 +236,7 @@ function AckComment({ person, ackAt }) {
       <div className="flex items-center justify-between flex-1">
         <div className="flex items-center gap-2 font-bold flex-1">
           {person.fullName} acknowledged this Check-In
-          <Icons.IconSquareCheckFilled size={24} className="text-accent-1" />
+          <IconSquareCheckFilled size={24} className="text-accent-1" />
         </div>
 
         <div className="flex items-center justify-between">

--- a/app/assets/js/features/Permissions/AccessLevel.tsx
+++ b/app/assets/js/features/Permissions/AccessLevel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 
 import { SelectBoxNoLabel } from "@/components/Form";
-import { IconBuildingCommunity, IconNetwork } from "@tabler/icons-react";
+import { IconBuildingCommunity, IconNetwork } from "turboui";
 import { ReducerActions } from "./usePermissionsState";
 import { PermissionLevels, PermissionOptions, PERMISSIONS_LIST, PUBLIC_PERMISSIONS_LIST } from ".";
 import { calculatePrivacyLevel } from "./utils";

--- a/app/assets/js/features/Permissions/PrivacyIndicator.tsx
+++ b/app/assets/js/features/Permissions/PrivacyIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconWorld, IconLockFilled } from "turboui";
 
 import { Project } from "@/models/projects";
 import { Goal } from "@/models/goals";
@@ -52,7 +52,7 @@ function PrivacyPublic({ size, type, disabled }: PrivacyProps) {
 
   return (
     <Tooltip content={content} testId="public-project-tooltip" delayDuration={100} disabled={disabled}>
-      <Icons.IconWorld size={size} />
+      <IconWorld size={size} />
     </Tooltip>
   );
 }
@@ -67,7 +67,7 @@ function PrivacyInternal({ size, type, disabled }: PrivacyProps) {
 
   return (
     <Tooltip content={content} testId="internal-project-tooltip" delayDuration={100} disabled={disabled}>
-      <Icons.IconLockFilled size={size} />
+      <IconLockFilled size={size} />
     </Tooltip>
   );
 }
@@ -84,7 +84,7 @@ function PrivacyConfidential({ space, size, type, disabled }: PrivacyProps & { s
 
   return (
     <Tooltip content={content} testId="confidential-project-tooltip" delayDuration={100} disabled={disabled}>
-      <Icons.IconLockFilled size={size} />
+      <IconLockFilled size={size} />
     </Tooltip>
   );
 }
@@ -99,7 +99,7 @@ function PrivacySecret({ size, type, disabled }: PrivacyProps) {
 
   return (
     <Tooltip content={content} testId="secret-project-tooltip" delayDuration={100} disabled={disabled}>
-      <Icons.IconLockFilled size={size} className="text-content-error" />
+      <IconLockFilled size={size} className="text-content-error" />
     </Tooltip>
   );
 }

--- a/app/assets/js/features/Reactions/index.tsx
+++ b/app/assets/js/features/Reactions/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconMoodPlus, IconX } from "turboui";
 import * as Reactions from "@/models/reactions";
 import * as Popover from "@radix-ui/react-popover";
 import * as api from "@/api";
@@ -117,7 +117,7 @@ function AddReaction({ form, size }) {
     <Popover.Root open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <div className="text-content-accent cursor-pointer bg-surface-dimmed rounded-full p-1">
-          <Icons.IconMoodPlus size={size - 2} />
+          <IconMoodPlus size={size - 2} />
         </div>
       </Popover.Trigger>
 
@@ -145,7 +145,7 @@ function ReactionPallete({ size, close, onSelected }) {
       <div className="flex items-start justify-between text-content-dimmed w-full">
         <div className="text-sm mb-2 font-medium">Add Reaction</div>
         <div className="">
-          <Icons.IconX size={16} onClick={close} className="cursor-pointer" />
+          <IconX size={16} onClick={close} className="cursor-pointer" />
         </div>
       </div>
 

--- a/app/assets/js/features/ResourceHub/AddFileWidget.tsx
+++ b/app/assets/js/features/ResourceHub/AddFileWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 
-import { IconX } from "@tabler/icons-react";
+import { IconX } from "turboui";
 import { findFileSize, resizeImage, uploadFile } from "@/models/blobs";
 import { ResourceHub, ResourceHubFile, ResourceHubFolder, createResourceHubFile } from "@/models/resourceHubs";
 

--- a/app/assets/js/features/ResourceHub/AddFilesButton.tsx
+++ b/app/assets/js/features/ResourceHub/AddFilesButton.tsx
@@ -1,12 +1,10 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Pages from "@/components/Pages";
 
 import { ResourceHubPermissions } from "@/models/resourceHubs";
 
 import { Airtable, Dropbox, Figma, GoogleLogo, Notion } from "@/components/Brands";
-import { PrimaryButton } from "turboui";
-import { MenuActionItem, SubMenu } from "turboui";
+import { MenuActionItem, SubMenu, IconFile, IconFolderFilled, IconUpload, PrimaryButton, IconLink } from "turboui";
 
 import { useNewFileModalsContext } from "./contexts/NewFileModalsContext";
 
@@ -28,7 +26,7 @@ function Options({ permissions }: { permissions: ResourceHubPermissions }) {
   return [
     <MenuActionItem
       key={1}
-      icon={Icons.IconFile}
+      icon={IconFile}
       onClick={navigateToNewDocument}
       testId="new-document"
       hidden={!permissions.canCreateDocument}
@@ -36,7 +34,7 @@ function Options({ permissions }: { permissions: ResourceHubPermissions }) {
     />,
     <MenuActionItem
       key={2}
-      icon={Icons.IconFolderFilled}
+      icon={IconFolderFilled}
       onClick={toggleShowAddFolder}
       testId="new-folder"
       hidden={!permissions.canCreateFolder}
@@ -44,7 +42,7 @@ function Options({ permissions }: { permissions: ResourceHubPermissions }) {
     />,
     <MenuActionItem
       key={3}
-      icon={Icons.IconUpload}
+      icon={IconUpload}
       onClick={selectFiles}
       testId="upload-files"
       hidden={!permissions.canCreateFile}
@@ -60,7 +58,7 @@ function NewLinkSubMenu({ permissions }: { permissions: ResourceHubPermissions }
   if (!permissions.canCreateLink) return <></>;
 
   return (
-    <SubMenu label="Add link" icon={Icons.IconLink}>
+    <SubMenu label="Add link" icon={IconLink}>
       <MenuActionItem
         onClick={() => navigateToNewLink("airtable")}
         testId="link-to-airtable"
@@ -89,7 +87,7 @@ function NewLinkSubMenu({ permissions }: { permissions: ResourceHubPermissions }
       <MenuActionItem
         onClick={() => navigateToNewLink()}
         testId="link-to-other-resource"
-        icon={Icons.IconLink}
+        icon={IconLink}
         children="Other"
       />
     </SubMenu>

--- a/app/assets/js/features/ResourceHub/FolderSelectField/index.tsx
+++ b/app/assets/js/features/ResourceHub/FolderSelectField/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { BeatLoader } from "react-spinners";
 
-import { IconArrowLeft } from "@tabler/icons-react";
+import { IconArrowLeft } from "turboui";
 import { NodeIcon } from "@/features/ResourceHub/NodeIcon";
 
 import { useViewModel, ViewModel, ViewModelNode, NotAllowedSelection } from "./viewModel";

--- a/app/assets/js/features/ResourceHub/LinkIcon.tsx
+++ b/app/assets/js/features/ResourceHub/LinkIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import * as BrandIcons from "@/components/Brands";
-import * as Icons from "@tabler/icons-react";
+import { IconLink } from "turboui";
 import { LinkOptions } from ".";
 
 interface Props {
@@ -29,6 +29,6 @@ export function LinkIcon({ type, size }: Props) {
       return <BrandIcons.Notion size={size} />;
     case "other":
     default:
-      return <Icons.IconLink size={size} />;
+      return <IconLink size={size} />;
   }
 }

--- a/app/assets/js/features/ResourceHub/NodeIcon.tsx
+++ b/app/assets/js/features/ResourceHub/NodeIcon.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import * as Hub from "@/models/resourceHubs";
-import * as Icons from "@tabler/icons-react";
+import { IconLink, IconAlignJustified, IconVideo, IconChartColumn, IconFolderFilled, IconLogs } from "turboui";
 
 import classNames from "classnames";
 import { assertPresent } from "@/utils/assertions";
@@ -18,7 +18,7 @@ export function NodeIcon({ node, size }: { node: Hub.ResourceHubNode; size: numb
     if (node.link?.type && node.link.type !== "other") {
       return <LinkIcon type={node.link.type as LinkOptions} size={size} />;
     } else {
-      return <FileIcon size={size} icon={Icons.IconLink} />;
+      return <FileIcon size={size} icon={IconLink} />;
     }
   }
 
@@ -27,15 +27,15 @@ export function NodeIcon({ node, size }: { node: Hub.ResourceHubNode; size: numb
   }
 
   if (Hub.isDocument(node)) {
-    return <FileIcon size={size} icon={Icons.IconAlignJustified} color="bg-sky-500" />;
+    return <FileIcon size={size} icon={IconAlignJustified} color="bg-sky-500" />;
   }
 
   if (Hub.hasContentType(node, "pdf")) {
-    return <FileIcon size={size} filetype="pdf" color="bg-red-500" icon={Icons.IconAlignJustified} />;
+    return <FileIcon size={size} filetype="pdf" color="bg-red-500" icon={IconAlignJustified} />;
   }
 
   if (Hub.hasContentType(node, "video")) {
-    return <FileIcon size={size} icon={Icons.IconVideo} />;
+    return <FileIcon size={size} icon={IconVideo} />;
   }
 
   if (Hub.hasContentType(node, "audio")) {
@@ -43,18 +43,18 @@ export function NodeIcon({ node, size }: { node: Hub.ResourceHubNode; size: numb
   }
 
   if (Hub.hasContentType(node, "zip")) {
-    return <FileIcon size={size} filetype="zip" icon={Icons.IconChartColumn} />;
+    return <FileIcon size={size} filetype="zip" icon={IconChartColumn} />;
   }
 
   if (Hub.hasContentType(node, "mov")) {
-    return <FileIcon size={size} filetype="mov" icon={Icons.IconVideo} />;
+    return <FileIcon size={size} filetype="mov" icon={IconVideo} />;
   }
 
-  return <FileIcon size={size} icon={Icons.IconAlignJustified} />;
+  return <FileIcon size={size} icon={IconAlignJustified} />;
 }
 
 function FolderIcon({ size }: { size: number }) {
-  return <Icons.IconFolderFilled size={size} className="text-sky-500" />;
+  return <IconFolderFilled size={size} className="text-sky-500" />;
 }
 
 interface FileIconProps {
@@ -77,7 +77,7 @@ export function FileIcon({ size, filetype, color, icon }: FileIconProps) {
     "flex flex-col items-center justify-between gap-0.5",
   );
 
-  icon = icon || Icons.IconLogs;
+  icon = icon || IconLogs;
 
   return (
     <div style={wrapperStyle} className="flex items-center justify-center relative">

--- a/app/assets/js/features/ResourceHub/components/ZeroNodes.tsx
+++ b/app/assets/js/features/ResourceHub/components/ZeroNodes.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IconFile } from "@tabler/icons-react";
+import { IconFile } from "turboui";
 
 export function HubZeroNodes() {
   return (

--- a/app/assets/js/features/SpaceTools/Discussions/ZeroState.tsx
+++ b/app/assets/js/features/SpaceTools/Discussions/ZeroState.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 
 import { GhostButton } from "turboui";
 import classNames from "classnames";
+import { IconSpeakerphone, IconBulb, IconMessage } from "turboui";
 
 export function ZeroState() {
   return (
@@ -30,9 +30,9 @@ function ExplanationAndButton() {
 function Examples() {
   return (
     <div className="relative w-full h-[170px] mt-10 opacity-75 px-[65px] flex flex-col gap-3">
-      <Example icon={Icons.IconSpeakerphone} title="Post Announcements" body="We have a new team member..." />
-      <Example icon={Icons.IconBulb} title="Pitch Ideas" body="I have an idea to expand..." />
-      <Example icon={Icons.IconMessage} title="Discuss ideas" body="We need to make a decision..." />
+      <Example icon={IconSpeakerphone} title="Post Announcements" body="We have a new team member..." />
+      <Example icon={IconBulb} title="Pitch Ideas" body="I have an idea to expand..." />
+      <Example icon={IconMessage} title="Discuss ideas" body="We need to make a decision..." />
     </div>
   );
 }

--- a/app/assets/js/features/SpaceTools/GoalsAndProjects/AllDoneState.tsx
+++ b/app/assets/js/features/SpaceTools/GoalsAndProjects/AllDoneState.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Time from "@/utils/time";
 
 import { Space } from "@/models/spaces";
@@ -8,6 +7,7 @@ import { Project } from "@/models/projects";
 
 import { Title } from "../components";
 import plurarize from "@/utils/plurarize";
+import { IconTrophy } from "turboui";
 
 interface Props {
   title: string;
@@ -22,7 +22,7 @@ export function AllDoneState(props: Props) {
       <Title title={props.title} />
 
       <div className="bg-surface-dimmed rounded mx-2 flex-1 flex flex-col px-2 py-4 items-center">
-        <Icons.IconTrophy size={35} />
+        <IconTrophy size={35} />
         <div className="text-sm font-bold mt-3 mb-1">All done!</div>
         <div className="text-xs mb-1">{message(props)}</div>
       </div>

--- a/app/assets/js/features/SpaceTools/GoalsAndProjects/ZeroState.tsx
+++ b/app/assets/js/features/SpaceTools/GoalsAndProjects/ZeroState.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 
-import { GhostButton } from "turboui";
+import { GhostButton, IconTargetArrow, IconHexagons } from "turboui";
 import classNames from "classnames";
 
 export function ZeroState() {
@@ -64,7 +63,7 @@ function WorkItem({ indent = 0, progress = 20, title, type = "goal" }) {
 }
 
 function WorkItemIcon({ type }) {
-  const iconType = type === "goal" ? Icons.IconTargetArrow : Icons.IconHexagons;
+  const iconType = type === "goal" ? IconTargetArrow : IconHexagons;
 
   const klass = classNames(
     "p-1",

--- a/app/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
+++ b/app/assets/js/features/Tasks/NewTaskModal/MultiPeopleSearch.tsx
@@ -3,9 +3,8 @@ import * as React from "react";
 import classNames from "classnames";
 
 import * as People from "@/models/people";
-import * as Icons from "@tabler/icons-react";
 
-import { Avatar } from "turboui";
+import { Avatar, IconX } from "turboui";
 import { createTestId } from "@/utils/testid";
 import { match } from "ts-pattern";
 
@@ -167,7 +166,7 @@ function PeopleList({ people, onRemove }: { people: People.Person[]; onRemove: (
 
       <div>{person.fullName}</div>
 
-      <Icons.IconX
+      <IconX
         size={12}
         onClick={() => onRemove(person)}
         className="cursor-pointer ml-1"

--- a/app/assets/js/features/activities/GoalClosing/index.tsx
+++ b/app/assets/js/features/activities/GoalClosing/index.tsx
@@ -1,15 +1,13 @@
 import * as People from "@/models/people";
 import * as React from "react";
 
-import * as Icons from "@tabler/icons-react";
-
 import { ActivityContentGoalClosing } from "@/api";
 import RichContent, { Summary } from "@/components/RichContent";
 import { Activity } from "@/models/activities";
 
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { usePaths } from "@/routes/paths";
-import { Link } from "turboui";
+import { Link, IconCheck, IconX } from "turboui";
 import { feedTitle, goalLink } from "../feedItemLinks";
 import { ActivityHandler } from "../interfaces";
 
@@ -106,7 +104,7 @@ function content(activity: Activity): ActivityContentGoalClosing {
 function AcomplishedBadge() {
   return (
     <div className="flex items-center gap-1 bg-green-500/20 rounded-xl py-0.5 px-2 pr-3 text-green-800">
-      <Icons.IconCheck size={16} />
+      <IconCheck size={16} />
       <div className="text-sm font-medium">Marked as accomplished</div>
     </div>
   );
@@ -115,7 +113,7 @@ function AcomplishedBadge() {
 function FailedBadge() {
   return (
     <div className="flex items-center gap-1 bg-red-500/20 rounded-xl py-0.5 px-2 pr-3 text-red-800">
-      <Icons.IconX size={16} />
+      <IconX size={16} />
       <div className="text-sm font-medium">Marked as not accomplished</div>
     </div>
   );

--- a/app/assets/js/features/activities/GoalDiscussionCreation/index.tsx
+++ b/app/assets/js/features/activities/GoalDiscussionCreation/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as People from "@/models/people";
-import * as Icons from "@tabler/icons-react";
 
 import { Activity, ActivityContentGoalDiscussionCreation } from "@/api";
 import RichContent, { Summary } from "@/components/RichContent";
@@ -10,7 +9,7 @@ import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { usePaths } from "@/routes/paths";
-import { Link } from "turboui";
+import { Link, IconEdit } from "turboui";
 import { ActivityHandler } from "../interfaces";
 import { feedTitle, goalLink } from "./../feedItemLinks";
 
@@ -45,7 +44,7 @@ const GoalDiscussionCreation: ActivityHandler = {
       <PageOptions.Root testId="options">
         {activity.author!.id! === me?.id && (
           <PageOptions.Link
-            icon={Icons.IconEdit}
+            icon={IconEdit}
             title="Edit"
             to={paths.goalDiscussionEditPath(activity.id!)}
             testId="edit"

--- a/app/assets/js/features/activities/GoalTimeframeEditing/TimeframeEdited.tsx
+++ b/app/assets/js/features/activities/GoalTimeframeEditing/TimeframeEdited.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IconArrowRight } from "@tabler/icons-react";
+import { IconArrowRight } from "turboui";
 import * as Timeframes from "@/utils/timeframes";
 import * as Goals from "@/models/goals";
 

--- a/app/assets/js/features/activities/GoalTimeframeEditing/index.tsx
+++ b/app/assets/js/features/activities/GoalTimeframeEditing/index.tsx
@@ -2,7 +2,7 @@ import * as People from "@/models/people";
 import * as React from "react";
 
 import * as Timeframes from "@/utils/timeframes";
-import * as Icons from "@tabler/icons-react";
+import { IconArrowRight } from "turboui";
 
 import { Activity, ActivityContentGoalTimeframeEditing } from "@/api";
 
@@ -46,7 +46,7 @@ const GoalTimeframeEditing: ActivityHandler = {
             </div>
           </div>
 
-          <Icons.IconArrowRight size={16} />
+          <IconArrowRight size={16} />
 
           <div className="flex items-center gap-1 font-medium">
             <div className="border border-stroke-base rounded-md px-2 py-0.5 bg-surface-dimmed font-medium text-sm">

--- a/app/assets/js/features/activities/ProjectTimelineEdited/index.tsx
+++ b/app/assets/js/features/activities/ProjectTimelineEdited/index.tsx
@@ -1,7 +1,7 @@
 import * as Milestones from "@/models/milestones";
 import * as People from "@/models/people";
 import * as Time from "@/utils/time";
-import * as Icons from "@tabler/icons-react";
+import { IconFlag3Filled } from "turboui";
 import * as React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
@@ -165,7 +165,7 @@ function MilestoneLink({ milestone }: { milestone: Milestones.Milestone }) {
 
   return (
     <div className="font-medium">
-      <Icons.IconFlag3Filled size={14} className="inline-block mr-1" />
+      <IconFlag3Filled size={14} className="inline-block mr-1" />
       <Link to={path}>{title}</Link> <span className="">&middot;</span> Due date on{" "}
       <FormattedTime time={milestone.deadlineAt!} format="long-date" />
     </div>

--- a/app/assets/js/features/auth/Buttons.tsx
+++ b/app/assets/js/features/auth/Buttons.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconMail } from "turboui";
 
 import classNames from "classnames";
 import { DivLink } from "turboui";
@@ -10,7 +10,7 @@ export function SignUpWithEmail() {
     <SignUpButton
       title="Sign up with email"
       link="/sign_up/email"
-      icon={<Icons.IconMail size={24} className="text-content-dimmed" />}
+      icon={<IconMail size={24} className="text-content-dimmed" />}
       testId="sign-up-with-email"
     />
   );

--- a/app/assets/js/features/auth/PasswordStrength.tsx
+++ b/app/assets/js/features/auth/PasswordStrength.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconCheck, IconCircleFilled } from "turboui";
 
 import classNames from "classnames";
 import { validatePassword } from "./validatePassword";
@@ -22,7 +22,7 @@ export function PasswordStrength({ password }) {
 }
 
 function CheckMark({ title, ok }) {
-  const icon = ok ? <Icons.IconCheck size={16} className="w-4" /> : <Icons.IconCircleFilled size={8} className="w-4" />;
+  const icon = ok ? <IconCheck size={16} className="w-4" /> : <IconCircleFilled size={8} className="w-4" />;
 
   const className = classNames("flex items-center gap-2", {
     "text-accent-1": ok,

--- a/app/assets/js/features/drafts/OngoingDraftActions.tsx
+++ b/app/assets/js/features/drafts/OngoingDraftActions.tsx
@@ -4,12 +4,10 @@ import { Discussion } from "@/models/discussions";
 import { ResourceHubDocument } from "@/models/resourceHubs";
 
 import { match } from "ts-pattern";
-import { IconX } from "@tabler/icons-react";
 
 import FormattedTime from "@/components/FormattedTime";
-import { ActionLink } from "turboui";
 import { CopyToClipboard } from "@/components/CopyToClipboard";
-import { GhostButton, PrimaryButton } from "turboui";
+import { GhostButton, PrimaryButton, IconX, ActionLink } from "turboui";
 
 type Resource = Discussion | ResourceHubDocument;
 type State = "actions" | "link";

--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -11,9 +11,8 @@ import RichContent from "@/components/RichContent";
 import { GoalTargetsField } from "@/features/goals/GoalTargetsV2";
 import { assertPresent } from "@/utils/assertions";
 import { durationHumanized } from "@/utils/time";
-import { IconInfoCircle } from "@tabler/icons-react";
 import { match } from "ts-pattern";
-import { DateField, Tooltip } from "turboui";
+import { DateField, Tooltip, IconInfoCircle } from "turboui";
 import { StatusSelector } from "./StatusSelector";
 
 interface Props {

--- a/app/assets/js/features/goals/GoalCheckIn/StatusSelector.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/StatusSelector.tsx
@@ -6,7 +6,7 @@ import { useFieldError, useFieldValue } from "@/components/Forms/FormContext";
 import { AddErrorFn } from "@/components/Forms/useForm/errors";
 import { useValidation } from "@/components/Forms/validations/hook";
 import { createTestId } from "@/utils/testid";
-import { IconCheck } from "@tabler/icons-react";
+import { IconCheck } from "turboui";
 import classNames from "classnames";
 
 type Status = "pending" | "on_track" | "concern" | "issue";

--- a/app/assets/js/features/goals/GoalForm/Target.tsx
+++ b/app/assets/js/features/goals/GoalForm/Target.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import classnames from "classnames";
-import * as Icons from "@tabler/icons-react";
+import { IconHash, IconX } from "turboui";
 import { FormState } from "./useForm";
 
 export function TargetHeader() {
   return (
     <Row
-      icon={<Icons.IconHash className="text-content-base ml-1.5" size={12} />}
+      icon={<IconHash className="text-content-base ml-1.5" size={12} />}
       name={<div className="text-xs font-bold">NAME</div>}
       from={<div className="text-xs font-bold">START</div>}
       to={<div className="text-xs font-bold">TARGET</div>}
@@ -110,7 +110,7 @@ export function Target({ form, target, placeholders = [], index }: TargetProps) 
   );
 
   const removeButton = (
-    <Icons.IconX
+    <IconX
       className="text-content-dimmed cursor-pointer"
       size={16}
       onClick={() => form.fields.removeTarget(target.id)}

--- a/app/assets/js/features/goals/GoalTargetsV2/AddTargetButton.tsx
+++ b/app/assets/js/features/goals/GoalTargetsV2/AddTargetButton.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus } from "turboui";
 import { useTargetsContext } from "./TargetsContext";
 
 export function AddTargetButton({ display }: { display: boolean }) {

--- a/app/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
+++ b/app/assets/js/features/goals/GoalTargetsV2/EditTargetCard.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import * as Goals from "@/models/goals";
-import { IconTrash } from "@tabler/icons-react";
+import { IconTrash } from "turboui";
 
 import classNames from "classnames";
 import { PrimaryButton, SecondaryButton } from "turboui";

--- a/app/assets/js/features/goals/GoalTargetsV2/components/ExpandIcon.tsx
+++ b/app/assets/js/features/goals/GoalTargetsV2/components/ExpandIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { IconChevronDown } from "@tabler/icons-react";
+import { IconChevronDown } from "turboui";
 
 interface Props {
   expanded: boolean;

--- a/app/assets/js/features/goals/GoalTree/GoalSelector.tsx
+++ b/app/assets/js/features/goals/GoalTree/GoalSelector.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Goals from "@/models/goals";
-import * as Icons from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight } from "turboui";
 
 import { buildTree, GoalNode, Node, TreeOptions } from "./tree";
 
@@ -106,7 +106,7 @@ function NodeExpandCollapseToggle({ node }: { node: GoalNode }) {
 
   const handleClick = () => toggleExpanded(node.id);
   const size = 16;
-  const ChevronIcon = expanded[node.id] ? Icons.IconChevronDown : Icons.IconChevronRight;
+  const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
 
   const className = classNames(
     "absolute flex items-center flex-row-reverse gap-1",

--- a/app/assets/js/features/goals/GoalTree/GoalSelectorDropdown.tsx
+++ b/app/assets/js/features/goals/GoalTree/GoalSelectorDropdown.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import * as Goals from "@/models/goals";
-import * as Icons from "@tabler/icons-react";
 
 import { buildTree, GoalNode, Node, TreeOptions } from "./tree";
 
 import { NodeIcon } from "./components/NodeIcon";
 import { TableRow } from "./components/TableRow";
 import { CompanyGoalOption } from "./components/CompanyGoalOption";
-import { PrimaryButton } from "turboui";
+import { PrimaryButton, IconChevronDown, IconChevronRight } from "turboui";
 import { ExpandableProvider, useExpandable } from "./context/Expandable";
 
 import classNames from "classnames";
@@ -64,7 +63,7 @@ export function GoalSelectorDropdown(props: GoalSelectorDropdownProps) {
           ) : (
             <div className="text-content-dimmed">Select a goal &hellip;</div>
           )}
-          <Icons.IconChevronDown size={20} />
+          <IconChevronDown size={20} />
         </div>
 
         {open && (
@@ -140,7 +139,7 @@ function NodeExpandCollapseToggle({ node }: { node: GoalNode }) {
 
   const handleClick = () => toggleExpanded(node.id);
   const size = 16;
-  const ChevronIcon = expanded[node.id] ? Icons.IconChevronDown : Icons.IconChevronRight;
+  const ChevronIcon = expanded[node.id] ? IconChevronDown : IconChevronRight;
 
   const className = classNames("flex items-center flex-row-reverse gap-1 w-5");
 

--- a/app/assets/js/features/goals/GoalTree/components/CompanyGoalOption.tsx
+++ b/app/assets/js/features/goals/GoalTree/components/CompanyGoalOption.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { TableRow } from "./TableRow";
-import { IconBuildingEstate } from "@tabler/icons-react";
-import { PrimaryButton } from "turboui";
+import { PrimaryButton, IconBuildingEstate } from "turboui";
 
 export function CompanyGoalOption({ handleSelect }: { handleSelect: () => void }) {
   return (

--- a/app/assets/js/features/goals/GoalTree/components/NodeIcon.tsx
+++ b/app/assets/js/features/goals/GoalTree/components/NodeIcon.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconTarget, IconHexagons } from "turboui";
 
 import { Node } from "../tree";
 
 export function NodeIcon({ node }: { node: Pick<Node, "type"> }) {
   switch (node.type) {
     case "goal":
-      return <Icons.IconTarget size={15} className="text-content-error shrink-0" />;
+      return <IconTarget size={15} className="text-content-error shrink-0" />;
     case "project":
-      return <Icons.IconHexagons size={15} className="text-indigo-500 shrink-0" />;
+      return <IconHexagons size={15} className="text-indigo-500 shrink-0" />;
     default:
       throw new Error(`Unknown node type: ${node.type}`);
   }

--- a/app/assets/js/features/projects/AccessLevel.tsx
+++ b/app/assets/js/features/projects/AccessLevel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { PermissionLevels } from "@/features/Permissions";
 import { match } from "ts-pattern";
-import * as Icons from "@tabler/icons-react";
+import { IconWorld, IconBuilding, IconLock, IconLockFilled } from "turboui";
 
 interface AccessLevelProps {
   tense: "present" | "future";
@@ -27,18 +27,18 @@ export function AccessLevel(props: AccessLevelProps) {
 
 function Icon(props: AccessLevelProps) {
   if (props.anonymous >= PermissionLevels.VIEW_ACCESS) {
-    return <Icons.IconWorld className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
+    return <IconWorld className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
   if (props.company >= PermissionLevels.VIEW_ACCESS) {
-    return <Icons.IconBuilding className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
+    return <IconBuilding className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
   if (props.space >= PermissionLevels.VIEW_ACCESS) {
-    return <Icons.IconLock className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
+    return <IconLock className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
-  return <Icons.IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
+  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
 }
 
 function calcTitle(props: AccessLevelProps) {

--- a/app/assets/js/features/projects/AccessSelectors.tsx
+++ b/app/assets/js/features/projects/AccessSelectors.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconBuilding, IconTent } from "turboui";
 
 import { PermissionLevels } from "../Permissions";
 import { Option } from "../Permissions/AccessFields";
@@ -16,14 +16,14 @@ export function AccessSelectors() {
         <Forms.SelectBox
           field={"access.companyMembers"}
           label="Company members"
-          labelIcon={<Icons.IconBuilding size={20} />}
+          labelIcon={<IconBuilding size={20} />}
           options={companyMembersOptions}
           hidden={shouldHide(companyMembersOptions)}
         />
         <Forms.SelectBox
           field={"access.spaceMembers"}
           label="Space members"
-          labelIcon={<Icons.IconTent size={20} />}
+          labelIcon={<IconTent size={20} />}
           options={spaceMembersOptions}
         />
       </Forms.FieldGroup>

--- a/app/assets/js/features/richtexteditor/components/AttachmentButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/AttachmentButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconPaperclip } from "turboui";
 
 import { AddBlobsEditorCommand } from "@/components/Editor/Blob/AddBlobsEditorCommand";
 import { ToolbarButton } from "./ToolbarButton";
@@ -40,7 +40,7 @@ export function AttachmentButton({ editor, iconSize }): JSX.Element {
   return (
     <>
       <ToolbarButton onClick={handleClick} title="Add an Image or File">
-        <Icons.IconPaperclip size={iconSize} />
+        <IconPaperclip size={iconSize} />
       </ToolbarButton>
 
       <input

--- a/app/assets/js/features/richtexteditor/components/BlockquoteButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/BlockquoteButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconBlockquote } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BlockquoteButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("blockquote")}
       title="Quote"
     >
-      <Icons.IconBlockquote size={iconSize} />
+      <IconBlockquote size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/BoldButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/BoldButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconBold } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BoldButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("bold")}
       title="Bold"
     >
-      <Icons.IconBold size={iconSize} strokeWidth={2.2} />
+      <IconBold size={iconSize} strokeWidth={2.2} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/BulletListButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/BulletListButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconList } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BulletListButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("bulletList")}
       title="Bullet List"
     >
-      <Icons.IconList size={iconSize} />
+      <IconList size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/CodeBlockButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/CodeBlockButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
-import { LucideCode } from "turboui";
+import { IconCode } from "turboui";
 
 export function CodeBlockButton({ editor, iconSize }): JSX.Element {
   return (
@@ -10,7 +10,7 @@ export function CodeBlockButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("codeblock")}
       title="Code Block"
     >
-      <LucideCode size={iconSize - 2} />
+      <IconCode size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/CodeBlockButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/CodeBlockButton.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { Code } from "lucide-react";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
+import { LucideCode } from "turboui";
 
 export function CodeBlockButton({ editor, iconSize }): JSX.Element {
   return (
@@ -10,7 +10,7 @@ export function CodeBlockButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("codeblock")}
       title="Code Block"
     >
-      <Code size={iconSize - 2} />
+      <LucideCode size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/ColorPicker.tsx
+++ b/app/assets/js/features/richtexteditor/components/ColorPicker.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
 
 import classNames from "classnames";
-import { SecondaryButton, LucidePaintBucket } from "turboui";
+import { SecondaryButton, IconPaintBucket } from "turboui";
 import { createTestId } from "@/utils/testid";
 
 const DROPDOWN_CLASS = classNames(
@@ -69,7 +69,7 @@ function BucketIcon({ iconSize, editor }): React.ReactElement {
   return (
     <div className="ProseMirror">
       <mark data-highlight={highlight} className="block px-1 py-0.5 rounded">
-        <LucidePaintBucket size={iconSize - 1} />
+        <IconPaintBucket size={iconSize - 1} />
       </mark>
     </div>
   );

--- a/app/assets/js/features/richtexteditor/components/ColorPicker.tsx
+++ b/app/assets/js/features/richtexteditor/components/ColorPicker.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
 
-import { PaintBucket } from "lucide-react";
 import classNames from "classnames";
-import { SecondaryButton } from "turboui";
+import { SecondaryButton, LucidePaintBucket } from "turboui";
 import { createTestId } from "@/utils/testid";
 
 const DROPDOWN_CLASS = classNames(
@@ -70,7 +69,7 @@ function BucketIcon({ iconSize, editor }): React.ReactElement {
   return (
     <div className="ProseMirror">
       <mark data-highlight={highlight} className="block px-1 py-0.5 rounded">
-        <PaintBucket size={iconSize - 1} />
+        <LucidePaintBucket size={iconSize - 1} />
       </mark>
     </div>
   );

--- a/app/assets/js/features/richtexteditor/components/DividerButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/DividerButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Minus } from "lucide-react";
 
 import { ToolbarButton } from "./ToolbarButton";
+import { LucideMinus } from "turboui";
 
 export function DividerButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().setHorizontalRule().run()} title="Divider">
-      <Minus size={iconSize} />
+      <LucideMinus size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/DividerButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/DividerButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 
 import { ToolbarButton } from "./ToolbarButton";
-import { LucideMinus } from "turboui";
+import { IconMinus } from "turboui";
 
 export function DividerButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().setHorizontalRule().run()} title="Divider">
-      <LucideMinus size={iconSize} />
+      <IconMinus size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/H1Button.tsx
+++ b/app/assets/js/features/richtexteditor/components/H1Button.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 
+import { IconH1 } from "turboui";
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
 export function H1Button({ editor, iconSize }): JSX.Element {
@@ -10,7 +10,7 @@ export function H1Button({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("heading", { level: 1 })}
       title="Heading 1"
     >
-      <Icons.IconH1 size={iconSize} />
+      <IconH1 size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/H2Button.tsx
+++ b/app/assets/js/features/richtexteditor/components/H2Button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconH2 } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function H2Button({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("heading", { level: 2 })}
       title="Heading 2"
     >
-      <Icons.IconH2 size={iconSize} />
+      <IconH2 size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/ItalicButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/ItalicButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconItalic } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function ItalicButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("italic")}
       title="Italic"
     >
-      <Icons.IconItalic size={iconSize} />
+      <IconItalic size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/LinkButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/LinkButton.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
-import * as Icons from "lucide-react";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
 import { EditorContext } from "@/components/Editor";
+import { LucideLink } from "turboui";
 
 export function LinkButton({ editor, iconSize }): JSX.Element {
   const { linkEditActive, setLinkEditActive } = React.useContext(EditorContext);
@@ -22,7 +22,7 @@ export function LinkButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("link") || linkEditActive}
       title="Add/Edit Links"
     >
-      <Icons.Link size={iconSize - 2} />
+      <LucideLink size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/LinkButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/LinkButton.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
 import { EditorContext } from "@/components/Editor";
-import { LucideLink } from "turboui";
+import { IconLink2 } from "turboui";
 
 export function LinkButton({ editor, iconSize }): JSX.Element {
   const { linkEditActive, setLinkEditActive } = React.useContext(EditorContext);
@@ -22,7 +22,7 @@ export function LinkButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("link") || linkEditActive}
       title="Add/Edit Links"
     >
-      <LucideLink size={iconSize - 2} />
+      <IconLink2 size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/NumberListButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/NumberListButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconListNumbers } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function NumberListButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("orderedList")}
       title="Numbered List"
     >
-      <Icons.IconListNumbers size={iconSize} />
+      <IconListNumbers size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/RedoButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/RedoButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconArrowForwardUp } from "turboui";
 
 import { ToolbarButton } from "./ToolbarButton";
 
 export function RedoButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().redo().run()} disabled={!editor?.can().redo()} title="Redo">
-      <Icons.IconArrowForwardUp size={iconSize} />
+      <IconArrowForwardUp size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/StrikeButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/StrikeButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconStrikethrough } from "turboui";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function StrikeButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("strike")}
       title="Strikethrough"
     >
-      <Icons.IconStrikethrough size={iconSize} />
+      <IconStrikethrough size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/app/assets/js/features/richtexteditor/components/Toolbar.tsx
+++ b/app/assets/js/features/richtexteditor/components/Toolbar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
-import * as Icons from "@tabler/icons-react";
+
+import { IconChevronDown } from "turboui";
 
 import { AttachmentButton } from "./AttachmentButton";
 import { BlockquoteButton } from "./BlockquoteButton";
@@ -120,7 +121,7 @@ function MobilePopupTools({ children }: { children: React.ReactNode }): JSX.Elem
   return (
     <Popover.Root>
       <Popover.Trigger className="mr-2">
-        <Icons.IconChevronDown size={20} />
+        <IconChevronDown size={20} />
       </Popover.Trigger>
       <Popover.Content className="z-10 p-2 bg-surface-base rounded-lg shadow-lg border border-stroke-base">
         <div className="flex flex-wrap gap-1">{children}</div>

--- a/app/assets/js/features/richtexteditor/components/UndoButton.tsx
+++ b/app/assets/js/features/richtexteditor/components/UndoButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 
+import { IconArrowBackUp } from "turboui";
 import { ToolbarButton } from "./ToolbarButton";
 
 export function UndoButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().undo().run()} disabled={!editor?.can().undo()} title="Undo">
-      <Icons.IconArrowBackUp size={iconSize} />
+      <IconArrowBackUp size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/app/assets/js/features/spaces/AccessLevel/index.tsx
+++ b/app/assets/js/features/spaces/AccessLevel/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { PermissionLevels } from "@/features/Permissions";
 import { match } from "ts-pattern";
-import * as Icons from "@tabler/icons-react";
+import { IconBuilding, IconLockFilled, IconWorld } from "turboui";
 
 interface AccessLevelProps {
   tense: "present" | "future";
@@ -26,14 +26,14 @@ export function AccessLevel(props: AccessLevelProps) {
 
 function Icon(props: AccessLevelProps) {
   if (props.anonymous >= PermissionLevels.VIEW_ACCESS) {
-    return <Icons.IconWorld className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
+    return <IconWorld className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
   if (props.company >= PermissionLevels.VIEW_ACCESS) {
-    return <Icons.IconBuilding className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
+    return <IconBuilding className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
-  return <Icons.IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
+  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
 }
 
 function calcTitle(props: AccessLevelProps) {

--- a/app/assets/js/features/spaces/AccessSelectors/index.tsx
+++ b/app/assets/js/features/spaces/AccessSelectors/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+
+import { IconBuilding } from "turboui";
 
 import { PermissionLevels } from "@/features/Permissions";
 
@@ -16,7 +17,7 @@ export function AccessSelectors() {
         <Forms.SelectBox
           field={"access.companyMembers"}
           label="Company members"
-          labelIcon={<Icons.IconBuilding size={20} />}
+          labelIcon={<IconBuilding size={20} />}
           options={companyMembersOptions}
           hidden={shouldHide(companyMembersOptions)}
         />

--- a/app/assets/js/features/spaces/PrivacyIndicator/index.tsx
+++ b/app/assets/js/features/spaces/PrivacyIndicator/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Spaces from "@/models/spaces";
 
+import { IconWorld, IconLockFilled } from "turboui";
 import { Tooltip } from "@/components/Tooltip";
 import { assertPresent } from "@/utils/assertions";
 
@@ -40,7 +40,7 @@ function PublicSpace({ size }: { size: number }) {
 
   return (
     <Tooltip content={content} testId="public-project-tooltip" delayDuration={100}>
-      <Icons.IconWorld size={size} />
+      <IconWorld size={size} />
     </Tooltip>
   );
 }
@@ -55,7 +55,7 @@ function InviteOnly({ size }: { size: number }) {
 
   return (
     <Tooltip content={content} testId="secret-space-tooltip" delayDuration={100} className="z-50">
-      <Icons.IconLockFilled size={size} />
+      <IconLockFilled size={size} />
     </Tooltip>
   );
 }

--- a/app/assets/js/layouts/CompanyLayout/Bell.tsx
+++ b/app/assets/js/layouts/CompanyLayout/Bell.tsx
@@ -1,7 +1,6 @@
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
-import { DivLink } from "turboui";
+import { DivLink, IconBell } from "turboui";
 
 import * as Notifications from "@/models/notifications";
 import classNames from "classnames";
@@ -26,7 +25,7 @@ export function Bell() {
 
   return (
     <DivLink to={path} className={className} style={style} testId="notifications-bell">
-      <Icons.IconBell size={20} stroke={1.5} className={iconClassName} />
+      <IconBell size={20} stroke={1.5} className={iconClassName} />
       <UnreadIndicator count={count} />
     </DivLink>
   );

--- a/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/CompanyDropdown.tsx
@@ -1,6 +1,7 @@
 import * as Companies from "@/models/companies";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
+
+import { IconBuildingEstate, IconRss, IconUserCircle, IconBinaryTree2, IconCircleKey, IconSwitch } from "turboui";
 
 import { Paths, usePaths } from "@/routes/paths";
 import { DropdownLinkItem, DropdownMenu, DropdownSeparator } from "./DropdownMenu";
@@ -12,25 +13,25 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
     <DropdownMenu
       testId="company-dropdown"
       name={company.name!}
-      icon={Icons.IconBuildingEstate}
+      icon={IconBuildingEstate}
       align="start"
       showDropdownIcon
     >
       <DropdownLinkItem
         path={paths.feedPath()}
-        icon={Icons.IconRss}
+        icon={IconRss}
         title="The Feed"
         testId="company-dropdown-company-feed"
       />
       <DropdownLinkItem
         path={paths.peoplePath()}
-        icon={Icons.IconUserCircle}
+        icon={IconUserCircle}
         title="People"
         testId="company-dropdown-people"
       />
       <DropdownLinkItem
         path={paths.orgChartPath()}
-        icon={Icons.IconBinaryTree2}
+        icon={IconBinaryTree2}
         title="Org Chart"
         testId="company-dropdown-org-chart"
       />
@@ -39,13 +40,13 @@ export function CompanyDropdown({ company }: { company: Companies.Company }) {
 
       <DropdownLinkItem
         path={paths.companyAdminPath()}
-        icon={Icons.IconCircleKey}
+        icon={IconCircleKey}
         title="Company Admin"
         testId="company-dropdown-company-admin"
       />
       <DropdownLinkItem
         path={Paths.lobbyPath()}
-        icon={Icons.IconSwitch}
+        icon={IconSwitch}
         title="Switch Company"
         testId="company-dropdown-switch"
       />

--- a/app/assets/js/layouts/CompanyLayout/DropdownMenu.tsx
+++ b/app/assets/js/layouts/CompanyLayout/DropdownMenu.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Popover from "@radix-ui/react-popover";
 
-import { DivLink } from "turboui";
+import { DivLink, IconChevronDown } from "turboui";
 
 import classNames from "classnames";
 
@@ -57,7 +56,7 @@ export function DropdownMenu(props: DropdownMenuProps) {
         <div className={triggerClassName} data-test-id={props.testId}>
           {React.createElement(props.icon, { size: 16 })}
           <div className="font-semibold">{props.name}</div>
-          {props.showDropdownIcon && <Icons.IconChevronDown size={16} />}
+          {props.showDropdownIcon && <IconChevronDown size={16} />}
         </div>
       </Popover.Trigger>
 

--- a/app/assets/js/layouts/CompanyLayout/HelpDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/HelpDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 import * as Companies from "@/models/companies";
 
+import { IconBrandDiscordFilled, IconLifebuoy, IconMail, IconSpeakerphone, IconMap2 } from "turboui";
 import { DropdownMenu, DropdownLinkItem } from "./DropdownMenu";
 import { encodeUrlParams } from "@/routes/paths";
 
@@ -10,15 +10,15 @@ const discordChatLink = "https://discord.gg/SGnvguhV";
 const newsLink = "https://operately.com/releases";
 const roadmap = "https://operately.com/roadmap";
 
-const DiscordIcon = Icons.IconBrandDiscordFilled;
+const DiscordIcon = IconBrandDiscordFilled;
 
 export function HelpDropdown({ company }: { company: Companies.Company }) {
   return (
-    <DropdownMenu testId="help-dropdown" name="Help" icon={Icons.IconLifebuoy} align="center" minWidth={200}>
-      <DropdownLinkItem path={contactUsLink(company)} icon={Icons.IconMail} title="Contact us" />
+    <DropdownMenu testId="help-dropdown" name="Help" icon={IconLifebuoy} align="center" minWidth={200}>
+      <DropdownLinkItem path={contactUsLink(company)} icon={IconMail} title="Contact us" />
       <DropdownLinkItem path={discordChatLink} icon={DiscordIcon} title="Discord chat" target="_blank" />
-      <DropdownLinkItem path={newsLink} icon={Icons.IconSpeakerphone} title="What's new" target="_blank" />
-      <DropdownLinkItem path={roadmap} icon={Icons.IconMap2} title="Roadmap" target="_blank" />
+      <DropdownLinkItem path={newsLink} icon={IconSpeakerphone} title="What's new" target="_blank" />
+      <DropdownLinkItem path={roadmap} icon={IconMap2} title="Roadmap" target="_blank" />
     </DropdownMenu>
   );
 }

--- a/app/assets/js/layouts/CompanyLayout/NewDropdown.tsx
+++ b/app/assets/js/layouts/CompanyLayout/NewDropdown.tsx
@@ -1,23 +1,23 @@
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
+import { IconPlus, IconTargetArrow, IconTable, IconTent, IconUser } from "turboui";
 import { DropdownLinkItem, DropdownMenu, DropdownSeparator } from "./DropdownMenu";
 
 import { usePaths } from "@/routes/paths";
 export function NewDropdown() {
   const paths = usePaths();
   return (
-    <DropdownMenu testId="new-dropdown" name="New" icon={Icons.IconPlus} align="end">
+    <DropdownMenu testId="new-dropdown" name="New" icon={IconPlus} align="end">
       <DropdownLinkItem
         path={paths.newGoalPath()}
-        icon={Icons.IconTargetArrow}
+        icon={IconTargetArrow}
         title="New goal"
         testId="new-dropdown-new-goal"
       />
 
       <DropdownLinkItem
         path={paths.newProjectPath()}
-        icon={Icons.IconTable}
+        icon={IconTable}
         title="New project"
         testId="new-dropdown-new-project"
       />
@@ -26,7 +26,7 @@ export function NewDropdown() {
 
       <DropdownLinkItem
         path={paths.newSpacePath()}
-        icon={Icons.IconTent}
+        icon={IconTent}
         title="New space"
         testId="new-dropdown-new-space"
       />
@@ -35,7 +35,7 @@ export function NewDropdown() {
 
       <DropdownLinkItem
         path={paths.companyManagePeopleAddPeoplePath()}
-        icon={Icons.IconUser}
+        icon={IconUser}
         title="New team member"
         testId="new-dropdown-new-team-member"
       />

--- a/app/assets/js/layouts/CompanyLayout/Review.tsx
+++ b/app/assets/js/layouts/CompanyLayout/Review.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useAssignmentsCount, useReviewRefreshSignal } from "@/models/assignments";
 
-import { IconCoffee } from "@tabler/icons-react";
+import { IconCoffee } from "turboui";
 import { DivLink } from "turboui";
 
 import { usePaths } from "@/routes/paths";

--- a/app/assets/js/layouts/CompanyLayout/index.tsx
+++ b/app/assets/js/layouts/CompanyLayout/index.tsx
@@ -1,6 +1,7 @@
 import * as Api from "@/api";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
+
+import { IconMenu2, IconHome2, IconBuildingEstate, IconBriefcase, IconCoffee, IconBell, IconUser, IconCircleKey, IconSwitch, IconDoorExit, IconUserCircle } from "turboui";
 
 import { logOut } from "@/routes/auth";
 import { useLoaderData } from "react-router-dom";
@@ -55,7 +56,7 @@ function MobileNavigation({ company }: { company: Api.Company }) {
         </div>
 
         <div className="">
-          <Icons.IconMenu2 size={24} onClick={() => setOpen(!open)} />
+          <IconMenu2 size={24} onClick={() => setOpen(!open)} />
         </div>
       </div>
 
@@ -64,43 +65,43 @@ function MobileNavigation({ company }: { company: Api.Company }) {
           className="flex flex-col bg-base absolute inset-0 top-10 bg-surface-bg border-t border-surface-outline"
           onClick={() => setOpen(false)}
         >
-          <MobileSectionLink to={paths.homePath()} icon={Icons.IconHome2}>
+          <MobileSectionLink to={paths.homePath()} icon={IconHome2}>
             Home
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.workMapPath()} icon={Icons.IconBuildingEstate}>
+          <MobileSectionLink to={paths.workMapPath()} icon={IconBuildingEstate}>
             Company
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.profilePath(me.id)} icon={Icons.IconBriefcase}>
+          <MobileSectionLink to={paths.profilePath(me.id)} icon={IconBriefcase}>
             My work
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.reviewPath()} icon={Icons.IconCoffee}>
+          <MobileSectionLink to={paths.reviewPath()} icon={IconCoffee}>
             Review
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.peoplePath()} icon={Icons.IconUserCircle}>
+          <MobileSectionLink to={paths.peoplePath()} icon={IconUserCircle}>
             People
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.notificationsPath()} icon={Icons.IconBell}>
+          <MobileSectionLink to={paths.notificationsPath()} icon={IconBell}>
             Notifications
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.accountPath()} icon={Icons.IconUser}>
+          <MobileSectionLink to={paths.accountPath()} icon={IconUser}>
             Account
           </MobileSectionLink>
 
-          <MobileSectionLink to={paths.companyAdminPath()} icon={Icons.IconCircleKey}>
+          <MobileSectionLink to={paths.companyAdminPath()} icon={IconCircleKey}>
             Company Admin
           </MobileSectionLink>
 
-          <MobileSectionLink to={Paths.lobbyPath()} icon={Icons.IconSwitch}>
+          <MobileSectionLink to={Paths.lobbyPath()} icon={IconSwitch}>
             Switch Company
           </MobileSectionLink>
 
-          <MobileSectionAction onClick={handleLogOut} icon={Icons.IconDoorExit}>
+          <MobileSectionAction onClick={handleLogOut} icon={IconDoorExit}>
             Log Out
           </MobileSectionAction>
         </div>
@@ -150,15 +151,15 @@ function DesktopNavigation({ company }: { company: Api.Company }) {
           </div>
 
           <div className="flex items-center gap-2.5 border-l border-surface-outline px-4">
-            <SectionLink to={paths.homePath()} icon={Icons.IconHome2}>
+            <SectionLink to={paths.homePath()} icon={IconHome2}>
               Home
             </SectionLink>
 
-            <SectionLink to={paths.workMapPath()} icon={Icons.IconBuildingEstate}>
+            <SectionLink to={paths.workMapPath()} icon={IconBuildingEstate}>
               Company
             </SectionLink>
 
-            <SectionLink to={paths.profilePath(me.id)} icon={Icons.IconBriefcase}>
+            <SectionLink to={paths.profilePath(me.id)} icon={IconBriefcase}>
               My work
             </SectionLink>
           </div>

--- a/app/assets/js/pages/AccountAppearancePage/index.tsx
+++ b/app/assets/js/pages/AccountAppearancePage/index.tsx
@@ -1,8 +1,9 @@
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
+
+import { IconSun, IconMoon, IconDeviceLaptop } from "turboui";
 
 import Forms from "@/components/Forms";
 import classnames from "classnames";
@@ -55,9 +56,9 @@ function Form() {
       </p>
 
       <div className="grid grid-cols-3 gap-4 mt-4 h-32">
-        <ColorModeOption icon={Icons.IconSun} title="Always Light" theme="light" />
-        <ColorModeOption icon={Icons.IconMoon} title="Always Dark" theme="dark" />
-        <ColorModeOption icon={Icons.IconDeviceLaptop} title="Same as System" theme="system" />
+        <ColorModeOption icon={IconSun} title="Always Light" theme="light" />
+        <ColorModeOption icon={IconMoon} title="Always Dark" theme="dark" />
+        <ColorModeOption icon={IconDeviceLaptop} title="Same as System" theme="system" />
       </div>
 
       <Forms.Submit saveText="Save Changes" />

--- a/app/assets/js/pages/AccountPage/index.tsx
+++ b/app/assets/js/pages/AccountPage/index.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { logOut } from "@/routes/auth";
 import { PageModule } from "@/routes/types";
 import { BurgerActionsGroup, BurgerButton, BurgerLink } from "./BurgerActions";
+import { IconUserCircle, IconPalette, IconLockPassword, IconDoorExit } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export default { name: "AccountPage", loader: Pages.emptyLoader, Page } as PageModule;
@@ -41,7 +41,7 @@ function ProfileLink() {
   const me = useMe()!;
 
   return (
-    <BurgerLink icon={Icons.IconUserCircle} to={paths.profileEditPath(me.id!)} testId="profile-link">
+    <BurgerLink icon={IconUserCircle} to={paths.profileEditPath(me.id!)} testId="profile-link">
       Profile
     </BurgerLink>
   );
@@ -50,7 +50,7 @@ function ProfileLink() {
 function AppearanceLink() {
   const paths = usePaths();
   return (
-    <BurgerLink icon={Icons.IconPalette} to={paths.accountAppearancePath()} testId="appearance-link">
+    <BurgerLink icon={IconPalette} to={paths.accountAppearancePath()} testId="appearance-link">
       Appearance
     </BurgerLink>
   );
@@ -59,7 +59,7 @@ function AppearanceLink() {
 function PasswordLink() {
   const paths = usePaths();
   return (
-    <BurgerLink icon={Icons.IconLockPassword} to={paths.accountSecurityPath()} testId="password-link">
+    <BurgerLink icon={IconLockPassword} to={paths.accountSecurityPath()} testId="password-link">
       Password &amp; Security
     </BurgerLink>
   );
@@ -75,7 +75,7 @@ function LogOutButton() {
   };
 
   return (
-    <BurgerButton onClick={handleClick} testId="log-out-button" icon={Icons.IconDoorExit}>
+    <BurgerButton onClick={handleClick} testId="log-out-button" icon={IconDoorExit}>
       Sign Out
     </BurgerButton>
   );

--- a/app/assets/js/pages/CompanyAdminManageAdminsPage/AddAdminsModal.tsx
+++ b/app/assets/js/pages/CompanyAdminManageAdminsPage/AddAdminsModal.tsx
@@ -6,7 +6,7 @@ import { PrimaryButton } from "turboui";
 
 import { Person } from "@/models/people";
 import PeopleSearch, { Option } from "@/components/PeopleSearch";
-import * as Icons from "@tabler/icons-react";
+import { IconX } from "turboui";
 import { FormState } from "./useForm";
 import * as People from "@/models/people";
 
@@ -95,7 +95,7 @@ function SearchField({ onSelect, loader, placeholder, alreadySelected }) {
 function RemoveIcon({ onClick }) {
   return (
     <div className="hover:cursor-pointer text-content-dimmed hover:text-content-accent" onClick={onClick}>
-      <Icons.IconX size={20} />
+      <IconX size={20} />
     </div>
   );
 }

--- a/app/assets/js/pages/CompanyAdminManageAdminsPage/AddOwnersModal.tsx
+++ b/app/assets/js/pages/CompanyAdminManageAdminsPage/AddOwnersModal.tsx
@@ -6,7 +6,7 @@ import { PrimaryButton } from "turboui";
 
 import { Person } from "@/models/people";
 import PeopleSearch, { Option } from "@/components/PeopleSearch";
-import * as Icons from "@tabler/icons-react";
+import { IconX } from "turboui";
 import { FormState } from "./useForm";
 import * as People from "@/models/people";
 
@@ -95,7 +95,7 @@ function SearchField({ onSelect, loader, placeholder, alreadySelected }) {
 function RemoveIcon({ onClick }) {
   return (
     <div className="hover:cursor-pointer text-content-dimmed hover:text-content-accent" onClick={onClick}>
-      <Icons.IconX size={20} />
+      <IconX size={20} />
     </div>
   );
 }

--- a/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
@@ -6,7 +6,7 @@ import * as Companies from "@/models/companies";
 import * as Invitations from "@/models/invitations";
 import * as People from "@/models/people";
 import * as Time from "@/utils/time";
-import * as Icons from "@tabler/icons-react";
+import { IconAlertTriangle, IconId, IconRefresh, IconUserX } from "turboui";
 import * as React from "react";
 
 import { CopyToClipboard } from "@/components/CopyToClipboard";
@@ -162,7 +162,7 @@ function ExpiredInvitationAndRenewButton({ person }: { person: People.Person }) 
       <RenewInvitationModal person={person} state={modal} />
 
       <div className="text-content-error font-semibold flex items-center gap-2">
-        <Icons.IconAlertTriangle size={20} />
+        <IconAlertTriangle size={20} />
         Invitation Expired
       </div>
 
@@ -210,7 +210,7 @@ function PersonOptions({ person }: { person: People.Person }) {
 function PersonOptionViewProfile({ person }: { person: People.Person }) {
   const paths = usePaths();
   return (
-    <MenuLinkItem icon={Icons.IconId} testId="view-profile" to={paths.profilePath(person.id!)}>
+    <MenuLinkItem icon={IconId} testId="view-profile" to={paths.profilePath(person.id!)}>
       View Profile
     </MenuLinkItem>
   );
@@ -220,7 +220,7 @@ function PersonOptionReissueInvitation({ person, onClick }: { person: People.Per
   if (!person.hasOpenInvitation) return null;
 
   return (
-    <MenuActionItem icon={Icons.IconRefresh} onClick={onClick} testId={createTestId("reissue-token", person.id!)}>
+    <MenuActionItem icon={IconRefresh} onClick={onClick} testId={createTestId("reissue-token", person.id!)}>
       Re-Issue Invitation
     </MenuActionItem>
   );
@@ -231,7 +231,7 @@ function PersonOptionRemove({ person, onClick }: { person: People.Person; onClic
   if (me!.id === person.id) return null;
 
   return (
-    <MenuActionItem icon={Icons.IconUserX} onClick={onClick} danger testId={createTestId("remove-person", person.id!)}>
+    <MenuActionItem icon={IconUserX} onClick={onClick} danger testId={createTestId("remove-person", person.id!)}>
       {person.hasOpenInvitation ? "Revoke Invitation" : "Deactivate Account"}
     </MenuActionItem>
   );

--- a/app/assets/js/pages/CompanyAdminPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/page.tsx
@@ -1,6 +1,6 @@
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
+import { IconUsers, IconUser, IconLetterCase, IconShieldLock, IconLock } from "turboui";
 import * as React from "react";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
@@ -68,15 +68,15 @@ function AdminsMenu() {
   return (
     <Paper.Section title="As an admin or owner, you can:">
       <div>
-        <OptionsMenuItem linkTo={managePeople} icon={Icons.IconUsers} title="Manage team members" />
+        <OptionsMenuItem linkTo={managePeople} icon={IconUsers} title="Manage team members" />
 
         <OptionsMenuItem
           linkTo={restorePath}
-          icon={Icons.IconUser}
+          icon={IconUser}
           title="Restore access for deactivated team members"
         />
 
-        <OptionsMenuItem linkTo={renameCompanyPath} icon={Icons.IconLetterCase} title="Rename the company" />
+        <OptionsMenuItem linkTo={renameCompanyPath} icon={IconLetterCase} title="Rename the company" />
       </div>
     </Paper.Section>
   );
@@ -100,8 +100,8 @@ function OwnersMenu() {
   return (
     <Paper.Section title="As an owner, you can:">
       <div>
-        <OptionsMenuItem linkTo={manageAdmins} icon={Icons.IconShieldLock} title="Manage administrators and owners" />
-        <OptionsMenuItem linkTo={manageTrustedDomains} icon={Icons.IconLock} title="Manage trusted email domains" />
+        <OptionsMenuItem linkTo={manageAdmins} icon={IconShieldLock} title="Manage administrators and owners" />
+        <OptionsMenuItem linkTo={manageTrustedDomains} icon={IconLock} title="Manage trusted email domains" />
       </div>
     </Paper.Section>
   );

--- a/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
@@ -1,8 +1,9 @@
 import * as Forms from "@/components/Form";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
+
+import { IconTrash } from "turboui";
 
 import { createTestId } from "@/utils/testid";
 import { GhostButton } from "turboui";
@@ -59,7 +60,7 @@ function TrustedEmailDomainItem({ domain, form }: { domain: string; form: FormSt
   return (
     <div className="flex items-center gap-2 bg-surface-dimmed border border-stroke-base px-3 py-2 rounded">
       <div className="flex-1 font-medium">{domain}</div>
-      <Icons.IconTrash
+      <IconTrash
         className="text-content-dimmed cursor-pointer hover:text-content-error shrink-0"
         size={16}
         onClick={() => form.removeDomain(domain)}

--- a/app/assets/js/pages/CompanyPermissionsPage/index.tsx
+++ b/app/assets/js/pages/CompanyPermissionsPage/index.tsx
@@ -1,7 +1,7 @@
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import { PageModule } from "@/routes/types";
-import * as Icons from "@tabler/icons-react";
+import { IconCheck, IconX } from "turboui";
 import * as React from "react";
 
 import { usePaths } from "@/routes/paths";
@@ -58,9 +58,9 @@ function Row({ permission, members, admins, owners }) {
 }
 
 function Yes() {
-  return <Icons.IconCheck />;
+  return <IconCheck />;
 }
 
 function No() {
-  return <Icons.IconX className="text-content-subtle" size={16} />;
+  return <IconX className="text-content-subtle" size={16} />;
 }

--- a/app/assets/js/pages/DiscussionPage/page.tsx
+++ b/app/assets/js/pages/DiscussionPage/page.tsx
@@ -3,7 +3,6 @@ import * as Paper from "@/components/PaperContainer";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Discussions from "@/models/discussions";
 import * as Reactions from "@/models/reactions";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import RichContent from "@/components/RichContent";
@@ -22,6 +21,7 @@ import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { assertPresent } from "@/utils/assertions";
 import { useNavigate } from "react-router-dom";
 import { useLoadedData } from "./loader";
+import { IconEdit, IconTrash } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export function Page() {
@@ -142,14 +142,14 @@ function Options() {
   return (
     <PageOptions.Root testId="options-button">
       <PageOptions.Link
-        icon={Icons.IconEdit}
+        icon={IconEdit}
         title="Edit"
         to={paths.discussionEditPath(discussion.id!)}
         testId="edit-discussion"
         keepOutsideOnBigScreen
       />
 
-      <PageOptions.Action icon={Icons.IconTrash} title="Delete" onClick={handleArchive} testId="archive-discussion" />
+      <PageOptions.Action icon={IconTrash} title="Delete" onClick={handleArchive} testId="archive-discussion" />
     </PageOptions.Root>
   );
 }

--- a/app/assets/js/pages/GoalCheckInPage/Header.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Header.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconSquareCheckFilled } from "turboui";
 
 import { Avatar } from "turboui";
 import FormattedTime from "@/components/FormattedTime";
@@ -56,7 +56,7 @@ function Acknowledgement({ update }) {
   if (update.acknowledgedAt) {
     return (
       <span className="flex items-center gap-1">
-        <Icons.IconSquareCheckFilled size={16} className="text-accent-1" />
+        <IconSquareCheckFilled size={16} className="text-accent-1" />
         <span className="hidden sm:inline">Acknowledged by</span>
         <span className="truncate">{update.acknowledgingPerson.fullName}</span>
       </span>

--- a/app/assets/js/pages/GoalCheckInPage/Options.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Options.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import * as Pages from "@/components/Pages";
-import * as Icons from "@tabler/icons-react";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 
 import { useLoadedData } from "./loader";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { compareIds } from "@/routes/paths";
+import { IconEdit } from "turboui";
 
 export function Options() {
   const { update } = useLoadedData();
@@ -20,7 +20,7 @@ export function Options() {
     <PageOptions.Root testId="check-in-options">
       {isEditVisible && (
         <PageOptions.Action
-          icon={Icons.IconEdit}
+          icon={IconEdit}
           title="Edit"
           onClick={() => setPageMode("edit")}
           testId="edit-check-in"

--- a/app/assets/js/pages/LobbyPage/index.tsx
+++ b/app/assets/js/pages/LobbyPage/index.tsx
@@ -1,11 +1,10 @@
 import * as Api from "@/api";
 import * as Pages from "@/components/Pages";
 import * as People from "@/models/people";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import { OperatelyLogo } from "@/components/OperatelyLogo";
-import { DivLink, Link } from "turboui";
+import { DivLink, Link, IconBuildingEstate, IconSparkles } from "turboui";
 
 import { Paths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
@@ -87,7 +86,7 @@ function CompanyCard({ company }: { company: Api.Company }) {
 
   return (
     <DivLink to={Paths.companyHomePath(company.id!)} className={className}>
-      <Icons.IconBuildingEstate size={40} className="text-cyan-500" strokeWidth={1} />
+      <IconBuildingEstate size={40} className="text-cyan-500" strokeWidth={1} />
       <div className="font-medium mt-2">{company.name}</div>
       <div className="text-xs">{plurarize(company.memberCount!, "member", "members")}</div>
     </DivLink>
@@ -111,7 +110,7 @@ function AddCompanyCard() {
       <div className="font-bold sm:text-lg">+ Create new</div>
       <div className="text-xs sm:text-sm font-medium">Add new organization</div>
       <div className="flex justify-end mt-3">
-        <Icons.IconSparkles size={32} className="text-white-1" strokeWidth={1} />
+        <IconSparkles size={32} className="text-white-1" strokeWidth={1} />
       </div>
     </DivLink>
   );

--- a/app/assets/js/pages/NotificationsPage/index.tsx
+++ b/app/assets/js/pages/NotificationsPage/index.tsx
@@ -3,7 +3,7 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Notifications from "@/models/notifications";
 import * as Signals from "@/signals";
-import * as Icons from "@tabler/icons-react";
+import { IconSparkles, IconX } from "turboui";
 import * as React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
@@ -66,7 +66,7 @@ function UnreadNotifications() {
 
       {unread.length === 0 && (
         <div className="px-12 pt-16 py-20 text-content-accent font-medium flex items-center flex-col gap-2">
-          <Icons.IconSparkles className="text-yellow-500" />
+          <IconSparkles className="text-yellow-500" />
           Nothing new for you.
         </div>
       )}
@@ -155,7 +155,7 @@ function NotificationItem({ notification }: any) {
 
       {notification.read ? null : (
         <div className="shrink-0 group-hover:opacity-100 opacity-0 cursor-pointer mb-4 mr-1" onClick={closeHandler}>
-          <Icons.IconX size={16} className="hover:text-content-accent" />
+          <IconX size={16} className="hover:text-content-accent" />
         </div>
       )}
     </div>

--- a/app/assets/js/pages/PeopleOrgChartPage/page.tsx
+++ b/app/assets/js/pages/PeopleOrgChartPage/page.tsx
@@ -1,7 +1,7 @@
 import * as Pages from "@/components/Pages";
 import * as React from "react";
 
-import * as Icons from "@tabler/icons-react";
+import { IconChevronUp, IconChevronDown } from "turboui";
 import { Avatar, Link } from "turboui";
 import { useLoadedData } from "./loader";
 
@@ -66,7 +66,7 @@ function Subtree({ node, chart }: { node: OrgChartNode; chart: OrgChart }) {
         className="text-xs text-content-dimmed text-right cursor-pointer flex items-center gap-1 justify-end -mt-5 px-2"
         onClick={() => chart.collapse(node.person.id!)}
       >
-        Collapse <Icons.IconChevronUp size={14} />
+        Collapse <IconChevronUp size={14} />
       </div>
 
       <div className="px-8 mt-4 mb-4">
@@ -115,9 +115,9 @@ function PersonCard({ node, chart }: { node: OrgChartNode; chart: OrgChart }) {
         >
           {node.totalReports}
           {chart.expanded.includes(person.id!) ? (
-            <Icons.IconChevronUp size={14} />
+            <IconChevronUp size={14} />
           ) : (
-            <Icons.IconChevronDown size={14} />
+            <IconChevronDown size={14} />
           )}
         </div>
       </div>

--- a/app/assets/js/pages/ProfilePage/index.tsx
+++ b/app/assets/js/pages/ProfilePage/index.tsx
@@ -6,9 +6,8 @@ import { toPersonWithLink } from "@/models/people";
 import { Feed, useItemsQuery } from "@/features/Feed";
 import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
-import { ProfilePage } from "turboui";
+import { ProfilePage, IconPencil } from "turboui";
 
-import { IconPencil } from "@tabler/icons-react";
 import { loader, useLoadedData } from "./loader";
 
 import { usePaths } from "@/routes/paths";

--- a/app/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -2,11 +2,10 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Reactions from "@/models/reactions";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import FormattedTime from "@/components/FormattedTime";
-import { Avatar } from "turboui";
+import { Avatar, IconEdit, IconSquareCheckFilled } from "turboui";
 
 import { TextSeparator } from "@/components/TextSeparator";
 import { compareIds } from "@/routes/paths";
@@ -132,7 +131,7 @@ function Acknowledgement() {
   if (checkIn.acknowledgedAt) {
     return (
       <span className="flex items-center gap-1">
-        <Icons.IconSquareCheckFilled size={16} className="text-accent-1" />
+        <IconSquareCheckFilled size={16} className="text-accent-1" />
         Acknowledged by {checkIn.acknowledgedBy!.fullName}
       </span>
     );
@@ -151,7 +150,7 @@ function Options() {
   return (
     <PageOptions.Root testId="options-button">
       <PageOptions.Link
-        icon={Icons.IconEdit}
+        icon={IconEdit}
         title="Edit check-in"
         to={paths.projectCheckInEditPath(checkIn.id!)}
         testId="edit-check-in"

--- a/app/assets/js/pages/ProjectContributorsAddPage/AddContributors.tsx
+++ b/app/assets/js/pages/ProjectContributorsAddPage/AddContributors.tsx
@@ -1,7 +1,7 @@
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Projects from "@/models/projects";
-import * as Icons from "@tabler/icons-react";
+import { IconPlus, IconX } from "turboui";
 import * as React from "react";
 
 import { useAddProjectContributors } from "@/api";
@@ -139,7 +139,7 @@ function AddMoreContributorsButton({ onClick }: { onClick: () => void }) {
   return (
     <div className="flex justify-center" style={{ marginTop: "-18px" }} data-test-id={createTestId("add-more")}>
       <SecondaryButton onClick={onClick}>
-        <Icons.IconPlus size={16} />
+        <IconPlus size={16} />
       </SecondaryButton>
     </div>
   );
@@ -161,7 +161,7 @@ function RemoveContributorButton({ index }) {
         className="border border-surface-outline rounded-full p-2 cursor-pointer text-content-subtle hover:text-content-accent bg-surface-base"
         onClick={onClick}
       >
-        <Icons.IconX size={16} />
+        <IconX size={16} />
       </div>
     </div>
   );

--- a/app/assets/js/pages/ProjectEditTimelinePage/MilestoneList.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/MilestoneList.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Milestones from "@/models/milestones";
 import * as TipTapEditor from "@/components/Editor";
 import * as Time from "@/utils/time";
-import * as Icons from "@tabler/icons-react";
+import { IconPlus, IconFlag3Filled, IconPencil, IconTrash } from "turboui";
 
 import classNames from "classnames";
 import FormattedTime from "@/components/FormattedTime";
@@ -56,7 +56,7 @@ function AddMilestoneButton({ onClick }) {
     >
       <div className="flex flex-col flex-1">
         <div className="flex items-center gap-1 text-content-dimmed font-medium">
-          <Icons.IconPlus size={16} className="text-content-dimmed shrink-0" />
+          <IconPlus size={16} className="text-content-dimmed shrink-0" />
           Add milestone
         </div>
       </div>
@@ -118,7 +118,7 @@ function MilestoneDisplay({ milestone, form, edit }) {
       <div className="flex items-start justify-between">
         <div className="flex flex-col flex-1">
           <div className="font-bold flex items-center gap-1">
-            <Icons.IconFlag3Filled size={16} className="shrink-0" />
+            <IconFlag3Filled size={16} className="shrink-0" />
             {milestone.title}
           </div>
 
@@ -138,7 +138,7 @@ function MilestoneDisplay({ milestone, form, edit }) {
               onClick={edit}
               data-test-id={"edit-" + milestoneTestID(milestone)}
             >
-              <Icons.IconPencil size={16} />
+              <IconPencil size={16} />
             </div>
 
             {milestone.deletable && (
@@ -147,7 +147,7 @@ function MilestoneDisplay({ milestone, form, edit }) {
                 onClick={() => form.milestoneList.remove(milestone.id)}
                 data-test-id={"remove-" + milestoneTestID(milestone)}
               >
-                <Icons.IconTrash size={16} />
+                <IconTrash size={16} />
               </div>
             )}
           </div>

--- a/app/assets/js/pages/ProjectMilestonePage/Options.tsx
+++ b/app/assets/js/pages/ProjectMilestonePage/Options.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
+import { IconEdit, IconArchive } from "turboui";
 import { FormState } from "./useForm";
 
 export function Options({ form }: { form: FormState }) {
@@ -10,7 +11,7 @@ export function Options({ form }: { form: FormState }) {
     <PageOptions.Root testId="project-options-button">
       {form.milestone.permissions?.canEditMilestone && (
         <PageOptions.Action
-          icon={Icons.IconEdit}
+          icon={IconEdit}
           title="Edit Name and Due Date"
           onClick={form.titleAndDeadline.startEditing}
           testId="edit-project-name-button"
@@ -18,7 +19,7 @@ export function Options({ form }: { form: FormState }) {
       )}
       {form.milestone.permissions?.canEditMilestone && (
         <PageOptions.Action
-          icon={Icons.IconArchive}
+          icon={IconArchive}
           title="Archive this milestone"
           onClick={form.archive}
           testId="archive-milestone-button"

--- a/app/assets/js/pages/ProjectMilestonePage/page.tsx
+++ b/app/assets/js/pages/ProjectMilestonePage/page.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Icons from "@tabler/icons-react";
+import { IconPencil, IconPlus } from "turboui";
 import * as Tasks from "@/models/tasks";
 
 import { useLoadedData, useRefresh } from "./loader";
@@ -76,7 +76,7 @@ function EditDescription({ form }) {
         className={"text-sm font-bold rounded-full p-1 hover:scale-110 transition cursor-pointer bg-sky-200"}
         onClick={() => form.description.startEditing()}
       >
-        <Icons.IconPencil size={14} />
+        <IconPencil size={14} />
       </div>
     </>
   );
@@ -90,7 +90,7 @@ function AddTask({ onClick }) {
         onClick={onClick}
         data-test-id="add-task"
       >
-        <Icons.IconPlus size={14} />
+        <IconPlus size={14} />
       </div>
     </>
   );

--- a/app/assets/js/pages/ProjectPage/Header.tsx
+++ b/app/assets/js/pages/ProjectPage/Header.tsx
@@ -1,10 +1,9 @@
 import * as Goals from "@/models/goals";
 import * as Projects from "@/models/projects";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import { PrivacyIndicator } from "@/features/Permissions";
-import { DimmedLink, DivLink } from "turboui";
+import { DimmedLink, DivLink, IconHexagons, IconTarget } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export function Header({ project }: { project: Projects.Project }) {
@@ -28,7 +27,7 @@ function ProjectName({ project }) {
 function ProjectIcon() {
   return (
     <div className="bg-indigo-500/10 p-1.5 rounded-lg">
-      <Icons.IconHexagons size={24} className="text-indigo-500" />
+      <IconHexagons size={24} className="text-indigo-500" />
     </div>
   );
 }
@@ -58,7 +57,7 @@ function ParentGoalLinked({ goal }: { goal: Goals.Goal }) {
   const paths = usePaths();
   return (
     <>
-      <Icons.IconTarget size={14} className="text-red-500" />
+      <IconTarget size={14} className="text-red-500" />
       <DivLink
         to={paths.goalPath(goal.id!)}
         className="text-sm text-content-dimmed mx-1 hover:underline font-medium"

--- a/app/assets/js/pages/ProjectPage/ProjectOptions.tsx
+++ b/app/assets/js/pages/ProjectPage/ProjectOptions.tsx
@@ -1,7 +1,8 @@
+import * as React from "react";
+
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as Projects from "@/models/projects";
-import * as Icons from "@tabler/icons-react";
-import * as React from "react";
+import { IconPlayerPlayFilled, IconEdit, IconPlayerPauseFilled, IconExchange, IconReplace, IconCircleCheck } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export function ProjectOptions({ project }) {
@@ -10,7 +11,7 @@ export function ProjectOptions({ project }) {
     <PageOptions.Root testId="project-options-button">
       {project.permissions.canPause && Projects.isResumable(project) && (
         <PageOptions.Link
-          icon={Icons.IconPlayerPlayFilled}
+          icon={IconPlayerPlayFilled}
           title="Resume the project"
           to={paths.resumeProjectPath(project.id)}
           testId="resume-project-link"
@@ -19,7 +20,7 @@ export function ProjectOptions({ project }) {
 
       {project.permissions.canEditName && (
         <PageOptions.Link
-          icon={Icons.IconEdit}
+          icon={IconEdit}
           title="Edit project name"
           to={paths.editProjectNamePath(project.id)}
           testId="edit-project-name-button"
@@ -28,7 +29,7 @@ export function ProjectOptions({ project }) {
 
       {project.permissions.canPause && Projects.isPausable(project) && (
         <PageOptions.Link
-          icon={Icons.IconPlayerPauseFilled}
+          icon={IconPlayerPauseFilled}
           title="Pause the project"
           to={paths.pauseProjectPath(project.id)}
           testId="pause-project-link"
@@ -37,7 +38,7 @@ export function ProjectOptions({ project }) {
 
       {project.permissions.canEditGoal && (
         <PageOptions.Link
-          icon={Icons.IconExchange}
+          icon={IconExchange}
           title="Change Parent Goal"
           to={paths.editProjectGoalPath(project.id)}
           testId="connect-project-to-goal-link"
@@ -46,7 +47,7 @@ export function ProjectOptions({ project }) {
 
       {project.permissions.canEditSpace && (
         <PageOptions.Link
-          icon={Icons.IconReplace}
+          icon={IconReplace}
           title="Move project to another space"
           to={paths.moveProjectPath(project.id)}
           testId="move-project-link"
@@ -55,7 +56,7 @@ export function ProjectOptions({ project }) {
 
       {project.permissions.canClose && project.status !== "closed" && (
         <PageOptions.Link
-          icon={Icons.IconCircleCheck}
+          icon={IconCircleCheck}
           title="Close the project"
           to={paths.projectClosePath(project.id)}
           testId="close-project"

--- a/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -10,8 +10,7 @@ import { Spacer } from "@/components/Spacer";
 import { CommentSection, useComments } from "@/features/CommentSection";
 import { ReactionList, useReactionsForm } from "@/features/Reactions";
 import { CurrentSubscriptions } from "@/features/Subscriptions";
-import { IconEdit } from "@tabler/icons-react";
-import { AvatarWithName } from "turboui";
+import { AvatarWithName, IconEdit } from "turboui";
 
 import { useClearNotificationsOnLoad } from "@/features/notifications";
 import { RetrospectiveContent } from "@/features/ProjectRetrospective";

--- a/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubDocumentPage/Options.tsx
@@ -5,7 +5,7 @@ import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import { assertPresent } from "@/utils/assertions";
 
 import { downloadMarkdown, exportToMarkdown } from "@/utils/markdown";
-import { IconCopy, IconEdit, IconFileExport, IconTrash } from "@tabler/icons-react";
+import { IconCopy, IconEdit, IconFileExport, IconTrash } from "turboui";
 import { useLoadedData } from "./loader";
 
 interface Props {

--- a/app/assets/js/pages/ResourceHubFilePage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubFilePage/Options.tsx
@@ -1,5 +1,5 @@
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import * as Icons from "@tabler/icons-react";
+import { IconEdit, IconDownload, IconTrash } from "turboui";
 import React from "react";
 
 import { useDownloadFile } from "@/models/blobs";
@@ -23,7 +23,7 @@ export function Options({ showDeleteModal }: Props) {
 
       {file.permissions.canEditFile && (
         <PageOptions.Link
-          icon={Icons.IconEdit}
+          icon={IconEdit}
           title="Edit"
           to={paths.resourceHubEditFilePath(file.id!)}
           testId="edit-file-link"
@@ -43,10 +43,10 @@ function DownloadAction() {
   const [downloadFile] = useDownloadFile(file.blob.url, file.name);
 
   return (
-    <PageOptions.Action icon={Icons.IconDownload} title="Download" onClick={downloadFile} testId="download-file-link" />
+    <PageOptions.Action icon={IconDownload} title="Download" onClick={downloadFile} testId="download-file-link" />
   );
 }
 
 function DeleteAction({ onClick }: { onClick: () => void }) {
-  return <PageOptions.Action icon={Icons.IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
+  return <PageOptions.Action icon={IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
 }

--- a/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
+++ b/app/assets/js/pages/ResourceHubLinkPage/Options.tsx
@@ -1,5 +1,5 @@
 import * as PageOptions from "@/components/PaperContainer/PageOptions";
-import * as Icons from "@tabler/icons-react";
+import { IconEdit, IconTrash } from "turboui";
 import React from "react";
 
 import { usePaths } from "@/routes/paths";
@@ -19,7 +19,7 @@ export function Options({ showDeleteModal }: Props) {
     <PageOptions.Root testId="options-button">
       {link.permissions.canEditLink && (
         <PageOptions.Link
-          icon={Icons.IconEdit}
+          icon={IconEdit}
           title="Edit"
           to={paths.resourceHubEditLinkPath(link.id!)}
           testId="edit-link-link"
@@ -35,5 +35,5 @@ interface DeleteActionProps {
 }
 
 function DeleteAction({ onClick }: DeleteActionProps) {
-  return <PageOptions.Action icon={Icons.IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
+  return <PageOptions.Action icon={IconTrash} title="Delete" onClick={onClick} testId="delete-resource-link" />;
 }

--- a/app/assets/js/pages/ReviewPage/AssignmentsList.tsx
+++ b/app/assets/js/pages/ReviewPage/AssignmentsList.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 
-import { IconTarget, IconHexagons } from "@tabler/icons-react";
 import { ReviewAssignment, AssignmentType } from "@/models/assignments";
 
 import FormattedTime from "@/components/FormattedTime";
 import { parseDate, relativeDay } from "@/utils/time";
 import { match } from "ts-pattern";
-import { DivLink } from "turboui";
+import { DivLink, IconTarget, IconHexagons } from "turboui";
 import classNames from "classnames";
 import { assertPresent } from "@/utils/assertions";
 

--- a/app/assets/js/pages/ReviewPage/page.tsx
+++ b/app/assets/js/pages/ReviewPage/page.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Signals from "@/signals";
-import * as Icons from "@tabler/icons-react";
 
 import { useLoadedData } from "./loader";
 import { AssignmentsList } from "./AssignmentsList";
 import classNames from "classnames";
+import { IconCoffee, IconMailFast, IconSparkles } from "turboui";
 
 export function Page() {
   const onLoad = () => Signals.publish(Signals.LocalSignal.RefreshReviewCount);
@@ -47,7 +47,7 @@ function Title() {
 function TitleIcon() {
   return (
     <div className="flex items-center justify-center">
-      <Icons.IconCoffee size={24} className="text-content-dimmed" />
+      <IconCoffee size={24} className="text-content-dimmed" />
     </div>
   );
 }
@@ -65,7 +65,7 @@ function SendingEmailsBanner() {
   return (
     <div className={className}>
       Sending you an email every morning
-      <Icons.IconMailFast size={20} className="inline-block ml-2" />
+      <IconMailFast size={20} className="inline-block ml-2" />
     </div>
   );
 }
@@ -119,7 +119,7 @@ function ForReview() {
 function MyWorkEmpty() {
   return (
     <div className="px-4 mt-4 flex items-center justify-center py-20 gap-2">
-      <Icons.IconSparkles size={20} className="text-yellow-500" />
+      <IconSparkles size={20} className="text-yellow-500" />
       All caught up!
     </div>
   );
@@ -128,7 +128,7 @@ function MyWorkEmpty() {
 function ForReviewEmpty() {
   return (
     <div className="px-4 mt-4 flex items-center justify-center py-28 gap-2">
-      <Icons.IconSparkles size={20} className="text-yellow-500" />
+      <IconSparkles size={20} className="text-yellow-500" />
       Nothing to review.
     </div>
   );

--- a/app/assets/js/pages/SpaceAddMembersPage/index.tsx
+++ b/app/assets/js/pages/SpaceAddMembersPage/index.tsx
@@ -2,8 +2,9 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
 import * as Spaces from "@/models/spaces";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
+
+import { IconPlus, IconX } from "turboui";
 
 import { PERMISSIONS_LIST, PermissionLevels } from "@/features/Permissions";
 
@@ -118,7 +119,7 @@ function AddMoreMembersButton({ onClick }: { onClick: () => void }) {
   return (
     <div className="flex justify-center" style={{ marginTop: "-18px" }} data-test-id={createTestId("add-more")}>
       <SecondaryButton onClick={onClick}>
-        <Icons.IconPlus size={16} />
+        <IconPlus size={16} />
       </SecondaryButton>
     </div>
   );
@@ -140,7 +141,7 @@ function RemoveMemberButton({ index }) {
         className="border border-surface-outline rounded-full p-2 cursor-pointer text-content-subtle hover:text-content-accent bg-surface-base"
         onClick={onClick}
       >
-        <Icons.IconX size={16} />
+        <IconX size={16} />
       </div>
     </div>
   );

--- a/app/assets/js/pages/TaskPage/page.tsx
+++ b/app/assets/js/pages/TaskPage/page.tsx
@@ -3,11 +3,10 @@ import * as Forms from "@/components/Form";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Tasks from "@/models/tasks";
-import * as Icons from "@tabler/icons-react";
 import * as React from "react";
 
 import RichContent from "@/components/RichContent";
-import { Avatar, PrimaryButton, SecondaryButton } from "turboui";
+import { Avatar, PrimaryButton, SecondaryButton, IconPencil, IconChecks } from "turboui";
 
 import { isContentEmpty } from "@/components/RichContent/isContentEmpty";
 import { MultiPeopleSearch } from "@/features/Tasks/NewTaskModal/MultiPeopleSearch";
@@ -124,7 +123,7 @@ function HeaderIcon({ form }: { form: FormState }) {
 
   return (
     <div className="">
-      <Icons.IconChecks size={48} className="text-accent-1" />
+      <IconChecks size={48} className="text-accent-1" />
     </div>
   );
 }
@@ -250,7 +249,7 @@ function EditDescription({ form, color }: { form: FormState; color: string }) {
         onClick={form.descriptionForm.startEditing}
         data-test-id="edit-description"
       >
-        <Icons.IconPencil size={12} />
+        <IconPencil size={12} />
       </div>
     </>
   );

--- a/app/ee/assets/js/layouts/SaasAdminLayout.tsx
+++ b/app/ee/assets/js/layouts/SaasAdminLayout.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
 
 import { Outlet } from "react-router-dom";
 
@@ -7,7 +6,7 @@ import { DevBar } from "@/features/DevBar";
 import { useScrollToTopOnNavigationChange } from "@/hooks/useScrollToTopOnNavigationChange";
 import { DivLink } from "turboui";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
-import { SecondaryButton } from "turboui";
+import { SecondaryButton, IconDoorExit } from "turboui";
 
 export default function SaasAdminLayout() {
   const outletDiv = React.useRef<HTMLDivElement>(null);
@@ -39,7 +38,7 @@ function Navigation() {
 
         <div>
           <SecondaryButton linkTo="/" size="sm">
-            <Icons.IconDoorExit className="inline-block mr-2" size={16} /> Exit Admin Panel
+            <IconDoorExit className="inline-block mr-2" size={16} /> Exit Admin Panel
           </SecondaryButton>
         </div>
       </div>

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
@@ -6,8 +6,7 @@ import * as React from "react";
 import { EnableFeatureModal } from "./EnableFeatureModal";
 
 import FormattedTime from "@/components/FormattedTime";
-import { IconFlare } from "@tabler/icons-react";
-import { Avatar } from "turboui";
+import { Avatar, IconFlare } from "turboui";
 
 import { useBoolState } from "@/hooks/useBoolState";
 import { useLoadedData } from "./loader";

--- a/app/jest.config.json
+++ b/app/jest.config.json
@@ -11,6 +11,9 @@
   "moduleNameMapper": {
     "^turboui$": "<rootDir>/../turboui/src",
     "^@/ee/(.*)$": "<rootDir>/ee/assets/js/$1",
-    "^@/(.*)$": "<rootDir>/assets/js/$1"
+    "^@/(.*)$": "<rootDir>/assets/js/$1",
+    "^@tabler/icons-react/dist/esm/icons/(.+)\\.mjs$": "<rootDir>/assets/js/__tests__/mocks/tabler-icons-react.js",
+    "^@tabler/icons-react/dist/esm/(.+)\\.mjs$": "<rootDir>/assets/js/__tests__/mocks/tabler-icons-react.js",
+    "^@tabler/icons-react$": "<rootDir>/assets/js/__tests__/mocks/tabler-icons-react.js"
   }
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,6 @@
         "@radix-ui/react-popover": "^1.0.5",
         "@radix-ui/react-tooltip": "^1.0.6",
         "@sentry/react": "^7.76.0",
-        "@tabler/icons-react": "^3.14.0",
         "@tiptap/core": "^2.3.0",
         "@tiptap/extension-link": "^2.3.0",
         "@tiptap/extension-mention": "^2.3.0",
@@ -74,6 +73,7 @@
     "../turboui": {
       "license": "Apache-2.0",
       "dependencies": {
+        "@tabler/icons-react": "^3.14.0",
         "@tiptap/core": "^2.3.0",
         "@tiptap/extension-link": "^2.3.0",
         "@tiptap/extension-mention": "^2.3.0",
@@ -110,7 +110,6 @@
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-popover": "^1.0.5",
         "@radix-ui/react-tooltip": "^1.0.6",
-        "@tabler/icons-react": "^3.14.0",
         "@types/react": "^18.3.5",
         "@types/react-datepicker": "^4.19.6",
         "date-fns": "^2.30.0",
@@ -3895,30 +3894,6 @@
       },
       "engines": {
         "node": ">=8.10"
-      }
-    },
-    "node_modules/@tabler/icons": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.14.0.tgz",
-      "integrity": "sha512-OakKjK1kuDWKoNwdnHHVMt11kTZAC10iZpN/8o/CSYdeBH7S3v5n8IyqAYynFxLI8yBGTyBvljtvWdmWh57zSg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      }
-    },
-    "node_modules/@tabler/icons-react": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.14.0.tgz",
-      "integrity": "sha512-3XdbuyhBNq8aZW0qagR9YL8diACZYSAtaw6VuwcO2l6HzVFPN6N5TDex9WTz/3lf+uktAvOv1kNuuFBjSjN9yw==",
-      "dependencies": {
-        "@tabler/icons": "3.14.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      },
-      "peerDependencies": {
-        "react": ">= 16"
       }
     },
     "node_modules/@tiptap/core": {
@@ -12047,19 +12022,6 @@
         "p-map": "^4.0.0"
       }
     },
-    "@tabler/icons": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.14.0.tgz",
-      "integrity": "sha512-OakKjK1kuDWKoNwdnHHVMt11kTZAC10iZpN/8o/CSYdeBH7S3v5n8IyqAYynFxLI8yBGTyBvljtvWdmWh57zSg=="
-    },
-    "@tabler/icons-react": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.14.0.tgz",
-      "integrity": "sha512-3XdbuyhBNq8aZW0qagR9YL8diACZYSAtaw6VuwcO2l6HzVFPN6N5TDex9WTz/3lf+uktAvOv1kNuuFBjSjN9yw==",
-      "requires": {
-        "@tabler/icons": "3.14.0"
-      }
-    },
     "@tiptap/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.5.tgz",
@@ -15945,6 +15907,7 @@
         "@storybook/react": "^8.6.14",
         "@storybook/react-vite": "^8.6.14",
         "@storybook/test": "^8.6.14",
+        "@tabler/icons-react": "^3.14.0",
         "@tiptap/core": "^2.3.0",
         "@tiptap/extension-link": "^2.3.0",
         "@tiptap/extension-mention": "^2.3.0",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,7 +25,6 @@
         "date-fns": "^2.30.0",
         "dot-prop": "^9.0.0",
         "i18next": "^22.4.14",
-        "lucide-react": "^0.475.0",
         "nprogress": "^0.2.0",
         "phoenix": "^1.7.14",
         "prosemirror-markdown": "^1.13.1",
@@ -83,7 +82,6 @@
         "@tiptap/react": "^2.3.0",
         "@tiptap/starter-kit": "^2.3.0",
         "@tiptap/suggestion": "^2.3.0",
-        "lucide-react": "^0.475.0",
         "react-hook-form": "^7.56.1",
         "react-hot-toast": "^2.5.2"
       },
@@ -7746,14 +7744,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lucide-react": {
-      "version": "0.475.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.475.0.tgz",
-      "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -14843,12 +14833,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "lucide-react": {
-      "version": "0.475.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.475.0.tgz",
-      "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
-      "requires": {}
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -15974,7 +15958,6 @@
         "esbuild": "0.25.2",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.7.0",
-        "lucide-react": "^0.475.0",
         "postcss": "^8.4.14",
         "react-hook-form": "^7.56.1",
         "react-hot-toast": "^2.5.2",

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,6 @@
     "date-fns": "^2.30.0",
     "dot-prop": "^9.0.0",
     "i18next": "^22.4.14",
-    "lucide-react": "^0.475.0",
     "nprogress": "^0.2.0",
     "phoenix": "^1.7.14",
     "prosemirror-markdown": "^1.13.1",

--- a/app/package.json
+++ b/app/package.json
@@ -5,7 +5,6 @@
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-tooltip": "^1.0.6",
     "@sentry/react": "^7.76.0",
-    "@tabler/icons-react": "^3.14.0",
     "@tiptap/core": "^2.3.0",
     "@tiptap/extension-link": "^2.3.0",
     "@tiptap/extension-mention": "^2.3.0",

--- a/app/priv/static/.vite/manifest.json
+++ b/app/priv/static/.vite/manifest.json
@@ -1,15 +1,15 @@
 {
-  "_vendor-DYFCo7zV.js": {
-    "file": "assets/vendor-DYFCo7zV.js",
+  "_vendor-6mcE7grO.js": {
+    "file": "assets/vendor-6mcE7grO.js",
     "name": "vendor"
   },
   "assets/js/app.tsx": {
-    "file": "assets/app-D1bwdeZ9.js",
+    "file": "assets/app-Cs8iBAN9.js",
     "name": "app",
     "src": "assets/js/app.tsx",
     "isEntry": true,
     "imports": [
-      "_vendor-DYFCo7zV.js"
+      "_vendor-6mcE7grO.js"
     ]
   }
 }

--- a/turboui/jest.config.json
+++ b/turboui/jest.config.json
@@ -9,9 +9,6 @@
     "<rootDir>/node_modules"
   ],
   "testEnvironment": "jsdom",
-  "transformIgnorePatterns": [
-    "/node_modules/(?!lucide-react|.+\\.js$)"
-  ],
   "moduleNameMapper": {
     "\\.css$": "<rootDir>/src/__mocks__/styleMock.js"
   }

--- a/turboui/jest.config.json
+++ b/turboui/jest.config.json
@@ -10,6 +10,10 @@
   ],
   "testEnvironment": "jsdom",
   "moduleNameMapper": {
-    "\\.css$": "<rootDir>/src/__mocks__/styleMock.js"
+    "\\.css$": "<rootDir>/src/__mocks__/styleMock.js",
+    "^@tabler/icons-react/dist/esm/icons/(.+)\\.mjs$": "<rootDir>/src/__mocks__/@tabler/icons-react.js",
+    "^@tabler/icons-react/dist/esm/(.+)\\.mjs$": "<rootDir>/src/__mocks__/@tabler/icons-react.js",
+    "^@tabler/icons-react$": "<rootDir>/src/__mocks__/@tabler/icons-react.js"
   }
 }
+

--- a/turboui/package-lock.json
+++ b/turboui/package-lock.json
@@ -7,6 +7,7 @@
       "name": "turboui",
       "license": "Apache-2.0",
       "dependencies": {
+        "@tabler/icons-react": "^3.14.0",
         "@tiptap/core": "^2.3.0",
         "@tiptap/extension-link": "^2.3.0",
         "@tiptap/extension-mention": "^2.3.0",
@@ -15,7 +16,6 @@
         "@tiptap/react": "^2.3.0",
         "@tiptap/starter-kit": "^2.3.0",
         "@tiptap/suggestion": "^2.3.0",
-        "lucide-react": "^0.475.0",
         "react-hook-form": "^7.56.1",
         "react-hot-toast": "^2.5.2"
       },
@@ -44,7 +44,6 @@
         "@radix-ui/react-dropdown-menu": "^2.1.1",
         "@radix-ui/react-popover": "^1.0.5",
         "@radix-ui/react-tooltip": "^1.0.6",
-        "@tabler/icons-react": "^3.14.0",
         "@types/react": "^18.3.5",
         "@types/react-datepicker": "^4.19.6",
         "date-fns": "^2.30.0",
@@ -3942,7 +3941,6 @@
       "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.31.0.tgz",
       "integrity": "sha512-dblAdeKY3+GA1U+Q9eziZ0ooVlZMHsE8dqP0RkwvRtEsAULoKOYaCUOcJ4oW1DjWegdxk++UAt2SlQVnmeHv+g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/codecalm"
@@ -3953,7 +3951,6 @@
       "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.31.0.tgz",
       "integrity": "sha512-2rrCM5y/VnaVKnORpDdAua9SEGuJKVqPtWxeQ/vUVsgaUx30LDgBZph7/lterXxDY1IKR6NO//HDhWiifXTi3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tabler/icons": "3.31.0"
       },
@@ -8774,14 +8771,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
-    },
-    "node_modules/lucide-react": {
-      "version": "0.475.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.475.0.tgz",
-      "integrity": "sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/turboui/package.json
+++ b/turboui/package.json
@@ -65,7 +65,6 @@
     "@tiptap/starter-kit": "^2.3.0",
     "@tiptap/suggestion": "^2.3.0",
     "react-hot-toast": "^2.5.2",
-    "lucide-react": "^0.475.0",
     "react-hook-form": "^7.56.1"
   }
 }

--- a/turboui/package.json
+++ b/turboui/package.json
@@ -42,7 +42,6 @@
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-popover": "^1.0.5",
     "@radix-ui/react-tooltip": "^1.0.6",
-    "@tabler/icons-react": "^3.14.0",
     "@types/react": "^18.3.5",
     "@types/react-datepicker": "^4.19.6",
     "date-fns": "^2.30.0",
@@ -64,6 +63,7 @@
     "@tiptap/react": "^2.3.0",
     "@tiptap/starter-kit": "^2.3.0",
     "@tiptap/suggestion": "^2.3.0",
+    "@tabler/icons-react": "^3.14.0",
     "react-hot-toast": "^2.5.2",
     "react-hook-form": "^7.56.1"
   }

--- a/turboui/src/ActionList/index.stories.tsx
+++ b/turboui/src/ActionList/index.stories.tsx
@@ -6,7 +6,7 @@ import {
   IconRotateDot,
   IconSettings,
   IconTrash,
-} from "@tabler/icons-react";
+} from "../icons";
 import React from "react";
 import { ActionList } from ".";
 

--- a/turboui/src/Button/Button.stories.tsx
+++ b/turboui/src/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconHome, IconSearch, IconSettings, IconStar, IconUser } from "@tabler/icons-react";
+import { IconHome, IconSearch, IconSettings, IconStar, IconUser } from "../icons";
 import { DangerButton, GhostButton, PrimaryButton, SecondaryButton } from "./index";
 
 const meta = {

--- a/turboui/src/Button/UnstalyedButton.tsx
+++ b/turboui/src/Button/UnstalyedButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import type { IconProps } from "@tabler/icons-react";
-import { IconChevronDown } from "@tabler/icons-react";
+import type { IconProps } from "../icons";
+import { IconChevronDown } from "../icons";
 import { match } from "ts-pattern";
 import { DivLink } from "../Link";
 import { Menu } from "../Menu";

--- a/turboui/src/Callouts/index.tsx
+++ b/turboui/src/Callouts/index.tsx
@@ -6,7 +6,7 @@ import {
   IconCircleCheckFilled,
   IconCircleXFilled,
   IconInfoCircleFilled,
-} from "@tabler/icons-react";
+} from "../icons";
 
 interface Props extends TestableElement {
   message: string | JSX.Element;

--- a/turboui/src/Chronometer/index.tsx
+++ b/turboui/src/Chronometer/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { match } from "ts-pattern";
 import classNames from "../utils/classnames";
-import { IconAlertTriangleFilled } from "@tabler/icons-react";
+import { IconAlertTriangleFilled } from "../icons";
 import { Tooltip } from "../Tooltip";
 import { durationHumanized, overdueDays } from "../utils/time";
 

--- a/turboui/src/Colors/Colors.stories.tsx
+++ b/turboui/src/Colors/Colors.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconHome, IconUser, IconSettings, IconBell, IconHeart, IconStar } from "@tabler/icons-react";
+import { IconHome, IconUser, IconSettings, IconBell, IconHeart, IconStar } from "../icons";
 import { Page } from "../Page";
 
 const meta = {

--- a/turboui/src/CommentSection/ActivityComponents.tsx
+++ b/turboui/src/CommentSection/ActivityComponents.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AvatarWithName } from "../Avatar";
 import FormattedTime from "../FormattedTime";
-import * as Icons from "@tabler/icons-react";
+import { IconSquareCheckFilled, IconSquareChevronsLeftFilled } from "../icons";
 import { ActivityProps, AcknowledgmentProps } from "./types";
 
 export function MilestoneCompletedActivity({ activity }: ActivityProps) {
@@ -17,7 +17,7 @@ export function MilestoneCompletedActivity({ activity }: ActivityProps) {
               link={activity.author.profileLink}
               className="font-semibold"
             />
-            <Icons.IconSquareCheckFilled size={20} className="text-accent-1" />
+            <IconSquareCheckFilled size={20} className="text-accent-1" />
             <div className="pr-2 font-semibold text-content-accent">
               completed the milestone
             </div>
@@ -47,7 +47,7 @@ export function MilestoneReopenedActivity({ activity }: ActivityProps) {
               link={activity.author.profileLink}
               className="font-semibold"
             />
-            <Icons.IconSquareChevronsLeftFilled size={20} className="text-yellow-500" />
+            <IconSquareChevronsLeftFilled size={20} className="text-yellow-500" />
             <div className="pr-2 font-semibold text-content-accent">
               re-opened the milestone
             </div>
@@ -77,7 +77,7 @@ export function AcknowledgmentActivity({ person, ackAt }: AcknowledgmentProps) {
             className="font-semibold"
           />
           <span>acknowledged this Check-In</span>
-          <Icons.IconSquareCheckFilled size={24} className="text-accent-1" />
+          <IconSquareCheckFilled size={24} className="text-accent-1" />
         </div>
 
         <div className="flex items-center justify-between">

--- a/turboui/src/CommentSection/CommentItem.tsx
+++ b/turboui/src/CommentSection/CommentItem.tsx
@@ -5,7 +5,7 @@ import { Menu, MenuActionItem } from "../Menu";
 import { BlackLink } from "../Link";
 import FormattedTime from "../FormattedTime";
 import RichContent from "../RichContent";
-import * as Icons from "@tabler/icons-react";
+import { IconEdit } from "../icons";
 import { CommentItemProps } from "./types";
 
 export function CommentItem({
@@ -45,7 +45,7 @@ export function CommentItem({
 
             {isOwnComment && onEdit && (
               <Menu size="small">
-                <MenuActionItem onClick={onEdit} icon={Icons.IconEdit}>
+                <MenuActionItem onClick={onEdit} icon={IconEdit}>
                   Edit
                 </MenuActionItem>
               </Menu>

--- a/turboui/src/DateField/index.tsx
+++ b/turboui/src/DateField/index.tsx
@@ -1,5 +1,5 @@
 import * as Popover from "@radix-ui/react-popover";
-import { IconCalendarEvent, IconCalendarPlus, IconX } from "@tabler/icons-react";
+import { IconCalendarEvent, IconCalendarPlus, IconX } from "../icons";
 import React, { useState } from "react";
 import ReactDatePicker from "react-datepicker";
 import { SecondaryButton } from "../Button";

--- a/turboui/src/GoalField/index.stories.tsx
+++ b/turboui/src/GoalField/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconTarget } from "@tabler/icons-react";
+import { IconTarget } from "../icons";
 import React from "react";
 import { Page } from "../Page";
 import { GoalField } from "./index";

--- a/turboui/src/GoalField/index.tsx
+++ b/turboui/src/GoalField/index.tsx
@@ -1,7 +1,7 @@
 import * as Popover from "@radix-ui/react-popover";
 import * as React from "react";
 
-import { IconCircleX, IconExternalLink, IconSearch } from "@tabler/icons-react";
+import { IconCircleX, IconExternalLink, IconSearch } from "../icons";
 import { IconGoal } from "../icons";
 import { DivLink } from "../Link";
 import { createTestId } from "../TestableElement";

--- a/turboui/src/GoalPage/Contributors.tsx
+++ b/turboui/src/GoalPage/Contributors.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle } from "../icons";
 import { GoalPage } from ".";
 import { Avatar } from "../Avatar";
 import { BlackLink, Link } from "../Link";

--- a/turboui/src/GoalPage/PageHeader.tsx
+++ b/turboui/src/GoalPage/PageHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IconChevronRight } from "@tabler/icons-react";
+import { IconChevronRight } from "../icons";
 import { GoalPage } from ".";
 import { IconGoal } from "../icons";
 import { BlackLink } from "../Link";

--- a/turboui/src/GoalPage/Sidebar.tsx
+++ b/turboui/src/GoalPage/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
   IconTrash,
   IconUserCheck,
   IconUserStar,
-} from "@tabler/icons-react";
+} from "../icons";
 
 export function Sidebar(props: GoalPage.State) {
   return (

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -4,7 +4,7 @@ import type { MiniWorkMap } from "../MiniWorkMap";
 
 import { PageNew } from "../Page";
 
-import { IconClipboardText, IconLogs, IconMessage, IconMessages } from "@tabler/icons-react";
+import { IconClipboardText, IconLogs, IconMessage, IconMessages } from "../icons";
 
 import { PrivacyField } from "../PrivacyField";
 import { MentionedPersonLookupFn } from "../RichEditor";

--- a/turboui/src/GoalTargetList/DeleteButton.tsx
+++ b/turboui/src/GoalTargetList/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import { IconTrash } from "@tabler/icons-react";
+import { IconTrash } from "../icons";
 import React from "react";
 import { SecondaryButton } from "../Button";
 import { State, TargetState } from "./useGoalTargetListState";

--- a/turboui/src/GoalTargetList/EditButton.tsx
+++ b/turboui/src/GoalTargetList/EditButton.tsx
@@ -1,4 +1,4 @@
-import { IconPencil } from "@tabler/icons-react";
+import { IconPencil } from "../icons";
 import React from "react";
 import { SecondaryButton } from "../Button";
 import { createTestId } from "../TestableElement";

--- a/turboui/src/GoalTargetList/ExpandIcon.tsx
+++ b/turboui/src/GoalTargetList/ExpandIcon.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { IconChevronDown } from "@tabler/icons-react";
+import { IconChevronDown } from "../icons";
 
 interface Props {
   expanded: boolean;

--- a/turboui/src/GoalTargetList/index.tsx
+++ b/turboui/src/GoalTargetList/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { PieChart } from "../PieChart";
 import { ExpandIcon } from "./ExpandIcon";
 
-import { IconGripVertical } from "@tabler/icons-react";
+import { IconGripVertical } from "../icons";
 import { DangerButton, PrimaryButton, SecondaryButton } from "../Button";
 import { DragAndDropProvider, useDraggable, useDraggingAnimation, useDropZone } from "../utils/DragAndDrop";
 

--- a/turboui/src/Menu/index.tsx
+++ b/turboui/src/Menu/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import * as Icons from "@tabler/icons-react";
+import { IconDots, IconChevronRight } from "../icons";
 
 import { TestableElement, createTestId } from "../TestableElement";
 import { DivLink } from "../Link";
@@ -67,7 +67,7 @@ function Trigger(props: MenuProps) {
   } else {
     return (
       <DropdownMenu.Trigger className={menuTriggerClass} data-test-id={props.testId}>
-        <Icons.IconDots size={20} />
+        <IconDots size={20} />
       </DropdownMenu.Trigger>
     );
   }
@@ -81,7 +81,7 @@ export function SubMenu({ label, icon, children, hidden }: SubMenuProps) {
       <DropdownMenu.SubTrigger asChild>
         <div className={menuItemClass} data-test-id={createTestId(label)}>
           <MenuItemIconAndTitle icon={icon}>{label}</MenuItemIconAndTitle>
-          <Icons.IconChevronRight size={16} />
+          <IconChevronRight size={16} />
         </div>
       </DropdownMenu.SubTrigger>
 

--- a/turboui/src/MilestoneField/index.tsx
+++ b/turboui/src/MilestoneField/index.tsx
@@ -1,7 +1,7 @@
 import * as Popover from "@radix-ui/react-popover";
 import * as React from "react";
 
-import { IconCircleX, IconExternalLink, IconSearch, IconFlag, IconPlus } from "@tabler/icons-react";
+import { IconCircleX, IconExternalLink, IconSearch, IconFlag, IconPlus } from "../icons";
 import { DivLink } from "../Link";
 import FormattedTime from "../FormattedTime";
 import classNames from "../utils/classnames";

--- a/turboui/src/MilestonePage/index.tsx
+++ b/turboui/src/MilestonePage/index.tsx
@@ -25,7 +25,7 @@ function calculateCompletionPercentage(stats: {
   return (stats.done / activeTasks) * 100;
 }
 // Using DateField instead of DueDateDisplay
-import { IconMessageCircle, IconPlus } from "@tabler/icons-react";
+import { IconMessageCircle, IconPlus } from "../icons";
 import { GhostButton } from "../Button";
 import { DateField } from "../DateField";
 import * as Types from "../TaskBoard/types";

--- a/turboui/src/Modal/index.tsx
+++ b/turboui/src/Modal/index.tsx
@@ -1,6 +1,7 @@
-import { IconX } from "@tabler/icons-react";
 import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+
+import { IconX } from "../icons";
 
 export interface ModalProps {
   /**

--- a/turboui/src/Page/Navigation.tsx
+++ b/turboui/src/Page/Navigation.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
-import * as Icons from "@tabler/icons-react";
+import { IconDots, IconSlash } from "../icons";
 import * as React from "react";
 
 import { Link } from "../Link";
@@ -54,7 +54,7 @@ function HiddenItems({ items, hiddenCount }: { items: Navigation.Item[]; hiddenC
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger className="border border-surface-outline px-1 rounded">
-        <Icons.IconDots className="cursor-pointer shrink-0" size={18} />
+        <IconDots className="cursor-pointer shrink-0" size={18} />
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
@@ -94,7 +94,7 @@ function NavSeparator() {
 
   return (
     <div className="shrink-0">
-      <Icons.IconSlash size={iconSize} />
+      <IconSlash size={iconSize} />
     </div>
   );
 }

--- a/turboui/src/Page/Page.stories.tsx
+++ b/turboui/src/Page/Page.stories.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Page } from "./index";
 import { PageFooter } from "./PageFooter";
-import { IconPencil } from "@tabler/icons-react";
-import { IconTrash } from "@tabler/icons-react";
+import { IconPencil, IconTrash } from "../icons";
 
 const meta = {
   title: "Components/Page",

--- a/turboui/src/Page/PageOptions.tsx
+++ b/turboui/src/Page/PageOptions.tsx
@@ -4,7 +4,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Page } from ".";
 import { match } from "ts-pattern";
 import { DivLink } from "../Link";
-import { IconX, IconDots } from "@tabler/icons-react";
+import { IconX, IconDots } from "../icons";
 import { createTestId } from "../TestableElement";
 
 import classNames from "classnames";

--- a/turboui/src/PersonField/index.stories.tsx
+++ b/turboui/src/PersonField/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { IconUserCheck } from "@tabler/icons-react";
+import { IconUserCheck } from "../icons";
 import React from "react";
 import { Page } from "../Page";
 import { genPeople, genPerson } from "../utils/storybook/genPeople";

--- a/turboui/src/PersonField/index.tsx
+++ b/turboui/src/PersonField/index.tsx
@@ -1,7 +1,7 @@
 import * as Popover from "@radix-ui/react-popover";
 import * as React from "react";
 
-import { IconCircleX, IconExternalLink, IconSearch, IconUser, IconUserPlus } from "@tabler/icons-react";
+import { IconCircleX, IconExternalLink, IconSearch, IconUser, IconUserPlus } from "../icons";
 import { Avatar } from "../Avatar";
 import { DivLink } from "../Link";
 import { createTestId } from "../TestableElement";

--- a/turboui/src/PrivacyField/index.tsx
+++ b/turboui/src/PrivacyField/index.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { match } from "ts-pattern";
 import classNames from "../utils/classnames";
 
-import { IconBuilding, IconChevronDown, IconLock, IconLockFilled, IconTent } from "@tabler/icons-react";
+import { IconBuilding, IconChevronDown, IconLock, IconLockFilled, IconTent } from "../icons";
 import { PrimaryButton, SecondaryButton } from "../Button";
 import { createTestId } from "../TestableElement";
 

--- a/turboui/src/PrivacyIndicator/index.tsx
+++ b/turboui/src/PrivacyIndicator/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import * as Icons from "@tabler/icons-react";
 import { match } from "ts-pattern";
 import { Tooltip } from "../Tooltip";
+import { IconLockFilled, IconWorld } from "../icons";
 
 const DEFAULT_SIZE = 24;
 
@@ -20,9 +20,9 @@ export function PrivacyIndicator(props: PrivacyIndicator.Props) {
   );
 
   const icon = match(props.privacyLevel)
-    .with("public", () => <Icons.IconWorld size={props.iconSize!} />)
-    .with("confidential", () => <Icons.IconLockFilled size={props.iconSize!} />)
-    .with("secret", () => <Icons.IconLockFilled size={props.iconSize!} className="text-content-error" />)
+    .with("public", () => <IconWorld size={props.iconSize!} />)
+    .with("confidential", () => <IconLockFilled size={props.iconSize!} />)
+    .with("secret", () => <IconLockFilled size={props.iconSize!} className="text-content-error" />)
     .exhaustive();
 
   return (

--- a/turboui/src/ProfilePage/components/index.tsx
+++ b/turboui/src/ProfilePage/components/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Avatar } from "../../Avatar";
 import { ProfilePage } from "../index";
-import { IconMail } from "@tabler/icons-react";
+import { IconMail } from "../../icons";
 
 export { Colleagues } from "./Colleagues";
 

--- a/turboui/src/ProfilePage/index.tsx
+++ b/turboui/src/ProfilePage/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { IconLogs, IconEye, IconClipboardCheck, IconUserCircle, IconCircleCheck } from "@tabler/icons-react";
+import { IconLogs, IconEye, IconClipboardCheck, IconUserCircle, IconCircleCheck } from "../icons";
 
 import { Page } from "../Page";
 import { Tabs, useTabs } from "../Tabs";

--- a/turboui/src/ProjectPage/PageHeader.tsx
+++ b/turboui/src/ProjectPage/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight } from "@tabler/icons-react";
+import { IconChevronRight } from "../icons";
 import React from "react";
 import { ProjectPage } from ".";
 import { IconProject } from "../icons";

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { PageNew } from "../Page";
 
-import { IconClipboardText, IconLogs, IconMessage, IconMessages, IconListCheck } from "@tabler/icons-react";
+import { IconClipboardText, IconLogs, IconMessage, IconMessages, IconListCheck } from "../icons";
 
 import { PrivacyField } from "../PrivacyField";
 import { BadgeStatus } from "../StatusBadge/types";

--- a/turboui/src/RichEditor/Blob/BlobView.tsx
+++ b/turboui/src/RichEditor/Blob/BlobView.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
-import * as Icons from "@tabler/icons-react";
 import { NodeViewContent, NodeViewWrapper } from "@tiptap/react";
 import classnames from "classnames";
 
+import { IconFileFilled, IconFileZip, IconPdf, IconTrash } from "../../icons";
 import classNames from "../../utils/classnames";
 
 //
@@ -69,7 +69,7 @@ function VideoView({ node, deleteNode, view, updateAttributes }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -156,7 +156,7 @@ function ImageView({ node, deleteNode, updateAttributes, view }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -201,7 +201,7 @@ function FileView({ node, deleteNode, view }) {
 
       {view.editable && (
         <div className="absolute top-2 right-2 p-2 hover:scale-105 bg-red-400 rounded-full group-hover:opacity-100 opacity-0 cursor-pointer transition-opacity">
-          <Icons.IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
+          <IconTrash onClick={deleteNode} size={16} className="text-content-accent" />
         </div>
       )}
     </NodeViewWrapper>
@@ -218,13 +218,13 @@ function HumanFilesize({ size }: { size: number }) {
 function FileIcon({ filetype }: { filetype: string }) {
   switch (filetype) {
     case "application/pdf":
-      return <Icons.IconPdf className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconPdf className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     case "application/zip":
-      return <Icons.IconFileZip className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileZip className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     case "text/plain":
-      return <Icons.IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
     default:
-      return <Icons.IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
+      return <IconFileFilled className="text-content-accent" size={48} data-drag-handle strokeWidth={1} />;
   }
 }
 

--- a/turboui/src/RichEditor/components/AttachmentButton.tsx
+++ b/turboui/src/RichEditor/components/AttachmentButton.tsx
@@ -1,4 +1,4 @@
-import * as Icons from "@tabler/icons-react";
+import { IconPaperclip } from "../../icons";
 import * as React from "react";
 
 import { AddBlobsEditorCommand } from "../Blob/AddBlobsEditorCommand";
@@ -40,7 +40,7 @@ export function AttachmentButton({ editor, iconSize }): JSX.Element {
   return (
     <>
       <ToolbarButton onClick={handleClick} title="Add an Image or File">
-        <Icons.IconPaperclip size={iconSize} />
+        <IconPaperclip size={iconSize} />
       </ToolbarButton>
 
       <input

--- a/turboui/src/RichEditor/components/BlockquoteButton.tsx
+++ b/turboui/src/RichEditor/components/BlockquoteButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconBlockquote } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BlockquoteButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("blockquote")}
       title="Quote"
     >
-      <Icons.IconBlockquote size={iconSize} />
+      <IconBlockquote size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/BoldButton.tsx
+++ b/turboui/src/RichEditor/components/BoldButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconBold } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BoldButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("bold")}
       title="Bold"
     >
-      <Icons.IconBold size={iconSize} strokeWidth={2.2} />
+      <IconBold size={iconSize} strokeWidth={2.2} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/BulletListButton.tsx
+++ b/turboui/src/RichEditor/components/BulletListButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconList } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function BulletListButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("bulletList")}
       title="Bullet List"
     >
-      <Icons.IconList size={iconSize} />
+      <IconList size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/CodeBlockButton.tsx
+++ b/turboui/src/RichEditor/components/CodeBlockButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Code } from "lucide-react";
 
+import { LucideCode } from "../../icons";
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
 export function CodeBlockButton({ editor, iconSize }): JSX.Element {
@@ -10,7 +10,7 @@ export function CodeBlockButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("codeblock")}
       title="Code Block"
     >
-      <Code size={iconSize - 2} />
+      <LucideCode size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/CodeBlockButton.tsx
+++ b/turboui/src/RichEditor/components/CodeBlockButton.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { LucideCode } from "../../icons";
+import { IconCode } from "../../icons";
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
 export function CodeBlockButton({ editor, iconSize }): JSX.Element {
@@ -10,7 +10,7 @@ export function CodeBlockButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("codeblock")}
       title="Code Block"
     >
-      <LucideCode size={iconSize - 2} />
+      <IconCode size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/ColorPicker.tsx
+++ b/turboui/src/RichEditor/components/ColorPicker.tsx
@@ -2,9 +2,9 @@ import * as Popover from "@radix-ui/react-popover";
 import * as React from "react";
 
 import classNames from "classnames";
-import { PaintBucket } from "lucide-react";
 import { SecondaryButton } from "../../Button";
 import { createTestId } from "../../TestableElement";
+import { LucidePaintBucket } from "../../icons";
 
 const DROPDOWN_CLASS = classNames(
   "border border-t-4 border-stroke-base",
@@ -70,7 +70,7 @@ function BucketIcon({ iconSize, editor }): React.ReactElement {
   return (
     <div className="ProseMirror">
       <mark data-highlight={highlight} className="block px-1 py-0.5 rounded">
-        <PaintBucket size={iconSize - 1} />
+        <LucidePaintBucket size={iconSize - 1} />
       </mark>
     </div>
   );

--- a/turboui/src/RichEditor/components/ColorPicker.tsx
+++ b/turboui/src/RichEditor/components/ColorPicker.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import classNames from "classnames";
 import { SecondaryButton } from "../../Button";
 import { createTestId } from "../../TestableElement";
-import { LucidePaintBucket } from "../../icons";
+import { IconPaintBucket } from "../../icons";
 
 const DROPDOWN_CLASS = classNames(
   "border border-t-4 border-stroke-base",
@@ -70,7 +70,7 @@ function BucketIcon({ iconSize, editor }): React.ReactElement {
   return (
     <div className="ProseMirror">
       <mark data-highlight={highlight} className="block px-1 py-0.5 rounded">
-        <LucidePaintBucket size={iconSize - 1} />
+        <IconPaintBucket size={iconSize - 1} />
       </mark>
     </div>
   );

--- a/turboui/src/RichEditor/components/DividerButton.tsx
+++ b/turboui/src/RichEditor/components/DividerButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import { Minus } from "lucide-react";
 
+import { LucideMinus } from "../../icons";
 import { ToolbarButton } from "./ToolbarButton";
 
 export function DividerButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().setHorizontalRule().run()} title="Divider">
-      <Minus size={iconSize} />
+      <LucideMinus size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/turboui/src/RichEditor/components/DividerButton.tsx
+++ b/turboui/src/RichEditor/components/DividerButton.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 
-import { LucideMinus } from "../../icons";
+import { IconMinus } from "../../icons";
+
 import { ToolbarButton } from "./ToolbarButton";
 
 export function DividerButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().setHorizontalRule().run()} title="Divider">
-      <LucideMinus size={iconSize} />
+      <IconMinus size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/turboui/src/RichEditor/components/H1Button.tsx
+++ b/turboui/src/RichEditor/components/H1Button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconH1 } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function H1Button({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("heading", { level: 1 })}
       title="Heading 1"
     >
-      <Icons.IconH1 size={iconSize} />
+      <IconH1 size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/H2Button.tsx
+++ b/turboui/src/RichEditor/components/H2Button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconH2 } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function H2Button({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("heading", { level: 2 })}
       title="Heading 2"
     >
-      <Icons.IconH2 size={iconSize} />
+      <IconH2 size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/ItalicButton.tsx
+++ b/turboui/src/RichEditor/components/ItalicButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconItalic } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function ItalicButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("italic")}
       title="Italic"
     >
-      <Icons.IconItalic size={iconSize} />
+      <IconItalic size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/LinkButton.tsx
+++ b/turboui/src/RichEditor/components/LinkButton.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
-import { LucideLink } from "../../icons";
+import { IconLink2 } from "../../icons";
 import { useLinkState } from "../EditorContext";
 
 export function LinkButton({ editor, iconSize }): JSX.Element {
@@ -22,7 +22,7 @@ export function LinkButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("link") || linkEditActive}
       title="Add/Edit Links"
     >
-      <LucideLink size={iconSize - 2} />
+      <IconLink2 size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/LinkButton.tsx
+++ b/turboui/src/RichEditor/components/LinkButton.tsx
@@ -1,8 +1,8 @@
-import * as Icons from "lucide-react";
 import * as React from "react";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
+import { LucideLink } from "../../icons";
 import { useLinkState } from "../EditorContext";
 
 export function LinkButton({ editor, iconSize }): JSX.Element {
@@ -22,7 +22,7 @@ export function LinkButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("link") || linkEditActive}
       title="Add/Edit Links"
     >
-      <Icons.Link size={iconSize - 2} />
+      <LucideLink size={iconSize - 2} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/NumberListButton.tsx
+++ b/turboui/src/RichEditor/components/NumberListButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconListNumbers } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function NumberListButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("orderedList")}
       title="Numbered List"
     >
-      <Icons.IconListNumbers size={iconSize} />
+      <IconListNumbers size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/RedoButton.tsx
+++ b/turboui/src/RichEditor/components/RedoButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconArrowForwardUp } from "../../icons";
 
 import { ToolbarButton } from "./ToolbarButton";
 
 export function RedoButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().redo().run()} disabled={!editor?.can().redo()} title="Redo">
-      <Icons.IconArrowForwardUp size={iconSize} />
+      <IconArrowForwardUp size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/turboui/src/RichEditor/components/StrikeButton.tsx
+++ b/turboui/src/RichEditor/components/StrikeButton.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconStrikethrough } from "../../icons";
 
 import { ToolbarToggleButton } from "./ToolbarToggleButton";
 
@@ -10,7 +10,7 @@ export function StrikeButton({ editor, iconSize }): JSX.Element {
       isActive={editor?.isActive("strike")}
       title="Strikethrough"
     >
-      <Icons.IconStrikethrough size={iconSize} />
+      <IconStrikethrough size={iconSize} />
     </ToolbarToggleButton>
   );
 }

--- a/turboui/src/RichEditor/components/Toolbar.tsx
+++ b/turboui/src/RichEditor/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import * as Popover from "@radix-ui/react-popover";
-import * as Icons from "@tabler/icons-react";
+import { IconChevronDown } from "../../icons";
 import * as React from "react";
 
 import { AttachmentButton } from "./AttachmentButton";
@@ -118,7 +118,7 @@ function MobilePopupTools({ children }: { children: React.ReactNode }): JSX.Elem
   return (
     <Popover.Root>
       <Popover.Trigger className="mr-2">
-        <Icons.IconChevronDown size={20} />
+        <IconChevronDown size={20} />
       </Popover.Trigger>
       <Popover.Content className="z-10 p-2 bg-surface-base rounded-lg shadow-lg border border-stroke-base">
         <div className="flex flex-wrap gap-1">{children}</div>

--- a/turboui/src/RichEditor/components/UndoButton.tsx
+++ b/turboui/src/RichEditor/components/UndoButton.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconArrowBackUp } from "../../icons";
 
 import { ToolbarButton } from "./ToolbarButton";
 
 export function UndoButton({ editor, iconSize }): JSX.Element {
   return (
     <ToolbarButton onClick={() => editor.chain().focus().undo().run()} disabled={!editor?.can().undo()} title="Undo">
-      <Icons.IconArrowBackUp size={iconSize} />
+      <IconArrowBackUp size={iconSize} />
     </ToolbarButton>
   );
 }

--- a/turboui/src/SpaceField/index.tsx
+++ b/turboui/src/SpaceField/index.tsx
@@ -1,7 +1,7 @@
 import * as Popover from "@radix-ui/react-popover";
 import * as React from "react";
 
-import { IconChevronDown, IconCircleX, IconSearch, IconTent } from "@tabler/icons-react";
+import { IconChevronDown, IconCircleX, IconSearch, IconTent } from "../icons";
 import { createTestId } from "../TestableElement";
 import classNames from "../utils/classnames";
 

--- a/turboui/src/StatusBadge/index.tsx
+++ b/turboui/src/StatusBadge/index.tsx
@@ -1,4 +1,4 @@
-import { IconCheck, IconCircleDashed, IconCircleFilled, IconX } from "@tabler/icons-react";
+import { IconCheck, IconCircleDashed, IconCircleFilled, IconX } from "../icons";
 import React from "react";
 import { BadgeStatus, StatusBadgeProps } from "./types";
 

--- a/turboui/src/Tabs/index.stories.tsx
+++ b/turboui/src/Tabs/index.stories.tsx
@@ -1,4 +1,4 @@
-import { IconHome, IconSettings, IconUser } from "@tabler/icons-react";
+import { IconHome, IconSettings, IconUser } from "../icons";
 import React from "react";
 import { Tabs, useTabs } from ".";
 

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -1,4 +1,4 @@
-import { IconFileText, IconMessageCircle, IconPlus } from "@tabler/icons-react";
+import { IconFileText, IconMessageCircle, IconPlus } from "../../icons";
 import React, { useState } from "react";
 import { DateField } from "../../DateField";
 import { BlackLink } from "../../Link";

--- a/turboui/src/TaskBoard/components/MilestoneCreationModal.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCreationModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { PrimaryButton, SecondaryButton } from "../../Button";
 import * as Types from "../types";
 import Modal from "../../Modal";
-import { IconCalendar } from "@tabler/icons-react";
+import { IconCalendar } from "../../icons";
 
 interface MilestoneCreationModalProps {
   isOpen: boolean;

--- a/turboui/src/TaskBoard/components/StatusSelector.tsx
+++ b/turboui/src/TaskBoard/components/StatusSelector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import * as Popover from "@radix-ui/react-popover";
 import classNames from "../../utils/classnames";
-import { IconCircleDashed, IconCircleDot, IconCircleCheck, IconX, IconChevronDown } from "@tabler/icons-react";
+import { IconCircleDashed, IconCircleDot, IconCircleCheck, IconX, IconChevronDown } from "../../icons";
 
 // Import types from the shared types module
 import * as Types from "../types";

--- a/turboui/src/TaskBoard/components/TaskCreationModal.tsx
+++ b/turboui/src/TaskBoard/components/TaskCreationModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { PrimaryButton, SecondaryButton } from "../../Button";
 import * as Types from "../types";
 import Modal from "../../Modal";
-import { IconCalendar, IconUser } from "@tabler/icons-react";
+import { IconCalendar, IconUser } from "../../icons";
 
 interface TaskCreationModalProps {
   isOpen: boolean;

--- a/turboui/src/TaskBoard/components/TaskFilter.tsx
+++ b/turboui/src/TaskBoard/components/TaskFilter.tsx
@@ -14,7 +14,7 @@ import {
   IconMessage,
   IconFlag,
   IconX,
-} from "@tabler/icons-react";
+} from "../../icons";
 import classNames from "../../utils/classnames";
 import * as Types from "../types";
 import { AvatarWithName } from "../../Avatar";

--- a/turboui/src/TaskBoard/components/TaskItem.tsx
+++ b/turboui/src/TaskBoard/components/TaskItem.tsx
@@ -1,4 +1,4 @@
-import { IconFileText, IconMessageCircle } from "@tabler/icons-react";
+import { IconFileText, IconMessageCircle } from "../../icons";
 import React, { useCallback, useState } from "react";
 import { DateField } from "../../DateField";
 import { BlackLink } from "../../Link";

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { useDraggingAnimation, useDropZone } from "../../utils/DragAndDrop";
 import { TaskItem } from "./TaskItem";
-import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight } from "../../icons";
 import * as Types from "../types";
 
 // Using TaskWithIndex from our shared types

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -4,7 +4,7 @@ import { DragAndDropProvider } from "../../utils/DragAndDrop";
 import { reorderTasks } from "../utils/taskReorderingUtils";
 import { applyFilters } from "../utils/taskFilterUtils";
 import * as Types from "../types";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus } from "../../icons";
 import TaskCreationModal from "./TaskCreationModal";
 import MilestoneCreationModal from "./MilestoneCreationModal";
 import { TaskList } from "./TaskList";

--- a/turboui/src/TaskPage/PageHeader.tsx
+++ b/turboui/src/TaskPage/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight } from "@tabler/icons-react";
+import { IconChevronRight } from "../icons";
 import React from "react";
 import { TaskPage } from ".";
 import { BlackLink } from "../Link";

--- a/turboui/src/TaskPage/PageOptions.tsx
+++ b/turboui/src/TaskPage/PageOptions.tsx
@@ -1,4 +1,4 @@
-import { IconCopy, IconTrash, IconCopy as IconDuplicate, IconArchive } from "@tabler/icons-react";
+import { IconCopy, IconTrash, IconCopy as IconDuplicate, IconArchive } from "../icons";
 import { TaskPage } from ".";
 
 export function pageOptions(props: TaskPage.State) {

--- a/turboui/src/TaskPage/Sidebar.tsx
+++ b/turboui/src/TaskPage/Sidebar.tsx
@@ -6,7 +6,7 @@ import {
   IconCalendar,
   IconLink,
   IconTrash,
-} from "@tabler/icons-react";
+} from "../icons";
 import React from "react";
 import { TaskPage } from ".";
 import { AvatarWithName } from "../Avatar";

--- a/turboui/src/TimeframeSelector/index.tsx
+++ b/turboui/src/TimeframeSelector/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as Popover from "@radix-ui/react-popover";
-import * as Icons from "@tabler/icons-react";
+import { IconCalendar, IconChevronDown, IconX } from "../icons";
 
 import { TimeframeSelectorDialog } from "../TimeframeSelectorDialog";
 
@@ -120,12 +120,12 @@ function TimeframeSelectorTrigger(props: TimeframeSelectorTriggerProps) {
   return (
     <Popover.Trigger asChild>
       <button type="button" className={className} onClick={handleClick}>
-        <Icons.IconCalendar size={iconSize} className="shrink-0" />
+        <IconCalendar size={iconSize} className="shrink-0" />
         <span className="truncate">{formatTimeframe(props.timeframe)}</span>
         {props.isDefaultTimeframe ? (
-          <Icons.IconChevronDown size={iconSize} className="shrink-0 ml-1" />
+          <IconChevronDown size={iconSize} className="shrink-0 ml-1" />
         ) : (
-          <Icons.IconX size={iconSize} className="shrink-0 ml-1 cursor-pointer" />
+          <IconX size={iconSize} className="shrink-0 ml-1 cursor-pointer" />
         )}
       </button>
     </Popover.Trigger>

--- a/turboui/src/TimeframeSelectorDialog/Chevrons.tsx
+++ b/turboui/src/TimeframeSelectorDialog/Chevrons.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import * as Icons from "@tabler/icons-react";
+import { IconChevronLeft, IconChevronRight } from "../icons";
 
 export function LeftChevron({ onClick }) {
   return (
-    <Icons.IconChevronLeft
+    <IconChevronLeft
       size={16}
       onClick={onClick}
       className="cursor-pointer text-content-dimmed hover:text-content"
@@ -13,7 +13,7 @@ export function LeftChevron({ onClick }) {
 
 export function RightChevron({ onClick }) {
   return (
-    <Icons.IconChevronRight
+    <IconChevronRight
       size={16}
       onClick={onClick}
       className="cursor-pointer text-content-dimmed hover:text-content"

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -2,7 +2,20 @@ import React from "react";
 import { shortName } from "../Avatar/AvatarWithName";
 import { BlackLink } from "../Link";
 import FormattedTime from "../FormattedTime";
-import * as Icons from "@tabler/icons-react";
+import {
+  IconUserPlus,
+  IconFlag,
+  IconFlagX,
+  IconCalendarPlus,
+  IconCalendarMinus,
+  IconFileText,
+  IconEdit,
+  IconPlus,
+  IconCircle,
+  IconActivity,
+  IconCircleCheck,
+  IconClockPlay,
+} from "../icons";
 import { TaskActivityProps, TaskActivity } from "./types";
 
 export function TaskActivityItem({ activity }: TaskActivityProps) {
@@ -43,42 +56,42 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
 
   switch (activity.type) {
     case "task-assignment":
-      return <Icons.IconUserPlus {...iconProps} className="text-blue-500" />;
+      return <IconUserPlus {...iconProps} className="text-blue-500" />;
     case "task-status-change":
       return getStatusIcon(activity.toStatus);
     case "task-milestone":
       return activity.action === "attached" ? (
-        <Icons.IconFlag {...iconProps} className="text-green-500" />
+        <IconFlag {...iconProps} className="text-green-500" />
       ) : (
-        <Icons.IconFlagX {...iconProps} className="text-orange-500" />
+        <IconFlagX {...iconProps} className="text-orange-500" />
       );
     case "task-due-date":
       return activity.toDueDate ? (
-        <Icons.IconCalendarPlus {...iconProps} className="text-blue-500" />
+        <IconCalendarPlus {...iconProps} className="text-blue-500" />
       ) : (
-        <Icons.IconCalendarMinus {...iconProps} className="text-orange-500" />
+        <IconCalendarMinus {...iconProps} className="text-orange-500" />
       );
     case "task-description":
-      return <Icons.IconFileText {...iconProps} className="text-purple-500" />;
+      return <IconFileText {...iconProps} className="text-purple-500" />;
     case "task-title":
-      return <Icons.IconEdit {...iconProps} className="text-gray-500" />;
+      return <IconEdit {...iconProps} className="text-gray-500" />;
     case "task-creation":
-      return <Icons.IconPlus {...iconProps} className="text-green-500" />;
+      return <IconPlus {...iconProps} className="text-green-500" />;
     default:
-      return <Icons.IconActivity {...iconProps} />;
+      return <IconActivity {...iconProps} />;
   }
 }
 
 function getStatusIcon(status: string) {
   switch (status) {
     case "not_started":
-      return <Icons.IconCircle size={12} className="text-gray-500" />;
+      return <IconCircle size={12} className="text-gray-500" />;
     case "in_progress":
-      return <Icons.IconClockPlay size={12} className="text-blue-500" />;
+      return <IconClockPlay size={12} className="text-blue-500" />;
     case "done":
-      return <Icons.IconCircleCheck size={12} className="text-green-500" />;
+      return <IconCircleCheck size={12} className="text-green-500" />;
     default:
-      return <Icons.IconCircle size={12} className="text-gray-500" />;
+      return <IconCircle size={12} className="text-gray-500" />;
   }
 }
 

--- a/turboui/src/Toasts/index.tsx
+++ b/turboui/src/Toasts/index.tsx
@@ -1,4 +1,4 @@
-import { IconExclamationCircleFilled } from "@tabler/icons-react";
+import { IconExclamationCircleFilled } from "../icons";
 import React from "react";
 import toast, { Toaster } from "react-hot-toast";
 

--- a/turboui/src/WorkMap/components/TableRow/ActionButtons.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ActionButtons.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { IconPlus, IconTrash } from "../../../icons";
 import { SecondaryButton } from "../../../Button";
 
 interface Props {

--- a/turboui/src/WorkMap/components/TableRow/ItemNameCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ItemNameCell.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IconChevronDown, IconChevronRight } from "@tabler/icons-react";
+import { IconChevronDown, IconChevronRight } from "../../../icons";
 import { BlackLink } from "../../../Link";
 import classNames from "../../../utils/classnames";
 import { useItemStatus } from "../../hooks/useItemStatus";

--- a/turboui/src/WorkMap/components/WorkMapTable.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTable.tsx
@@ -3,7 +3,7 @@ import { WorkMap } from "..";
 import { TableRow } from "./TableRow";
 import classNames from "../../utils/classnames";
 import { Tooltip } from "../../Tooltip";
-import { IconInfoCircle } from "@tabler/icons-react";
+import { IconInfoCircle } from "../../icons";
 
 interface Props {
   items: WorkMap.Item[];

--- a/turboui/src/WorkMap/hooks/useWorkMapTab.ts
+++ b/turboui/src/WorkMap/hooks/useWorkMapTab.ts
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { IconLayoutGrid, IconTarget, IconChecklist, IconCircleCheck, IconPlayerPause } from "@tabler/icons-react";
+import { IconLayoutGrid, IconTarget, IconChecklist, IconCircleCheck, IconPlayerPause } from "../../icons";
 
 import * as sort from "../utils/sort";
 import { processItems, processPersonalItems } from "../utils/itemProcessor";

--- a/turboui/src/__mocks__/@tabler/icons-react.js
+++ b/turboui/src/__mocks__/@tabler/icons-react.js
@@ -1,0 +1,26 @@
+// Mock for @tabler/icons-react
+const createMockIcon = (name) => {
+  const component = (props) => {
+    return {
+      type: 'svg',
+      props: {
+        ...props,
+        'data-testid': `mock-icon-${name}`,
+      },
+      key: null,
+      ref: null,
+    };
+  };
+  component.displayName = name;
+  return component;
+};
+
+// Create a proxy that returns a mock icon for any imported icon
+module.exports = new Proxy(
+  {},
+  {
+    get: function(target, prop) {
+      return createMockIcon(prop);
+    }
+  }
+);

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -147,7 +147,17 @@ import IconGripVertical from "@tabler/icons-react/dist/esm/icons/IconGripVertica
 
 import type { IconProps as TablerIconProps } from "@tabler/icons-react";
 
+import { Link as LucideLink } from "lucide-react";
+import { Code as LucideCode } from "lucide-react";
+import { PaintBucket as LucidePaintBucket } from "lucide-react";
+import { Minus as LucideMinus } from "lucide-react";
+
 export {
+  LucideLink,
+  LucideCode,
+  LucidePaintBucket,
+  LucideMinus,
+
   IconTarget,
   IconHexagons,
   IconAlertTriangleFilled,

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -144,20 +144,11 @@ import IconUserStar from "@tabler/icons-react/dist/esm/icons/IconUserStar.mjs";
 import IconFilter from "@tabler/icons-react/dist/esm/icons/IconFilter.mjs";
 import IconCircleDot from "@tabler/icons-react/dist/esm/icons/IconCircleDot.mjs";
 import IconGripVertical from "@tabler/icons-react/dist/esm/icons/IconGripVertical.mjs";
+import IconMinus from "@tabler/icons-react/dist/esm/icons/IconMinus.mjs";
 
 import type { IconProps as TablerIconProps } from "@tabler/icons-react";
 
-import { Link as LucideLink } from "lucide-react";
-import { Code as LucideCode } from "lucide-react";
-import { PaintBucket as LucidePaintBucket } from "lucide-react";
-import { Minus as LucideMinus } from "lucide-react";
-
 export {
-  LucideLink,
-  LucideCode,
-  LucidePaintBucket,
-  LucideMinus,
-
   IconTarget,
   IconHexagons,
   IconAlertTriangleFilled,
@@ -300,6 +291,7 @@ export {
   IconCircleDot,
   IconFilter,
   IconGripVertical,
+  IconMinus,
 };
 
 export interface IconProps {
@@ -338,5 +330,91 @@ export function IconProject({ size = 16, className = "" }: IconProps) {
     <div className={outer} style={{ width: size, height: size }}>
       <IconChecklist size={innerSize} />
     </div>
+  );
+}
+
+export function IconPaintBucket({
+  size = 24,
+  color = "currentColor",
+  strokeWidth = 2,
+  className = "",
+  ...props
+}: TablerIconProps) {
+  const { stroke, ...otherProps } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      stroke={color}
+      {...otherProps}
+    >
+      <path d="m19 11-8-8-8.6 8.6a2 2 0 0 0 0 2.8l5.2 5.2c.8.8 2 .8 2.8 0L19 11Z" />
+      <path d="m5 2 5 5" />
+      <path d="M2 13h15" />
+      <path d="M22 20a2 2 0 1 1-4 0c0-1.6 1.7-2.4 2-4 .3 1.6 2 2.4 2 4Z" />
+    </svg>
+  );
+}
+
+export function IconCode({
+  size = 24,
+  color = "currentColor",
+  strokeWidth = 2,
+  className = "",
+  ...props
+}: TablerIconProps) {
+  const { stroke, ...otherProps } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      stroke={color}
+      {...otherProps}
+    >
+      <polyline points="16 18 22 12 16 6" />
+      <polyline points="8 6 2 12 8 18" />
+    </svg>
+  );
+}
+
+export function IconLink2({
+  size = 24,
+  color = "currentColor",
+  strokeWidth = 2,
+  className = "",
+  ...props
+}: TablerIconProps) {
+  const { stroke, ...otherProps } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      stroke={color}
+      {...otherProps}
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
   );
 }

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -1,12 +1,303 @@
 import React from "react";
-import { IconTarget } from "@tabler/icons-react";
-import classNames from "../utils/classnames";
-import { IconChecklist } from "@tabler/icons-react";
 
-interface IconProps {
+import classNames from "../utils/classnames";
+
+import IconTarget from "@tabler/icons-react/dist/esm/icons/IconTarget.mjs";
+import IconChecklist from "@tabler/icons-react/dist/esm/icons/IconChecklist.mjs";
+import IconAlertTriangleFilled from "@tabler/icons-react/dist/esm/icons/IconAlertTriangleFilled.mjs";
+import IconCircleCheckFilled from "@tabler/icons-react/dist/esm/icons/IconCircleCheckFilled.mjs";
+import IconCircleXFilled from "@tabler/icons-react/dist/esm/icons/IconCircleXFilled.mjs";
+import IconInfoCircleFilled from "@tabler/icons-react/dist/esm/icons/IconInfoCircleFilled.mjs";
+import IconQuestionMark from "@tabler/icons-react/dist/esm/icons/IconQuestionMark.mjs";
+import IconCheck from "@tabler/icons-react/dist/esm/icons/IconCheck.mjs";
+import IconCopy from "@tabler/icons-react/dist/esm/icons/IconCopy.mjs";
+import IconTrash from "@tabler/icons-react/dist/esm/icons/IconTrash.mjs";
+import IconPdf from "@tabler/icons-react/dist/esm/icons/IconPdf.mjs";
+import IconFileZip from "@tabler/icons-react/dist/esm/icons/IconFileZip.mjs";
+import IconFileFilled from "@tabler/icons-react/dist/esm/icons/IconFileFilled.mjs";
+import IconCalendar from "@tabler/icons-react/dist/esm/icons/IconCalendar.mjs";
+import IconX from "@tabler/icons-react/dist/esm/icons/IconX.mjs";
+import IconFlag3Filled from "@tabler/icons-react/dist/esm/icons/IconFlag3Filled.mjs";
+import IconLink from "@tabler/icons-react/dist/esm/icons/IconLink.mjs";
+import IconArrowLeft from "@tabler/icons-react/dist/esm/icons/IconArrowLeft.mjs";
+import IconChevronDown from "@tabler/icons-react/dist/esm/icons/IconChevronDown.mjs";
+import IconDots from "@tabler/icons-react/dist/esm/icons/IconDots.mjs";
+import IconSlash from "@tabler/icons-react/dist/esm/icons/IconSlash.mjs";
+import IconInfoCircle from "@tabler/icons-react/dist/esm/icons/IconInfoCircle.mjs";
+import IconHexagons from "@tabler/icons-react/dist/esm/icons/IconHexagons.mjs";
+import IconSquareCheckFilled from "@tabler/icons-react/dist/esm/icons/IconSquareCheckFilled.mjs";
+import IconSquareChevronsLeftFilled from "@tabler/icons-react/dist/esm/icons/IconSquareChevronsLeftFilled.mjs";
+import IconEdit from "@tabler/icons-react/dist/esm/icons/IconEdit.mjs";
+import IconArrowRight from "@tabler/icons-react/dist/esm/icons/IconArrowRight.mjs";
+import IconBuildingCommunity from "@tabler/icons-react/dist/esm/icons/IconBuildingCommunity.mjs";
+import IconNetwork from "@tabler/icons-react/dist/esm/icons/IconNetwork.mjs";
+import IconWorld from "@tabler/icons-react/dist/esm/icons/IconWorld.mjs";
+import IconLockFilled from "@tabler/icons-react/dist/esm/icons/IconLockFilled.mjs";
+import IconHash from "@tabler/icons-react/dist/esm/icons/IconHash.mjs";
+import IconBuildingEstate from "@tabler/icons-react/dist/esm/icons/IconBuildingEstate.mjs";
+import IconMail from "@tabler/icons-react/dist/esm/icons/IconMail.mjs";
+import IconCircleFilled from "@tabler/icons-react/dist/esm/icons/IconCircleFilled.mjs";
+import IconPlus from "@tabler/icons-react/dist/esm/icons/IconPlus.mjs";
+import IconChevronRight from "@tabler/icons-react/dist/esm/icons/IconChevronRight.mjs";
+import IconBuilding from "@tabler/icons-react/dist/esm/icons/IconBuilding.mjs";
+import IconLock from "@tabler/icons-react/dist/esm/icons/IconLock.mjs";
+import IconMoodPlus from "@tabler/icons-react/dist/esm/icons/IconMoodPlus.mjs";
+import IconTent from "@tabler/icons-react/dist/esm/icons/IconTent.mjs";
+import IconFile from "@tabler/icons-react/dist/esm/icons/IconFile.mjs";
+import IconFolderFilled from "@tabler/icons-react/dist/esm/icons/IconFolderFilled.mjs";
+import IconUpload from "@tabler/icons-react/dist/esm/icons/IconUpload.mjs";
+import IconItalic from "@tabler/icons-react/dist/esm/icons/IconItalic.mjs";
+import IconBold from "@tabler/icons-react/dist/esm/icons/IconBold.mjs";
+import IconH1 from "@tabler/icons-react/dist/esm/icons/IconH1.mjs";
+import IconArrowBackUp from "@tabler/icons-react/dist/esm/icons/IconArrowBackUp.mjs";
+import IconSpeakerphone from "@tabler/icons-react/dist/esm/icons/IconSpeakerphone.mjs";
+import IconBulb from "@tabler/icons-react/dist/esm/icons/IconBulb.mjs";
+import IconMessage from "@tabler/icons-react/dist/esm/icons/IconMessage.mjs";
+import IconTrophy from "@tabler/icons-react/dist/esm/icons/IconTrophy.mjs";
+import IconStrikethrough from "@tabler/icons-react/dist/esm/icons/IconStrikethrough.mjs";
+import IconAlignJustified from "@tabler/icons-react/dist/esm/icons/IconAlignJustified.mjs";
+import IconVideo from "@tabler/icons-react/dist/esm/icons/IconVideo.mjs";
+import IconChartColumn from "@tabler/icons-react/dist/esm/icons/IconChartColumn.mjs";
+import IconLogs from "@tabler/icons-react/dist/esm/icons/IconLogs.mjs";
+import IconArrowForwardUp from "@tabler/icons-react/dist/esm/icons/IconArrowForwardUp.mjs";
+import IconTable from "@tabler/icons-react/dist/esm/icons/IconTable.mjs";
+import IconUser from "@tabler/icons-react/dist/esm/icons/IconUser.mjs";
+import IconTargetArrow from "@tabler/icons-react/dist/esm/icons/IconTargetArrow.mjs";
+import IconPaperclip from "@tabler/icons-react/dist/esm/icons/IconPaperclip.mjs";
+import IconBlockquote from "@tabler/icons-react/dist/esm/icons/IconBlockquote.mjs";
+import IconH2 from "@tabler/icons-react/dist/esm/icons/IconH2.mjs";
+import IconList from "@tabler/icons-react/dist/esm/icons/IconList.mjs";
+import IconListNumbers from "@tabler/icons-react/dist/esm/icons/IconListNumbers.mjs";
+import IconBrandDiscordFilled from "@tabler/icons-react/dist/esm/icons/IconBrandDiscordFilled.mjs";
+import IconLifebuoy from "@tabler/icons-react/dist/esm/icons/IconLifebuoy.mjs";
+import IconMap2 from "@tabler/icons-react/dist/esm/icons/IconMap2.mjs";
+import IconSun from "@tabler/icons-react/dist/esm/icons/IconSun.mjs";
+import IconMoon from "@tabler/icons-react/dist/esm/icons/IconMoon.mjs";
+import IconDeviceLaptop from "@tabler/icons-react/dist/esm/icons/IconDeviceLaptop.mjs";
+import IconPencil from "@tabler/icons-react/dist/esm/icons/IconPencil.mjs";
+import IconArchive from "@tabler/icons-react/dist/esm/icons/IconArchive.mjs";
+import IconPlayerPlayFilled from "@tabler/icons-react/dist/esm/icons/IconPlayerPlayFilled.mjs";
+import IconPlayerPauseFilled from "@tabler/icons-react/dist/esm/icons/IconPlayerPauseFilled.mjs";
+import IconExchange from "@tabler/icons-react/dist/esm/icons/IconExchange.mjs";
+import IconReplace from "@tabler/icons-react/dist/esm/icons/IconReplace.mjs";
+import IconCircleCheck from "@tabler/icons-react/dist/esm/icons/IconCircleCheck.mjs";
+import IconDoorExit from "@tabler/icons-react/dist/esm/icons/IconDoorExit.mjs";
+import IconLockPassword from "@tabler/icons-react/dist/esm/icons/IconLockPassword.mjs";
+import IconPalette from "@tabler/icons-react/dist/esm/icons/IconPalette.mjs";
+import IconUserCircle from "@tabler/icons-react/dist/esm/icons/IconUserCircle.mjs";
+import IconCoffee from "@tabler/icons-react/dist/esm/icons/IconCoffee.mjs";
+import IconBell from "@tabler/icons-react/dist/esm/icons/IconBell.mjs";
+import IconRss from "@tabler/icons-react/dist/esm/icons/IconRss.mjs";
+import IconSparkles from "@tabler/icons-react/dist/esm/icons/IconSparkles.mjs";
+import IconBinaryTree2 from "@tabler/icons-react/dist/esm/icons/IconBinaryTree2.mjs";
+import IconCircleKey from "@tabler/icons-react/dist/esm/icons/IconCircleKey.mjs";
+import IconSwitch from "@tabler/icons-react/dist/esm/icons/IconSwitch.mjs";
+import IconMenu2 from "@tabler/icons-react/dist/esm/icons/IconMenu2.mjs";
+import IconHome2 from "@tabler/icons-react/dist/esm/icons/IconHome2.mjs";
+import IconBriefcase from "@tabler/icons-react/dist/esm/icons/IconBriefcase.mjs";
+import IconFileExport from "@tabler/icons-react/dist/esm/icons/IconFileExport.mjs";
+import IconMailFast from "@tabler/icons-react/dist/esm/icons/IconMailFast.mjs";
+import IconFlare from "@tabler/icons-react/dist/esm/icons/IconFlare.mjs";
+import IconChecks from "@tabler/icons-react/dist/esm/icons/IconChecks.mjs";
+import IconAlertTriangle from "@tabler/icons-react/dist/esm/icons/IconAlertTriangle.mjs";
+import IconId from "@tabler/icons-react/dist/esm/icons/IconId.mjs";
+import IconRefresh from "@tabler/icons-react/dist/esm/icons/IconRefresh.mjs";
+import IconUserX from "@tabler/icons-react/dist/esm/icons/IconUserX.mjs";
+import IconUsers from "@tabler/icons-react/dist/esm/icons/IconUsers.mjs";
+import IconLetterCase from "@tabler/icons-react/dist/esm/icons/IconLetterCase.mjs";
+import IconShieldLock from "@tabler/icons-react/dist/esm/icons/IconShieldLock.mjs";
+import IconDownload from "@tabler/icons-react/dist/esm/icons/IconDownload.mjs";
+import IconChevronUp from "@tabler/icons-react/dist/esm/icons/IconChevronUp.mjs";
+import IconCircleArrowRight from "@tabler/icons-react/dist/esm/icons/IconCircleArrowRight.mjs";
+import IconRotateDot from "@tabler/icons-react/dist/esm/icons/IconRotateDot.mjs";
+import IconSettings from "@tabler/icons-react/dist/esm/icons/IconSettings.mjs";
+import IconHome from "@tabler/icons-react/dist/esm/icons/IconHome.mjs";
+import IconSearch from "@tabler/icons-react/dist/esm/icons/IconSearch.mjs";
+import IconStar from "@tabler/icons-react/dist/esm/icons/IconStar.mjs";
+import IconCircleX from "@tabler/icons-react/dist/esm/icons/IconCircleX.mjs";
+import IconExternalLink from "@tabler/icons-react/dist/esm/icons/IconExternalLink.mjs";
+import IconFlag from "@tabler/icons-react/dist/esm/icons/IconFlag.mjs";
+import IconClipboardText from "@tabler/icons-react/dist/esm/icons/IconClipboardText.mjs";
+import IconMessages from "@tabler/icons-react/dist/esm/icons/IconMessages.mjs";
+import IconListCheck from "@tabler/icons-react/dist/esm/icons/IconListCheck.mjs";
+import IconCalendarEvent from "@tabler/icons-react/dist/esm/icons/IconCalendarEvent.mjs";
+import IconCalendarPlus from "@tabler/icons-react/dist/esm/icons/IconCalendarPlus.mjs";
+import IconHeart from "@tabler/icons-react/dist/esm/icons/IconHeart.mjs";
+import IconLayoutGrid from "@tabler/icons-react/dist/esm/icons/IconLayoutGrid.mjs";
+import IconExclamationCircleFilled from "@tabler/icons-react/dist/esm/icons/IconExclamationCircleFilled.mjs";
+import IconBellOff from "@tabler/icons-react/dist/esm/icons/IconBellOff.mjs";
+import IconFileText from "@tabler/icons-react/dist/esm/icons/IconFileText.mjs";
+import IconMessageCircle from "@tabler/icons-react/dist/esm/icons/IconMessageCircle.mjs";
+import IconPlayerPause from "@tabler/icons-react/dist/esm/icons/IconPlayerPause.mjs";
+import IconCircleDashed from "@tabler/icons-react/dist/esm/icons/IconCircleDashed.mjs";
+import IconChevronLeft from "@tabler/icons-react/dist/esm/icons/IconChevronLeft.mjs";
+import IconEye from "@tabler/icons-react/dist/esm/icons/IconEye.mjs";
+import IconClipboardCheck from "@tabler/icons-react/dist/esm/icons/IconClipboardCheck.mjs";
+import IconClockPlay from "@tabler/icons-react/dist/esm/icons/IconClockPlay.mjs";
+import IconCircle from "@tabler/icons-react/dist/esm/icons/IconCircle.mjs";
+import IconActivity from "@tabler/icons-react/dist/esm/icons/IconActivity.mjs";
+import IconFlagX from "@tabler/icons-react/dist/esm/icons/IconFlagX.mjs";
+import IconUserPlus from "@tabler/icons-react/dist/esm/icons/IconUserPlus.mjs";
+import IconCalendarMinus from "@tabler/icons-react/dist/esm/icons/IconCalendarMinus.mjs";
+import IconUserCheck from "@tabler/icons-react/dist/esm/icons/IconUserCheck.mjs";
+import IconUserStar from "@tabler/icons-react/dist/esm/icons/IconUserStar.mjs";
+import IconFilter from "@tabler/icons-react/dist/esm/icons/IconFilter.mjs";
+import IconCircleDot from "@tabler/icons-react/dist/esm/icons/IconCircleDot.mjs";
+import IconGripVertical from "@tabler/icons-react/dist/esm/icons/IconGripVertical.mjs";
+
+import type { IconProps as TablerIconProps } from "@tabler/icons-react";
+
+export {
+  IconTarget,
+  IconHexagons,
+  IconAlertTriangleFilled,
+  IconCircleCheckFilled,
+  IconCircleXFilled,
+  IconInfoCircleFilled,
+  IconQuestionMark,
+  IconCheck,
+  IconCopy,
+  IconTrash,
+  IconPdf,
+  IconFileZip,
+  IconFileFilled,
+  IconCalendar,
+  IconX,
+  IconFlag3Filled,
+  IconLink,
+  IconArrowLeft,
+  IconChevronDown,
+  IconDots,
+  IconSlash,
+  IconSquareCheckFilled,
+  IconSquareChevronsLeftFilled,
+  IconEdit,
+  IconArrowRight,
+  IconInfoCircle,
+  IconMail,
+  IconCircleFilled,
+  IconPlus,
+  IconChevronRight,
+  IconBuilding,
+  IconLock,
+  IconMoodPlus,
+  IconBuildingCommunity,
+  IconNetwork,
+  IconWorld,
+  IconLockFilled,
+  IconHash,
+  IconBuildingEstate,
+  IconTent,
+  IconFile,
+  IconFolderFilled,
+  IconUpload,
+  IconItalic,
+  IconBold,
+  IconH1,
+  IconArrowBackUp,
+  IconSpeakerphone,
+  IconBulb,
+  IconMessage,
+  IconTrophy,
+  IconStrikethrough,
+  IconAlignJustified,
+  IconVideo,
+  IconChartColumn,
+  IconLogs,
+  IconArrowForwardUp,
+  IconTable,
+  IconUser,
+  IconTargetArrow,
+  IconPaperclip,
+  IconBlockquote,
+  IconH2,
+  IconList,
+  IconListNumbers,
+  IconBrandDiscordFilled,
+  IconLifebuoy,
+  IconMap2,
+  IconSun,
+  IconMoon,
+  IconDeviceLaptop,
+  IconPencil,
+  IconArchive,
+  IconPlayerPlayFilled,
+  IconPlayerPauseFilled,
+  IconExchange,
+  IconReplace,
+  IconCircleCheck,
+  IconUserCircle,
+  IconLockPassword,
+  IconCoffee,
+  IconBell,
+  IconRss,
+  IconBinaryTree2,
+  IconCircleKey,
+  IconSwitch,
+  IconMenu2,
+  IconHome2,
+  IconBriefcase,
+  IconDoorExit,
+  IconPalette,
+  IconSparkles,
+  IconFileExport,
+  IconMailFast,
+  IconFlare,
+  IconChecks,
+  IconAlertTriangle,
+  IconId,
+  IconRefresh,
+  IconUserX,
+  IconUsers,
+  IconLetterCase,
+  IconShieldLock,
+  IconDownload,
+  IconChevronUp,
+  IconCircleArrowRight,
+  IconRotateDot,
+  IconSettings,
+  IconHome,
+  IconSearch,
+  IconStar,
+  IconCircleX,
+  IconExternalLink,
+  IconFlag,
+  IconClipboardText,
+  IconMessages,
+  IconListCheck,
+  IconCalendarEvent,
+  IconCalendarPlus,
+  IconHeart,
+  IconLayoutGrid,
+  IconExclamationCircleFilled,
+  IconBellOff,
+  IconFileText,
+  IconMessageCircle,
+  IconChecklist,
+  IconPlayerPause,
+  IconCircleDashed,
+  IconChevronLeft,
+  IconEye,
+  IconClipboardCheck,
+  IconClockPlay,
+  IconCircle,
+  IconActivity,
+  IconFlagX,
+  IconUserPlus,
+  IconCalendarMinus,
+  IconUserCheck,
+  IconUserStar,
+  IconCircleDot,
+  IconFilter,
+  IconGripVertical,
+};
+
+export interface IconProps {
   size?: number;
   className?: string;
 }
+
+export type { TablerIconProps };
 
 export function IconGoal({ size = 16, className = "" }: IconProps) {
   const outer = classNames(

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -14,6 +14,7 @@ export * from "./StatusBadge";
 export * from "./TimeframeSelector";
 export * from "./Timeline";
 export * from "./WorkMap";
+export * from "./icons";
 
 export { DateField } from "./DateField";
 export { FormattedTime } from "./FormattedTime";


### PR DESCRIPTION
I've optimized the imports of tabler icons.

It should help us with https://github.com/operately/operately/issues/2703. Although rebuilding is still too slow, these changes improved it by about 10s.