### PR TITLE
feat: Add minDateLimit and maxDateLimit props to DateField

### DIFF
--- a/turboui/src/DateField/components/InlineCalendar.tsx
+++ b/turboui/src/DateField/components/InlineCalendar.tsx
@@ -2,13 +2,16 @@ import React from "react";
 import { IconChevronLeft, IconChevronRight } from "../../icons";
 import { DateField } from "../index";
 import classNames from "../../utils/classnames";
+import * as time from "../../utils/time";
 
 interface Props {
   selectedDate: DateField.ContextualDate | null;
   setSelectedDate: React.Dispatch<React.SetStateAction<DateField.ContextualDate | null>>;
+  minDateLimit?: Date;
+  maxDateLimit?: Date;
 }
 
-export function InlineCalendar({ selectedDate, setSelectedDate }: Props) {
+export function InlineCalendar({ selectedDate, setSelectedDate, minDateLimit, maxDateLimit }: Props) {
   const [calendarDate, setCalendarDate] = React.useState(new Date());
 
   const today = new Date();
@@ -49,19 +52,25 @@ export function InlineCalendar({ selectedDate, setSelectedDate }: Props) {
     const isSelected = isSelectedDay(day, currentMonth, currentYear, selectedDate);
     const isToday = today.getDate() === day && today.getMonth() === currentMonth && today.getFullYear() === currentYear;
 
+    // Check if the date is disabled (outside of min/max range)
+    const isDisabled = isDateDisabled(date, minDateLimit, maxDateLimit);
+
     const handleDayClick = (day: Date) => {
+      if (isDisabled) return; // Prevent selection if disabled
       const value = new Intl.DateTimeFormat("en-US", { year: "numeric", month: "short", day: "numeric" }).format(day);
       setSelectedDate({ date: day, dateType: "day", value });
     };
+
     const className = classNames(
       "w-7 h-7 text-xs rounded-full transition-colors",
       isSelected && "border border-blue-500 bg-blue-50 text-blue-700",
-      isToday && !isSelected && "border border-blue-300 text-blue-600 hover:bg-blue-50",
-      !isSelected && !isToday && "hover:bg-gray-100 hover:text-blue-500",
+      isToday && !isSelected && !isDisabled && "border border-blue-300 text-blue-600 hover:bg-blue-50",
+      !isSelected && !isToday && !isDisabled && "hover:bg-gray-100 hover:text-blue-500",
+      isDisabled && "opacity-50 cursor-not-allowed line-through text-gray-400",
     );
 
     days.push(
-      <button key={day} onClick={() => handleDayClick(date)} className={className}>
+      <button key={day} onClick={() => handleDayClick(date)} className={className} disabled={isDisabled}>
         {day}
       </button>,
     );
@@ -102,7 +111,12 @@ export function InlineCalendar({ selectedDate, setSelectedDate }: Props) {
   );
 }
 
-function isSelectedDay(day: number, month: number, year: number, selectedDate: DateField.ContextualDate | null): boolean {
+function isSelectedDay(
+  day: number,
+  month: number,
+  year: number,
+  selectedDate: DateField.ContextualDate | null,
+): boolean {
   return Boolean(
     selectedDate &&
       selectedDate.dateType === "day" &&
@@ -110,4 +124,20 @@ function isSelectedDay(day: number, month: number, year: number, selectedDate: D
       selectedDate.date.getMonth() === month &&
       selectedDate.date.getFullYear() === year,
   );
+}
+
+function isDateDisabled(date: Date, minDateLimit?: Date, maxDateLimit?: Date): boolean {
+  if (minDateLimit) {
+    if (time.compareAsc(date, minDateLimit) < 0) {
+      return true;
+    }
+  }
+
+  if (maxDateLimit) {
+    if (time.compareAsc(date, maxDateLimit) > 0) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/turboui/src/DateField/components/MonthSelector.tsx
+++ b/turboui/src/DateField/components/MonthSelector.tsx
@@ -8,9 +8,18 @@ interface Props {
   setSelectedDate: React.Dispatch<React.SetStateAction<DateField.ContextualDate>>;
   visibleYears: number[];
   useStartOfPeriod?: boolean;
+  minDateLimit?: Date;
+  maxDateLimit?: Date;
 }
 
-export function MonthSelector({ selectedDate, setSelectedDate, visibleYears, useStartOfPeriod = false }: Props) {
+export function MonthSelector({
+  selectedDate,
+  setSelectedDate,
+  visibleYears,
+  useStartOfPeriod = false,
+  minDateLimit,
+  maxDateLimit,
+}: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
@@ -45,17 +54,24 @@ export function MonthSelector({ selectedDate, setSelectedDate, visibleYears, use
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>
             <div className="grid grid-cols-4 gap-1">
-              {generateMonths(year, useStartOfPeriod).map((month) => (
-                <OptionButton
-                  key={month.value}
-                  onClick={() => handleSelect(month)}
-                  isSelected={isSelectedMonth(month.value, year, selectedDate)}
-                  isCurrent={isCurrentMonth(month.value, year)}
-                  className="py-1 px-2 text-xs"
-                >
-                  {month.label}
-                </OptionButton>
-              ))}
+              {generateMonths(year, useStartOfPeriod).map((month) => {
+                const monthDate = new Date(month.value);
+                // Check if month is disabled (outside of min/max range)
+                const isDisabled = isMonthDisabled(monthDate, minDateLimit, maxDateLimit);
+
+                return (
+                  <OptionButton
+                    key={month.value}
+                    onClick={() => !isDisabled && handleSelect(month)}
+                    isSelected={isSelectedMonth(month.value, year, selectedDate)}
+                    isCurrent={isCurrentMonth(month.value, year)}
+                    isDisabled={isDisabled}
+                    className="py-1 px-2 text-xs"
+                  >
+                    {month.label}
+                  </OptionButton>
+                );
+              })}
             </div>
           </div>
         ))}
@@ -80,4 +96,42 @@ function isCurrentMonth(monthValue: string, year: number) {
   const currentMonth = today.getMonth();
 
   return monthDate.getMonth() === currentMonth && year === currentYear;
+}
+
+function isMonthDisabled(monthDate: Date, minDateLimit?: Date, maxDateLimit?: Date): boolean {
+  if (minDateLimit) {
+    if (compareMonthsOnly(monthDate, minDateLimit) < 0) {
+      return true;
+    }
+  }
+
+  if (maxDateLimit) {
+    if (compareMonthsOnly(monthDate, maxDateLimit) > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Compares two dates by month and year only
+ * Returns:
+ * -1 if date1's month/year is before date2's month/year
+ *  0 if date1's month/year is the same as date2's month/year
+ *  1 if date1's month/year is after date2's month/year
+ */
+function compareMonthsOnly(date1: Date, date2: Date): number {
+  // Compare years first
+  if (date1.getFullYear() !== date2.getFullYear()) {
+    return date1.getFullYear() < date2.getFullYear() ? -1 : 1;
+  }
+
+  // If years are the same, compare months
+  if (date1.getMonth() !== date2.getMonth()) {
+    return date1.getMonth() < date2.getMonth() ? -1 : 1;
+  }
+
+  // If both year and month are the same
+  return 0;
 }

--- a/turboui/src/DateField/components/OptionButton.tsx
+++ b/turboui/src/DateField/components/OptionButton.tsx
@@ -7,18 +7,22 @@ interface DatePickerOptionButtonProps {
   className?: string;
   ref?: React.Ref<HTMLButtonElement>;
   isCurrent?: boolean;
+  isDisabled?: boolean;
 }
 
 export const OptionButton = React.forwardRef<HTMLButtonElement, DatePickerOptionButtonProps>(
-  ({ children, isSelected, onClick, className = "", isCurrent = false }, ref) => {
+  ({ children, isSelected, onClick, className = "", isCurrent = false, isDisabled = false }, ref) => {
     return (
       <button
         ref={ref}
         onClick={onClick}
+        disabled={isDisabled}
         className={`
           rounded text-center transition-colors
           ${
-            isSelected
+            isDisabled
+              ? "opacity-50 cursor-not-allowed line-through text-gray-400"
+              : isSelected
               ? "bg-blue-50 text-blue-700 font-medium"
               : isCurrent
               ? "border border-blue-300 text-blue-600 hover:bg-blue-50"

--- a/turboui/src/DateField/components/QuarterSelector.tsx
+++ b/turboui/src/DateField/components/QuarterSelector.tsx
@@ -8,9 +8,18 @@ interface Props {
   setSelectedDate: React.Dispatch<React.SetStateAction<DateField.ContextualDate>>;
   visibleYears: number[];
   useStartOfPeriod?: boolean;
+  minDateLimit?: Date;
+  maxDateLimit?: Date;
 }
 
-export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears, useStartOfPeriod = false }: Props) {
+export function QuarterSelector({
+  selectedDate,
+  setSelectedDate,
+  visibleYears,
+  useStartOfPeriod = false,
+  minDateLimit,
+  maxDateLimit,
+}: Props) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   useLayoutEffect(() => {
@@ -45,17 +54,24 @@ export function QuarterSelector({ selectedDate, setSelectedDate, visibleYears, u
           <div key={year} className="mb-4 last:mb-0">
             <div className="text-xs font-medium text-gray-500 mb-1">{year}</div>
             <div className="flex space-x-1">
-              {generateQuarters(year, useStartOfPeriod).map((quarter) => (
-                <OptionButton
-                  key={quarter.value}
-                  onClick={() => handleSelect(quarter)}
-                  isSelected={isSelectedQuarter(quarter.value, year, selectedDate)}
-                  isCurrent={isCurrentQuarter(quarter.value, year)}
-                  className="flex-1 py-1 px-2 text-xs"
-                >
-                  {quarter.label}
-                </OptionButton>
-              ))}
+              {generateQuarters(year, useStartOfPeriod).map((quarter) => {
+                const quarterDate = new Date(quarter.value);
+                // Check if quarter is disabled (outside of min/max range)
+                const isDisabled = isQuarterDisabled(quarterDate, minDateLimit, maxDateLimit);
+
+                return (
+                  <OptionButton
+                    key={quarter.value}
+                    onClick={() => !isDisabled && handleSelect(quarter)}
+                    isSelected={isSelectedQuarter(quarter.value, year, selectedDate)}
+                    isCurrent={isCurrentQuarter(quarter.value, year)}
+                    isDisabled={isDisabled}
+                    className="flex-1 py-1 px-2 text-xs"
+                  >
+                    {quarter.label}
+                  </OptionButton>
+                );
+              })}
             </div>
           </div>
         ))}
@@ -92,4 +108,49 @@ function isCurrentQuarter(quarterValue: string, year: number): boolean {
   } catch (e) {
     return false;
   }
+}
+
+function isQuarterDisabled(quarterDate: Date, minDateLimit?: Date, maxDateLimit?: Date): boolean {
+  if (minDateLimit) {
+    if (compareQuartersOnly(quarterDate, minDateLimit) < 0) {
+      return true;
+    }
+  }
+
+  if (maxDateLimit) {
+    if (compareQuartersOnly(quarterDate, maxDateLimit) > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getQuarter(date: Date): number {
+  return Math.floor(date.getMonth() / 3);
+}
+
+/**
+ * Compares two dates by quarter and year only
+ * Returns:
+ * -1 if date1's quarter/year is before date2's quarter/year
+ *  0 if date1's quarter/year is the same as date2's quarter/year
+ *  1 if date1's quarter/year is after date2's quarter/year
+ */
+function compareQuartersOnly(date1: Date, date2: Date): number {
+  // Compare years first
+  if (date1.getFullYear() !== date2.getFullYear()) {
+    return date1.getFullYear() < date2.getFullYear() ? -1 : 1;
+  }
+
+  // If years are the same, compare quarters
+  const quarter1 = getQuarter(date1);
+  const quarter2 = getQuarter(date2);
+
+  if (quarter1 !== quarter2) {
+    return quarter1 < quarter2 ? -1 : 1;
+  }
+
+  // If both year and quarter are the same
+  return 0;
 }

--- a/turboui/src/DateField/components/YearSelector.tsx
+++ b/turboui/src/DateField/components/YearSelector.tsx
@@ -8,9 +8,18 @@ interface Props {
   setSelectedDate: React.Dispatch<React.SetStateAction<DateField.ContextualDate>>;
   years: number[];
   useStartOfPeriod?: boolean;
+  minDateLimit?: Date;
+  maxDateLimit?: Date;
 }
 
-export function YearSelector({ selectedDate, setSelectedDate, years, useStartOfPeriod = false }: Props) {
+export function YearSelector({
+  selectedDate,
+  setSelectedDate,
+  years,
+  useStartOfPeriod = false,
+  minDateLimit,
+  maxDateLimit,
+}: Props) {
   const currentYear = new Date().getFullYear();
   const currentYearRef = useRef<HTMLButtonElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -45,18 +54,24 @@ export function YearSelector({ selectedDate, setSelectedDate, years, useStartOfP
     <div className="mb-3">
       <div ref={containerRef} className="max-h-48 overflow-y-auto p-2">
         <div className="flex flex-col space-y-1 mx-auto">
-          {years.map((year) => (
-            <OptionButton
-              key={year}
-              ref={year === currentYear ? currentYearRef : undefined}
-              onClick={() => handleSelect(year)}
-              isSelected={isSelectedYear(year, selectedDate)}
-              isCurrent={year === currentYear}
-              className="px-3 py-1.5 text-sm"
-            >
-              {year}
-            </OptionButton>
-          ))}
+          {years.map((year) => {
+            // Check if year is disabled (outside of min/max range)
+            const isDisabled = isYearDisabled(year, minDateLimit, maxDateLimit);
+
+            return (
+              <OptionButton
+                key={year}
+                ref={year === currentYear ? currentYearRef : undefined}
+                onClick={() => !isDisabled && handleSelect(year)}
+                isSelected={isSelectedYear(year, selectedDate)}
+                isCurrent={year === currentYear}
+                isDisabled={isDisabled}
+                className="px-3 py-1.5 text-sm"
+              >
+                {year}
+              </OptionButton>
+            );
+          })}
         </div>
       </div>
     </div>
@@ -67,4 +82,24 @@ function isSelectedYear(year: number, selectedDate: DateField.ContextualDate | n
   if (!selectedDate?.date) return false;
 
   return selectedDate.dateType === "year" && selectedDate.date.getFullYear() === year;
+}
+
+function isYearDisabled(year: number, minDateLimit?: Date, maxDateLimit?: Date): boolean {
+  if (minDateLimit) {
+    const minYear = minDateLimit.getFullYear();
+
+    if (year < minYear) {
+      return true;
+    }
+  }
+
+  if (maxDateLimit) {
+    const maxYear = maxDateLimit.getFullYear();
+
+    if (year > maxYear) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/turboui/src/DateField/index.stories.tsx
+++ b/turboui/src/DateField/index.stories.tsx
@@ -338,6 +338,86 @@ export const AllStates: Story = {
               </div>
             </div>
           </div>
+
+          <div className="border-t border-stroke-base pt-12">
+            <h2 className="text-lg font-bold mb-8">Date Limits</h2>
+            <div className="grid grid-cols-2 gap-8">
+              <div>
+                <h3 className="text-sm font-bold mb-2">Min Date Limit</h3>
+                <p className="text-xs text-gray-500 mb-2">Dates before July 10, 2025 are disabled</p>
+                <DateField
+                  minDateLimit={new Date(2025, 6, 10)} // July 10, 2025
+                  placeholder="Select a date..."
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold mb-2">Max Date Limit</h3>
+                <p className="text-xs text-gray-500 mb-2">Dates after August 20, 2025 are disabled</p>
+                <DateField
+                  maxDateLimit={new Date(2025, 7, 20)} // August 20, 2025
+                  placeholder="Select a date..."
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold mb-2">Both Limits</h3>
+                <p className="text-xs text-gray-500 mb-2">
+                  Only dates between July 10 and August 20, 2025 are selectable
+                </p>
+                <DateField
+                  minDateLimit={new Date(2025, 6, 10)} // July 10, 2025
+                  maxDateLimit={new Date(2025, 7, 20)} // August 20, 2025
+                  placeholder="Select a date within range..."
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold mb-2">Month View with Limits</h3>
+                <p className="text-xs text-gray-500 mb-2">Shows how months outside range are disabled</p>
+                <DateField
+                  minDateLimit={new Date(2025, 3, 1)} // April 1, 2025
+                  maxDateLimit={new Date(2025, 8, 30)} // September 30, 2025
+                  placeholder="Select a month..."
+                  date={{
+                    dateType: "month",
+                    date: new Date(2025, 5, 1),
+                    value: "Jun 2025",
+                  }}
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold mb-2">Quarter View with Limits</h3>
+                <p className="text-xs text-gray-500 mb-2">Shows how quarters outside range are disabled</p>
+                <DateField
+                  minDateLimit={new Date(2025, 3, 1)} // April 1, 2025
+                  maxDateLimit={new Date(2025, 8, 30)} // September 30, 2025
+                  placeholder="Select a quarter..."
+                  date={{
+                    dateType: "quarter",
+                    date: new Date(2025, 5, 1),
+                    value: "Q2 2025",
+                  }}
+                />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold mb-2">Year View with Limits</h3>
+                <p className="text-xs text-gray-500 mb-2">Shows how years outside range are disabled</p>
+                <DateField
+                  minDateLimit={new Date(2024, 0, 1)} // January 1, 2024
+                  maxDateLimit={new Date(2026, 11, 31)} // December 31, 2026
+                  placeholder="Select a year..."
+                  date={{
+                    dateType: "year",
+                    date: new Date(2025, 0, 1),
+                    value: "2025",
+                  }}
+                />
+              </div>
+            </div>
+          </div>
         </div>
       </Page>
     );

--- a/turboui/src/DateField/index.tsx
+++ b/turboui/src/DateField/index.tsx
@@ -26,6 +26,8 @@ export namespace DateField {
     date?: ContextualDate | null;
     minYear?: number;
     maxYear?: number;
+    minDateLimit?: Date;
+    maxDateLimit?: Date;
     placeholder?: string;
     readonly?: boolean;
     showOverdueWarning?: boolean;
@@ -74,6 +76,8 @@ export function DateField({
   useStartOfPeriod = false,
   size = "std",
   testId = "date-field",
+  minDateLimit,
+  maxDateLimit,
 }: DateField.Props) {
   const [open, setOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState<DateField.ContextualDate | null>(date || null);
@@ -155,6 +159,8 @@ export function DateField({
             yearOptions={yearOptions}
             testId={testId}
             useStartOfPeriod={useStartOfPeriod}
+            minDateLimit={minDateLimit}
+            maxDateLimit={maxDateLimit}
           />
         </Popover.Content>
       </Popover.Portal>
@@ -256,6 +262,8 @@ interface DatePickerContentProps {
   yearOptions: number[];
   testId: string;
   useStartOfPeriod?: boolean;
+  minDateLimit?: Date;
+  maxDateLimit?: Date;
 }
 
 function DatePickerContent(props: DatePickerContentProps) {
@@ -269,6 +277,9 @@ function DatePickerContent(props: DatePickerContentProps) {
     onClearDate,
     yearOptions,
     testId,
+    minDateLimit,
+    maxDateLimit,
+    useStartOfPeriod,
   } = props;
 
   return (
@@ -285,7 +296,12 @@ function DatePickerContent(props: DatePickerContentProps) {
 
       {dateType === "day" && (
         <div className="mb-3">
-          <InlineCalendar selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
+          <InlineCalendar
+            selectedDate={selectedDate}
+            setSelectedDate={setSelectedDate}
+            minDateLimit={minDateLimit}
+            maxDateLimit={maxDateLimit}
+          />
         </div>
       )}
 
@@ -294,7 +310,9 @@ function DatePickerContent(props: DatePickerContentProps) {
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
           visibleYears={yearOptions}
-          useStartOfPeriod={props.useStartOfPeriod}
+          useStartOfPeriod={useStartOfPeriod}
+          minDateLimit={minDateLimit}
+          maxDateLimit={maxDateLimit}
         />
       )}
 
@@ -303,7 +321,9 @@ function DatePickerContent(props: DatePickerContentProps) {
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
           visibleYears={yearOptions}
-          useStartOfPeriod={props.useStartOfPeriod}
+          useStartOfPeriod={useStartOfPeriod}
+          minDateLimit={minDateLimit}
+          maxDateLimit={maxDateLimit}
         />
       )}
 
@@ -312,7 +332,9 @@ function DatePickerContent(props: DatePickerContentProps) {
           selectedDate={selectedDate}
           setSelectedDate={setSelectedDate}
           years={yearOptions}
-          useStartOfPeriod={props.useStartOfPeriod}
+          useStartOfPeriod={useStartOfPeriod}
+          minDateLimit={minDateLimit}
+          maxDateLimit={maxDateLimit}
         />
       )}
 

--- a/turboui/src/utils/time.tsx
+++ b/turboui/src/utils/time.tsx
@@ -75,6 +75,14 @@ export function compareAsc(date1: Date | null, date2: Date | null, { nullsFirst 
   return datefsn.compareAsc(date1!, date2!);
 }
 
+export function compareDesc(date1: Date | null, date2: Date | null, { nullsFirst = false } = {}) {
+  if (!date1 && !date2) return 0;
+  if (!date1 && date2) return nullsFirst ? -1 : 1;
+  if (date1 && !date2) return nullsFirst ? 1 : -1;
+
+  return datefsn.compareDesc(date1!, date2!);
+}
+
 export function parse(date: string | Date | null | undefined) {
   if (date === null || date === undefined) {
     return null;


### PR DESCRIPTION
Now we can optionally set a min and max date when we use the DateField component. Any date outside of the range is shown disabled.