### PR TITLE
chore: Add migration for populating Goals timeframe with contextual date

### DIFF
--- a/app/lib/operately/contextual_dates/contextual_date.ex
+++ b/app/lib/operately/contextual_dates/contextual_date.ex
@@ -23,6 +23,8 @@ defmodule Operately.ContextualDates.ContextualDate do
     validate_value_format(changeset, date_type)
   end
 
+  defp validate_value_format(changeset, :day), do: changeset
+
   defp validate_value_format(changeset, :month) do
     value = get_field(changeset, :value)
     valid_months = ~w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec)
@@ -42,18 +44,6 @@ defmodule Operately.ContextualDates.ContextualDate do
       changeset
     else
       add_error(changeset, :value, "must be a valid quarter format (Q1, Q2, Q3, Q4)")
-    end
-  end
-
-  defp validate_value_format(changeset, :day) do
-    # For day type, the value should be in ISO format (YYYY-MM-DD)
-    value = get_field(changeset, :value)
-    date = get_field(changeset, :date)
-
-    if value == Date.to_iso8601(date) do
-      changeset
-    else
-      add_error(changeset, :value, "must match the date field in ISO format (YYYY-MM-DD)")
     end
   end
 

--- a/app/lib/operately/data/change_065_timeframe_contextual_date_backfill.ex
+++ b/app/lib/operately/data/change_065_timeframe_contextual_date_backfill.ex
@@ -22,13 +22,13 @@ defmodule Operately.Data.Change065TimeframeContextualDateBackfill do
   defp update_goal_timeframe(goal) do
     contextual_start_date = %{
       date_type: :day,
-      value: Date.to_iso8601(goal.timeframe.start_date),
+      value: Calendar.strftime(goal.timeframe.start_date, "%b %d, %Y"),
       date: goal.timeframe.start_date
     }
 
     contextual_end_date = %{
       date_type: :day,
-      value: Date.to_iso8601(goal.timeframe.end_date),
+      value: Calendar.strftime(goal.timeframe.end_date, "%b %d, %Y"),
       date: goal.timeframe.end_date
     }
 

--- a/app/lib/operately/data/change_065_timeframe_contextual_date_backfill.ex
+++ b/app/lib/operately/data/change_065_timeframe_contextual_date_backfill.ex
@@ -1,0 +1,48 @@
+defmodule Operately.Data.Change065TimeframeContextualDateBackfill do
+  import Ecto.Query
+  alias Operately.Repo
+  alias Operately.Goals.Goal
+
+  def run do
+    goals_with_timeframes = Repo.all(from g in Goal,
+      where: not is_nil(g.timeframe),
+      select: g
+    )
+
+    {success_count, error_count} = Enum.reduce(goals_with_timeframes, {0, 0}, fn goal, {success, error} ->
+      case update_goal_timeframe(goal) do
+        {:ok, _} -> {success + 1, error}
+        {:error, _} -> {success, error + 1}
+      end
+    end)
+
+    {:ok, %{success_count: success_count, error_count: error_count}}
+  end
+
+  defp update_goal_timeframe(goal) do
+    contextual_start_date = %{
+      date_type: :day,
+      value: Date.to_iso8601(goal.timeframe.start_date),
+      date: goal.timeframe.start_date
+    }
+
+    contextual_end_date = %{
+      date_type: :day,
+      value: Date.to_iso8601(goal.timeframe.end_date),
+      date: goal.timeframe.end_date
+    }
+
+    updated_timeframe = %{
+      type: goal.timeframe.type,
+      start_date: goal.timeframe.start_date,
+      end_date: goal.timeframe.end_date,
+      contextual_start_date: contextual_start_date,
+      contextual_end_date: contextual_end_date
+    }
+
+
+    goal
+    |> Goal.changeset(%{timeframe: updated_timeframe})
+    |> Repo.update()
+  end
+end

--- a/app/priv/repo/migrations/20250716095720_populate_existing_goals_timeframe_with_contextual_date.exs
+++ b/app/priv/repo/migrations/20250716095720_populate_existing_goals_timeframe_with_contextual_date.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.PopulateExistingGoalsTimeframeWithContextualDate do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change065TimeframeContextualDateBackfill.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/contextual_dates/contextual_date_test.exs
+++ b/app/test/operately/contextual_dates/contextual_date_test.exs
@@ -27,17 +27,6 @@ defmodule Operately.ContextualDates.ContextualDateTest do
       changeset = ContextualDate.changeset(%ContextualDate{}, params)
       assert changeset.valid?
     end
-
-    test "returns error when value doesn't match ISO format of date" do
-      params = %{
-        date_type: :day,
-        value: "2025-07-16",
-        date: ~D[2025-07-15]
-      }
-
-      changeset = ContextualDate.changeset(%ContextualDate{}, params)
-      assert %{value: ["must match the date field in ISO format (YYYY-MM-DD)"]} = errors_on(changeset)
-    end
   end
 
   describe "validate_value_format/2 for month type" do

