### PR TITLE
chore: Remove 3 colors from the system

### DIFF
--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -55,9 +55,8 @@
   --color-callout-warning-icon: var(--color-yellow-400);
   --color-callout-warning-message: var(--color-yellow-700);
 
-  --color-callout-error: var(--color-red-50);
-  --color-callout-error-icon: var(--color-red-400);
-  --color-callout-error-message: var(--color-red-700);
+  --color-callout-error-bg: var(--color-red-50);
+  --color-callout-error-content: var(--color-red-700);
 
   --color-callout-success-bg: var(--color-emerald-50);
   --color-callout-success-content: var(--color-emerald-600);
@@ -99,9 +98,8 @@
   --color-callout-warning-icon: var(--color-yellow-300);
   --color-callout-warning-message: var(--color-yellow-200);
 
-  --color-callout-error: var(--color-red-900);
-  --color-callout-error-icon: var(--color-red-300);
-  --color-callout-error-message: var(--color-red-200);
+  --color-callout-error-bg: var(--color-red-900);
+  --color-callout-error-content: var(--color-red-300);
 
   --color-callout-success-bg: var(--color-emerald-900);
   --color-callout-success-content: var(--color-emerald-300);

--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -59,9 +59,8 @@
   --color-callout-error-icon: var(--color-red-400);
   --color-callout-error-message: var(--color-red-700);
 
-  --color-callout-success: var(--color-green-50);
-  --color-callout-success-icon: var(--color-green-400);
-  --color-callout-success-message: var(--color-green-700);
+  --color-callout-success-bg: var(--color-emerald-50);
+  --color-callout-success-content: var(--color-emerald-600);
 }
 
 .dark {
@@ -104,9 +103,8 @@
   --color-callout-error-icon: var(--color-red-300);
   --color-callout-error-message: var(--color-red-200);
 
-  --color-callout-success: var(--color-green-900);
-  --color-callout-success-icon: var(--color-green-300);
-  --color-callout-success-message: var(--color-green-200);
+  --color-callout-success-bg: var(--color-emerald-900);
+  --color-callout-success-content: var(--color-emerald-300);
 }
 
 body {

--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -47,13 +47,11 @@
   --color-accent-1: rgba(37, 155, 105, 1);
   --color-accent-1-light: rgba(37, 155, 105, 0.8);
 
-  --color-callout-info: var(--color-blue-50);
-  --color-callout-info-icon: var(--color-blue-400);
-  --color-callout-info-message: var(--color-blue-700);
+  --color-callout-info-bg: var(--color-blue-50);
+  --color-callout-info-content: var(--color-blue-700);
 
-  --color-callout-warning: var(--color-yellow-50);
-  --color-callout-warning-icon: var(--color-yellow-400);
-  --color-callout-warning-message: var(--color-yellow-700);
+  --color-callout-warning-bg: var(--color-amber-50);
+  --color-callout-warning-content: var(--color-amber-700);
 
   --color-callout-error-bg: var(--color-red-50);
   --color-callout-error-content: var(--color-red-700);
@@ -90,13 +88,11 @@
   --color-accent-1: rgba(37, 155, 105, 1);
   --color-accent-1-light: rgba(37, 155, 105, 0.8);
 
-  --color-callout-info: var(--color-blue-900);
-  --color-callout-info-icon: var(--color-blue-300);
-  --color-callout-info-message: var(--color-blue-200);
+  --color-callout-info-bg: var(--color-blue-900);
+  --color-callout-info-content: var(--color-blue-300);
 
-  --color-callout-warning: var(--color-yellow-900);
-  --color-callout-warning-icon: var(--color-yellow-300);
-  --color-callout-warning-message: var(--color-yellow-200);
+  --color-callout-warning-bg: var(--color-amber-900);
+  --color-callout-warning-content: var(--color-amber-300);
 
   --color-callout-error-bg: var(--color-red-900);
   --color-callout-error-content: var(--color-red-300);

--- a/app/assets/css/prosemirror.css
+++ b/app/assets/css/prosemirror.css
@@ -16,8 +16,8 @@
   left: 0em;
   width: 100%;
   height: 100%;
-  color: var(--color-accent-1);
-  border: 2px dashed var(--color-accent-1);
+  color: var(--color-brand-1);
+  border: 2px dashed var(--color-brand-1);
   background-color: rgba(0,255,0,0.1);
   padding-bottom: 1em;
 }

