### PR TITLE
fix: DateField now omits current year

### DIFF
--- a/app/assets/js/pages/ProjectPage/TimelineSection.tsx
+++ b/app/assets/js/pages/ProjectPage/TimelineSection.tsx
@@ -3,8 +3,9 @@ import * as Projects from "@/models/projects";
 import * as Time from "@/utils/time";
 import * as React from "react";
 
+import { parseContextualDate } from "@/models/contextualDates";
 import { MilestoneIcon } from "@/components/MilestoneIcon";
-import { Link, SecondaryButton } from "turboui";
+import { Link, SecondaryButton, DateField } from "turboui";
 import { DimmedLabel } from "./Label";
 
 import FormattedTime from "@/components/FormattedTime";
@@ -12,6 +13,7 @@ import { assertPresent } from "@/utils/assertions";
 import { match } from "ts-pattern";
 
 import { usePaths } from "@/routes/paths";
+
 export function TimelineSection({ project }: { project: Projects.Project }) {
   return (
     <div className="border-t border-stroke-base py-6">
@@ -56,25 +58,27 @@ function Content({ project }) {
 }
 
 function StartDate({ project }: { project: Projects.Project }) {
+  const date = parseContextualDate(project.timeframe?.contextualStartDate);
+
   return (
     <div>
       <DimmedLabel>Start Date</DimmedLabel>
       <div className="font-semibold">
-        {/* <FormattedTime time={project.startedAt!} format="short-date" /> */}
-        {project.timeframe?.contextualStartDate?.value}
+        <DateField date={date} hideCalendarIcon readonly />
       </div>
     </div>
   );
 }
 
 function EndDate({ project }: { project: Projects.Project }) {
+  const date = parseContextualDate(project.timeframe?.contextualEndDate);
+
   return (
     <div>
       <DimmedLabel>Due Date</DimmedLabel>
       {project.timeframe?.contextualEndDate ? (
         <div className="font-semibold">
-          {/* <FormattedTime time={project.deadline} format="short-date" /> */}
-          {project.timeframe?.contextualEndDate?.value}
+          <DateField date={date} hideCalendarIcon readonly />
         </div>
       ) : (
         <div>

--- a/turboui/src/DateField/index.tsx
+++ b/turboui/src/DateField/index.tsx
@@ -11,6 +11,7 @@ import classNames from "../utils/classnames";
 import { isOverdue } from "../utils/time";
 import { createTestId, TestableElement } from "../TestableElement";
 import { match } from "ts-pattern";
+import { getDateWithoutCurrentYear } from "./utils";
 
 const DATE_TYPES = [
   { value: "day" as const, label: "Day" },
@@ -190,7 +191,7 @@ function DatePickerTrigger({
   size,
   testId,
 }: DatePickerTriggerProps) {
-  let displayText = selectedDate?.value || label;
+  let displayText = selectedDate ? getDateWithoutCurrentYear(selectedDate) : label;
   const isDateOverdue = selectedDate?.date && isOverdue(selectedDate.date);
 
   const fieldSize = match(size)

--- a/turboui/src/DateField/utils.ts
+++ b/turboui/src/DateField/utils.ts
@@ -1,3 +1,5 @@
+import { DateField } from ".";
+
 export const getCurrentYear = () => new Date().getFullYear();
 
 export const generateQuarters = (year = getCurrentYear(), useStartOfPeriod = false) => [
@@ -9,7 +11,11 @@ export const generateQuarters = (year = getCurrentYear(), useStartOfPeriod = fal
 
 export const generateMonths = (year = getCurrentYear(), useStartOfPeriod = false) => [
   { value: useStartOfPeriod ? `${year}-01-01` : `${year}-01-31`, label: "Jan", name: "January" },
-  { value: useStartOfPeriod ? `${year}-02-01` : `${year}-02-${year % 4 === 0 ? "29" : "28"}`, label: "Feb", name: "February" }, // Leap year handling
+  {
+    value: useStartOfPeriod ? `${year}-02-01` : `${year}-02-${year % 4 === 0 ? "29" : "28"}`,
+    label: "Feb",
+    name: "February",
+  }, // Leap year handling
   { value: useStartOfPeriod ? `${year}-03-01` : `${year}-03-31`, label: "Mar", name: "March" },
   { value: useStartOfPeriod ? `${year}-04-01` : `${year}-04-30`, label: "Apr", name: "April" },
   { value: useStartOfPeriod ? `${year}-05-01` : `${year}-05-31`, label: "May", name: "May" },
@@ -25,3 +31,27 @@ export const generateMonths = (year = getCurrentYear(), useStartOfPeriod = false
 export const getYearDate = (year: number, useStartOfPeriod = false) => {
   return useStartOfPeriod ? new Date(year, 0, 1) : new Date(year, 11, 31);
 };
+
+/**
+ * Formats the date display text, omitting the year if it matches the current year
+ * @param date The selected date object
+ * @returns Formatted date string
+ */
+export function getDateWithoutCurrentYear(date: DateField.ContextualDate) {
+  if (date.dateType !== "day") {
+    return date.value;
+  }
+
+  const parts = date.value.split(",");
+
+  if (parts.length === 2) {
+    const currentYear = new Date().getFullYear();
+    const selectedYear = parseInt(parts[1]!.trim());
+
+    if (selectedYear === currentYear) {
+      return parts[0]!.trim();
+    }
+  }
+
+  return date.value;
+}


### PR DESCRIPTION
The DateField component now displays dates without the year if the year is the current one.