### PR TITLE
chore: Add migration to convert old project retrospectives to new format

### DIFF
--- a/app/lib/operately/data/change_061_convert_retrospective_content.ex
+++ b/app/lib/operately/data/change_061_convert_retrospective_content.ex
@@ -1,0 +1,64 @@
+defmodule Operately.Data.Change061ConvertRetrospectiveContent do
+  alias Operately.Repo
+  alias Operately.Projects.Retrospective
+
+  def run do
+    retrospectives = Repo.all(Retrospective)
+
+    Enum.each(retrospectives, fn retrospective ->
+      if should_convert?(retrospective) do
+        convert_and_update(retrospective)
+      end
+    end)
+  end
+
+  defp should_convert?(retrospective) do
+    case retrospective.content do
+      %{"whatWentWell" => _, "whatDidYouLearn" => _, "whatCouldHaveGoneBetter" => _} -> true
+      _ -> false
+    end
+  end
+
+  defp convert_and_update(retrospective) do
+    new_content = update_content(retrospective.content)
+
+    retrospective
+    |> Ecto.Changeset.change(%{content: new_content})
+    |> Repo.update!()
+  end
+
+  defp update_content(content) do
+    what_went_well = content["whatWentWell"]
+    what_did_learn = content["whatDidYouLearn"]
+    what_could_better = content["whatCouldHaveGoneBetter"]
+
+    %{
+      "type" => "doc",
+      "content" => [
+        # What went well section
+        %{"type" => "heading", "attrs" => %{"level" => 2}, "content" => [%{"type" => "text", "text" => "What went well?"}]},
+        merge_content_or_empty(what_went_well),
+        %{"type" => "paragraph", "content" => []},
+
+        # What could have gone better section
+        %{"type" => "heading", "attrs" => %{"level" => 2}, "content" => [%{"type" => "text", "text" => "What could have gone better?"}]},
+        merge_content_or_empty(what_could_better),
+        %{"type" => "paragraph", "content" => []},
+
+        # What did you learn section
+        %{"type" => "heading", "attrs" => %{"level" => 2}, "content" => [%{"type" => "text", "text" => "What did you learn?"}]},
+        merge_content_or_empty(what_did_learn),
+        %{"type" => "paragraph", "content" => []}
+      ] |> List.flatten()
+    }
+  end
+
+  # Helper function to handle content that might be missing or in different formats
+  defp merge_content_or_empty(section) do
+    case section do
+      %{"content" => content} when is_list(content) and content != [] -> content
+      %{"content" => _} -> [%{"type" => "paragraph", "content" => [%{"type" => "text", "text" => ""}]}]
+      _ -> [%{"type" => "paragraph", "content" => [%{"type" => "text", "text" => ""}]}]
+    end
+  end
+end

