### PR TITLE
chore: DatePicker action buttons now work

### DIFF
--- a/turboui/src/DatePicker/components/ActionButtons.tsx
+++ b/turboui/src/DatePicker/components/ActionButtons.tsx
@@ -8,17 +8,19 @@ interface ActionButtonsProps {
 }
 
 export const ActionButtons: React.FC<ActionButtonsProps> = ({ selectedDate, onCancel, onSetDeadline }) => {
+  const handleConfirm = () => {
+    if (selectedDate) {
+      onSetDeadline?.(selectedDate.toISOString());
+    }
+  };
+
   return (
     <div className="grid grid-cols-2 gap-2 mt-6">
-      <SecondaryButton onClick={onCancel} size="sm">
+      <SecondaryButton onClick={() => onCancel?.()} size="sm">
         Cancel
       </SecondaryButton>
-      <PrimaryButton
-        onClick={() => onSetDeadline?.(selectedDate?.toISOString() || "")}
-        disabled={!selectedDate}
-        size="sm"
-      >
-        <span className="whitespace-nowrap">Set Deadline</span>
+      <PrimaryButton onClick={handleConfirm} disabled={!selectedDate} size="sm">
+        <span className="whitespace-nowrap">Confirm</span>
       </PrimaryButton>
     </div>
   );

--- a/turboui/src/DatePicker/index.tsx
+++ b/turboui/src/DatePicker/index.tsx
@@ -41,26 +41,45 @@ export function DatePicker({
   const [open, setOpen] = useState(false);
   const [dateType, setDateType] = useState<DateType>(initialType || "exact");
   const [selectedDate, setSelectedDate] = useState<SelectedDate>({ type: initialType, date: initialDate });
+  const [previousSelectedDate, setPreviousSelectedDate] = useState<SelectedDate>({
+    type: initialType,
+    date: initialDate,
+  });
 
   const yearOptions = Array.from({ length: maxYear - minYear + 1 }, (_, i) => minYear + i);
 
   const handleOpenChange = (isOpen: boolean) => {
     setOpen(isOpen);
+
+    if (isOpen) {
+      setPreviousSelectedDate({ ...selectedDate });
+    }
   };
 
   const handleTriggerClick = () => {
     setOpen(!open);
+
+    if (!open) {
+      setPreviousSelectedDate({ ...selectedDate });
+    }
+  };
+
+  const handleCancel = () => {
+    setSelectedDate(previousSelectedDate);
+    setOpen(false);
+    onCancel?.();
+  };
+
+  const handleDateSelect = (date: string) => {
+    setOpen(false);
+    onDateSelect?.(date);
   };
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
       <Popover.Trigger asChild>
         <div>
-          <DatePickerTrigger
-            selectedDate={selectedDate}
-            label={triggerLabel}
-            onClick={handleTriggerClick}
-          />
+          <DatePickerTrigger selectedDate={selectedDate} label={triggerLabel} onClick={handleTriggerClick} />
         </div>
       </Popover.Trigger>
 
@@ -71,8 +90,8 @@ export function DatePicker({
             selectedDate={selectedDate}
             setDateType={setDateType}
             setSelectedDate={setSelectedDate}
-            onDateSelect={onDateSelect}
-            onCancel={onCancel}
+            onDateSelect={handleDateSelect}
+            onCancel={handleCancel}
             yearOptions={yearOptions}
           />
         </Popover.Content>


### PR DESCRIPTION
Now, when the user clicks the Cancel button, the popover closes and the date value is reverted to what it was before the popover was opened.

When the user clicks the Confirm button, the popover closes and the value the user chose is set as the date.