### PR TITLE
fix: Handle at_risk status in project check-in migration

### DIFF
--- a/app/lib/operately/data/change_058_update_projects_last_check_in_status.ex
+++ b/app/lib/operately/data/change_058_update_projects_last_check_in_status.ex
@@ -21,7 +21,7 @@ defmodule Operately.Data.Change058UpdateProjectsLastCheckInStatus do
     SELECT DISTINCT last_check_in_status
     FROM projects
     WHERE last_check_in_status IS NOT NULL
-    AND last_check_in_status NOT IN ('on_track', 'caution', 'issue')
+    AND last_check_in_status NOT IN ('on_track', 'caution', 'issue', 'at_risk')
     """
 
     %{rows: rows} = Repo.query!(sql)
@@ -33,6 +33,14 @@ defmodule Operately.Data.Change058UpdateProjectsLastCheckInStatus do
     UPDATE projects
     SET last_check_in_status = 'off_track'
     WHERE last_check_in_status = 'issue'
+    """
+
+    Repo.query!(sql)
+
+    sql = """
+    UPDATE projects
+    SET last_check_in_status = 'off_track'
+    WHERE last_check_in_status = 'at_risk'
     """
 
     Repo.query!(sql)

--- a/app/test/operately/data/change_058_update_projects_last_check_in_status_test.exs
+++ b/app/test/operately/data/change_058_update_projects_last_check_in_status_test.exs
@@ -10,14 +10,14 @@ defmodule Operately.Data.Change058UpdateProjectsLastCheckInStatusTest do
   end
 
   test "updates 'issue' status to 'off_track'", ctx do
-    projects = create_projects_with_statuses(ctx, ["on_track", "caution", "issue", "issue", "on_track", "caution"])
+    projects = create_projects_with_statuses(ctx, ["on_track", "caution", "issue", "issue", "on_track", "caution", "at_risk"])
 
     Operately.Data.Change058UpdateProjectsLastCheckInStatus.run()
 
     updated_projects = reload_projects(projects)
 
     assert_statuses(updated_projects, [
-      :on_track, :caution, :off_track, :off_track, :on_track, :caution
+      :on_track, :caution, :off_track, :off_track, :on_track, :caution, :off_track
     ])
   end
 


### PR DESCRIPTION
I'm extending the project check-in migration to also handle the `at_risk` status.