### PR TITLE
chore: Bootstrap module analyzer

### DIFF
--- a/app/assets/custom-vite-plugins.mjs
+++ b/app/assets/custom-vite-plugins.mjs
@@ -1,0 +1,47 @@
+// based on: https://github.com/vitejs/vite/issues/19091
+export const resumeStdinPlugin = {
+  name: "resume-stdin",
+  configureServer: () => {
+    // runs when the dev server is triggered, but not on other commands:
+    process.stdin.resume();
+    // an 'end' listener is already added in `setupSIGTERMListener` here: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L1537
+  },
+};
+
+// Tracking resource consumpition per JS module
+export const moduleAnalyzerPlugin = {
+  name: "module-analyzer",
+  generateBundle(options, bundle) {
+    console.log("\n=== MODULE ANALYSIS ===");
+    const moduleMap = new Map();
+
+    Object.values(bundle).forEach((chunk) => {
+      if (chunk.type === "chunk") {
+        Object.keys(chunk.modules || {}).forEach((moduleId) => {
+          let packageName;
+          if (moduleId.includes("node_modules/")) {
+            const parts = moduleId.split("node_modules/")[1].split("/");
+            packageName = parts[0].startsWith("@") ? `${parts[0]}/${parts[1]}` : parts[0];
+            packageName = `node_modules/${packageName}`;
+          } else {
+            packageName = "app-source";
+          }
+          moduleMap.set(packageName, (moduleMap.get(packageName) || 0) + 1);
+        });
+      }
+    });
+
+    const sortedModules = Array.from(moduleMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20);
+
+    let totalModules = 0;
+    sortedModules.forEach(([packageName, count]) => {
+      console.log(`${packageName.padEnd(60)} ${count.toString().padStart(4)} modules`);
+      totalModules += count;
+    });
+
+    console.log(`${"TOTAL".padEnd(40)} ${totalModules.toString().padStart(4)} modules`);
+    console.log("========================\n");
+  },
+};

--- a/app/vite.config.mjs
+++ b/app/vite.config.mjs
@@ -1,64 +1,49 @@
-import { defineConfig, splitVendorChunkPlugin } from 'vite';
-import { fileURLToPath } from 'url';
-import react from '@vitejs/plugin-react';
-import path from 'path';
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+import { defineConfig, splitVendorChunkPlugin } from "vite";
+import { moduleAnalyzerPlugin, resumeStdinPlugin } from "./assets/custom-vite-plugins.mjs";
 
-// Based on: https://github.com/vitejs/vite/issues/19091
-const resumeStdinPlugin = {
-  name: "resume-stdin",
-  configureServer: () => {
-    // runs when the dev server is triggered, but not on other commands:
-    process.stdin.resume();
-    // an 'end' listener is already added in `setupSIGTERMListener` here: https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L1537
-  },
-};
-
+const isProd = process.env.NODE_ENV === "production";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Check for deployment mode
-const isProd = process.env.NODE_ENV === 'production';
-
 export default defineConfig({
-  plugins: [
-    resumeStdinPlugin,
-    react(), 
-    splitVendorChunkPlugin()
-  ],
+  plugins: [resumeStdinPlugin, moduleAnalyzerPlugin, react(), splitVendorChunkPlugin()],
 
   root: __dirname,
-  
+
   build: {
-    outDir: 'priv/static',
+    outDir: "priv/static",
     emptyOutDir: true,
     minify: isProd,
-    sourcemap: !isProd || 'inline',
-    target: 'es2020',
+    sourcemap: !isProd || "inline",
+    target: "es2020",
     manifest: true,
     rollupOptions: {
       input: {
-        app: path.resolve(__dirname, 'assets/js/app.tsx')
-      }
-    }
+        app: path.resolve(__dirname, "assets/js/app.tsx"),
+      },
+    },
   },
-  
+
   resolve: {
-    dedupe: ['react', 'react-dom', 'react-router', 'react-router-dom'],
+    dedupe: ["react", "react-dom", "react-router", "react-router-dom"],
 
     alias: [
-      { find: /^@\/ee\/(.*)$/, replacement: path.resolve(__dirname, 'ee/assets/js/$1')},
-      { find: /^@\/(.*)$/, replacement: path.resolve(__dirname, 'assets/js/$1')},
-      { find: 'turboui', replacement: path.resolve(__dirname, '../turboui/src')}
-    ] 
+      { find: /^@\/ee\/(.*)$/, replacement: path.resolve(__dirname, "ee/assets/js/$1") },
+      { find: /^@\/(.*)$/, replacement: path.resolve(__dirname, "assets/js/$1") },
+      { find: "turboui", replacement: path.resolve(__dirname, "../turboui/src") },
+    ],
   },
-  
+
   // Vite has built-in watch mode via the dev server
   server: {
     watch: {
       usePolling: false,
-      ignored: ['**/node_modules/**', '**/.git/**', '!../turboui/src/**']
+      ignored: ["**/node_modules/**", "**/.git/**", "!../turboui/src/**"],
     },
     hmr: true,
     port: 4005,
-    host: "0.0.0.0"
-  }
+    host: "0.0.0.0",
+  },
 });


### PR DESCRIPTION
We were using this module to track down that Vite slowness comes from excessive Tabler icon compilation. I'm adding it permanently to out setup.

Example output:

```
=== MODULE ANALYSIS ===
app-source                                                    848 modules
node_modules/date-fns                                         626 modules
node_modules/@tabler/icons-react                              145 modules
node_modules/@popperjs/core                                   114 modules
node_modules/react-spinners                                    54 modules
node_modules/markdown-it                                       53 modules
node_modules/axios                                             50 modules
node_modules/@babel/runtime                                    48 modules
node_modules/@sentry/utils                                     46 modules
node_modules/@sentry/core                                      38 modules
node_modules/@radix-ui/react-tooltip                           36 modules
node_modules/@sentry-internal/tracing                          30 modules
node_modules/@radix-ui/react-menu                              27 modules
node_modules/react-modal                                       23 modules
node_modules/@sentry/browser                                   21 modules
node_modules/@radix-ui/react-dropdown-menu                     21 modules
node_modules/@radix-ui/react-popover                           20 modules
node_modules/@tiptap/pm                                        20 modules
node_modules/use-callback-ref                                  18 modules
node_modules/prop-types                                        18 modules
TOTAL                                                        2256 modules
========================
```

Before this (https://github.com/operately/operately/pull/2766), tabler was a 🐷 with 11k modules.