### PR TITLE
feat: New Project Retrospective can be edited

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1100,8 +1100,8 @@ export interface PersonPermissions {
 }
 
 export interface Project {
-  id?: string | null;
-  name?: string | null;
+  id: string;
+  name: string;
   insertedAt?: string | null;
   updatedAt?: string | null;
   startedAt?: string | null;
@@ -1109,11 +1109,12 @@ export interface Project {
   nextUpdateScheduledAt?: string | null;
   nextCheckInScheduledAt?: string | null;
   privacy?: string | null;
-  status?: string | null;
+  status: string;
+  successStatus: SuccessStatus;
   closedAt?: string | null;
   retrospective?: ProjectRetrospective | null;
   description?: string | null;
-  goalId?: string | null;
+  goalId: string;
   goal?: Goal | null;
   lastCheckIn?: ProjectCheckIn | null;
   milestones?: Milestone[] | null;
@@ -1215,16 +1216,16 @@ export interface ProjectPermissions {
 }
 
 export interface ProjectRetrospective {
-  id?: string | null;
-  author?: Person | null;
-  project?: Project | null;
-  content?: string | null;
-  closedAt?: string | null;
-  permissions?: ProjectPermissions | null;
-  reactions?: Reaction[] | null;
-  subscriptionList?: SubscriptionList | null;
-  potentialSubscribers?: Subscriber[] | null;
-  notifications?: Notification[] | null;
+  id: string;
+  author: Person;
+  project: Project;
+  content: string;
+  closedAt: string;
+  permissions: ProjectPermissions;
+  reactions: Reaction[];
+  subscriptionList: SubscriptionList;
+  potentialSubscribers: Subscriber[];
+  notifications: Notification[];
 }
 
 export interface ProjectReviewRequest {
@@ -1697,6 +1698,8 @@ export type GoalStatus =
   | "dropped"
   | "pending"
   | "outdated";
+
+export type SuccessStatus = "achieved" | "missed";
 
 export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secret";
 
@@ -2484,11 +2487,11 @@ export interface CloseGoalResult {
 }
 
 export interface CloseProjectInput {
-  projectId: string;
+  projectId: Id;
   retrospective: string;
   successStatus: string;
   sendNotificationsToEveryone?: boolean;
-  subscriberIds?: string[];
+  subscriberIds?: Id[];
 }
 
 export interface CloseProjectResult {
@@ -2860,12 +2863,13 @@ export interface EditProjectPermissionsResult {
 }
 
 export interface EditProjectRetrospectiveInput {
-  id?: string | null;
-  content?: string | null;
+  id: Id;
+  content: string;
+  successStatus: string;
 }
 
 export interface EditProjectRetrospectiveResult {
-  retrospective?: ProjectRetrospective | null;
+  retrospective: ProjectRetrospective;
 }
 
 export interface EditProjectTimelineInput {

--- a/app/assets/js/features/ProjectRetrospective/Form.tsx
+++ b/app/assets/js/features/ProjectRetrospective/Form.tsx
@@ -29,26 +29,27 @@ export function Form({ mode, project, retrospective }: Props) {
 
   const form = Forms.useForm({
     fields: {
-      success: "yes",
+      success: project.successStatus === "missed" ? "no" : "yes",
       retrospective: retrospective ? JSON.parse(retrospective.content!) : emptyContent(),
     },
-    cancel: () => navigate(paths.projectPath(project.id!)),
+    cancel: () => navigate(paths.projectPath(project.id)),
     submit: async () => {
       if (mode == "create") {
         await post({
-          projectId: project.id!,
+          projectId: project.id,
           retrospective: JSON.stringify(form.values.retrospective),
           sendNotificationsToEveryone: subscriptionsState.subscriptionType == Options.ALL,
           subscriberIds: subscriptionsState.currentSubscribersList,
           successStatus: form.values.success === "yes" ? "achieved" : "missed",
         });
-        navigate(paths.projectPath(project.id!));
+        navigate(paths.projectPath(project.id));
       } else {
         await edit({
           id: retrospective!.id,
           content: JSON.stringify(form.values.retrospective),
+          successStatus: form.values.success === "yes" ? "achieved" : "missed",
         });
-        navigate(paths.projectPath(retrospective?.id!));
+        navigate(paths.projectRetrospectivePath(project.id));
       }
     },
   });
@@ -62,7 +63,7 @@ export function Form({ mode, project, retrospective }: Props) {
 
       <Subscribers mode={mode} project={project} subscriptionsState={subscriptionsState} />
 
-      <Forms.Submit saveText="Close Project" />
+      <Forms.Submit saveText={mode === "create" ? "Close Project" : "Save"} />
     </Forms.Form>
   );
 }
@@ -86,7 +87,7 @@ function RetrospectiveNotes({ project }: { project: Projects.Project }) {
       <Forms.RichTextArea
         field="retrospective"
         label="Retrospective notes"
-        mentionSearchScope={{ type: "project", id: project.id! }}
+        mentionSearchScope={{ type: "project", id: project.id }}
         placeholder="What went well? What didn't? What did you learn?"
         required
       />
@@ -105,7 +106,7 @@ function Subscribers({ mode, project, subscriptionsState }: SubscribersProps) {
 
   return (
     <div className="my-10">
-      <SubscribersSelector state={subscriptionsState} projectName={project.name!} />
+      <SubscribersSelector state={subscriptionsState} projectName={project.name} />
     </div>
   );
 }

--- a/app/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -40,7 +40,7 @@ export function Page() {
       <Paper.Root>
         <Navigation project={checkIn.project} />
 
-        <Paper.Body className="p-4 md:p-8 lg:px-28 lg:pt-8" noPadding banner={banner(checkIn)}>
+        <Paper.Body className="p-4 md:p-8 lg:px-28 lg:pt-8" noPadding banner={banner(checkIn.project)}>
           <Options />
           <Title />
           <StatusSection checkIn={checkIn} reviewer={checkIn.project!.reviewer} />

--- a/app/assets/js/pages/ProjectRetrospectiveEditPage/page.tsx
+++ b/app/assets/js/pages/ProjectRetrospectiveEditPage/page.tsx
@@ -3,18 +3,22 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
 import { ProjectRetrospectiveNavigation } from "@/components/ProjectPageNavigation";
+import { Form } from "@/features/ProjectRetrospective";
 import { useLoadedData } from "./loader";
+import { assertPresent } from "@/utils/assertions";
 
 export function Page() {
   const { retrospective } = useLoadedData();
+  assertPresent(retrospective.project, "project must be present in retrospective");
 
   return (
     <Pages.Page title="Editing Retrospective">
-      <Paper.Root size="small">
+      <Paper.Root>
         <ProjectRetrospectiveNavigation project={retrospective.project} />
         <Paper.Body minHeight="none">
-          <div className="text-content-accent text-3xl font-extrabold mb-8">Editing retrospective</div>
+          <div className="text-content-accent text-3xl font-extrabold mb-8">Editing Project Retrospective</div>
 
+          <Form mode="edit" project={retrospective.project} retrospective={retrospective} />
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>

--- a/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
+++ b/app/assets/js/pages/ProjectRetrospectivePage/page.tsx
@@ -55,7 +55,7 @@ function Options() {
 
   return (
     <PageOptions.Root testId="project-options-button">
-      {false && retrospective.permissions?.canEditRetrospective && (
+      {retrospective.permissions?.canEditRetrospective && (
         <PageOptions.Link
           icon={IconEdit}
           title="Edit retrospective"

--- a/app/lib/operately_web/api/mutations/close_project.ex
+++ b/app/lib/operately_web/api/mutations/close_project.ex
@@ -6,11 +6,11 @@ defmodule OperatelyWeb.Api.Mutations.CloseProject do
   alias Operately.Operations.ProjectClosed
 
   inputs do
-    field :project_id, :string
+    field :project_id, :id
     field :retrospective, :string
     field :success_status, :string
     field? :send_notifications_to_everyone, :boolean
-    field? :subscriber_ids, list_of(:string)
+    field? :subscriber_ids, list_of(:id)
   end
 
   outputs do
@@ -40,16 +40,13 @@ defmodule OperatelyWeb.Api.Mutations.CloseProject do
   end
 
   defp parse_inputs(inputs) do
-    {:ok, project_id} = decode_id(inputs.project_id)
-    {:ok, subscriber_ids} = decode_id(inputs[:subscriber_ids], :allow_nil)
-
     {:ok, %{
-      project_id: project_id,
+      project_id: inputs.project_id,
       content: Jason.decode!(inputs.retrospective),
       success_status: String.to_atom(inputs.success_status),
       send_to_everyone: inputs[:send_notifications_to_everyone] || false,
       subscription_parent_type: :project_retrospective,
-      subscriber_ids: subscriber_ids || []
+      subscriber_ids: inputs[:subscriber_ids] || []
     }}
   end
 end

--- a/app/lib/operately_web/api/serializers/project.ex
+++ b/app/lib/operately_web/api/serializers/project.ex
@@ -5,6 +5,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       name: project.name,
       privacy: OperatelyWeb.Api.Serializer.serialize(project.privacy),
       status: project.status,
+      success_status: Atom.to_string(project.success_status),
       goal_id: project.goal_id && OperatelyWeb.Paths.goal_id(project.goal_id),
     }
   end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -276,8 +276,8 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :project do
-    field? :id, :string, null: true
-    field? :name, :string, null: true
+    field :id, :string
+    field :name, :string
     field? :inserted_at, :date, null: true
     field? :updated_at, :date, null: true
     field? :started_at, :date, null: true
@@ -285,11 +285,12 @@ defmodule OperatelyWeb.Api.Types do
     field? :next_update_scheduled_at, :date, null: true
     field? :next_check_in_scheduled_at, :date, null: true
     field? :privacy, :string, null: true
-    field? :status, :string, null: true
+    field :status, :string
+    field :success_status, :success_status
     field? :closed_at, :date, null: true
     field? :retrospective, :project_retrospective, null: true
     field? :description, :string, null: true
-    field? :goal_id, :string, null: true
+    field :goal_id, :string
     field? :goal, :goal, null: true
     field? :last_check_in, :project_check_in, null: true
     field? :milestones, list_of(:milestone), null: true
@@ -312,16 +313,16 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :project_retrospective do
-    field? :id, :string, null: true
-    field? :author, :person, null: true
-    field? :project, :project, null: true
-    field? :content, :string, null: true
-    field? :closed_at, :date, null: true
-    field? :permissions, :project_permissions, null: true
-    field? :reactions, list_of(:reaction), null: true
-    field? :subscription_list, :subscription_list, null: true
-    field? :potential_subscribers, list_of(:subscriber), null: true
-    field? :notifications, list_of(:notification), null: true
+    field :id, :string
+    field :author, :person
+    field :project, :project
+    field :content, :string
+    field :closed_at, :date
+    field :permissions, :project_permissions
+    field :reactions, list_of(:reaction)
+    field :subscription_list, :subscription_list
+    field :potential_subscribers, list_of(:subscriber)
+    field :notifications, list_of(:notification)
   end
 
   object :messages_board do
@@ -1655,4 +1656,6 @@ defmodule OperatelyWeb.Api.Types do
 
     field? :assignees, list_of(:person), null: true
   end
+
+  enum(:success_status, values: [:achieved, :missed])
 end

--- a/app/test/features/project_retrospective_test.exs
+++ b/app/test/features/project_retrospective_test.exs
@@ -28,27 +28,21 @@ defmodule Operately.Features.ProjectRetrospectiveTest do
     |> Steps.assert_retrospective_error()
   end
 
-  # @tag login_as: :champion
-  # feature "edit project retrospective", ctx do
-  #   params = %{
-  #     "author" => ctx.champion,
-  #     "what-went-well" => "We built the thing",
-  #     "what-could-ve-gone-better" => "We built the thing",
-  #     "what-did-you-learn" => "We learned the thing"
-  #   }
-  #   edited_params = %{
-  #     "what-went-well" => "We built the thing (edited)",
-  #     "what-could-ve-gone-better" => "We built the thing (edited)",
-  #     "what-did-you-learn" => "We learned the thing (edited)"
-  #   }
+  @tag login_as: :champion
+  feature "edit project retrospective", ctx do
+    params = %{
+      "author" => ctx.champion,
+      "notes" => "We built the thing",
+    }
+    edited_notes = "We built the thing (edited)"
 
-  #   ctx
-  #   |> Steps.initiate_project_closing()
-  #   |> Steps.fill_in_retrospective(params)
-  #   |> Steps.submit_retrospective()
-  #   |> Steps.assert_project_retrospective_posted(params)
-  #   |> Steps.edit_project_retrospective(edited_params)
-  #   |> Steps.submit_retrospective()
-  #   |> Steps.assert_project_retrospective_edited(edited_params)
-  # end
+    ctx
+    |> Steps.initiate_project_closing()
+    |> Steps.fill_in_retrospective(params)
+    |> Steps.submit_retrospective()
+    |> Steps.assert_project_retrospective_posted(params)
+    |> Steps.edit_project_retrospective(edited_notes)
+    |> Steps.submit_retrospective()
+    |> Steps.assert_project_retrospective_edited(edited_notes)
+  end
 end

--- a/app/test/support/features/project_retrospective_steps.ex
+++ b/app/test/support/features/project_retrospective_steps.ex
@@ -28,21 +28,17 @@ defmodule Operately.Support.Features.ProjectRetrospectiveSteps do
     |> UI.click(testid: "submit")
   end
 
-  step :edit_project_retrospective, ctx, params do
+  step :edit_project_retrospective, ctx, notes do
     ctx
     |> UI.sleep(200)
     |> UI.click(testid: "project-options-button")
     |> UI.click(testid: "edit-retrospective")
-    |> fill_rich_text("what-went-well", params["what-went-well"])
-    |> fill_rich_text("what-could-ve-gone-better", params["what-could-ve-gone-better"])
-    |> fill_rich_text("what-did-you-learn", params["what-did-you-learn"])
+    |> fill_rich_text("retrospective-notes", notes)
   end
 
-  step :assert_project_retrospective_edited, ctx, params do
+  step :assert_project_retrospective_edited, ctx, notes do
     ctx
-    |> UI.assert_text(params["what-went-well"])
-    |> UI.assert_text(params["what-could-ve-gone-better"])
-    |> UI.assert_text(params["what-did-you-learn"])
+    |> UI.assert_text(notes)
   end
 
   step :assert_project_retrospective_posted, ctx, params do


### PR DESCRIPTION
This work is part of https://github.com/operately/operately/issues/2709.

Now, project retrospectives can be edited.