### PR TITLE
chore: Custom task completed and canceled icons

### DIFF
--- a/turboui/src/TaskBoard/components/StatusSelector.tsx
+++ b/turboui/src/TaskBoard/components/StatusSelector.tsx
@@ -1,71 +1,23 @@
 import React from "react";
 import * as Popover from "@radix-ui/react-popover";
 import classNames from "../../utils/classnames";
-import { IconCircleDashed, IconCircleDot, IconCircleCheckFilled, IconX, IconChevronDown, IconCheck } from "../../icons";
-
-// Custom CircleCheck SVG component based on Linear's design
-//
-// Why custom instead of Tabler's IconCircleCheckFilled:
-// - Tabler icons have built-in whitespace within their 24x24 viewBox and use stroke-based design
-// - This makes the checkmark inside IconCircleCheckFilled very small and hard to see
-// - Custom SVGs that use fill-based design and full viewBox utilization appear more prominent
-// - This implementation uses a 24x24 viewBox (matching Tabler) but with optimized sizing:
-//   * Circle spans from 2-22 (radius 10) leaving minimal padding
-//   * Checkmark is carefully positioned and sized for visibility
-//   * Uses currentColor to inherit design system colors (text-success)
-const CustomCircleCheck = ({ size = 14, className = "" }: { size?: number; className?: string }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    className={`${className} flex-shrink-0`}
-    role="img"
-    focusable="false"
-    aria-hidden="true"
-    xmlns="http://www.w3.org/2000/svg"
-    style={{ width: size, height: size }}
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM17.3 9.8C17.69 9.41 17.69 8.78 17.3 8.39C16.91 8 16.28 8 15.89 8.39L10.5 13.78L8.11 11.39C7.72 11 7.09 11 6.7 11.39C6.31 11.78 6.31 12.41 6.7 12.8L9.8 15.9C10.19 16.29 10.82 16.29 11.21 15.9L17.3 9.8Z"
-      fill="currentColor"
-    />
-  </svg>
-);
-
-// Custom CircleX SVG component for canceled status
-// Similar to CustomCircleCheck but with an X instead of checkmark, in grey
-const CustomCircleX = ({ size = 14, className = "" }: { size?: number; className?: string }) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    className={`${className} flex-shrink-0`}
-    role="img"
-    focusable="false"
-    aria-hidden="true"
-    xmlns="http://www.w3.org/2000/svg"
-    style={{ width: size, height: size }}
-  >
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM16.24 9.26C16.63 8.87 16.63 8.24 16.24 7.85C15.85 7.46 15.22 7.46 14.83 7.85L12 10.68L9.17 7.85C8.78 7.46 8.15 7.46 7.76 7.85C7.37 8.24 7.37 8.87 7.76 9.26L10.59 12.09L7.76 14.92C7.37 15.31 7.37 15.94 7.76 16.33C8.15 16.72 8.78 16.72 9.17 16.33L12 13.5L14.83 16.33C15.22 16.72 15.85 16.72 16.24 16.33C16.63 15.94 16.63 15.31 16.24 14.92L13.41 12.09L16.24 9.26Z"
-      fill="currentColor"
-    />
-  </svg>
-);
+import {
+  IconCircleDashed,
+  IconCircleDot,
+  IconChevronDown,
+  IconCheck,
+  IconCircleCheckCustom,
+  IconCircleXCustom,
+} from "../../icons";
 
 // Import types from the shared types module
 import * as Types from "../types";
 
 // Create colored icon components for each status
 const ColoredIconCircleDot = (props: any) => <IconCircleDot {...props} className="text-brand-1" />;
-const ColoredIconCircleCheckFilled = (props: any) => <CustomCircleCheck {...props} className="text-success" />;
+const ColoredIconCircleCheckFilled = (props: any) => <IconCircleCheckCustom {...props} className="text-success" />;
 const ColoredIconCheck = (props: any) => <IconCheck {...props} className="text-success" />;
-const ColoredIconX = (props: any) => <IconX {...props} className="text-red-500" />;
-const ColoredIconCircleX = (props: any) => <CustomCircleX {...props} className="text-content-dimmed" />;
+const ColoredIconCircleX = (props: any) => <IconCircleXCustom {...props} className="text-content-dimmed" />;
 
 // Map task status to labels and icons
 const taskStatusConfig: Record<Types.Status, { label: string; icon: any; color?: string; buttonColor?: string }> = {
@@ -306,7 +258,7 @@ export function StatusSelector({
                       {React.createElement(config.icon, { size: 18 })}
                       <div className="text-sm truncate">{config.label}</div>
                     </div>
-                    {isCurrentStatus && <IconCircleCheckFilled size={14} className="text-primary-500 ml-2" />}
+                    {isCurrentStatus && <IconCircleCheckCustom size={14} className="text-primary-500 ml-2" />}
                   </div>
                 );
               })}

