### PR TITLE
feat: Date Picker scrolls to current year when tab changes

### DIFF
--- a/turboui/src/DatePicker/components/MonthSelector.tsx
+++ b/turboui/src/DatePicker/components/MonthSelector.tsx
@@ -1,16 +1,37 @@
-import React from "react";
+import React, { useRef, useLayoutEffect } from "react";
 import { generateMonths } from "../utils";
 
 interface Props {
   selectedDate: Date | undefined;
-  setSelectedDate: (date: Date) => void;
+  setSelectedDate: (date: Date | undefined) => void;
   visibleYears: number[];
 }
 
 export function MonthSelector({ selectedDate, setSelectedDate, visibleYears }: Props) {
+  const currentYear = new Date().getFullYear(); // Should be 2025
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setSelectedDate(undefined);
+    const currentYearIndex = visibleYears.indexOf(currentYear);
+
+    if (currentYearIndex !== -1 && containerRef.current) {
+      const totalYears = visibleYears.length;
+
+      // Calculate the scroll percentage (0 to 1) where current year should be positioned
+      // For example, if 2025 is the middle year in 2020-2030 range, percentage would be ~0.5
+      const scrollPercentage = currentYearIndex / (totalYears - 1);
+
+      // Get scrollable height
+      const scrollHeight = containerRef.current.scrollHeight - containerRef.current.clientHeight;
+
+      containerRef.current.scrollTop = scrollHeight * scrollPercentage;
+    }
+  }, []);
+
   return (
     <div className="mb-3">
-      <div className="max-h-48 overflow-y-auto p-2">
+      <div ref={containerRef} className="max-h-48 overflow-y-auto p-2">
         {visibleYears.map((year) => (
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>

--- a/turboui/src/DatePicker/components/QuarterSelector.tsx
+++ b/turboui/src/DatePicker/components/QuarterSelector.tsx
@@ -1,16 +1,37 @@
-import React from "react";
+import React, { useRef, useLayoutEffect } from "react";
 import { generateQuarters } from "../utils";
 
 interface Props {
   selectedDate: Date | undefined;
-  setSelectedDate: (date: Date) => void;
+  setSelectedDate: (date: Date | undefined) => void;
   visibleYears: number[];
 }
 
 export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears }: Props) {
+  const currentYear = new Date().getFullYear();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setSelectedDate(undefined);
+    const currentYearIndex = visibleYears.indexOf(currentYear);
+
+    if (currentYearIndex !== -1 && containerRef.current) {
+      const totalYears = visibleYears.length;
+
+      // Calculate the scroll percentage (0 to 1) where current year should be positioned
+      // For example, if 2025 is the middle year in 2020-2030 range, percentage would be ~0.5
+      const scrollPercentage = currentYearIndex / (totalYears - 1);
+
+      // Get scrollable height
+      const scrollHeight = containerRef.current.scrollHeight - containerRef.current.clientHeight;
+
+      containerRef.current.scrollTop = scrollHeight * scrollPercentage;
+    }
+  }, []);
+
   return (
     <div className="mb-3">
-      <div className="max-h-48 overflow-y-auto p-2">
+      <div ref={containerRef} className="max-h-48 overflow-y-auto p-2">
         {visibleYears.map((year) => (
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>

--- a/turboui/src/DatePicker/components/YearSelector.tsx
+++ b/turboui/src/DatePicker/components/YearSelector.tsx
@@ -1,19 +1,42 @@
-import React from "react";
+import React, { useRef, useLayoutEffect } from "react";
 
 interface Props {
   selectedDate: Date | undefined;
-  setSelectedDate: (date: Date) => void;
+  setSelectedDate: (date: Date | undefined) => void;
   years: number[];
 }
 
 export function YearSelector({ selectedDate, setSelectedDate, years }: Props) {
+  const currentYear = new Date().getFullYear();
+  const currentYearRef = useRef<HTMLButtonElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    setSelectedDate(undefined);
+    const currentYearIndex = years.indexOf(currentYear);
+
+    if (currentYearIndex !== -1 && containerRef.current) {
+      const totalYears = years.length;
+
+      // Calculate the scroll percentage (0 to 1) where current year should be positioned
+      // For example, if 2025 is the middle year in 2020-2030 range, percentage would be ~0.5
+      const scrollPercentage = currentYearIndex / (totalYears - 1);
+
+      // Get scrollable height
+      const scrollHeight = containerRef.current.scrollHeight - containerRef.current.clientHeight;
+
+      containerRef.current.scrollTop = scrollHeight * scrollPercentage;
+    }
+  }, []);
+
   return (
     <div className="mb-3">
-      <div className="max-h-48 overflow-y-auto p-2">
+      <div ref={containerRef} className="max-h-48 overflow-y-auto p-2">
         <div className="flex flex-col space-y-1 mx-auto">
           {years.map((year) => (
             <button
               key={year}
+              ref={year === currentYear ? currentYearRef : undefined}
               onClick={() => setSelectedDate(new Date(year, 0, 1))}
               className={`px-3 py-1.5 text-center text-sm rounded transition-colors ${
                 selectedDate?.getFullYear() === year ? "bg-blue-50 text-blue-700 font-medium" : "hover:bg-gray-50"


### PR DESCRIPTION
Now, the current year is always within view when the date type tab changes.