--- a/app/priv/repo/migrations/20250625110430_convert_existing_project_retrospectives_to_new_format.exs
+++ b/app/priv/repo/migrations/20250625110430_convert_existing_project_retrospectives_to_new_format.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.ConvertExistingProjectRetrospectivesToNewFormat do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change061ConvertRetrospectiveContent.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/data/change_061_convert_retrospective_content_test.exs
+++ b/app/test/operately/data/change_061_convert_retrospective_content_test.exs
@@ -1,0 +1,138 @@
+defmodule Operately.Data.Change061ConvertRetrospectiveContentTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_project(:project, :space)
+  end
+
+  test "converts old-format retrospectives to new format", ctx do
+    old_format_content = %{
+      "whatWentWell" => %{
+        "type" => "doc",
+        "content" => [
+          %{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Team collaboration was excellent"}]}
+        ]
+      },
+      "whatDidYouLearn" => %{
+        "type" => "doc",
+        "content" => [
+          %{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Agile planning helped"}]}
+        ]
+      },
+      "whatCouldHaveGoneBetter" => %{
+        "type" => "doc",
+        "content" => [
+          %{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Communication with stakeholders"}]}
+        ]
+      }
+    }
+
+    retrospective = Operately.ProjectsFixtures.retrospective_fixture(%{
+      project_id: ctx.project.id,
+      author_id: ctx.creator.id,
+      content: old_format_content,
+    })
+
+    Operately.Data.Change061ConvertRetrospectiveContent.run()
+
+    updated_retrospective = Repo.reload(retrospective)
+
+    # The content should now be a single document with headings
+    assert updated_retrospective.content["type"] == "doc"
+    assert updated_retrospective.content["content"] |> is_list()
+
+    # Extract heading texts and paragraph content for verification
+    content_items = updated_retrospective.content["content"]
+    headings = Enum.filter(content_items, fn item -> item["type"] == "heading" end)
+    heading_texts = Enum.map(headings, fn heading ->
+      Enum.at(heading["content"], 0)["text"]
+    end)
+
+    # Check each heading exists
+    assert Enum.member?(heading_texts, "What went well?")
+    assert Enum.member?(heading_texts, "What could have gone better?")
+    assert Enum.member?(heading_texts, "What did you learn?")
+
+    # Check the content of the paragraphs
+    paragraphs = Enum.filter(content_items, fn item -> item["type"] == "paragraph" end)
+    paragraph_texts = Enum.map(paragraphs, fn paragraph ->
+      case paragraph["content"] do
+        [%{"text" => text} | _] -> text
+        _ -> ""
+      end
+    end) |> Enum.filter(fn text -> text != "" end)
+
+    # Verify the paragraph contents were preserved
+    assert Enum.member?(paragraph_texts, "Team collaboration was excellent")
+    assert Enum.member?(paragraph_texts, "Agile planning helped")
+    assert Enum.member?(paragraph_texts, "Communication with stakeholders")
+  end
+
+  test "ignores retrospectives already in the new format", ctx do
+    new_format_content = %{
+      "type" => "doc",
+      "content" => [
+        %{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "This is already in the new format"}]}
+      ]
+    }
+
+    retrospective = Operately.ProjectsFixtures.retrospective_fixture(%{
+      project_id: ctx.project.id,
+      author_id: ctx.creator.id,
+      content: new_format_content,
+    })
+    original_content = retrospective.content
+
+    Operately.Data.Change061ConvertRetrospectiveContent.run()
+
+    updated_retrospective = Repo.reload(retrospective)
+    assert updated_retrospective.content == original_content
+  end
+
+  test "handles empty or nil content sections gracefully", ctx do
+    partial_content = %{
+      "whatWentWell" => %{
+        "type" => "doc",
+        "content" => [
+          %{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Good things happened"}]}
+        ]
+      },
+      "whatDidYouLearn" => %{
+        "type" => "doc",
+        "content" => []
+      },
+      "whatCouldHaveGoneBetter" => nil
+    }
+
+    retrospective = Operately.ProjectsFixtures.retrospective_fixture(%{
+      project_id: ctx.project.id,
+      author_id: ctx.creator.id,
+      content: partial_content,
+    })
+
+    Operately.Data.Change061ConvertRetrospectiveContent.run()
+
+    updated_retrospective = Repo.reload(retrospective)
+
+    # The content should now be a single document
+    assert updated_retrospective.content["type"] == "doc"
+    assert updated_retrospective.content["content"] |> is_list()
+
+    # Verify the content from the non-empty section was preserved
+    content_items = updated_retrospective.content["content"]
+    paragraphs = Enum.filter(content_items, fn item -> item["type"] == "paragraph" end)
+    paragraph_texts = Enum.map(paragraphs, fn paragraph ->
+      case paragraph["content"] do
+        [%{"text" => text} | _] -> text
+        _ -> ""
+      end
+    end) |> Enum.filter(fn text -> text != "" end)
+
+    assert Enum.member?(paragraph_texts, "Good things happened")
+  end
+end


### PR DESCRIPTION
I've added a migration to convert all the existing project retrospectives to the new format.