### PR TITLE
chore: Add success_status field to Goal

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -2471,15 +2471,16 @@ export interface ChangeTaskDescriptionResult {
 }
 
 export interface CloseGoalInput {
-  goalId?: Id | null;
-  success?: string | null;
-  retrospective?: string | null;
-  sendNotificationsToEveryone?: boolean | null;
-  subscriberIds?: Id[] | null;
+  goalId: Id;
+  success: string;
+  retrospective: string;
+  sendNotificationsToEveryone: boolean;
+  subscriberIds: Id[];
+  successStatus: string;
 }
 
 export interface CloseGoalResult {
-  goal?: Goal | null;
+  goal: Goal;
 }
 
 export interface CloseProjectInput {

--- a/app/assets/js/pages/GoalClosingPage/Form.tsx
+++ b/app/assets/js/pages/GoalClosingPage/Form.tsx
@@ -30,9 +30,12 @@ export function Form() {
       retrospective: emptyContent(),
     },
     submit: async () => {
+      const successStatus = form.values.success === "yes" ? "achieved" : "missed";
+
       await close({
         goalId: goal.id,
         success: form.values.success,
+        successStatus: successStatus,
         retrospective: JSON.stringify(form.values.retrospective),
         sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
         subscriberIds: subscriptionsState.currentSubscribersList,
@@ -60,10 +63,10 @@ function AccomplishedOrDropped() {
   return (
     <Forms.RadioButtons
       field="success"
-      label="Was this goal accomplished?"
+      label="Was this goal achieved?"
       options={[
-        { value: "yes", label: "Accomplished" },
-        { value: "no", label: "Not accomplished" },
+        { value: "yes", label: "Achieved" },
+        { value: "no", label: "Not achieved" },
       ]}
     />
   );

--- a/app/lib/operately/data/change_062_set_goal_success_status.ex
+++ b/app/lib/operately/data/change_062_set_goal_success_status.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Data.Change062SetGoalSuccessStatus do
+  import Ecto.Query
+
+  alias Operately.Repo
+  alias Operately.Goals.Goal
+
+  def run do
+    Goal
+    |> where([g], not is_nil(g.closed_at) or not is_nil(g.success))
+    |> Repo.all()
+    |> Enum.each(fn goal ->
+      update_success_status(goal)
+    end)
+  end
+
+  defp update_success_status(goal) do
+    success_status = if goal.success == "yes", do: :achieved, else: :missed
+
+    goal
+    |> Ecto.Changeset.change(%{success_status: success_status})
+    |> Repo.update!()
+  end
+end

--- a/app/lib/operately/goals/goal.ex
+++ b/app/lib/operately/goals/goal.ex
@@ -35,6 +35,7 @@ defmodule Operately.Goals.Goal do
     field :closed_at, :utc_datetime
     belongs_to :closed_by, Operately.People.Person, foreign_key: :closed_by_id
     field :success, :string
+    field :success_status, Ecto.Enum, values: [:achieved, :missed]
 
     # populated with after load hooks
     field :my_role, :string, virtual: true
@@ -72,6 +73,7 @@ defmodule Operately.Goals.Goal do
       :closed_at,
       :closed_by_id,
       :success,
+      :success_status,
       :last_check_in_id,
       :last_update_status
     ])
@@ -89,6 +91,7 @@ defmodule Operately.Goals.Goal do
   @impl WorkMapItem
   def status(goal = %__MODULE__{}) do
     cond do
+      goal.success_status -> goal.success_status
       goal.success == "yes" -> :achieved
       goal.success == "no" -> :missed
       goal.closed_at -> :completed

--- a/app/lib/operately/operations/goal_closing.ex
+++ b/app/lib/operately/operations/goal_closing.ex
@@ -10,7 +10,8 @@ defmodule Operately.Operations.GoalClosing do
     changeset = Goals.Goal.changeset(goal, %{
       closed_at: DateTime.utc_now(),
       closed_by_id: author.id,
-      success: attrs.success
+      success: attrs.success,
+      success_status: attrs.success_status
     })
 
     Multi.new()

--- a/app/lib/operately_web/api/mutations/close_goal.ex
+++ b/app/lib/operately_web/api/mutations/close_goal.ex
@@ -6,15 +6,16 @@ defmodule OperatelyWeb.Api.Mutations.CloseGoal do
   alias Operately.Operations.GoalClosing
 
   inputs do
-    field? :goal_id, :id, null: true
-    field? :success, :string, null: true
-    field? :retrospective, :string, null: true
-    field? :send_notifications_to_everyone, :boolean, null: true
-    field? :subscriber_ids, list_of(:id), null: true
+    field :goal_id, :id
+    field :success, :string
+    field :retrospective, :string
+    field :send_notifications_to_everyone, :boolean
+    field :subscriber_ids, list_of(:id)
+    field :success_status, :string
   end
 
   outputs do
-    field? :goal, :goal, null: true
+    field :goal, :goal
   end
 
   def call(conn, inputs) do
@@ -42,6 +43,7 @@ defmodule OperatelyWeb.Api.Mutations.CloseGoal do
   defp parse_inputs(inputs) do
     {:ok, %{
       success: inputs.success,
+      success_status: String.to_atom(inputs.success_status),
       content: Jason.decode!(inputs.retrospective),
       send_to_everyone: inputs[:send_notifications_to_everyone] || false,
       subscriber_ids: inputs[:subscriber_ids] || [],

--- a/app/priv/repo/migrations/20250625144717_add_success_status_to_goals.exs
+++ b/app/priv/repo/migrations/20250625144717_add_success_status_to_goals.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddSuccessStatusToGoals do
+  use Ecto.Migration
+
+  def change do
+    alter table(:goals) do
+      add :success_status, :string
+    end
+  end
+end

--- a/app/priv/repo/migrations/20250625145111_run_goal_success_status_migration.exs
+++ b/app/priv/repo/migrations/20250625145111_run_goal_success_status_migration.exs
@@ -1,0 +1,12 @@
+defmodule Operately.Repo.Migrations.RunGoalSuccessStatusMigration do
+  use Ecto.Migration
+
+  def up do
+    Code.ensure_loaded(Operately.Data.Change062SetGoalSuccessStatus)
+    Operately.Data.Change062SetGoalSuccessStatus.run()
+  end
+
+  def down do
+    # This migration cannot be reversed
+  end
+end

--- a/app/test/operately/data/change_062_set_goal_success_status_test.exs
+++ b/app/test/operately/data/change_062_set_goal_success_status_test.exs
@@ -1,0 +1,55 @@
+defmodule Operately.Data.Change062SetGoalSuccessStatusTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+  alias Operately.GoalsFixtures
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> setup_test_goals()
+  end
+
+  test "sets success_status for closed goals", ctx do
+    Operately.Data.Change062SetGoalSuccessStatus.run()
+
+    achieved_goal = Repo.get(Operately.Goals.Goal, ctx.achieved_goal.id)
+    missed_goal = Repo.get(Operately.Goals.Goal, ctx.missed_goal.id)
+    open_goal = Repo.get(Operately.Goals.Goal, ctx.open_goal.id)
+    success_only_goal = Repo.get(Operately.Goals.Goal, ctx.success_only_goal.id)
+
+    assert achieved_goal.success_status == :achieved
+    assert missed_goal.success_status == :missed
+    assert open_goal.success_status == nil
+    assert success_only_goal.success_status == :achieved
+  end
+
+  defp setup_test_goals(ctx) do
+    achieved_goal = GoalsFixtures.goal_fixture(ctx.creator, %{space_id: ctx.space.id})
+    set_goal_attributes(achieved_goal.id, closed_at: ~U[2025-06-01 10:00:00Z], success: "yes")
+
+    missed_goal = GoalsFixtures.goal_fixture(ctx.creator, %{space_id: ctx.space.id})
+    set_goal_attributes(missed_goal.id, closed_at: ~U[2025-06-01 10:00:00Z], success: "no")
+
+    success_only_goal = GoalsFixtures.goal_fixture(ctx.creator, %{space_id: ctx.space.id})
+    set_goal_attributes(success_only_goal.id, success: "yes")
+
+    open_goal = GoalsFixtures.goal_fixture(ctx.creator, %{space_id: ctx.space.id})
+
+    ctx
+    |> Map.put(:achieved_goal, achieved_goal)
+    |> Map.put(:missed_goal, missed_goal)
+    |> Map.put(:open_goal, open_goal)
+    |> Map.put(:success_only_goal, success_only_goal)
+  end
+
+  defp set_goal_attributes(goal_id, attrs) do
+    goal_id = Ecto.UUID.dump!(goal_id)
+
+    Enum.each(attrs, fn {field, value} ->
+      update_sql = "UPDATE goals SET #{field} = $1 WHERE id = $2"
+      Repo.query!(update_sql, [value, goal_id])
+    end)
+  end
+end


### PR DESCRIPTION
This is part of https://github.com/operately/operately/issues/2709.

I've added the `success_status` field to Goal.