### PR TITLE
chore: Add useStartOfPeriod flag to DatePicker component

### DIFF
--- a/turboui/src/DatePicker/components/MonthSelector.tsx
+++ b/turboui/src/DatePicker/components/MonthSelector.tsx
@@ -7,9 +7,10 @@ interface Props {
   selectedDate?: DatePicker.ContextualDate;
   setSelectedDate: React.Dispatch<React.SetStateAction<DatePicker.ContextualDate>>;
   visibleYears: number[];
+  useStartOfPeriod?: boolean;
 }
 
-export function MonthSelector({ selectedDate, setSelectedDate, visibleYears }: Props) {
+export function MonthSelector({ selectedDate, setSelectedDate, visibleYears, useStartOfPeriod = false }: Props) {
   const currentYear = new Date().getFullYear(); // Should be 2025
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -43,7 +44,7 @@ export function MonthSelector({ selectedDate, setSelectedDate, visibleYears }: P
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>
             <div className="grid grid-cols-4 gap-1">
-              {generateMonths(year).map((month) => (
+              {generateMonths(year, useStartOfPeriod).map((month) => (
                 <OptionButton
                   key={month.value}
                   onClick={() => handleSelect(month)}

--- a/turboui/src/DatePicker/components/QuarterSelector.tsx
+++ b/turboui/src/DatePicker/components/QuarterSelector.tsx
@@ -7,9 +7,10 @@ interface Props {
   selectedDate?: DatePicker.ContextualDate;
   setSelectedDate: React.Dispatch<React.SetStateAction<DatePicker.ContextualDate>>;
   visibleYears: number[];
+  useStartOfPeriod?: boolean;
 }
 
-export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears }: Props) {
+export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears, useStartOfPeriod = false }: Props) {
   const currentYear = new Date().getFullYear();
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -43,7 +44,7 @@ export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears }:
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>
             <div className="flex space-x-1">
-              {generateQuarters(year).map((quarter) => (
+              {generateQuarters(year, useStartOfPeriod).map((quarter) => (
                 <OptionButton
                   key={quarter.value}
                   onClick={() => handleSelect(quarter)}

--- a/turboui/src/DatePicker/components/YearSelector.tsx
+++ b/turboui/src/DatePicker/components/YearSelector.tsx
@@ -1,14 +1,16 @@
 import React, { useRef, useLayoutEffect } from "react";
 import { OptionButton } from "./OptionButton";
 import { DatePicker } from "../index";
+import { getYearDate } from "../utils";
 
 interface Props {
   selectedDate?: DatePicker.ContextualDate;
   setSelectedDate: React.Dispatch<React.SetStateAction<DatePicker.ContextualDate>>;
   years: number[];
+  useStartOfPeriod?: boolean;
 }
 
-export function YearSelector({ selectedDate, setSelectedDate, years }: Props) {
+export function YearSelector({ selectedDate, setSelectedDate, years, useStartOfPeriod = false }: Props) {
   const currentYear = new Date().getFullYear();
   const currentYearRef = useRef<HTMLButtonElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -31,7 +33,7 @@ export function YearSelector({ selectedDate, setSelectedDate, years }: Props) {
   }, []);
 
   const handleSelect = (year: number) => {
-    const date = new Date(year, 0, 1);
+    const date = getYearDate(year, useStartOfPeriod);
     setSelectedDate({
       dateType: "year",
       date: date,

--- a/turboui/src/DatePicker/index.tsx
+++ b/turboui/src/DatePicker/index.tsx
@@ -30,6 +30,7 @@ export namespace DatePicker {
     showOverdueWarning?: boolean;
     variant?: "inline" | "form-field";
     hideCalendarIcon?: boolean;
+    useStartOfPeriod?: boolean;
   }
 
   export type DateType = "day" | "month" | "quarter" | "year";
@@ -68,6 +69,7 @@ export function DatePicker({
   showOverdueWarning = false,
   variant = "inline",
   hideCalendarIcon = false,
+  useStartOfPeriod = false,
   testId = "date-field",
 }: DatePicker.Props) {
   const [open, setOpen] = useState(false);
@@ -145,9 +147,10 @@ export function DatePicker({
             setSelectedDate={setSelectedDate}
             onDateSelect={handleDateSelect}
             onCancel={handleCancel}
-            yearOptions={yearOptions}
             onClearDate={handleClearDate}
+            yearOptions={yearOptions}
             testId={testId}
+            useStartOfPeriod={useStartOfPeriod}
           />
         </Popover.Content>
       </Popover.Portal>
@@ -233,6 +236,7 @@ interface DatePickerContentProps {
   onClearDate?: () => void;
   yearOptions: number[];
   testId: string;
+  useStartOfPeriod?: boolean;
 }
 
 function DatePickerContent(props: DatePickerContentProps) {
@@ -267,15 +271,15 @@ function DatePickerContent(props: DatePickerContentProps) {
       )}
 
       {dateType === "month" && (
-        <MonthSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} visibleYears={yearOptions} />
+        <MonthSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} visibleYears={yearOptions} useStartOfPeriod={props.useStartOfPeriod} />
       )}
 
       {dateType === "quarter" && (
-        <QuarterSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} visibleYears={yearOptions} />
+        <QuarterSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} visibleYears={yearOptions} useStartOfPeriod={props.useStartOfPeriod} />
       )}
 
       {dateType === "year" && (
-        <YearSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} years={yearOptions} />
+        <YearSelector selectedDate={selectedDate} setSelectedDate={setSelectedDate} years={yearOptions} useStartOfPeriod={props.useStartOfPeriod} />
       )}
 
       <ActionButtons selectedDate={selectedDate} onCancel={onCancel} onSetDeadline={onDateSelect} />

--- a/turboui/src/DatePicker/utils.ts
+++ b/turboui/src/DatePicker/utils.ts
@@ -1,23 +1,27 @@
 export const getCurrentYear = () => new Date().getFullYear();
 
-export const generateQuarters = (year = getCurrentYear()) => [
-  { value: `${year}-03-31`, label: "Q1" },
-  { value: `${year}-06-30`, label: "Q2" },
-  { value: `${year}-09-30`, label: "Q3" },
-  { value: `${year}-12-31`, label: "Q4" },
+export const generateQuarters = (year = getCurrentYear(), useStartOfPeriod = false) => [
+  { value: useStartOfPeriod ? `${year}-01-01` : `${year}-03-31`, label: "Q1" },
+  { value: useStartOfPeriod ? `${year}-04-01` : `${year}-06-30`, label: "Q2" },
+  { value: useStartOfPeriod ? `${year}-07-01` : `${year}-09-30`, label: "Q3" },
+  { value: useStartOfPeriod ? `${year}-10-01` : `${year}-12-31`, label: "Q4" },
 ];
 
-export const generateMonths = (year = getCurrentYear()) => [
-  { value: `${year}-01-31`, label: "Jan", name: "January" },
-  { value: `${year}-02-${year % 4 === 0 ? "29" : "28"}`, label: "Feb", name: "February" }, // Leap year handling
-  { value: `${year}-03-31`, label: "Mar", name: "March" },
-  { value: `${year}-04-30`, label: "Apr", name: "April" },
-  { value: `${year}-05-31`, label: "May", name: "May" },
-  { value: `${year}-06-30`, label: "Jun", name: "June" },
-  { value: `${year}-07-31`, label: "Jul", name: "July" },
-  { value: `${year}-08-31`, label: "Aug", name: "August" },
-  { value: `${year}-09-30`, label: "Sep", name: "September" },
-  { value: `${year}-10-31`, label: "Oct", name: "October" },
-  { value: `${year}-11-30`, label: "Nov", name: "November" },
-  { value: `${year}-12-31`, label: "Dec", name: "December" },
+export const generateMonths = (year = getCurrentYear(), useStartOfPeriod = false) => [
+  { value: useStartOfPeriod ? `${year}-01-01` : `${year}-01-31`, label: "Jan", name: "January" },
+  { value: useStartOfPeriod ? `${year}-02-01` : `${year}-02-${year % 4 === 0 ? "29" : "28"}`, label: "Feb", name: "February" }, // Leap year handling
+  { value: useStartOfPeriod ? `${year}-03-01` : `${year}-03-31`, label: "Mar", name: "March" },
+  { value: useStartOfPeriod ? `${year}-04-01` : `${year}-04-30`, label: "Apr", name: "April" },
+  { value: useStartOfPeriod ? `${year}-05-01` : `${year}-05-31`, label: "May", name: "May" },
+  { value: useStartOfPeriod ? `${year}-06-01` : `${year}-06-30`, label: "Jun", name: "June" },
+  { value: useStartOfPeriod ? `${year}-07-01` : `${year}-07-31`, label: "Jul", name: "July" },
+  { value: useStartOfPeriod ? `${year}-08-01` : `${year}-08-31`, label: "Aug", name: "August" },
+  { value: useStartOfPeriod ? `${year}-09-01` : `${year}-09-30`, label: "Sep", name: "September" },
+  { value: useStartOfPeriod ? `${year}-10-01` : `${year}-10-31`, label: "Oct", name: "October" },
+  { value: useStartOfPeriod ? `${year}-11-01` : `${year}-11-30`, label: "Nov", name: "November" },
+  { value: useStartOfPeriod ? `${year}-12-01` : `${year}-12-31`, label: "Dec", name: "December" },
 ];
+
+export const getYearDate = (year: number, useStartOfPeriod = false) => {
+  return useStartOfPeriod ? new Date(year, 0, 1) : new Date(year, 11, 31);
+};


### PR DESCRIPTION
The DatePicker component can now be used to set contextual dates which use the beginning of a period of time instead of the end. For example, when the users sets year "2026", instead of the value being "2026-12-31", it will be "2026-01-01". This feature will enable the component to be used for setting the start date of Goals and Projects.