### PR TITLE
chore: Standardize Project CheckIn and Goal Update status in activities

### DIFF
--- a/app/assets/js/components/status/constants.tsx
+++ b/app/assets/js/components/status/constants.tsx
@@ -1,11 +1,6 @@
 export const COLORS = {
-  completed: "green",
-  accomplished: "green",
-  not_accomplished: "red",
   on_track: "green",
   caution: "yellow",
-  concern: "yellow",
-  issue: "red",
   off_track: "red",
   paused: "gray",
   outdated: "gray",
@@ -13,13 +8,8 @@ export const COLORS = {
 };
 
 export const TITLES = {
-  completed: "Completed",
-  accomplished: "Accomplished",
-  not_accomplished: "Not Accomplished",
   on_track: "On Track",
   caution: "Caution",
-  concern: "Concern",
-  issue: "Issue",
   off_track: "Off Track",
   paused: "Paused",
   outdated: "Outdated",

--- a/app/assets/js/features/activities/GoalCheckIn/index.tsx
+++ b/app/assets/js/features/activities/GoalCheckIn/index.tsx
@@ -9,9 +9,9 @@ import { ActivityHandler } from "../interfaces";
 import { richContentToString } from "@/components/RichContent";
 import { usePaths } from "@/routes/paths";
 import { truncateString } from "@/utils/strings";
-import { match } from "ts-pattern";
 import { Link } from "turboui";
 import { feedTitle, goalLink } from "../feedItemLinks";
+import { SmallStatusIndicator } from "@/components/status";
 
 const GoalCheckIn: ActivityHandler = {
   pagePath(paths, activity: Activity): string {
@@ -39,18 +39,10 @@ const GoalCheckIn: ActivityHandler = {
     const fullMessage = richContentToString(JSON.parse(update.message!));
     const message = truncateString(fullMessage, 180);
 
-    const status = match(update.status)
-      .with("pending", () => <span>Pending</span>)
-      .with("on_track", () => <span>On Track</span>)
-      .with("concern", () => <span>Needs Caution</span>) // legacy
-      .with("caution", () => <span>Needs Caution</span>)
-      .with("issue", () => <span>Off Track</span>) // legacy
-      .with("off_track", () => <span>Off Track</span>)
-      .run();
-
     return (
       <div className="ProseMirror">
-        {status} &mdash; <span>{message}</span>
+        <SmallStatusIndicator status={update.status!} />
+        <span>{message}</span>
       </div>
     );
   },


### PR DESCRIPTION
I'm working on https://github.com/operately/operately/issues/2709.

Now, Project Check-in and Goal update activities display the resource status in the same way.