### PR TITLE
fix: Display red progress bar for off_track resources

### DIFF
--- a/turboui/src/ProgressBar/index.tsx
+++ b/turboui/src/ProgressBar/index.tsx
@@ -13,7 +13,7 @@ export function ProgressBar({ progress, status, size = "md", showLabel = false }
     .with("on_track", "completed", "achieved", () => "bg-emerald-500 dark:bg-emerald-400")
     .with("paused", "dropped", () => "bg-gray-400 dark:bg-gray-500")
     .with("caution", "partial", () => "bg-amber-500 dark:bg-amber-400")
-    .with("issue", "missed", () => "bg-red-500 dark:bg-red-400")
+    .with("off_track", "missed", () => "bg-red-500 dark:bg-red-400")
     .with("pending", () => "bg-blue-500 dark:bg-blue-400")
     .otherwise(() => "bg-gray-400 dark:bg-gray-500");
 

--- a/turboui/src/ProgressBar/types.ts
+++ b/turboui/src/ProgressBar/types.ts
@@ -21,7 +21,7 @@ export type ProgressBarStatus =
   // Progress states
   | "on_track"
   | "caution"
-  | "issue"
+  | "off_track"
   | "paused"
   | "pending"
   // Completion states
@@ -29,6 +29,7 @@ export type ProgressBarStatus =
   | "partial"
   | "missed"
   // Legacy/alternative states
+  | "issue"
   | "completed"
   | "dropped"
   | "failed";


### PR DESCRIPTION
Now, resources with `off_track` status have a red progress bar.