### PR TITLE
fix: Handle pending status for new projects and goals

### DIFF
--- a/app/lib/operately/goals/goal.ex
+++ b/app/lib/operately/goals/goal.ex
@@ -94,10 +94,9 @@ defmodule Operately.Goals.Goal do
       goal.success_status -> goal.success_status
       goal.success == "yes" -> :achieved
       goal.success == "no" -> :missed
-      goal.closed_at -> :completed
       Operately.Goals.outdated?(goal) -> :outdated
       goal.last_update_status -> goal.last_update_status
-      true -> :on_track
+      true -> :pending
     end
   end
 

--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -103,7 +103,7 @@ defmodule Operately.Projects.Project do
       project.status == "paused" -> :paused
       Operately.Projects.outdated?(project) -> :outdated
       project.last_check_in -> project.last_check_in.status
-      true -> :on_track
+      true -> :pending
     end
   end
 

--- a/app/test/operately/goals/goal_test.exs
+++ b/app/test/operately/goals/goal_test.exs
@@ -42,13 +42,13 @@ defmodule Operately.Goals.GoalTest do
       end
     end
 
-    test "a goal without update should be 'on_track'", ctx do
+    test "a goal which is not outdated and without update should be 'pending'", ctx do
       ctx =
         ctx
         |> Factory.add_goal(:goal, :space)
         |> Factory.preload(:goal, :last_update)
 
-      assert Goal.status(ctx.goal) == :on_track
+      assert Goal.status(ctx.goal) == :pending
     end
   end
 

--- a/app/test/operately/work_maps/work_map_item_test.exs
+++ b/app/test/operately/work_maps/work_map_item_test.exs
@@ -38,7 +38,7 @@ defmodule Operately.WorkMaps.WorkMapItemTest do
       end
     end
 
-    test "a project without check-in should be 'on_track'", ctx do
+    test "a project which is not outdated and without check-in should be 'pending'", ctx do
       ctx =
         ctx
         |> Factory.add_project(:project, :space)
@@ -46,7 +46,7 @@ defmodule Operately.WorkMaps.WorkMapItemTest do
         |> Factory.preload(:project, :milestones)
 
       item = WorkMapItem.build_item(ctx.project, [], false)
-      assert item.status == :on_track
+      assert item.status == :pending
     end
   end
 end


### PR DESCRIPTION
Previously, quick adding a project or goal would create an item with the `pending` status, but after reloading the page, the newly created item would have the `on_track` status.

Now, new items have the `pending` status until there is a check-in/update or until the status is changed to `outdated`.