--- a/app/test/operately/data/change_065_timeframe_contextual_date_backfill_test.exs
+++ b/app/test/operately/data/change_065_timeframe_contextual_date_backfill_test.exs
@@ -1,0 +1,56 @@
+defmodule Operately.Data.Change065TimeframeContextualDateBackfillTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+
+  describe "TimeframeContextualDateBackfill" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+    end
+
+    test "adds contextual dates to a goal's timeframe", ctx do
+      start_date = ~D[2023-01-01]
+      end_date = ~D[2023-12-31]
+
+      ctx = Factory.add_goal(ctx, :goal, :space, timeframe: %{type: "year", start_date: start_date, end_date: end_date})
+
+      Operately.Data.Change065TimeframeContextualDateBackfill.run()
+
+      goal = Repo.reload(ctx.goal)
+
+      assert goal.timeframe.contextual_start_date.date_type == :day
+      assert goal.timeframe.contextual_start_date.value == "2023-01-01"
+      assert goal.timeframe.contextual_start_date.date == start_date
+
+      assert goal.timeframe.contextual_end_date.date_type == :day
+      assert goal.timeframe.contextual_end_date.value == "2023-12-31"
+      assert goal.timeframe.contextual_end_date.date == end_date
+    end
+
+    test "run/0 backfills contextual dates for all goals with timeframes", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:goal1, :space, timeframe: %{type: "year", start_date: ~D[2023-01-01], end_date: ~D[2023-12-31]})
+        |> Factory.add_goal(:goal2, :space, timeframe: %{type: "quarter", start_date: ~D[2023-04-01], end_date: ~D[2023-06-30]})
+
+      {:ok, result} = Operately.Data.Change065TimeframeContextualDateBackfill.run()
+
+      assert result.success_count == 2
+      assert result.error_count == 0
+
+      goal1 = Repo.reload(ctx.goal1)
+      assert goal1.timeframe.contextual_start_date.date_type == :day
+      assert goal1.timeframe.contextual_start_date.value == "2023-01-01"
+      assert goal1.timeframe.contextual_end_date.date_type == :day
+      assert goal1.timeframe.contextual_end_date.value == "2023-12-31"
+
+      goal2 = Repo.reload(ctx.goal2)
+      assert goal2.timeframe.contextual_start_date.date_type == :day
+      assert goal2.timeframe.contextual_start_date.value == "2023-04-01"
+      assert goal2.timeframe.contextual_end_date.date_type == :day
+      assert goal2.timeframe.contextual_end_date.value == "2023-06-30"
+    end
+  end
+end

--- a/app/test/operately/data/change_065_timeframe_contextual_date_backfill_test.exs
+++ b/app/test/operately/data/change_065_timeframe_contextual_date_backfill_test.exs
@@ -21,11 +21,11 @@ defmodule Operately.Data.Change065TimeframeContextualDateBackfillTest do
       goal = Repo.reload(ctx.goal)
 
       assert goal.timeframe.contextual_start_date.date_type == :day
-      assert goal.timeframe.contextual_start_date.value == "2023-01-01"
+      assert goal.timeframe.contextual_start_date.value == "Jan 01, 2023"
       assert goal.timeframe.contextual_start_date.date == start_date
 
       assert goal.timeframe.contextual_end_date.date_type == :day
-      assert goal.timeframe.contextual_end_date.value == "2023-12-31"
+      assert goal.timeframe.contextual_end_date.value == "Dec 31, 2023"
       assert goal.timeframe.contextual_end_date.date == end_date
     end
 
@@ -42,15 +42,15 @@ defmodule Operately.Data.Change065TimeframeContextualDateBackfillTest do
 
       goal1 = Repo.reload(ctx.goal1)
       assert goal1.timeframe.contextual_start_date.date_type == :day
-      assert goal1.timeframe.contextual_start_date.value == "2023-01-01"
+      assert goal1.timeframe.contextual_start_date.value == "Jan 01, 2023"
       assert goal1.timeframe.contextual_end_date.date_type == :day
-      assert goal1.timeframe.contextual_end_date.value == "2023-12-31"
+      assert goal1.timeframe.contextual_end_date.value == "Dec 31, 2023"
 
       goal2 = Repo.reload(ctx.goal2)
       assert goal2.timeframe.contextual_start_date.date_type == :day
-      assert goal2.timeframe.contextual_start_date.value == "2023-04-01"
+      assert goal2.timeframe.contextual_start_date.value == "Apr 01, 2023"
       assert goal2.timeframe.contextual_end_date.date_type == :day
-      assert goal2.timeframe.contextual_end_date.value == "2023-06-30"
+      assert goal2.timeframe.contextual_end_date.value == "Jun 30, 2023"
     end
   end
 end


### PR DESCRIPTION
I've added a migration to populate the existing Goals timeframe with contextual dates.