### PR TITLE
chore: Standardize goal updates status

### DIFF
--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -95,6 +95,7 @@ function OverviewStatus({ goal }: { goal: Goals.Goal }) {
     .with("concern", () => <OverviewConcern goal={goal} />)
     .with("caution", () => <OverviewConcern goal={goal} />)
     .with("issue", () => <OverviewIssue goal={goal} />)
+    .with("off_track", () => <OverviewIssue goal={goal} />)
     .run();
 }
 

--- a/app/assets/js/features/goals/GoalCheckIn/StatusSelector.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/StatusSelector.tsx
@@ -9,38 +9,26 @@ import { createTestId } from "@/utils/testid";
 import { IconCheck } from "turboui";
 import classNames from "classnames";
 
-type Status = "pending" | "on_track" | "concern" | "issue";
-type LegacyStatus = "caution";
+type Status = "on_track" | "caution" | "off_track";
 
-type AnyStatus = Status | LegacyStatus;
+const STATUS_OPTIONS = ["on_track", "caution", "off_track"] as const;
 
-const STATUS_OPTIONS = ["pending", "on_track", "concern", "issue"] as const;
-
-const LEGACY_STATUS_MAP: Record<LegacyStatus, Status> = {
-  caution: "concern",
-};
-
-const STATUS_COLORS: Record<AnyStatus, string> = {
-  pending: "bg-stone-500",
+const STATUS_COLORS: Record<Status, string> = {
   on_track: "bg-accent-1",
-  concern: "bg-yellow-500",
   caution: "bg-yellow-500",
-  issue: "bg-red-500",
+  off_track: "bg-red-500",
 };
 
-const STATUS_LABELS: Record<AnyStatus, string> = {
-  pending: "Pending",
+const STATUS_LABELS: Record<Status, string> = {
   on_track: "On track",
-  concern: "Needs attention",
-  caution: "Needs attention",
-  issue: "At risk",
+  caution: "Caution",
+  off_track: "Off track",
 };
 
 const STATUS_DESCRIPTIONS_TEMPLATE = (reviewer: string) => ({
-  pending: "Work has not started yet.",
-  on_track: "Progressing well. No blockers.",
-  concern: `There are emerging risks. ${reviewer} should be aware.`,
-  issue: `Blocked or significantly behind. ${reviewer}'s help is needed.`,
+  on_track: "Progressing as planned. No blockers.",
+  caution: `Emerging risks or delays. ${reviewer} should be aware.`,
+  off_track: `Significant problems affecting success. ${reviewer}'s help is needed.`,
 });
 
 interface SelectGoalStatusProps {
@@ -86,7 +74,7 @@ export function StatusSelector(props: SelectGoalStatusProps) {
 
 type StatusPickerProps = {
   value: Status | null;
-  rawValue: AnyStatus;
+  rawValue: Status;
   setValue: (value: Status) => void;
   reviewerFirstName: string;
   error: boolean;
@@ -144,7 +132,7 @@ function StatusPickerOption({ status, description, color, isSelected, onClick, t
   );
 }
 
-function StatusTrigger({ value, error }: { value: AnyStatus | null; error?: boolean }) {
+function StatusTrigger({ value, error }: { value: Status | null; error?: boolean }) {
   const className = classNames(
     "border rounded-lg",
     "px-2 py-1.5",
@@ -184,17 +172,13 @@ function normalizeStatus(value: string | null) {
     return value as Status;
   }
 
-  if (value in LEGACY_STATUS_MAP) {
-    return LEGACY_STATUS_MAP[value as LegacyStatus];
-  }
-
   throw new Error(`Invalid status value: ${value}`);
 }
 
-function assertValidStatus(value: string | null): asserts value is AnyStatus | null {
+function assertValidStatus(value: string | null): asserts value is Status | null {
   if (value === null) return;
 
-  if (STATUS_OPTIONS.includes(value as Status) || value in LEGACY_STATUS_MAP) {
+  if (STATUS_OPTIONS.includes(value as Status)) {
     return;
   }
 

--- a/app/lib/operately/data/change_059_update_goal_update_status.ex
+++ b/app/lib/operately/data/change_059_update_goal_update_status.ex
@@ -1,0 +1,54 @@
+defmodule Operately.Data.Change059UpdateGoalUpdateStatus do
+  alias Operately.Repo
+
+  def run do
+    Repo.transaction(fn ->
+      unexpected_statuses = find_unexpected_statuses()
+
+      if length(unexpected_statuses) > 0 do
+        statuses_str = Enum.join(unexpected_statuses, ", ")
+        raise "Found unexpected goal update statuses: #{statuses_str}"
+      end
+
+      update_statuses()
+    end)
+  end
+
+  defp find_unexpected_statuses do
+    sql = """
+    SELECT DISTINCT status
+    FROM goal_updates
+    WHERE status IS NOT NULL
+    AND status NOT IN ('on_track', 'caution', 'concern', 'issue', 'pending')
+    """
+
+    %{rows: rows} = Repo.query!(sql)
+    Enum.map(rows, fn [status] -> status end)
+  end
+
+  defp update_statuses do
+    # Update 'issue' statuses to 'off_track'
+    update_issue_sql = """
+    UPDATE goal_updates
+    SET status = 'off_track'
+    WHERE status = 'issue'
+    """
+    Repo.query!(update_issue_sql)
+
+    # Update 'concern' statuses to 'caution'
+    update_concern_sql = """
+    UPDATE goal_updates
+    SET status = 'caution'
+    WHERE status = 'concern'
+    """
+    Repo.query!(update_concern_sql)
+
+    # Update 'pending' statuses to 'on_track'
+    update_pending_sql = """
+    UPDATE goal_updates
+    SET status = 'on_track'
+    WHERE status = 'pending'
+    """
+    Repo.query!(update_pending_sql)
+  end
+end

--- a/app/lib/operately/goals/goal.ex
+++ b/app/lib/operately/goals/goal.ex
@@ -18,15 +18,15 @@ defmodule Operately.Goals.Goal do
     belongs_to :reviewer, Operately.People.Person, foreign_key: :reviewer_id
     belongs_to :creator, Operately.People.Person, foreign_key: :creator_id
 
-    has_many :targets, Operately.Goals.Target
+    has_many :targets, Target
     has_many :projects, Operately.Projects.Project, foreign_key: :goal_id
 
     has_one :access_context, Operately.Access.Context, foreign_key: :goal_id
 
     # Check-Ins (they are called updates for historical reasons)
-    has_many :updates, Operately.Goals.Update
-    belongs_to :last_update, Operately.Goals.Update, foreign_key: :last_check_in_id
-    field :last_update_status, Ecto.Enum, values: [:on_track, :concern, :caution, :issue, :pending]
+    has_many :updates, Update
+    belongs_to :last_update, Update, foreign_key: :last_check_in_id
+    field :last_update_status, Ecto.Enum, values: Update.valid_statuses()
     field :next_update_scheduled_at, :utc_datetime
 
     embeds_one :timeframe, Operately.Goals.Timeframe, on_replace: :delete

--- a/app/lib/operately/goals/update.ex
+++ b/app/lib/operately/goals/update.ex
@@ -5,6 +5,8 @@ defmodule Operately.Goals.Update do
   alias Operately.Notifications
   alias Operately.Goals.Update.Permissions
 
+  @valid_statuses [:on_track, :caution, :off_track]
+
   schema "goal_updates" do
     belongs_to :goal, Operately.Goals.Goal, foreign_key: :goal_id
     belongs_to :author, Operately.People.Person, foreign_key: :author_id
@@ -15,7 +17,7 @@ defmodule Operately.Goals.Update do
     has_many :comments, Operately.Updates.Comment, foreign_key: :entity_id, where: [entity_type: :goal_update]
 
     field :message, :map
-    field :status, Ecto.Enum, values: [:on_track, :concern, :caution, :issue, :pending]
+    field :status, Ecto.Enum, values: @valid_statuses
     embeds_one :timeframe, Operately.Goals.Timeframe, on_replace: :delete
 
     field :acknowledged_at, :utc_datetime
@@ -58,6 +60,8 @@ defmodule Operately.Goals.Update do
       :subscription_list_id
     ])
   end
+
+  def valid_statuses, do: @valid_statuses
 
   #
   # After load hooks

--- a/app/lib/operately_email/emails/goal_check_in_email.ex
+++ b/app/lib/operately_email/emails/goal_check_in_email.ex
@@ -65,29 +65,24 @@ defmodule OperatelyEmail.Emails.GoalCheckInEmail do
       ])
     end
 
-    defp status_msg(:pending) do
-      [text("The goal is "), bg_gray("pending"), text(". Work has not started yet.")]
-    end
-
     defp status_msg(:on_track) do
-      [text("The goal is "), bg_green("on-track"), text(".")]
+      [text("The goal is "), bg_green("on-track"), text(". Progressing as planned.")]
     end
 
-    defp status_msg(:concern) do
-      [text("The goal "), bg_yellow("needs attention"), text(" due to emerging risks.")]
+    defp status_msg(:caution) do
+      [text("The goal "), bg_yellow("needs attention"), text(" due to emerging risks or delays.")]
     end
 
-    defp status_msg(:issue) do
-      [text("The goal is "), bg_red("at risk"), text(" due to blockers or significant delays.")]
+    defp status_msg(:off_track) do
+      [text("The goal is "), bg_red("off track"), text(" due to significant problems affecting success.")]
     end
 
-    def reviewer_note(:pending, _), do: []
     def reviewer_note(:on_track, _), do: []
 
-    def reviewer_note(:concern, reviewer),
+    def reviewer_note(:caution, reviewer),
       do: [text(" "), text(Person.first_name(reviewer)), text(" should be aware.")]
 
-    def reviewer_note(:issue, reviewer),
+    def reviewer_note(:off_track, reviewer),
       do: [text(" "), text(Person.first_name(reviewer) <> "'s"), text(" help is needed.")]
 
     defp due_date(date) do
@@ -112,9 +107,7 @@ defmodule OperatelyEmail.Emails.GoalCheckInEmail do
     defp human_duration(n), do: "#{div(n, 30)} months"
 
     defp normalize_status(:on_track), do: :on_track
-    defp normalize_status(:concern), do: :concern
-    defp normalize_status(:caution), do: :concern
-    defp normalize_status(:issue), do: :issue
-    defp normalize_status(:pending), do: :pending
+    defp normalize_status(:caution), do: :caution
+    defp normalize_status(:off_track), do: :off_track
   end
 end

--- a/app/lib/operately_web/api/mutations/post_goal_progress_update.ex
+++ b/app/lib/operately_web/api/mutations/post_goal_progress_update.ex
@@ -67,7 +67,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdate do
            %{"id" => id, "value" => t["value"]}
          end),
        content: inputs.content,
-       status: inputs.status,
+       status: String.to_atom(inputs.status),
        due_date: inputs.due_date,
        send_to_everyone: inputs[:send_notifications_to_everyone] || false,
        subscription_parent_type: :goal_update,

--- a/app/priv/repo/migrations/20250623174536_update_goal_updates_status.exs
+++ b/app/priv/repo/migrations/20250623174536_update_goal_updates_status.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.UpdateGoalUpdatesStatus do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change059UpdateGoalUpdateStatus.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/data/change_059_update_goal_update_status_test.exs
+++ b/app/test/operately/data/change_059_update_goal_update_status_test.exs
@@ -1,0 +1,75 @@
+defmodule Operately.Data.Change059UpdateGoalUpdateStatusTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+  alias Operately.GoalsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_goal(:goal, :space)
+  end
+
+  test "updates statuses according to mapping", ctx do
+    updates = create_updates_with_statuses(ctx, [
+      "on_track",    # should remain on_track
+      "caution",     # should remain caution
+      "concern",     # should become caution
+      "issue",       # should become off_track
+      "pending"      # should become on_track
+    ])
+
+    Operately.Data.Change059UpdateGoalUpdateStatus.run()
+
+    updated_updates = reload_updates(updates)
+
+    assert_statuses(updated_updates, [
+      :on_track, :caution, :caution, :off_track, :on_track
+    ])
+  end
+
+  test "raises error when unexpected statuses exist", ctx do
+    _updates = create_updates_with_statuses(ctx, ["on_track", "caution", "invalid_status"])
+
+    assert_raise RuntimeError, ~r/Found unexpected goal update statuses: invalid_status/, fn ->
+      Operately.Data.Change059UpdateGoalUpdateStatus.run()
+    end
+  end
+
+  #
+  # Helpers
+  #
+
+  defp create_updates_with_statuses(ctx, statuses) do
+    updates = Enum.map(statuses, fn status ->
+      insert_update_with_status(ctx, status)
+    end)
+
+    updates
+  end
+
+  defp assert_statuses(updates, expected_statuses) do
+    actual_statuses = Enum.map(updates, & &1.status)
+    assert actual_statuses == expected_statuses
+  end
+
+  defp reload_updates(updates) do
+    Enum.map(updates, &Repo.reload/1)
+  end
+
+  defp insert_update_with_status(ctx, status) do
+    update = GoalsFixtures.goal_update_fixture(ctx.creator, ctx.goal)
+
+    # Update its status directly via SQL to bypass validations
+    update_id = Ecto.UUID.dump!(update.id)
+    update_sql = """
+    UPDATE goal_updates
+    SET status = $1
+    WHERE id = $2
+    """
+
+    Repo.query!(update_sql, [status, update_id])
+    %{update | status: status}
+  end
+end

--- a/app/test/operately_web/api/mutations/post_goal_progress_update_test.exs
+++ b/app/test/operately_web/api/mutations/post_goal_progress_update_test.exs
@@ -122,7 +122,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
       assert {200, res} =
                mutation(ctx.conn, :post_goal_progress_update, %{
                  goal_id: Paths.goal_id(ctx.goal),
-                 status: "issue",
+                 status: "off_track",
                  content: RichText.rich_text("Content", :as_string),
                  new_target_values: new_target_values(ctx.goal),
                  send_notifications_to_everyone: true,
@@ -152,7 +152,7 @@ defmodule OperatelyWeb.Api.Mutations.PostGoalProgressUpdateTest do
       assert {200, res} =
                mutation(ctx.conn, :post_goal_progress_update, %{
                  goal_id: Paths.goal_id(ctx.goal),
-                 status: "pending",
+                 status: "on_track",
                  content: content,
                  new_target_values: new_target_values(ctx.goal),
                  send_notifications_to_everyone: false,


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2709.

From now on, goal updates will have the following statuses:
- On track
- Caution
- Off track