--- a/app/assets/css/reactdatepicker-custom.css
+++ b/app/assets/css/reactdatepicker-custom.css
@@ -69,14 +69,14 @@
 }
 
 .react-datepicker__day--in-range {
-  background-color: var(--color-accent-1);
+  background-color: var(--color-brand-1);
   color: var(--color-white-1);
   font-weight: 600;
 }
 
 .react-datepicker__day--in-range,
 .react-datepicker__day--in-range:hover {
-  background-color: var(--color-accent-1) !important;
+  background-color: var(--color-brand-1) !important;
   color: var(--color-white-1);
 }
 
@@ -157,12 +157,12 @@
 }
 
 .react-datepicker__quarter-text--selected {
-  background-color: var(--color-accent-1);
+  background-color: var(--color-brand-1);
   color: var(--color-white-1);
 }
 
 .react-datepicker__quarter-text.react-datepicker__quarter-text--selected:hover {
-  background-color: var(--color-accent-1);
+  background-color: var(--color-brand-1);
   color: var(--color-white-1);
 }
 
@@ -193,7 +193,7 @@
 }
 
 .react-datepicker__month-text--selected {
-  background-color: var(--color-accent-1);
+  background-color: var(--color-brand-1);
   color: var(--color-white-1);
 }
 
@@ -202,7 +202,7 @@
 }
 
 .react-datepicker__month-text.react-datepicker__month-text--selected:hover {
-  background-color: var(--color-accent-1) !important;
+  background-color: var(--color-brand-1) !important;
   color: var(--color-white-1);
 }
 
@@ -229,12 +229,12 @@
 }
 
 .react-datepicker__year-text--selected {
-  background-color: var(--color-accent-1);
+  background-color: var(--color-brand-1);
   color: var(--color-white-1);
 }
 
 .react-datepicker__year-text.react-datepicker__year-text--selected:hover {
-  background-color: var(--color-accent-1) !important;
+  background-color: var(--color-brand-1) !important;
   color: var(--color-white-1);
 }
 

