### PR TITLE
feat: Add DateField to Project timeline page

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1131,6 +1131,7 @@ export interface Project {
   updatedAt?: string | null;
   startedAt?: string | null;
   deadline?: string | null;
+  timeframe?: Timeframe;
   nextUpdateScheduledAt?: string | null;
   nextCheckInScheduledAt?: string | null;
   privacy?: string | null;
@@ -2987,8 +2988,8 @@ export interface EditProjectRetrospectiveResult {
 
 export interface EditProjectTimelineInput {
   projectId?: string | null;
-  projectStartDate?: string | null;
-  projectDueDate?: string | null;
+  projectStartDate: ContextualDate | null;
+  projectDueDate: ContextualDate | null;
   milestoneUpdates?: EditProjectTimelineMilestoneUpdateInput[] | null;
   newMilestones?: EditProjectTimelineNewMilestoneInput[] | null;
 }

--- a/app/assets/js/pages/ProjectEditTimelinePage/page.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/page.tsx
@@ -3,12 +3,11 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import { PrimaryButton, SecondaryButton } from "turboui";
+import { PrimaryButton, SecondaryButton, DateField } from "turboui";
 
 import { useLoadedData } from "./loader";
 import { useForm, FormState } from "./useForm";
 
-import { DateSelector } from "./DateSelector";
 import { MilestoneList } from "./MilestoneList";
 import { unstable_usePrompt } from "react-router-dom";
 
@@ -87,11 +86,11 @@ function StartDate({ form }) {
     <div className="flex flex-col gap-1 flex-1">
       <div className="uppercase text-xs text-content-accent font-bold">Start Date</div>
       <div className="flex-1">
-        <DateSelector
+        <DateField
           date={form.startTime}
-          onChange={form.setStartTime}
-          minDate={null}
-          maxDate={form.dueDate}
+          onDateSelect={form.setStartTime}
+          placeholder="Not set"
+          variant="form-field"
           testId="project-start"
         />
       </div>
@@ -104,11 +103,11 @@ function DueDate({ form }) {
     <div className="flex flex-col gap-1 flex-1">
       <div className="uppercase text-xs text-content-accent font-bold">Due Date</div>
       <div className="flex-1">
-        <DateSelector
+        <DateField
           date={form.dueDate}
-          onChange={form.setDueDate}
-          minDate={form.startTime}
-          maxDate={null}
+          onDateSelect={form.setDueDate}
+          placeholder="Not set"
+          variant="form-field"
           testId="project-due"
         />
       </div>

--- a/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 
 import { usePaths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
+import { DateField } from "turboui";
+import { parseContextualDate, serializeContextualDate } from "@/models/contextualDates";
 import { MilestoneListState, useMilestoneListState } from "./useMilestoneListState";
+import { assertPresent } from "@/utils/assertions";
 
 interface Error {
   field: string;
@@ -14,11 +17,11 @@ interface Error {
 export interface FormState {
   projectId: string;
 
-  startTime: Date | null;
-  setStartTime: (date: Date | null) => void;
+  startTime: DateField.ContextualDate | null;
+  setStartTime: (date: DateField.ContextualDate | null) => void;
 
-  dueDate: Date | null;
-  setDueDate: (date: Date | null) => void;
+  dueDate: DateField.ContextualDate | null;
+  setDueDate: (date: DateField.ContextualDate | null) => void;
 
   milestoneList: MilestoneListState;
   milestoneBeingEdited: string | null;
@@ -34,15 +37,17 @@ export interface FormState {
 }
 
 export function useForm(project: Projects.Project): FormState {
+  assertPresent(project.timeframe);
+
   const paths = usePaths();
   const navigate = useNavigate();
   const milestonesPath = paths.projectMilestonesPath(project.id!);
 
-  const oldStart = Time.parseDate(project.startedAt);
-  const oldDue = Time.parseDate(project.deadline);
+  const oldStart = parseContextualDate(project.timeframe.contextualStartDate);
+  const oldDue = parseContextualDate(project.timeframe.contextualEndDate);
 
-  const [startTime, setStartTime] = React.useState<Date | null>(oldStart);
-  const [dueDate, setDueDate] = React.useState<Date | null>(oldDue);
+  const [startTime, setStartTime] = React.useState<DateField.ContextualDate | null>(oldStart);
+  const [dueDate, setDueDate] = React.useState<DateField.ContextualDate | null>(oldDue);
   const [milestoneBeingEdited, setMilestoneBeingEdited] = React.useState<string | null>(null);
 
   const submitted = React.useRef(false);
@@ -51,8 +56,8 @@ export function useForm(project: Projects.Project): FormState {
   const milestoneList = useMilestoneListState(project);
 
   const hasChanges = React.useMemo(() => {
-    if (Time.dateChanged(startTime, oldStart)) return true;
-    if (Time.dateChanged(dueDate, oldDue)) return true;
+    if (Time.dateChanged(startTime?.date || null, oldStart?.date || null)) return true;
+    if (Time.dateChanged(dueDate?.date || null, oldDue?.date || null)) return true;
     if (milestoneList.hasChanges) return true;
 
     return false;
@@ -63,8 +68,8 @@ export function useForm(project: Projects.Project): FormState {
   const submit = async () => {
     await edit({
       projectId: project.id,
-      projectStartDate: startTime && Time.toDateWithoutTime(startTime),
-      projectDueDate: dueDate && Time.toDateWithoutTime(dueDate),
+      projectStartDate: serializeContextualDate(startTime),
+      projectDueDate: serializeContextualDate(dueDate),
       newMilestones: milestoneList.newMilestones.map((m) => ({
         title: m.title,
         description: m.description,

--- a/app/assets/js/pages/ProjectMilestonesPage/page.tsx
+++ b/app/assets/js/pages/ProjectMilestonesPage/page.tsx
@@ -3,17 +3,18 @@ import React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Milestones from "@/models/milestones";
-import * as Time from "@/utils/time";
+import { Project } from "@/models/projects";
+import { parseContextualDate } from "@/models/contextualDates";
 
 import FormattedTime from "@/components/FormattedTime";
-import { GhostButton } from "turboui";
-
-import { MilestoneIcon } from "@/components/MilestoneIcon";
-import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
-import { Link } from "turboui";
-import { useLoadedData } from "./loader";
+import { GhostButton, DateField, Link } from "turboui";
 
 import { usePaths } from "@/routes/paths";
+import { assertPresent } from "@/utils/assertions";
+import { MilestoneIcon } from "@/components/MilestoneIcon";
+import { ProjectPageNavigation } from "@/components/ProjectPageNavigation";
+import { useLoadedData } from "./loader";
+
 export function Page() {
   const { project } = useLoadedData();
 
@@ -51,30 +52,29 @@ function Title({ project }) {
   );
 }
 
-function Dates({ project }) {
-  const start = Time.parseDate(project.startedAt);
-  const end = Time.parseDate(project.deadline);
+function Dates({ project }: { project: Project }) {
+  assertPresent(project.timeframe);
 
   return (
     <div className="flex items-center gap-12 mb-8">
       <div className="flex flex-col">
         <div className="text-sm font-bold">Start Date</div>
-        {start && (
-          <div className="text-content-accent">
-            <FormattedTime time={start} format="long-date" />
-          </div>
-        )}
+        <DateField
+          date={parseContextualDate(project.timeframe.contextualStartDate)}
+          placeholder="No start date"
+          readonly
+          hideCalendarIcon
+        />
       </div>
 
       <div className="flex flex-col">
         <div className="text-sm font-bold">Due Date</div>
-        {end ? (
-          <div className="text-content-accent">
-            <FormattedTime time={end} format="long-date" />
-          </div>
-        ) : (
-          <div className="text-content-dimmed">No due date</div>
-        )}
+        <DateField
+          date={parseContextualDate(project.timeframe.contextualEndDate)}
+          placeholder="No due date"
+          readonly
+          hideCalendarIcon
+        />
       </div>
     </div>
   );

--- a/app/lib/operately/projects/edit_timeline_operation.ex
+++ b/app/lib/operately/projects/edit_timeline_operation.ex
@@ -4,15 +4,14 @@ defmodule Operately.Projects.EditTimelineOperation do
 
   alias Operately.Activities
   alias Operately.Projects.{Project, Milestone}
-  alias Operately.ContextualDates.ContextualDate
 
   def run(author, project, attrs) do
     changeset = Project.changeset(project, %{
-      started_at: attrs.project_start_date,
-      deadline: attrs.project_due_date,
+      started_at: attrs. project_start_date && NaiveDateTime.new!(attrs.project_start_date.date, ~T[00:00:00]),
+      deadline: attrs.project_due_date && NaiveDateTime.new!(attrs.project_due_date.date, ~T[00:00:00]),
       timeframe: %{
-        contextual_start_date: ContextualDate.create_day_date(attrs.project_start_date),
-        contextual_end_date: ContextualDate.create_day_date(attrs.project_due_date),
+        contextual_start_date: attrs.project_start_date,
+        contextual_end_date: attrs.project_due_date,
       }
     })
 

--- a/app/lib/operately_web/api/mutations/edit_project_timeline.ex
+++ b/app/lib/operately_web/api/mutations/edit_project_timeline.ex
@@ -9,8 +9,8 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectTimeline do
   inputs do
     field? :project_id, :string, null: true
 
-    field? :project_start_date, :date, null: true
-    field? :project_due_date, :date, null: true
+    field :project_start_date, :contextual_date, null: true
+    field :project_due_date, :contextual_date, null: true
 
     field? :milestone_updates, list_of(:edit_project_timeline_milestone_update_input), null: true
     field? :new_milestones, list_of(:edit_project_timeline_new_milestone_input), null: true
@@ -48,8 +48,8 @@ defmodule OperatelyWeb.Api.Mutations.EditProjectTimeline do
     {:ok, %{
       project_id: project_id,
 
-      project_start_date: parse_date(inputs.project_start_date),
-      project_due_date: inputs[:project_due_date] && parse_date(inputs.project_due_date),
+      project_start_date: inputs.project_start_date,
+      project_due_date: inputs.project_due_date,
 
       milestone_updates: Enum.map(inputs.milestone_updates, fn update ->
         {:ok, milestone_id} = decode_id(update.id)

--- a/app/lib/operately_web/api/serializers/project.ex
+++ b/app/lib/operately_web/api/serializers/project.ex
@@ -21,6 +21,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       started_at: OperatelyWeb.Api.Serializer.serialize(project.started_at),
       closed_at: OperatelyWeb.Api.Serializer.serialize(project.closed_at),
       deadline: OperatelyWeb.Api.Serializer.serialize(project.deadline),
+      timeframe: OperatelyWeb.Api.Serializer.serialize(project.timeframe),
       is_archived: project.deleted_at != nil,
       is_outdated: Operately.Projects.outdated?(project),
       space: OperatelyWeb.Api.Serializer.serialize(project.group),

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -282,6 +282,7 @@ defmodule OperatelyWeb.Api.Types do
     field? :updated_at, :date, null: true
     field? :started_at, :date, null: true
     field? :deadline, :date, null: true
+    field? :timeframe, :timeframe
     field? :next_update_scheduled_at, :date, null: true
     field? :next_check_in_scheduled_at, :date, null: true
     field? :privacy, :string, null: true


### PR DESCRIPTION
Now we can choose contextual dates when setting a project start date and deadline.