### PR TITLE
fix: Error message is displayed if Milestone is saved without a start date

### DIFF
--- a/app/assets/js/pages/ProjectEditTimelinePage/page.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/page.tsx
@@ -49,10 +49,6 @@ function Header({ form }: { form: FormState }) {
           </div>
         )}
       </Paper.Banner>
-
-      {form.errors.length > 0 && (
-        <div className="text-content-error text-sm font-medium text-center mb-4">Please fill out all fields</div>
-      )}
     </div>
   );
 }
@@ -93,7 +89,14 @@ function StartDate({ form }: { form: FormState }) {
           variant="form-field"
           testId="project-start"
           maxDateLimit={form.dueDate?.date}
+          error={form.errors.includes("startTime")}
         />
+
+        {form.errors.includes("startTime") && (
+          <div className="text-red-500 text-xs mt-1" data-test-id="due-date-error">
+            Start date is required
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
+++ b/app/assets/js/pages/ProjectEditTimelinePage/useForm.tsx
@@ -8,11 +8,6 @@ import { DateField } from "turboui";
 import { parseContextualDate, serializeContextualDate } from "@/models/contextualDates";
 import { MilestoneListState, useMilestoneListState } from "./useMilestoneListState";
 
-interface Error {
-  field: string;
-  message: string;
-}
-
 export interface FormState {
   projectId: string;
 
@@ -28,7 +23,7 @@ export interface FormState {
 
   submit: () => void;
   cancel: () => void;
-  errors: Error[];
+  errors: string[];
   hasChanges: boolean;
   submitting: boolean;
 
@@ -46,6 +41,7 @@ export function useForm(project: Projects.Project): FormState {
   const [startTime, setStartTime] = React.useState<DateField.ContextualDate | null>(oldStart);
   const [dueDate, setDueDate] = React.useState<DateField.ContextualDate | null>(oldDue);
   const [milestoneBeingEdited, setMilestoneBeingEdited] = React.useState<string | null>(null);
+  const [errors, setErrors] = useErrors([startTime]);
 
   const submitted = React.useRef(false);
   const canceled = React.useRef(false);
@@ -63,6 +59,11 @@ export function useForm(project: Projects.Project): FormState {
   const [edit, { loading }] = Projects.useEditProjectTimeline();
 
   const submit = async () => {
+    if (!startTime) {
+      setErrors(prev => [...prev, "startTime"]);
+      return;
+    }
+
     await edit({
       projectId: project.id,
       projectStartDate: serializeContextualDate(startTime),
@@ -89,8 +90,6 @@ export function useForm(project: Projects.Project): FormState {
     navigate(milestonesPath);
   };
 
-  const errors = [];
-
   return {
     projectId: project.id!,
 
@@ -115,4 +114,14 @@ export function useForm(project: Projects.Project): FormState {
       return hasChanges;
     },
   };
+}
+
+function useErrors(deps: any[]) {
+  const [errors, setErrors] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    setErrors([]);
+  }, deps);
+
+  return [errors, setErrors] as const;
 }


### PR DESCRIPTION
Now if the user tries to save a Milestone without a start date, an error message is shown. Previously, saving the Milestone wouldn't work, but no error would be shown to the user.