### PR TITLE
feat: Add inline and form-field variants to DatePicker

### DIFF
--- a/turboui/src/DatePicker/DatePicker.stories.tsx
+++ b/turboui/src/DatePicker/DatePicker.stories.tsx
@@ -29,6 +29,11 @@ const meta = {
       control: "boolean",
       description: "Whether to show a warning color for overdue dates",
     },
+    variant: {
+      control: "radio",
+      options: ["inline", "form-field"],
+      description: "Styling variant: inline (default) or form-field (with border)",
+    },
     onDateSelect: { action: "date selected" },
     onCancel: { action: "canceled" },
   },
@@ -56,6 +61,89 @@ export const Default: Story = {
       value: new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(new Date()),
     },
     readonly: false,
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+/**
+ * This story demonstrates both variants of the DatePicker: inline and form-field.
+ */
+export const VariantComparison: Story = {
+  tags: ["autodocs"],
+  render: () => {
+    const today = new Date();
+
+    return (
+      <div className="max-w-3xl mx-auto bg-white p-8">
+        <div className="mb-10">
+          <h2 className="text-lg font-bold mb-4">Variant: inline (default)</h2>
+          <div className="flex flex-col gap-4">
+            <div>
+              <h3 className="text-sm font-medium mb-2">Normal</h3>
+              <DatePicker
+                initialDate={{
+                  date: today,
+                  dateType: "day",
+                  value: new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
+                    today,
+                  ),
+                }}
+                variant="inline"
+              />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium mb-2">Read-only</h3>
+              <DatePicker
+                initialDate={{
+                  date: today,
+                  dateType: "day",
+                  value: new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
+                    today,
+                  ),
+                }}
+                variant="inline"
+                readonly
+              />
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-lg font-bold mb-4">Variant: form-field</h2>
+          <div className="flex flex-col gap-4">
+            <div>
+              <h3 className="text-sm font-medium mb-2">Normal</h3>
+              <DatePicker
+                initialDate={{
+                  date: today,
+                  dateType: "day",
+                  value: new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
+                    today,
+                  ),
+                }}
+                variant="form-field"
+              />
+            </div>
+            <div>
+              <h3 className="text-sm font-medium mb-2">Read-only</h3>
+              <DatePicker
+                initialDate={{
+                  date: today,
+                  dateType: "day",
+                  value: new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
+                    today,
+                  ),
+                }}
+                variant="form-field"
+                readonly
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   },
   parameters: {
     layout: "padded",

--- a/turboui/src/DatePicker/index.tsx
+++ b/turboui/src/DatePicker/index.tsx
@@ -28,6 +28,7 @@ export namespace DatePicker {
     triggerLabel?: string;
     readonly?: boolean;
     showOverdueWarning?: boolean;
+    variant?: "inline" | "form-field";
   }
 
   export type DateType = "day" | "month" | "quarter" | "year";
@@ -64,6 +65,7 @@ export function DatePicker({
   triggerLabel = "Date",
   readonly = false,
   showOverdueWarning = false,
+  variant = "inline",
   testId,
 }: DatePicker.Props) {
   const [open, setOpen] = useState(false);
@@ -117,6 +119,7 @@ export function DatePicker({
             label={triggerLabel}
             readonly={readonly}
             showOverdueWarning={showOverdueWarning}
+            variant={variant}
             testId={testId}
           />
         </div>
@@ -146,6 +149,7 @@ interface DatePickerTriggerProps extends TestableElement {
   className?: string;
   readonly?: boolean;
   showOverdueWarning: boolean;
+  variant?: "inline" | "form-field";
 }
 
 function DatePickerTrigger({
@@ -155,14 +159,15 @@ function DatePickerTrigger({
   className,
   readonly = false,
   showOverdueWarning,
+  variant,
   testId,
 }: DatePickerTriggerProps) {
   const triggerClassName = classNames(
     "inline-block focus:outline-none focus:ring-2 focus:ring-primary-base",
-    {
-      "hover:bg-surface-dimmed rounded-lg px-1.5 py-1 -mx-1.5 -my-1": !readonly,
-      "border border-surface-outline rounded-lg w-full hover:bg-surface-dimmed px-2 py-1.5": false,
-    },
+    variant === "inline"
+      ? "rounded-lg px-1.5 py-1 -mx-1.5 -my-1"
+      : "border border-surface-outline rounded-lg w-full px-2 py-1.5",
+    !readonly ? "hover:bg-surface-dimmed" : "",
     className,
   );
 


### PR DESCRIPTION
Now we can choose between an `inline` and `form-field` DatePicker variant.