### PR TITLE
fix: Goal Check-in page now works when the status is 'caution'

### DIFF
--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -92,7 +92,7 @@ function OverviewStatus({ goal }: { goal: Goals.Goal }) {
   return match(value)
     .with("pending", () => <OverviewPending />)
     .with("on_track", () => <OverviewOnTrack />)
-    .with("concern", () => <OverviewConcern goal={goal} />)
+    .with("caution", () => <OverviewConcern goal={goal} />)
     .with("off_track", () => <OverviewIssue goal={goal} />)
     .run();
 }


### PR DESCRIPTION
The Goal Check-in page was not handling the `caution` status.