### PR TITLE
fix: Don't assume that reviewers can't be deselected for project discussions

### DIFF
--- a/app/assets/js/features/Subscriptions/useSubscriptions.tsx
+++ b/app/assets/js/features/Subscriptions/useSubscriptions.tsx
@@ -1,8 +1,8 @@
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
-import { compareIds } from "@/routes/paths";
 import { Subscriber } from "@/models/notifications";
+import { compareIds } from "@/routes/paths";
 import { Options } from ".";
 
 export interface SubscriptionsState {
@@ -20,10 +20,10 @@ interface Opts {
   ignoreMe?: boolean;
 }
 
-export function useSubscriptions(subscribers: Subscriber[], opts?: Opts): SubscriptionsState {
+export function useSubscriptions(allSubscribers: Subscriber[], opts?: Opts): SubscriptionsState {
   const me = useMe();
 
-  subscribers = opts?.ignoreMe ? subscribers.filter((s) => !compareIds(s.person!.id, me?.id)) : subscribers;
+  const subscribers = opts?.ignoreMe ? allSubscribers.filter((s) => !compareIds(s.person!.id, me?.id)) : allSubscribers;
   const alwaysNotify = useMemo(() => findPrioritySubscribers(subscribers, opts), []);
 
   const [selectedSubscribers, setSelectedSubscribers] = useState<Subscriber[]>(

--- a/app/assets/js/pages/ProjectDiscussionNewPage/index.tsx
+++ b/app/assets/js/pages/ProjectDiscussionNewPage/index.tsx
@@ -65,10 +65,7 @@ function Form() {
 
   assertPresent(project.potentialSubscribers, "potentialSubscribers must be present in project");
 
-  const subscriptionsState = useSubscriptions(project.potentialSubscribers, {
-    ignoreMe: true,
-    notifyPrioritySubscribers: true,
-  });
+  const subscriptionsState = useSubscriptions(project.potentialSubscribers, { ignoreMe: true });
 
   const form = useForm({ project, subscriptionsState });
 

--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -128,13 +128,15 @@ defmodule Operately.Projects.Project do
     total_milestones = length(project.milestones)
 
     if total_milestones > 0 do
-      completed_milestones = Enum.count(project.milestones, fn milestone ->
-        case milestone do
-          %{status: status} when status == :done -> true
-          _ -> false
-        end
-      end)
-      (completed_milestones / total_milestones) * 100
+      completed_milestones =
+        Enum.count(project.milestones, fn milestone ->
+          case milestone do
+            %{status: status} when status == :done -> true
+            _ -> false
+          end
+        end)
+
+      completed_milestones / total_milestones * 100
     else
       0
     end


### PR DESCRIPTION
tldr: the subscription mechanism was copied from the check-in page where you can't deselect the reviewer. This makes sense in the context of the check-in, but not for project discussions.

fixes https://github.com/operately/operately/issues/2957