--- a/app/assets/js/components/Badges/AccessLevelBadges.tsx
+++ b/app/assets/js/components/Badges/AccessLevelBadges.tsx
@@ -80,7 +80,7 @@ const permissionData: PermissionData = {
   [PermissionLevels.FULL_ACCESS]: {
     testId: "full-access-badge",
     title: "Full Access",
-    colors: "bg-callout-warning text-callout-warning-message",
+    colors: "bg-callout-warning-bg text-callout-warning-content",
     description: {
       project: joinStr(
         "Has full access to the project and can perform any action, ",
@@ -94,7 +94,7 @@ const permissionData: PermissionData = {
   [PermissionLevels.EDIT_ACCESS]: {
     testId: "edit-access-badge",
     title: "Edit Access",
-    colors: "bg-callout-info text-callout-info-message",
+    colors: "bg-callout-info-bg text-callout-info-content",
     description: {
       project: joinStr(
         "Can edit the project, including its details, tasks, and comments, ",
@@ -110,7 +110,7 @@ const permissionData: PermissionData = {
   [PermissionLevels.COMMENT_ACCESS]: {
     testId: "comment-access-badge",
     title: "Comment Access",
-    colors: "bg-callout-error text-callout-error-message",
+    colors: "bg-callout-error-bg text-callout-error-content",
     description: {
       project: joinStr(
         "Can comment on the project, including tasks, and check-ins. ",

--- a/app/assets/js/components/Badges/AccessLevelBadges.tsx
+++ b/app/assets/js/components/Badges/AccessLevelBadges.tsx
@@ -123,7 +123,7 @@ const permissionData: PermissionData = {
   [PermissionLevels.VIEW_ACCESS]: {
     testId: "view-access-badge",
     title: "View Access",
-    colors: "bg-callout-success text-callout-success-message",
+    colors: "bg-callout-success-bg text-callout-success-content",
     description: {
       project: joinStr(
         "Can view the project, including its details, tasks, and comments. ",

--- a/app/assets/js/components/Callouts/index.tsx
+++ b/app/assets/js/components/Callouts/index.tsx
@@ -39,10 +39,10 @@ export function ErrorCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconCircleXFilled}
-      iconClassName="text-callout-error-icon"
-      backgroundColor="bg-callout-error"
-      titleColor="text-callout-error-message"
-      messageColor="text-callout-error-message"
+      iconClassName="text-callout-error-content"
+      backgroundColor="bg-callout-error-bg"
+      titleColor="text-callout-error-content"
+      messageColor="text-callout-error-content"
     />
   );
 }

--- a/app/assets/js/components/Callouts/index.tsx
+++ b/app/assets/js/components/Callouts/index.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { TestableElement } from "@/utils/testid";
 
-import {
-  IconAlertTriangleFilled,
-  IconCircleCheckFilled,
-  IconCircleXFilled,
-  IconInfoCircleFilled,
-} from "turboui";
+import { IconAlertTriangleFilled, IconCircleCheckFilled, IconCircleXFilled, IconInfoCircleFilled } from "turboui";
 
 interface Props extends TestableElement {
   message: string | JSX.Element;
@@ -57,10 +52,10 @@ export function SuccessCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconCircleCheckFilled}
-      iconClassName="text-callout-success-icon"
-      backgroundColor="bg-callout-success"
-      titleColor="text-callout-success-message"
-      messageColor="text-callout-success-message"
+      iconClassName="text-callout-success-content"
+      backgroundColor="bg-callout-success-bg"
+      titleColor="text-callout-success-content"
+      messageColor="text-callout-success-content"
     />
   );
 }

--- a/app/assets/js/components/Callouts/index.tsx
+++ b/app/assets/js/components/Callouts/index.tsx
@@ -13,10 +13,10 @@ export function InfoCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconInfoCircleFilled}
-      iconClassName="text-callout-info-icon"
-      backgroundColor="bg-callout-info"
-      titleColor="text-callout-info-message"
-      messageColor="text-callout-info-message"
+      iconClassName="text-callout-info-content"
+      backgroundColor="bg-callout-info-bg"
+      titleColor="text-callout-info-content"
+      messageColor="text-callout-info-content"
     />
   );
 }
@@ -26,10 +26,10 @@ export function WarningCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconAlertTriangleFilled}
-      iconClassName="text-callout-warning-icon"
-      backgroundColor="bg-callout-error"
-      titleColor="text-callout-warning-message"
-      messageColor="text-callout-warning-message"
+      iconClassName="text-callout-warning-content"
+      backgroundColor="bg-callout-warning-bg"
+      titleColor="text-callout-warning-content"
+      messageColor="text-callout-warning-content"
     />
   );
 }

--- a/app/assets/js/features/ResourceHub/FileDragAndDropArea.tsx
+++ b/app/assets/js/features/ResourceHub/FileDragAndDropArea.tsx
@@ -14,7 +14,7 @@ export function FileDragAndDropArea({ children }) {
   );
 
   const messageClassName = classNames(
-    "p-6 bg-callout-info text-white text-sm rounded-md shadow-lg",
+    "p-6 bg-callout-info-bg text-white text-sm rounded-md shadow-lg",
     "transition-transform transform scale-95 duration-300",
     isFileDragging ? "scale-100 opacity-100" : "scale-95 opacity-0",
   );

--- a/app/assets/js/features/projects/AccessLevel.tsx
+++ b/app/assets/js/features/projects/AccessLevel.tsx
@@ -38,7 +38,7 @@ function Icon(props: AccessLevelProps) {
     return <IconLock className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
-  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
+  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-content" size={30} strokeWidth={2} />;
 }
 
 function calcTitle(props: AccessLevelProps) {

--- a/app/assets/js/features/spaces/AccessLevel/index.tsx
+++ b/app/assets/js/features/spaces/AccessLevel/index.tsx
@@ -33,7 +33,7 @@ function Icon(props: AccessLevelProps) {
     return <IconBuilding className="text-content-accent ml-1.5 mr-3" size={30} strokeWidth={2} />;
   }
 
-  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-icon" size={30} strokeWidth={2} />;
+  return <IconLockFilled className="ml-1.5 mr-3 text-callout-error-content" size={30} strokeWidth={2} />;
 }
 
 function calcTitle(props: AccessLevelProps) {

--- a/app/assets/js/pages/ReviewPage/page.tsx
+++ b/app/assets/js/pages/ReviewPage/page.tsx
@@ -55,10 +55,10 @@ function TitleIcon() {
 function SendingEmailsBanner() {
   const className = classNames(
     "text-sm font-medium",
-    "bg-callout-success text-callout-success-message",
+    "bg-callout-success-bg text-callout-success-content",
     "px-2 py-1",
     "rounded",
-    "border border-callout-success",
+    "border border-callout-success-bg",
     "absolute top-2 right-2",
   );
 

--- a/app/assets/tailwind.config.js
+++ b/app/assets/tailwind.config.js
@@ -47,9 +47,8 @@ module.exports = {
         "callout-warning-icon": "var(--color-callout-warning-icon)",
         "callout-warning-message": "var(--color-callout-warning-message)",
 
-        "callout-error": "var(--color-callout-error)",
-        "callout-error-icon": "var(--color-callout-error-icon)",
-        "callout-error-message": "var(--color-callout-error-message)",
+        "callout-error-bg": "var(--color-callout-error-bg)",
+        "callout-error-content": "var(--color-callout-error-content)",
 
         "callout-success-bg": "var(--color-callout-success-bg)",
         "callout-success-content": "var(--color-callout-success-content)",

--- a/app/assets/tailwind.config.js
+++ b/app/assets/tailwind.config.js
@@ -39,13 +39,11 @@ module.exports = {
         "accent-1": "var(--color-accent-1)",
         "accent-1-light": "var(--color-accent-1-light)",
 
-        "callout-info": "var(--color-callout-info)",
-        "callout-info-icon": "var(--color-callout-info-icon)",
-        "callout-info-message": "var(--color-callout-info-message)",
+        "callout-info-bg": "var(--color-callout-info-bg)",
+        "callout-info-content": "var(--color-callout-info-content)",
 
-        "callout-warning": "var(--color-callout-warning)",
-        "callout-warning-icon": "var(--color-callout-warning-icon)",
-        "callout-warning-message": "var(--color-callout-warning-message)",
+        "callout-warning-bg": "var(--color-callout-warning-bg)",
+        "callout-warning-content": "var(--color-callout-warning-content)",
 
         "callout-error-bg": "var(--color-callout-error-bg)",
         "callout-error-content": "var(--color-callout-error-content)",

--- a/app/assets/tailwind.config.js
+++ b/app/assets/tailwind.config.js
@@ -51,9 +51,8 @@ module.exports = {
         "callout-error-icon": "var(--color-callout-error-icon)",
         "callout-error-message": "var(--color-callout-error-message)",
 
-        "callout-success": "var(--color-callout-success)",
-        "callout-success-icon": "var(--color-callout-success-icon)",
-        "callout-success-message": "var(--color-callout-success-message)",
+        "callout-success-bg": "var(--color-callout-success-bg)",
+        "callout-success-content": "var(--color-callout-success-content)",
 
         brand: {
           1: "#3185FF",

--- a/turboui/src/Button/index.tsx
+++ b/turboui/src/Button/index.tsx
@@ -68,7 +68,7 @@ export function SecondaryButton(props: BaseButtonProps) {
     <UnstyledButton
       {...props}
       className={className}
-      spinner={<Spinner loading={props.loading} size={props.size} color="var(--color-accent-1)" />}
+      spinner={<Spinner loading={props.loading} size={props.size} color="var(--color-brand-1)" />}
     />
   );
 }

--- a/turboui/src/Callouts/index.tsx
+++ b/turboui/src/Callouts/index.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { TestableElement } from "../TestableElement";
 
-import {
-  IconAlertTriangleFilled,
-  IconCircleCheckFilled,
-  IconCircleXFilled,
-  IconInfoCircleFilled,
-} from "../icons";
+import { IconAlertTriangleFilled, IconCircleCheckFilled, IconCircleXFilled, IconInfoCircleFilled } from "../icons";
 
 interface Props extends TestableElement {
   message: string | JSX.Element;
@@ -57,10 +52,10 @@ export function SuccessCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconCircleCheckFilled}
-      iconClassName="text-callout-success-icon"
-      backgroundColor="bg-callout-success"
-      titleColor="text-callout-success-message"
-      messageColor="text-callout-success-message"
+      iconClassName="text-callout-success-content"
+      backgroundColor="bg-callout-success-bg"
+      titleColor="text-callout-success-content"
+      messageColor="text-callout-success-content"
     />
   );
 }

--- a/turboui/src/Callouts/index.tsx
+++ b/turboui/src/Callouts/index.tsx
@@ -39,10 +39,10 @@ export function ErrorCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconCircleXFilled}
-      iconClassName="text-callout-error-icon"
-      backgroundColor="bg-callout-error"
-      titleColor="text-callout-error-message"
-      messageColor="text-callout-error-message"
+      iconClassName="text-callout-error-content"
+      backgroundColor="bg-callout-error-bg"
+      titleColor="text-callout-error-content"
+      messageColor="text-callout-error-content"
     />
   );
 }

--- a/turboui/src/Callouts/index.tsx
+++ b/turboui/src/Callouts/index.tsx
@@ -13,10 +13,10 @@ export function InfoCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconInfoCircleFilled}
-      iconClassName="text-callout-info-icon"
-      backgroundColor="bg-callout-info"
-      titleColor="text-callout-info-message"
-      messageColor="text-callout-info-message"
+      iconClassName="text-callout-info-content"
+      backgroundColor="bg-callout-info-bg"
+      titleColor="text-callout-info-content"
+      messageColor="text-callout-info-content"
     />
   );
 }
@@ -26,10 +26,10 @@ export function WarningCallout(props: Props) {
     <UnstyledCallout
       {...props}
       icon={IconAlertTriangleFilled}
-      iconClassName="text-callout-warning-icon"
-      backgroundColor="bg-callout-error"
-      titleColor="text-callout-warning-message"
-      messageColor="text-callout-warning-message"
+      iconClassName="text-callout-warning-content"
+      backgroundColor="bg-callout-warning-bg"
+      titleColor="text-callout-warning-content"
+      messageColor="text-callout-warning-content"
     />
   );
 }

--- a/turboui/src/Colors/Colors.stories.tsx
+++ b/turboui/src/Colors/Colors.stories.tsx
@@ -160,34 +160,24 @@ export const AllColors: StoryObj = {
           title="Accent Colors"
           colors={[
             {
-              color: "bg-callout-info",
-              name: "callout-info",
+              color: "bg-callout-info-bg",
+              name: "callout-info-bg",
               description: "Information callout background color",
             },
             {
-              color: "bg-callout-info-icon",
-              name: "callout-info-icon",
+              color: "bg-callout-info-content",
+              name: "callout-info-content",
               description: "Information callout icon color",
             },
             {
-              color: "bg-callout-info-message",
-              name: "callout-info-message",
-              description: "Information callout message text",
-            },
-            {
-              color: "bg-callout-warning",
-              name: "callout-warning",
+              color: "bg-callout-warning-bg",
+              name: "callout-warning-bg",
               description: "Warning callout background color",
             },
             {
-              color: "bg-callout-warning-icon",
-              name: "callout-warning-icon",
-              description: "Warning callout icon color",
-            },
-            {
-              color: "bg-callout-warning-message",
-              name: "callout-warning-message",
-              description: "Warning callout message text",
+              color: "bg-callout-warning-content",
+              name: "callout-warning-content",
+              description: "Warning callout content message color",
             },
             {
               color: "bg-callout-error-bg",
@@ -197,7 +187,7 @@ export const AllColors: StoryObj = {
             {
               color: "bg-callout-error-content",
               name: "callout-error-content",
-              description: "Error callout message text",
+              description: "Error callout content message text",
             },
             {
               color: "bg-callout-success-bg",
@@ -207,7 +197,7 @@ export const AllColors: StoryObj = {
             {
               color: "bg-callout-success-content",
               name: "callout-success-content",
-              description: "Success callout message text",
+              description: "Success callout content message text",
             },
           ]}
         />

--- a/turboui/src/Colors/Colors.stories.tsx
+++ b/turboui/src/Colors/Colors.stories.tsx
@@ -44,7 +44,7 @@ const ColorSection: React.FC<ColorSectionProps> = ({ title, colors }) => (
     <h3 className="text-lg font-semibold mb-1">{title}</h3>
     <div className="text-sm mb-4">
       {title === "Background Colors" && "Colors used for backgrounds and surface."}
-      {title === "Interactive Components" && "Form backgrounds, callouts, etc."}
+      {title === "Accent Colors" && "For badges, error states, callouts, tooltips"}
       {title === "Borders And Separators" && "Colors used for dividers, borders, and other separators"}
       {title === "Solid Colors" && "CTA, buttons, Avatar background, etc."}
       {title === "Text Colors" && "Colors used for text content, icons, warnings, and other content"}
@@ -157,7 +157,7 @@ export const AllColors: StoryObj = {
         />
 
         <ColorSection
-          title="Interactive Components"
+          title="Accent Colors"
           colors={[
             {
               color: "bg-callout-info",
@@ -190,18 +190,13 @@ export const AllColors: StoryObj = {
               description: "Warning callout message text",
             },
             {
-              color: "bg-callout-error",
-              name: "callout-error",
+              color: "bg-callout-error-bg",
+              name: "callout-error-bg",
               description: "Error callout background color",
             },
             {
-              color: "bg-callout-error-icon",
-              name: "callout-error-icon",
-              description: "Error callout icon color",
-            },
-            {
-              color: "bg-callout-error-message",
-              name: "callout-error-message",
+              color: "bg-callout-error-content",
+              name: "callout-error-content",
               description: "Error callout message text",
             },
             {

--- a/turboui/src/Colors/Colors.stories.tsx
+++ b/turboui/src/Colors/Colors.stories.tsx
@@ -205,18 +205,13 @@ export const AllColors: StoryObj = {
               description: "Error callout message text",
             },
             {
-              color: "bg-callout-success",
-              name: "callout-success",
+              color: "bg-callout-success-bg",
+              name: "callout-success-bg",
               description: "Success callout background color",
             },
             {
-              color: "bg-callout-success-icon",
-              name: "callout-success-icon",
-              description: "Success callout icon color",
-            },
-            {
-              color: "bg-callout-success-message",
-              name: "callout-success-message",
+              color: "bg-callout-success-content",
+              name: "callout-success-content",
               description: "Success callout message text",
             },
           ]}

--- a/turboui/src/GoalPage/Sidebar.tsx
+++ b/turboui/src/GoalPage/Sidebar.tsx
@@ -13,17 +13,10 @@ import { PersonField } from "../PersonField";
 import { PrivacyField } from "../PrivacyField";
 import { Summary } from "../RichContent";
 import { StatusBadge } from "../StatusBadge";
+import { WarningCallout } from "../Callouts";
 import { durationHumanized, isOverdue } from "../utils/time";
 
-import {
-  IconAlertTriangleFilled,
-  IconCircleArrowRight,
-  IconCircleCheck,
-  IconRotateDot,
-  IconTrash,
-  IconUserCheck,
-  IconUserStar,
-} from "../icons";
+import { IconCircleArrowRight, IconCircleCheck, IconRotateDot, IconTrash, IconUserCheck, IconUserStar } from "../icons";
 
 export function Sidebar(props: GoalPage.State) {
   return (
@@ -195,9 +188,8 @@ function OverdueWarning(props: GoalPage.State) {
   const duration = durationHumanized(props.dueDate, new Date());
 
   return (
-    <div className="bg-callout-error p-3 text-callout-warning-message rounded mt-2 text-sm flex items-center gap-2">
-      <IconAlertTriangleFilled size={16} className="text-callout-warning-icon" />
-      Overdue by {duration}.
+    <div className="mt-2">
+      <WarningCallout message={`Overdue by ${duration}.`} />
     </div>
   );
 }

--- a/turboui/src/PersonCard/index.tsx
+++ b/turboui/src/PersonCard/index.tsx
@@ -33,7 +33,7 @@ export function PersonCard(props: PersonCard.Props) {
   const location = useLocation();
 
   const className = classNames("flex items-center gap-2 text-sm rounded-xl px-4 py-3 bg-surface-dimmed", "relative", {
-    "border-2 border-accent-1": highlight,
+    "border-2 border-brand-1": highlight,
     "border-2 border-stroke-base": !highlight,
     "cursor-pointer": !link,
   });

--- a/turboui/src/ProgressBar/index.tsx
+++ b/turboui/src/ProgressBar/index.tsx
@@ -10,7 +10,7 @@ export function ProgressBar({ progress, status, size = "md", showLabel = false }
 
   // Determine color based on status
   const progressColor = match(status)
-    .with("on_track", "completed", "achieved", () => "bg-green-500 dark:bg-green-400")
+    .with("on_track", "completed", "achieved", () => "bg-emerald-500 dark:bg-emerald-400")
     .with("paused", "dropped", () => "bg-gray-400 dark:bg-gray-500")
     .with("caution", "partial", () => "bg-amber-500 dark:bg-amber-400")
     .with("issue", "missed", () => "bg-red-500 dark:bg-red-400")
@@ -22,13 +22,11 @@ export function ProgressBar({ progress, status, size = "md", showLabel = false }
     .with("sm", () => "h-1")
     .with("lg", () => "h-3")
     .with("md", () => "h-2")
-    .exhaustive()
+    .exhaustive();
 
   return (
     <div role="progress-bar" className="w-full flex items-center gap-2">
-      <div
-        className={`w-full ${heightClass} bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden`}
-      >
+      <div className={`w-full ${heightClass} bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden`}>
         <div
           className={`h-full rounded-full ${progressColor} relative overflow-hidden`}
           style={{ width: progressWidth }}

--- a/turboui/src/ProjectPage/MilestoneItem.tsx
+++ b/turboui/src/ProjectPage/MilestoneItem.tsx
@@ -41,7 +41,7 @@ export function MilestoneItem({ milestone, canEdit, onUpdate, isLast = false }: 
         {/* Timeline flag icon as marker */}
         <div className="flex flex-col items-center mt-1">
           {isCompleted ? (
-            <IconFlagFilled size={20} className={classNames("flex-shrink-0", "text-accent-1")} />
+            <IconFlagFilled size={20} className={classNames("flex-shrink-0", "bg-callout-success-content")} />
           ) : (
             <IconFlag
               size={20}

--- a/turboui/src/RichEditor/Blob/BlobView.tsx
+++ b/turboui/src/RichEditor/Blob/BlobView.tsx
@@ -240,7 +240,7 @@ function LoadingProgressBar({ progress, barClassName }: { progress: number; barC
 
   return (
     <div className={className}>
-      <div className="bg-accent-1 h-full" style={{ width: `${progress}%` }}></div>
+      <div className="bg-callout-success-content h-full" style={{ width: `${progress}%` }}></div>
     </div>
   );
 }

--- a/turboui/src/RichEditor/extensions/MentionPeople/MentionList.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/MentionList.tsx
@@ -108,8 +108,8 @@ interface ItemListProps {
 
 function ItemList({ items, selectItem, selectedIndex }: ItemListProps): JSX.Element {
   const baseClass = "px-1.5 py-1 text-left";
-  const selectedClass = baseClass + " bg-accent-1 text-content-accent";
-  const unselectedClass = baseClass + " text-content-accent hover:bg-accent-1";
+  const selectedClass = baseClass + " bg-brand-1 text-content-accent";
+  const unselectedClass = baseClass + " text-content-accent hover:bg-brand-1";
 
   return (
     <>

--- a/turboui/src/StatusBadge/index.tsx
+++ b/turboui/src/StatusBadge/index.tsx
@@ -21,26 +21,26 @@ const getStatusProperties = (status: BadgeStatus) => {
   switch (status) {
     case "on_track":
       return {
-        bgColor: "bg-green-50 dark:bg-green-900/30",
-        textColor: "text-green-700 dark:text-green-300",
-        dotColor: "bg-green-500 dark:bg-green-400",
-        borderColor: "border-green-200 dark:border-green-800",
+        bgColor: "bg-callout-success-bg",
+        textColor: "text-callout-success-content",
+        dotColor: "bg-callout-success-content",
+        borderColor: "border-emerald-200",
         label: "On track",
       };
     case "completed":
       return {
-        bgColor: "bg-green-50 dark:bg-green-900/30",
-        textColor: "text-green-700 dark:text-green-300",
-        dotColor: "bg-green-500 dark:bg-green-400",
-        borderColor: "border-green-200 dark:border-green-800",
+        bgColor: "bg-callout-success-bg",
+        textColor: "text-callout-success-content",
+        dotColor: "bg-callout-success-content",
+        borderColor: "border-emerald-200",
         label: "Completed",
       };
     case "achieved":
       return {
-        bgColor: "bg-green-50 dark:bg-green-900/30",
-        textColor: "text-green-700 dark:text-green-300",
-        dotColor: "bg-green-500 dark:bg-green-400",
-        borderColor: "border-green-200 dark:border-green-800",
+        bgColor: "bg-callout-success-bg",
+        textColor: "text-callout-success-content",
+        dotColor: "bg-callout-success-content",
+        borderColor: "border-emerald-200",
         label: "Achieved",
       };
     case "paused":

--- a/turboui/src/TaskPage/Sidebar.tsx
+++ b/turboui/src/TaskPage/Sidebar.tsx
@@ -1,14 +1,9 @@
-import {
-  IconAlertTriangleFilled,
-  IconArchive,
-  IconCalendar,
-  IconLink,
-  IconTrash,
-} from "../icons";
+import { IconArchive, IconCalendar, IconLink, IconTrash } from "../icons";
 import { NotificationToggle } from "../NotificationToggle";
 import React from "react";
 import { TaskPage } from ".";
 import { AvatarWithName } from "../Avatar";
+import { WarningCallout } from "../Callouts";
 import { DateField } from "../DateField";
 import FormattedTime from "../FormattedTime";
 import { MilestoneField } from "../MilestoneField";
@@ -126,11 +121,7 @@ function Subscription(props: TaskPage.State) {
 
   return (
     <SidebarSection title="Notifications">
-      <NotificationToggle
-        isSubscribed={props.isSubscribed}
-        onToggle={handleToggle}
-        entityType="task"
-      />
+      <NotificationToggle isSubscribed={props.isSubscribed} onToggle={handleToggle} entityType="task" />
     </SidebarSection>
   );
 }
@@ -197,9 +188,8 @@ function OverdueWarning(props: TaskPage.State) {
   const duration = durationHumanized(props.dueDate, new Date());
 
   return (
-    <div className="bg-callout-error p-3 text-callout-warning-message rounded mt-2 text-sm flex items-center gap-2">
-      <IconAlertTriangleFilled size={16} className="text-callout-warning-icon" />
-      Overdue by {duration}.
+    <div className="mt-2">
+      <WarningCallout message={`Overdue by ${duration}.`} />
     </div>
   );
 }

--- a/turboui/src/Toasts/index.tsx
+++ b/turboui/src/Toasts/index.tsx
@@ -24,7 +24,7 @@ const toastConfigs: Record<ToastType, ToastConfig> = {
   },
   info: {
     icon: IconInfoCircleFilled,
-    iconColor: "text-callout-info-icon",
+    iconColor: "text-callout-info-content",
   },
 };
 

--- a/turboui/src/Toasts/index.tsx
+++ b/turboui/src/Toasts/index.tsx
@@ -6,7 +6,7 @@ export function ToasterBar() {
   return <Toaster position="bottom-right" reverseOrder={true} />;
 }
 
-type ToastType = 'error' | 'success' | 'info';
+type ToastType = "error" | "success" | "info";
 
 interface ToastConfig {
   icon: React.ComponentType<{ className?: string; size?: number }>;
@@ -16,11 +16,11 @@ interface ToastConfig {
 const toastConfigs: Record<ToastType, ToastConfig> = {
   error: {
     icon: IconExclamationCircleFilled,
-    iconColor: "text-callout-error-icon",
+    iconColor: "text-callout-error-content",
   },
   success: {
     icon: IconCircleCheckFilled,
-    iconColor: "text-callout-success-icon",
+    iconColor: "text-callout-success-content",
   },
   info: {
     icon: IconInfoCircleFilled,
@@ -46,13 +46,13 @@ const showToast = (type: ToastType, title: string, description: string) => {
 };
 
 export const showErrorToast = (title: string, description: string) => {
-  showToast('error', title, description);
+  showToast("error", title, description);
 };
 
 export const showSuccessToast = (title: string, description: string) => {
-  showToast('success', title, description);
+  showToast("success", title, description);
 };
 
 export const showInfoToast = (title: string, description: string) => {
-  showToast('info', title, description);
+  showToast("info", title, description);
 };

--- a/turboui/tailwind.config.js
+++ b/turboui/tailwind.config.js
@@ -44,13 +44,11 @@ module.exports = {
         "accent-1": "var(--color-accent-1)",
         "accent-1-light": "var(--color-accent-1-light)",
 
-        "callout-info": "var(--color-callout-info)",
-        "callout-info-icon": "var(--color-callout-info-icon)",
-        "callout-info-message": "var(--color-callout-info-message)",
+        "callout-info-bg": "var(--color-callout-info-bg)",
+        "callout-info-content": "var(--color-callout-info-content)",
 
-        "callout-warning": "var(--color-callout-warning)",
-        "callout-warning-icon": "var(--color-callout-warning-icon)",
-        "callout-warning-message": "var(--color-callout-warning-message)",
+        "callout-warning-bg": "var(--color-callout-warning-bg)",
+        "callout-warning-content": "var(--color-callout-warning-content)",
 
         "callout-error-bg": "var(--color-callout-error-bg)",
         "callout-error-content": "var(--color-callout-error-content)",

--- a/turboui/tailwind.config.js
+++ b/turboui/tailwind.config.js
@@ -10,12 +10,12 @@ module.exports = {
   theme: {
     extend: {
       animation: {
-        'fadeIn': 'fadeIn 0.3s ease-in-out',
+        fadeIn: "fadeIn 0.3s ease-in-out",
       },
       keyframes: {
         fadeIn: {
-          '0%': { opacity: '0', transform: 'translateY(-4px)' },
-          '100%': { opacity: '1', transform: 'translateY(0)' },
+          "0%": { opacity: "0", transform: "translateY(-4px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" },
         },
       },
       colors: {
@@ -56,9 +56,8 @@ module.exports = {
         "callout-error-icon": "var(--color-callout-error-icon)",
         "callout-error-message": "var(--color-callout-error-message)",
 
-        "callout-success": "var(--color-callout-success)",
-        "callout-success-icon": "var(--color-callout-success-icon)",
-        "callout-success-message": "var(--color-callout-success-message)",
+        "callout-success-bg": "var(--color-callout-success-bg)",
+        "callout-success-content": "var(--color-callout-success-content)",
 
         brand: {
           1: "#3185FF",

--- a/turboui/tailwind.config.js
+++ b/turboui/tailwind.config.js
@@ -52,9 +52,8 @@ module.exports = {
         "callout-warning-icon": "var(--color-callout-warning-icon)",
         "callout-warning-message": "var(--color-callout-warning-message)",
 
-        "callout-error": "var(--color-callout-error)",
-        "callout-error-icon": "var(--color-callout-error-icon)",
-        "callout-error-message": "var(--color-callout-error-message)",
+        "callout-error-bg": "var(--color-callout-error-bg)",
+        "callout-error-content": "var(--color-callout-error-content)",
 
         "callout-success-bg": "var(--color-callout-success-bg)",
         "callout-success-content": "var(--color-callout-success-content)",


### PR DESCRIPTION
Removed 3 `callout-*` colors. Related to #2817. Next steps will be to remove `accent-*` and `success`.

Also realized that `emerald` greens in Tailwind are closer to what we previously had as main custom green than pure `green`.

![CleanShot 2025-07-02 at 14 13 10@2x](https://github.com/user-attachments/assets/371a7977-bb33-4077-bdb2-fa03adf0d11f)
