### PR TITLE
feat: start and due dates can be updated on Project V2 page

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -474,6 +474,14 @@ export interface ActivityContentProjectDiscussionSubmitted {
   discussion?: CommentThread | null;
 }
 
+export interface ActivityContentProjectDueDateUpdating {
+  company: Company;
+  space: Space;
+  project: Project;
+  oldDueDate: string | null;
+  newDueDate: string | null;
+}
+
 export interface ActivityContentProjectGoalConnection {
   project?: Project | null;
   goal?: Goal | null;
@@ -556,6 +564,14 @@ export interface ActivityContentProjectReviewSubmitted {
   projectId?: string | null;
   reviewId?: string | null;
   project?: Project | null;
+}
+
+export interface ActivityContentProjectStartDateUpdating {
+  company: Company;
+  space: Space;
+  project: Project;
+  oldStartDate: string | null;
+  newStartDate: string | null;
 }
 
 export interface ActivityContentProjectTimelineEdited {
@@ -1676,6 +1692,8 @@ export type ActivityContent =
   | ActivityContentProjectReviewAcknowledged
   | ActivityContentProjectReviewCommented
   | ActivityContentProjectReviewRequestSubmitted
+  | ActivityContentProjectDueDateUpdating
+  | ActivityContentProjectStartDateUpdating
   | ActivityContentProjectReviewSubmitted
   | ActivityContentProjectTimelineEdited
   | ActivityContentSpaceJoining
@@ -3340,6 +3358,24 @@ export interface ProjectDiscussionsEditResult {
   discussion: Update;
 }
 
+export interface ProjectsUpdateDueDateInput {
+  projectId: Id;
+  dueDate: ContextualDate | null;
+}
+
+export interface ProjectsUpdateDueDateResult {
+  success: boolean | null;
+}
+
+export interface ProjectsUpdateStartDateInput {
+  projectId: Id;
+  startDate: ContextualDate | null;
+}
+
+export interface ProjectsUpdateStartDateResult {
+  success: boolean | null;
+}
+
 export interface PublishDiscussionInput {
   id?: Id | null;
 }
@@ -4315,6 +4351,18 @@ class ApiNamespaceAi {
   }
 }
 
+class ApiNamespaceProjects {
+  constructor(private client: ApiClient) {}
+
+  async updateDueDate(input: ProjectsUpdateDueDateInput): Promise<ProjectsUpdateDueDateResult> {
+    return this.client.post("/projects/update_due_date", input);
+  }
+
+  async updateStartDate(input: ProjectsUpdateStartDateInput): Promise<ProjectsUpdateStartDateResult> {
+    return this.client.post("/projects/update_start_date", input);
+  }
+}
+
 export class ApiClient {
   private basePath: string;
   private headers: any;
@@ -4323,6 +4371,7 @@ export class ApiClient {
   public apiNamespaceSpaces: ApiNamespaceSpaces;
   public apiNamespaceGoals: ApiNamespaceGoals;
   public apiNamespaceAi: ApiNamespaceAi;
+  public apiNamespaceProjects: ApiNamespaceProjects;
 
   constructor() {
     this.apiNamespaceRoot = new ApiNamespaceRoot(this);
@@ -4330,6 +4379,7 @@ export class ApiClient {
     this.apiNamespaceSpaces = new ApiNamespaceSpaces(this);
     this.apiNamespaceGoals = new ApiNamespaceGoals(this);
     this.apiNamespaceAi = new ApiNamespaceAi(this);
+    this.apiNamespaceProjects = new ApiNamespaceProjects(this);
   }
 
   setBasePath(basePath: string) {
@@ -6801,6 +6851,21 @@ export default {
     useEditAgentDailyRun: () =>
       useMutation<AiEditAgentDailyRunInput, AiEditAgentDailyRunResult>(
         defaultApiClient.apiNamespaceAi.editAgentDailyRun,
+      ),
+  },
+
+  projects: {
+    updateDueDate: (input: ProjectsUpdateDueDateInput) => defaultApiClient.apiNamespaceProjects.updateDueDate(input),
+    useUpdateDueDate: () =>
+      useMutation<ProjectsUpdateDueDateInput, ProjectsUpdateDueDateResult>(
+        defaultApiClient.apiNamespaceProjects.updateDueDate,
+      ),
+
+    updateStartDate: (input: ProjectsUpdateStartDateInput) =>
+      defaultApiClient.apiNamespaceProjects.updateStartDate(input),
+    useUpdateStartDate: () =>
+      useMutation<ProjectsUpdateStartDateInput, ProjectsUpdateStartDateResult>(
+        defaultApiClient.apiNamespaceProjects.updateStartDate,
       ),
   },
 };

--- a/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
@@ -1,0 +1,85 @@
+import type { ActivityContentProjectDueDateUpdating } from "@/api";
+import type { Activity } from "@/models/activities";
+import { Paths } from "@/routes/paths";
+import React from "react";
+import { FormattedTime } from "turboui";
+import { feedTitle, projectLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
+
+const ProjectDueDateUpdating: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(_paths: Paths, _activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle(props: { activity: Activity; page: string }) {
+    const { project, newDueDate } = content(props.activity);
+
+    const message = newDueDate ? (
+      <>
+        changed the due date to <FormattedTime time={newDueDate} format="short-date" />
+      </>
+    ) : (
+      "cleared the due date"
+    );
+
+    if (props.page === "project") {
+      return feedTitle(props.activity, message);
+    } else {
+      return feedTitle(props.activity, message, " on the", projectLink(project!));
+    }
+  },
+
+  FeedItemContent(props: { activity: Activity; page: any }) {
+    const { oldDueDate } = content(props.activity);
+
+    if (oldDueDate) {
+      const time = <FormattedTime time={oldDueDate} format="short-date" />;
+
+      return <>Previously the due date was {time}</>;
+    } else {
+      return <>Previously had no due date</>;
+    }
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(_props: { activity: Activity }) {
+    return <></>;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentProjectDueDateUpdating {
+  return activity.content as ActivityContentProjectDueDateUpdating;
+}
+
+export default ProjectDueDateUpdating;

--- a/app/assets/js/features/activities/ProjectStartDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectStartDateUpdating/index.tsx
@@ -1,0 +1,85 @@
+import type { ActivityContentProjectStartDateUpdating } from "@/api";
+import type { Activity } from "@/models/activities";
+import { Paths } from "@/routes/paths";
+import React from "react";
+import { FormattedTime } from "turboui";
+import { feedTitle, projectLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
+
+const ProjectStartDateUpdating: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(_paths: Paths, _activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle(props: { activity: Activity; page: string }) {
+    const { project, newStartDate } = content(props.activity);
+
+    const message = newStartDate ? (
+      <>
+        changed the start date to <FormattedTime time={newStartDate} format="short-date" />
+      </>
+    ) : (
+      "cleared the start date"
+    );
+
+    if (props.page === "project") {
+      return feedTitle(props.activity, message);
+    } else {
+      return feedTitle(props.activity, message, " on the", projectLink(project!));
+    }
+  },
+
+  FeedItemContent(props: { activity: Activity; page: any }) {
+    const { oldStartDate } = content(props.activity);
+
+    if (oldStartDate) {
+      const time = <FormattedTime time={oldStartDate} format="short-date" />;
+
+      return <>Previously the start date was {time}</>;
+    } else {
+      return <>Previously had no start date</>;
+    }
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(_props: { activity: Activity }) {
+    return <></>;
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+function content(activity: Activity): ActivityContentProjectStartDateUpdating {
+  return activity.content as ActivityContentProjectStartDateUpdating;
+}
+
+export default ProjectStartDateUpdating;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -64,6 +64,8 @@ const ActivityHandler: interfaces.ActivityHandler = {
 export default ActivityHandler;
 
 export const DISPLAYED_IN_FEED = [
+  "project_due_date_updating",
+  "project_start_date_updating",
   "goal_target_updating",
   "goal_target_deleting",
   "goal_target_adding",
@@ -215,6 +217,8 @@ import SpaceMembersAdded from "@/features/activities/SpaceMembersAdded";
 import GoalChampionUpdating from "./GoalChampionUpdating";
 import GoalDueDateUpdating from "./GoalDueDateUpdating";
 import GoalReviewerUpdating from "./GoalReviewerUpdating";
+import ProjectDueDateUpdating from "./ProjectDueDateUpdating";
+import ProjectStartDateUpdating from "./ProjectStartDateUpdating";
 
 import { Paths } from "../../routes/paths";
 import GoalNameUpdating from "./GoalNameUpdating";
@@ -297,6 +301,8 @@ function handler(activity: Activity) {
     .with("goal_target_deleting", () => GoalTargetDeleting)
     .with("goal_target_updating", () => GoalTargetUpdating)
     .with("project_discussion_submitted", () => ProjectDiscussionSubmitted)
+    .with("project_due_date_updating", () => ProjectDueDateUpdating)
+    .with("project_start_date_updating", () => ProjectStartDateUpdating)
     .otherwise(() => {
       throw new Error("Unknown activity action: " + activity.action);
     });

--- a/app/lib/operately/activities/content/project_due_date_updating.ex
+++ b/app/lib/operately/activities/content/project_due_date_updating.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Activities.Content.ProjectDueDateUpdating do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :project, Operately.Projects.Project
+    field :old_due_date, :date
+    field :new_due_date, :date
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields) -- [:old_due_date, :new_due_date])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/content/project_start_date_updating.ex
+++ b/app/lib/operately/activities/content/project_start_date_updating.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Activities.Content.ProjectStartDateUpdating do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :project, Operately.Projects.Project
+    field :old_start_date, :date
+    field :new_start_date, :date
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields) -- [:old_start_date, :new_start_date])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/context_auto_assigner.ex
+++ b/app/lib/operately/activities/context_auto_assigner.ex
@@ -85,6 +85,8 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "project_retrospective_commented",
     "project_key_resource_added",
     "project_key_resource_deleted",
+    "project_start_date_updating",
+    "project_due_date_updating"
   ]
 
   @task_actions [

--- a/app/lib/operately/activities/notifications/project_due_date_updating.ex
+++ b/app/lib/operately/activities/notifications/project_due_date_updating.ex
@@ -1,0 +1,5 @@
+defmodule Operately.Activities.Notifications.ProjectDueDateUpdating do
+  def dispatch(_activity) do
+    {:ok, []}
+  end
+end

--- a/app/lib/operately/activities/notifications/project_start_date_updating.ex
+++ b/app/lib/operately/activities/notifications/project_start_date_updating.ex
@@ -1,0 +1,5 @@
+defmodule Operately.Activities.Notifications.ProjectStartDateUpdating do
+  def dispatch(_activity) do
+    {:ok, []}
+  end
+end

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -56,6 +56,11 @@ defmodule OperatelyWeb.Api do
     mutation(:update_access_levels, OperatelyWeb.Api.Goals.UpdateAccessLevels)
   end
 
+  namespace(:projects) do
+    mutation(:update_due_date, OperatelyWeb.Api.Projects.UpdateDueDate)
+    mutation(:update_start_date, OperatelyWeb.Api.Projects.UpdateStartDate)
+  end
+
   namespace(:spaces) do
     query(:search, OperatelyWeb.Api.Spaces.Search)
   end

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -1,0 +1,188 @@
+defmodule OperatelyWeb.Api.Projects do
+  alias __MODULE__.SharedMultiSteps, as: Steps
+
+  defmodule UpdateDueDate do
+    use TurboConnect.Mutation
+
+    inputs do
+      field :project_id, :id, null: false
+      field :due_date, :contextual_date, null: true
+    end
+
+    outputs do
+      field :success, :boolean, null: true
+    end
+
+    def call(conn, inputs) do
+      conn
+      |> Steps.start_transaction()
+      |> Steps.find_project(inputs.project_id)
+      |> Steps.check_permissions(:can_edit_timeline)
+      |> Steps.update_project_due_date(inputs.due_date)
+      |> Steps.save_activity(:project_due_date_updating, fn changes ->
+        %{
+          company_id: changes.project.company_id,
+          space_id: changes.project.group_id,
+          project_id: changes.project.id,
+          old_due_date: Operately.ContextualDates.Timeframe.end_date(changes.project.timeframe),
+          new_due_date: Operately.ContextualDates.Timeframe.end_date(changes.updated_project.timeframe)
+        }
+      end)
+      |> Steps.commit()
+      |> Steps.respond(fn _ -> %{success: true} end)
+    end
+  end
+
+  defmodule UpdateStartDate do
+    use TurboConnect.Mutation
+
+    inputs do
+      field :project_id, :id, null: false
+      field :start_date, :contextual_date, null: true
+    end
+
+    outputs do
+      field :success, :boolean, null: true
+    end
+
+    def call(conn, inputs) do
+      conn
+      |> Steps.start_transaction()
+      |> Steps.find_project(inputs.project_id)
+      |> Steps.check_permissions(:can_edit_timeline)
+      |> Steps.update_project_start_date(inputs.start_date)
+      |> Steps.save_activity(:project_start_date_updating, fn changes ->
+        %{
+          company_id: changes.project.company_id,
+          space_id: changes.project.group_id,
+          project_id: changes.project.id,
+          old_start_date: Operately.ContextualDates.Timeframe.start_date(changes.project.timeframe),
+          new_start_date: Operately.ContextualDates.Timeframe.start_date(changes.updated_project.timeframe)
+        }
+      end)
+      |> Steps.commit()
+      |> Steps.respond(fn _ -> %{success: true} end)
+    end
+  end
+
+  defmodule SharedMultiSteps do
+    require Logger
+
+    def start_transaction(conn) do
+      Ecto.Multi.new()
+      |> Ecto.Multi.put(:conn, conn)
+      |> Ecto.Multi.run(:me, fn _repo, %{conn: conn} ->
+        {:ok, conn.assigns.current_person}
+      end)
+    end
+
+    def find_project(multi, project_id) do
+      Ecto.Multi.run(multi, :project, fn _repo, %{me: me} ->
+        case Operately.Projects.Project.get(me, id: project_id, opts: [preload: [:access_context]]) do
+          {:ok, project} -> {:ok, project}
+          {:error, _} -> {:error, {:not_found, "Project not found"}}
+        end
+      end)
+    end
+
+    def check_permissions(multi, permission) do
+      Ecto.Multi.run(multi, :permissions, fn _repo, %{project: project} ->
+        Operately.Projects.Permissions.check(project.request_info.access_level, permission)
+      end)
+    end
+
+    def update_project_due_date(multi, new_due_date) do
+      Ecto.Multi.update(multi, :updated_project, fn %{project: project} ->
+        cond do
+          new_due_date == nil && project.timeframe == nil ->
+            Operately.Projects.Project.changeset(project, %{timeframe: nil})
+
+          project.timeframe == nil ->
+            Operately.Projects.Project.changeset(project, %{
+              timeframe: %{
+                contextual_start_date: nil,
+                contextual_end_date: new_due_date
+              }
+            })
+
+          true ->
+            Operately.Projects.Project.changeset(project, %{
+              timeframe: %{
+                contextual_start_date: project.timeframe.contextual_start_date,
+                contextual_end_date: new_due_date
+              }
+            })
+        end
+      end)
+    end
+
+    def update_project_start_date(multi, new_start_date) do
+      Ecto.Multi.update(multi, :updated_project, fn %{project: project} ->
+        cond do
+          new_start_date == nil && project.timeframe == nil ->
+            Operately.Projects.Project.changeset(project, %{timeframe: nil})
+
+          project.timeframe == nil ->
+            Operately.Projects.Project.changeset(project, %{
+              timeframe: %{
+                contextual_start_date: new_start_date,
+                contextual_end_date: nil
+              }
+            })
+
+          true ->
+            Operately.Projects.Project.changeset(project, %{
+              timeframe: %{
+                contextual_start_date: new_start_date,
+                contextual_end_date: project.timeframe.contextual_end_date
+              }
+            })
+        end
+      end)
+    end
+
+    def save_activity(multi, activity_type, callback) do
+      Ecto.Multi.merge(multi, fn changes ->
+        Operately.Activities.insert_sync(Ecto.Multi.new(), changes.me.id, activity_type, fn _ -> callback.(changes) end)
+      end)
+    end
+
+    def commit(multi) do
+      Operately.Repo.transaction(multi)
+    end
+
+    def respond(result, ok_callback, error_callback \\ &handle_error/1) do
+      case result do
+        {:ok, changes} ->
+          {:ok, ok_callback.(changes)}
+
+        {:error, _, :idempotent, changes} ->
+          {:ok, ok_callback.(changes)}
+
+        e ->
+          error_callback.(e)
+      end
+    end
+
+    defp handle_error(reason) do
+      case reason do
+        {:error, _failed_operation, {:not_found, message}, _changes} ->
+          {:error, :not_found, message}
+
+        {:error, _failed_operation, :not_found, _changes} ->
+          {:error, :not_found}
+
+        {:error, _failed_operation, :forbidden, _changes} ->
+          {:error, :not_found}
+
+        {:error, _failed_operation, reason, _changes} ->
+          Logger.error("Transaction failed: #{inspect(reason)}")
+          {:error, :internal_server_error}
+
+        e ->
+          Logger.error("Unexpected error: #{inspect(e)}")
+          {:error, :internal_server_error}
+      end
+    end
+  end
+end

--- a/app/lib/operately_web/api/serializers/activity_content/project_due_date_updating.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/project_due_date_updating.ex
@@ -1,0 +1,16 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ProjectDueDateUpdating do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      company_id: Serializer.serialize(content["company_id"], level: :essential),
+      company: Serializer.serialize(content["company"], level: :essential),
+      space_id: Serializer.serialize(content["space_id"], level: :essential),
+      space: Serializer.serialize(content["space"], level: :essential),
+      project_id: Serializer.serialize(content["project_id"], level: :essential),
+      project: Serializer.serialize(content["project"], level: :essential),
+      old_due_date: Serializer.serialize(content["old_due_date"], level: :essential),
+      new_due_date: Serializer.serialize(content["new_due_date"], level: :essential)
+    }
+  end
+end

--- a/app/lib/operately_web/api/serializers/activity_content/project_start_date_updating.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/project_start_date_updating.ex
@@ -1,0 +1,16 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ProjectStartDateUpdating do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      company_id: Serializer.serialize(content["company_id"], level: :essential),
+      company: Serializer.serialize(content["company"], level: :essential),
+      space_id: Serializer.serialize(content["space_id"], level: :essential),
+      space: Serializer.serialize(content["space"], level: :essential),
+      project_id: Serializer.serialize(content["project_id"], level: :essential),
+      project: Serializer.serialize(content["project"], level: :essential),
+      old_start_date: Serializer.serialize(content["old_start_date"], level: :essential),
+      new_start_date: Serializer.serialize(content["new_start_date"], level: :essential)
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -77,6 +77,22 @@ defmodule OperatelyWeb.Api.Types do
     field :new_due_date, :date, null: true
   end
 
+  object :activity_content_project_due_date_updating do
+    field :company, :company
+    field :space, :space
+    field :project, :project
+    field :old_due_date, :date, null: true
+    field :new_due_date, :date, null: true
+  end
+
+  object :activity_content_project_start_date_updating do
+    field :company, :company
+    field :space, :space
+    field :project, :project
+    field :old_start_date, :date, null: true
+    field :new_start_date, :date, null: true
+  end
+
   object :activity_content_goal_reviewer_updating do
     field :company, :company
     field :space, :space
@@ -482,6 +498,8 @@ defmodule OperatelyWeb.Api.Types do
       :activity_content_project_review_acknowledged,
       :activity_content_project_review_commented,
       :activity_content_project_review_request_submitted,
+      :activity_content_project_due_date_updating,
+      :activity_content_project_start_date_updating,
       :activity_content_project_review_submitted,
       :activity_content_project_timeline_edited,
       :activity_content_space_joining,

--- a/app/test/operately_web/api/projects_test.exs
+++ b/app/test/operately_web/api/projects_test.exs
@@ -1,0 +1,163 @@
+defmodule OperatelyWeb.Api.ProjectsTest do
+  alias Operately.ContextualDates.Timeframe
+
+  use OperatelyWeb.TurboCase
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:engineering)
+    |> Factory.add_project(:project, :engineering)
+  end
+
+  describe "update due date" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, [:projects, :update_due_date], %{})
+    end
+
+    test "it requires a project_id", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {400, res} = mutation(ctx.conn, [:projects, :update_due_date], %{due_date: %{date: "2023-01-01", date_type: "day"}})
+      assert res.message == "Missing required fields: project_id"
+    end
+
+    test "it updates the due date", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      contextual_date = %{
+        date: "2026-01-01",
+        date_type: "day",
+        value: "Jan 1, 2026"
+      }
+
+      assert {200, res} = mutation(ctx.conn, [:projects, :update_due_date], %{
+        project_id: Paths.project_id(ctx.project),
+        due_date: contextual_date
+      })
+      assert res.success == true
+
+      ctx = Factory.reload(ctx, :project)
+      assert Timeframe.end_date(ctx.project.timeframe) == ~D[2026-01-01]
+    end
+
+    test "it can update the due date to nil", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {200, res} = mutation(ctx.conn, [:projects, :update_due_date], %{
+        project_id: Paths.project_id(ctx.project),
+        due_date: nil
+      })
+      assert res.success == true
+
+      ctx = Factory.reload(ctx, :project)
+      assert ctx.project.timeframe.contextual_end_date == nil
+    end
+
+    test "it creates an activity when due date is updated", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      contextual_date = %{
+        date: "2026-01-01",
+        date_type: "day",
+        value: "Jan 1, 2026"
+      }
+
+      before_count = count_activities(ctx.project.id, "project_due_date_updating")
+
+      assert {200, _} = mutation(ctx.conn, [:projects, :update_due_date], %{
+        project_id: Paths.project_id(ctx.project),
+        due_date: contextual_date
+      })
+
+      after_count = count_activities(ctx.project.id, "project_due_date_updating")
+      assert after_count == before_count + 1
+    end
+  end
+
+  describe "update start date" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, [:projects, :update_start_date], %{})
+    end
+
+    test "it requires a project_id", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {400, res} = mutation(ctx.conn, [:projects, :update_start_date], %{start_date: %{date: "2023-01-01", date_type: "day"}})
+      assert res.message == "Missing required fields: project_id"
+    end
+
+    test "it updates the start date", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      contextual_date = %{
+        date: "2025-01-01",
+        date_type: "day",
+        value: "Jan 1, 2025"
+      }
+
+      assert {200, res} = mutation(ctx.conn, [:projects, :update_start_date], %{
+        project_id: Paths.project_id(ctx.project),
+        start_date: contextual_date
+      })
+      assert res.success == true
+
+      ctx = Factory.reload(ctx, :project)
+      assert Timeframe.start_date(ctx.project.timeframe) == ~D[2025-01-01]
+    end
+
+    test "it can update the start date to nil", ctx do
+      # First set a timeframe with an end date
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      end_date = %{
+        date: "2026-01-01",
+        date_type: "day",
+        value: "Jan 1, 2026"
+      }
+
+      assert {200, _} = mutation(ctx.conn, [:projects, :update_due_date], %{
+        project_id: Paths.project_id(ctx.project),
+        due_date: end_date
+      })
+
+      # Then test setting the start date to nil
+      assert {200, res} = mutation(ctx.conn, [:projects, :update_start_date], %{
+        project_id: Paths.project_id(ctx.project),
+        start_date: nil
+      })
+      assert res.success == true
+
+      ctx = Factory.reload(ctx, :project)
+      assert ctx.project.timeframe != nil
+      assert Timeframe.start_date(ctx.project.timeframe) == nil
+      assert Timeframe.end_date(ctx.project.timeframe) == ~D[2026-01-01]
+    end
+
+    test "it creates an activity when start date is updated", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      contextual_date = %{
+        date: "2025-01-01",
+        date_type: "day",
+        value: "Jan 1, 2025"
+      }
+
+      before_count = count_activities(ctx.project.id, "project_start_date_updating")
+
+      assert {200, _} = mutation(ctx.conn, [:projects, :update_start_date], %{
+        project_id: Paths.project_id(ctx.project),
+        start_date: contextual_date
+      })
+
+      after_count = count_activities(ctx.project.id, "project_start_date_updating")
+      assert after_count == before_count + 1
+    end
+  end
+
+  defp count_activities(project_id, action) do
+    Operately.Activities.Activity
+    |> Operately.Repo.all(where: [action: action, resource_id: project_id])
+    |> length()
+  end
+end


### PR DESCRIPTION
A Project's start and due dates can now be edited on the Project V2 page.