--- a/turboui/src/TaskBoard/components/TaskFilter.tsx
+++ b/turboui/src/TaskBoard/components/TaskFilter.tsx
@@ -8,12 +8,13 @@ import {
   IconCircle,
   IconCircleDashed,
   IconCircleDot,
-  IconCircleCheck,
   IconUser,
   IconCalendar,
   IconMessage,
   IconFlag,
   IconX,
+  IconCircleCheckCustom,
+  IconCircleXCustom,
 } from "../../icons";
 import classNames from "../../utils/classnames";
 import * as Types from "../types";
@@ -24,8 +25,8 @@ import { PrimaryButton, SecondaryButton } from "../../Button";
 const taskStatusConfig: Record<Types.Status, { label: string; icon: React.ReactNode; color?: string }> = {
   pending: { label: "Not started", icon: <IconCircleDashed size={14} />, color: "text-content-dimmed" },
   in_progress: { label: "In progress", icon: <IconCircleDot size={14} />, color: "text-brand-1" },
-  done: { label: "Done", icon: <IconCircleCheck size={14} />, color: "text-success" },
-  canceled: { label: "Canceled", icon: <IconX size={14} />, color: "text-red-500" },
+  done: { label: "Done", icon: <IconCircleCheckCustom size={14} />, color: "text-success" },
+  canceled: { label: "Canceled", icon: <IconCircleXCustom size={14} />, color: "text-content-dimmed" },
 };
 
 interface FilterOption {
@@ -492,7 +493,7 @@ export function TaskFilter({ filters, onFiltersChange, tasks }: TaskFilterProps)
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-surface-base border border-surface-outline rounded-lg shadow-lg p-6 w-full max-w-md mx-4">
             <h3 className="text-lg font-semibold text-content-base mb-4">Search content</h3>
-            
+
             <input
               type="text"
               value={contentSearchTerm}

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -430,3 +430,61 @@ export function IconLink2({
     </svg>
   );
 }
+
+// Custom CircleCheck icon with prominent checkmark
+//
+// Why custom instead of Tabler's IconCircleCheckFilled:
+// - Tabler icons have built-in whitespace within their 24x24 viewBox and use stroke-based design
+// - This makes the checkmark inside IconCircleCheckFilled very small and hard to see
+// - Custom SVGs that use fill-based design and full viewBox utilization appear more prominent
+// - This implementation uses a 24x24 viewBox (matching Tabler) but with optimized sizing:
+//   * Circle spans from 2-22 (radius 10) leaving minimal padding
+//   * Checkmark is carefully positioned and sized for visibility
+//   * Uses currentColor to inherit design system colors (text-success)
+export function IconCircleCheckCustom({ size = 14, className = "" }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={`${className} flex-shrink-0`}
+      role="img"
+      focusable="false"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: size, height: size }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM17.3 9.8C17.69 9.41 17.69 8.78 17.3 8.39C16.91 8 16.28 8 15.89 8.39L10.5 13.78L8.11 11.39C7.72 11 7.09 11 6.7 11.39C6.31 11.78 6.31 12.41 6.7 12.8L9.8 15.9C10.19 16.29 10.82 16.29 11.21 15.9L17.3 9.8Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+// Custom CircleX icon for canceled status
+// More prominent than Tabler's IconX in a filled circle, designed to match IconCircleCheckCustom
+export function IconCircleXCustom({ size = 14, className = "" }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      className={`${className} flex-shrink-0`}
+      role="img"
+      focusable="false"
+      aria-hidden="true"
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ width: size, height: size }}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM16.24 9.26C16.63 8.87 16.63 8.24 16.24 7.85C15.85 7.46 15.22 7.46 14.83 7.85L12 10.68L9.17 7.85C8.78 7.46 8.15 7.46 7.76 7.85C7.37 8.24 7.37 8.87 7.76 9.26L10.59 12.09L7.76 14.92C7.37 15.31 7.37 15.94 7.76 16.33C8.15 16.72 8.78 16.72 9.17 16.33L12 13.5L14.83 16.33C15.22 16.72 15.85 16.72 16.24 16.33C16.63 15.94 16.63 15.31 16.24 14.92L13.41 12.09L16.24 9.26Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
<img width="444" height="328" alt="CleanShot 2025-08-04 at 13 36 06@2x" src="https://github.com/user-attachments/assets/416e9c90-44be-4b0c-bafa-c2ffe1953392" />

more visible and legible check and cross than Tabler's