### PR TITLE
feat: Add flag to hide DatePicker calendar icon

### DIFF
--- a/turboui/src/DatePicker/DatePicker.stories.tsx
+++ b/turboui/src/DatePicker/DatePicker.stories.tsx
@@ -278,3 +278,83 @@ export const ReadOnly: Story = {
     layout: "padded",
   },
 };
+
+/**
+ * This story demonstrates the DatePicker with and without the calendar icon.
+ */
+export const WithoutCalendarIcon: Story = {
+  tags: ["autodocs"],
+  render: () => {
+    const today = new Date();
+    const formattedDate = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(
+      today,
+    );
+
+    return (
+      <div className="max-w-3xl mx-auto bg-white p-8">
+        <div className="flex flex-col gap-8">
+          <div>
+            <h2 className="text-lg font-bold mb-4">With Calendar Icon (Default)</h2>
+            <div className="flex flex-col gap-4">
+              <div>
+                <h3 className="text-sm font-medium mb-2">Inline Variant</h3>
+                <DatePicker
+                  initialDate={{
+                    date: today,
+                    dateType: "day",
+                    value: formattedDate,
+                  }}
+                  variant="inline"
+                />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium mb-2">Form Field Variant</h3>
+                <DatePicker
+                  initialDate={{
+                    date: today,
+                    dateType: "day",
+                    value: formattedDate,
+                  }}
+                  variant="form-field"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-lg font-bold mb-4">Without Calendar Icon</h2>
+            <div className="flex flex-col gap-4">
+              <div>
+                <h3 className="text-sm font-medium mb-2">Inline Variant</h3>
+                <DatePicker
+                  initialDate={{
+                    date: today,
+                    dateType: "day",
+                    value: formattedDate,
+                  }}
+                  variant="inline"
+                  hideCalendarIcon={true}
+                />
+              </div>
+              <div>
+                <h3 className="text-sm font-medium mb-2">Form Field Variant</h3>
+                <DatePicker
+                  initialDate={{
+                    date: today,
+                    dateType: "day",
+                    value: formattedDate,
+                  }}
+                  variant="form-field"
+                  hideCalendarIcon={true}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    layout: "padded",
+  },
+};

--- a/turboui/src/DatePicker/index.tsx
+++ b/turboui/src/DatePicker/index.tsx
@@ -29,6 +29,7 @@ export namespace DatePicker {
     readonly?: boolean;
     showOverdueWarning?: boolean;
     variant?: "inline" | "form-field";
+    hideCalendarIcon?: boolean;
   }
 
   export type DateType = "day" | "month" | "quarter" | "year";
@@ -66,6 +67,7 @@ export function DatePicker({
   readonly = false,
   showOverdueWarning = false,
   variant = "inline",
+  hideCalendarIcon = false,
   testId,
 }: DatePicker.Props) {
   const [open, setOpen] = useState(false);
@@ -120,6 +122,7 @@ export function DatePicker({
             readonly={readonly}
             showOverdueWarning={showOverdueWarning}
             variant={variant}
+            hideCalendarIcon={hideCalendarIcon}
             testId={testId}
           />
         </div>
@@ -144,22 +147,22 @@ export function DatePicker({
 
 interface DatePickerTriggerProps extends TestableElement {
   selectedDate?: DatePicker.ContextualDate;
-  label?: string;
+  label: string;
   onClick: () => void;
-  className?: string;
-  readonly?: boolean;
+  readonly: boolean;
   showOverdueWarning: boolean;
-  variant?: "inline" | "form-field";
+  variant: "inline" | "form-field";
+  hideCalendarIcon: boolean;
 }
 
 function DatePickerTrigger({
   selectedDate,
-  label = "Date",
+  label,
   onClick,
-  className,
-  readonly = false,
+  readonly,
   showOverdueWarning,
   variant,
+  hideCalendarIcon,
   testId,
 }: DatePickerTriggerProps) {
   const triggerClassName = classNames(
@@ -168,7 +171,6 @@ function DatePickerTrigger({
       ? "rounded-lg px-1.5 py-1 -mx-1.5 -my-1"
       : "border border-surface-outline rounded-lg w-full px-2 py-1.5",
     !readonly ? "hover:bg-surface-dimmed" : "",
-    className,
   );
 
   const handleClick = (e: React.MouseEvent) => {
@@ -199,10 +201,12 @@ function DatePickerTrigger({
       data-testid={testId}
     >
       <span className={elemClass}>
-        <IconCalendarEvent
-          size={16}
-          className={isDateOverdue && showOverdueWarning ? "text-content-error -mt-[1px]" : "-mt-[1px]"}
-        />
+        {!hideCalendarIcon && (
+          <IconCalendarEvent
+            size={16}
+            className={isDateOverdue && showOverdueWarning ? "text-content-error -mt-[1px]" : "-mt-[1px]"}
+          />
+        )}
         <span className="truncate">{displayText}</span>
       </span>
     </button>


### PR DESCRIPTION
Now, the DatePicker calendar icon can be hidden. This will be useful when we use this component in the Work Map.