### PR TITLE
chore: Add support for enums to API inputs

### DIFF
--- a/app/lib/turbo_connect/plugs/parse_inputs.ex
+++ b/app/lib/turbo_connect/plugs/parse_inputs.ex
@@ -187,6 +187,17 @@ defmodule TurboConnect.Plugs.ParseInputs do
           end
         end)
 
+      types.enums[type] != nil ->
+        enum_values = types.enums[type]
+        value = String.to_atom(value)
+
+        if value in enum_values do
+          {:ok, value}
+        else
+          allowed_values = enum_values |> Enum.join(", ")
+          {:error, 400, "Invalid value for enum #{type}: #{value}. Allowed values: #{allowed_values}"}
+        end
+
       true ->
         {:error, 400, "Unknown input type: #{type}"}
     end


### PR DESCRIPTION
Now we can use enums when defining the inputs of a mutation or query. 

Example:

```
// app/lib/operately_web/api/types.ex
enum(:contextual_date_type, values: [:day, :month, :quarter, :year])

// some mutation
inputs do
   field :due_date, :contextual_date, null: true
end
```