### PR TITLE
chore: Update status of closed projects in Work Map

### DIFF
--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -99,8 +99,7 @@ defmodule Operately.Projects.Project do
   @impl WorkMapItem
   def status(project = %__MODULE__{}) do
     cond do
-      project.closed_at -> :completed
-      project.status == "closed" -> :completed
+      project.success_status -> project.success_status
       project.status == "paused" -> :paused
       Operately.Projects.outdated?(project) -> :outdated
       project.last_check_in -> project.last_check_in.status

--- a/app/test/operately/work_maps/work_map_item_test.exs
+++ b/app/test/operately/work_maps/work_map_item_test.exs
@@ -19,7 +19,7 @@ defmodule Operately.WorkMaps.WorkMapItemTest do
         |> Factory.preload(:project, :milestones)
 
       item = WorkMapItem.build_item(ctx.project, [], false)
-      assert item.status == :completed
+      assert item.status == :achieved
     end
 
     @status [:on_track, :caution, :off_track]


### PR DESCRIPTION
Now, the statuses "Achieved" and "Missed" are shown for projects in the Work Map completed tab.