### PR TITLE
chore: Adjust Contextual Dates date types

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -878,7 +878,7 @@ export interface CompanyPermissions {
 }
 
 export interface ContextualDate {
-  dateType: string;
+  dateType: ContextualDateType;
   value: string;
   date: string;
 }
@@ -1703,6 +1703,8 @@ export type UpdateContent =
   | UpdateContentReview
   | UpdateContentProjectDiscussion
   | UpdateContentMessage;
+
+export type ContextualDateType = "day" | "month" | "quarter" | "year";
 
 export type GoalPrivacyValues = "public" | "internal" | "confidential" | "secret";
 

--- a/app/lib/operately/contextual_dates/contextual_date.ex
+++ b/app/lib/operately/contextual_dates/contextual_date.ex
@@ -2,9 +2,11 @@ defmodule Operately.ContextualDates.ContextualDate do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @valid_types [:day, :month, :quarter, :year]
+
   @primary_key false
   embedded_schema do
-    field :date_type, Ecto.Enum, values: [:day, :month, :quarter, :year]
+    field :date_type, Ecto.Enum, values: @valid_types
     field :value, :string
     field :date, :date
   end
@@ -66,4 +68,6 @@ defmodule Operately.ContextualDates.ContextualDate do
       add_error(changeset, :value, "must match the year of the date field")
     end
   end
+
+  def valid_types, do: @valid_types
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1381,8 +1381,10 @@ defmodule OperatelyWeb.Api.Types do
     field? :contextual_end_date, :contextual_date
   end
 
+  enum(:contextual_date_type, values: Operately.ContextualDates.ContextualDate.valid_types())
+
   object :contextual_date do
-    field :date_type, :string
+    field :date_type, :contextual_date_type
     field :value, :string
     field :date, :date
   end

--- a/turboui/src/DatePicker/DatePicker.stories.tsx
+++ b/turboui/src/DatePicker/DatePicker.stories.tsx
@@ -15,12 +15,12 @@ const meta = {
   argTypes: {
     initialType: {
       control: "select",
-      options: ["exact", "month", "quarter", "year"],
+      options: ["day", "month", "quarter", "year"],
       description: "The initial date type selected",
     },
     initialDate: {
       control: "text",
-      description: "Initial selected date in YYYY-MM-DD format (for exact date type)",
+      description: "Initial selected date in YYYY-MM-DD format (for day date type)",
     },
     onDateSelect: { action: "date selected" },
     onCancel: { action: "canceled" },
@@ -43,7 +43,7 @@ export const Default: Story = {
     </div>
   ),
   args: {
-    initialType: "exact",
+    initialType: "day",
     initialDate: new Date(),
   },
   parameters: {

--- a/turboui/src/DatePicker/components/InlineCalendar.tsx
+++ b/turboui/src/DatePicker/components/InlineCalendar.tsx
@@ -46,7 +46,7 @@ export function InlineCalendar({ selectedDate, setSelectedDate }: Props) {
     const date = new Date(currentYear, currentMonth, day);
 
     const isSelected = selectedDate.date
-      ? selectedDate.type === "exact" &&
+      ? selectedDate.type === "day" &&
         selectedDate.date.getDate() === day &&
         selectedDate.date.getMonth() === currentMonth &&
         selectedDate.date.getFullYear() === currentYear
@@ -54,7 +54,7 @@ export function InlineCalendar({ selectedDate, setSelectedDate }: Props) {
     const isToday = today.getDate() === day && today.getMonth() === currentMonth && today.getFullYear() === currentYear;
 
     const handleDayClick = (day: Date) => {
-      setSelectedDate({ date: day, type: "exact" });
+      setSelectedDate({ date: day, type: "day" });
     };
 
     days.push(

--- a/turboui/src/DatePicker/index.tsx
+++ b/turboui/src/DatePicker/index.tsx
@@ -11,7 +11,7 @@ import ActionButtons from "./components/ActionButtons";
 import classNames from "../utils/classnames";
 
 const DATE_TYPES = [
-  { value: "exact" as const, label: "Day" },
+  { value: "day" as const, label: "Day" },
   { value: "month" as const, label: "Month" },
   { value: "quarter" as const, label: "Quarter" },
   { value: "year" as const, label: "Year" },
@@ -39,7 +39,7 @@ export function DatePicker({
   triggerLabel = "Date",
 }: DatePicker.Props) {
   const [open, setOpen] = useState(false);
-  const [dateType, setDateType] = useState<DateType>(initialType || "exact");
+  const [dateType, setDateType] = useState<DateType>(initialType || "day");
   const [selectedDate, setSelectedDate] = useState<SelectedDate>({ type: initialType, date: initialDate });
   const [previousSelectedDate, setPreviousSelectedDate] = useState<SelectedDate>({
     type: initialType,
@@ -130,7 +130,7 @@ function DatePickerTrigger({ selectedDate, label = "Date", onClick, className }:
 
   if (date && type) {
     switch (type) {
-      case "exact":
+      case "day":
         // Full date: Jul 14, 2025
         displayText = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
           date,
@@ -183,7 +183,7 @@ function DatePickerContent(props: {
 
       <DateTypeSelector dateType={dateType} dateTypes={DATE_TYPES} setDateType={setDateType} />
 
-      {dateType === "exact" && (
+      {dateType === "day" && (
         <div className="mb-3">
           <InlineCalendar selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
         </div>

--- a/turboui/src/DatePicker/types.ts
+++ b/turboui/src/DatePicker/types.ts
@@ -1,4 +1,4 @@
-export type DateType = "exact" | "month" | "quarter" | "year";
+export type DateType = "day" | "month" | "quarter" | "year";
 
 export interface SelectedDate {
   date?: Date;


### PR DESCRIPTION
I ran into some problems while integrating the DatePicker component with the backend resources because there types weren't exactly the same. These changes address this issue.