### PR TITLE
fix: TipTap doesn't break when documents are pasted with images

### DIFF
--- a/app/assets/js/components/Editor/Blob/PasteHtmlImagesPlugin.tsx
+++ b/app/assets/js/components/Editor/Blob/PasteHtmlImagesPlugin.tsx
@@ -1,0 +1,62 @@
+import { Plugin } from "prosemirror-state";
+
+/**
+ * This plugin removes images from HTML content when pasting from websites,
+ * while preserving all other formatting like bold text, headings, etc.
+ */
+export const PasteHtmlImagesPlugin = new Plugin({
+  props: {
+    handlePaste: (view, event) => {
+      const html = event.clipboardData?.getData('text/html');
+
+      // Only process if we have HTML with images
+      if (!html || !html.includes('<img')) return false;
+      
+      // Create a temporary element to parse the HTML
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = html;
+      
+      // Find all img elements and remove them
+      const images = tempDiv.querySelectorAll('img');
+      if (images.length === 0) return false;
+      
+      images.forEach(img => img.remove());
+      
+      // Find and remove empty paragraphs (that might have contained only images)
+      const paragraphs = tempDiv.querySelectorAll('p');
+      paragraphs.forEach(p => {
+        if (p.innerHTML.trim() === '') {
+          p.remove();
+        }
+      });
+      
+      // Get the modified HTML with images removed but formatting preserved
+      const modifiedHtml = tempDiv.innerHTML;
+      
+      // Create a new clipboard data object
+      const clipboardData = new DataTransfer();
+      
+      // Set the modified HTML
+      clipboardData.setData('text/html', modifiedHtml);
+      
+      // Set plain text as fallback
+      clipboardData.setData('text/plain', tempDiv.textContent || '');
+      
+      // Create a new clipboard event with our modified data
+      const clipboardEvent = new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: clipboardData
+      });
+      
+      // Stop the original paste event
+      event.preventDefault();
+      
+      // Let TipTap handle the new paste event with images removed
+      view.dom.dispatchEvent(clipboardEvent);
+      
+      // Return true to prevent further handling of the original paste event
+      return true;
+    }
+  }
+});

--- a/app/assets/js/components/Editor/Blob/PasteHtmlImagesPlugin.tsx
+++ b/app/assets/js/components/Editor/Blob/PasteHtmlImagesPlugin.tsx
@@ -3,60 +3,36 @@ import { Plugin } from "prosemirror-state";
 /**
  * This plugin removes images from HTML content when pasting from websites,
  * while preserving all other formatting like bold text, headings, etc.
+ * 
+ * It focuses only on the HTML transformation step to avoid TypeScript compatibility
+ * issues between different ProseMirror versions.
  */
 export const PasteHtmlImagesPlugin = new Plugin({
   props: {
-    handlePaste: (view, event) => {
-      const html = event.clipboardData?.getData('text/html');
-
-      // Only process if we have HTML with images
-      if (!html || !html.includes('<img')) return false;
+    // This hook runs when parsing HTML during paste operations
+    transformPastedHTML(html) {
+      // Case insensitive check for image tags (handles <img>, <IMG>, etc.)
+      if (!/\<img|\<IMG/i.test(html)) return html;
       
-      // Create a temporary element to parse the HTML
-      const tempDiv = document.createElement('div');
-      tempDiv.innerHTML = html;
+      // Create a DOMParser to safely parse HTML without executing scripts
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
       
       // Find all img elements and remove them
-      const images = tempDiv.querySelectorAll('img');
-      if (images.length === 0) return false;
+      const images = doc.querySelectorAll('img');
+      if (images.length === 0) return html;
       
       images.forEach(img => img.remove());
       
       // Find and remove empty paragraphs (that might have contained only images)
-      const paragraphs = tempDiv.querySelectorAll('p');
+      const paragraphs = doc.querySelectorAll('p');
       paragraphs.forEach(p => {
         if (p.innerHTML.trim() === '') {
           p.remove();
         }
       });
       
-      // Get the modified HTML with images removed but formatting preserved
-      const modifiedHtml = tempDiv.innerHTML;
-      
-      // Create a new clipboard data object
-      const clipboardData = new DataTransfer();
-      
-      // Set the modified HTML
-      clipboardData.setData('text/html', modifiedHtml);
-      
-      // Set plain text as fallback
-      clipboardData.setData('text/plain', tempDiv.textContent || '');
-      
-      // Create a new clipboard event with our modified data
-      const clipboardEvent = new ClipboardEvent('paste', {
-        bubbles: true,
-        cancelable: true,
-        clipboardData: clipboardData
-      });
-      
-      // Stop the original paste event
-      event.preventDefault();
-      
-      // Let TipTap handle the new paste event with images removed
-      view.dom.dispatchEvent(clipboardEvent);
-      
-      // Return true to prevent further handling of the original paste event
-      return true;
+      return doc.body.innerHTML;
     }
   }
 });

--- a/app/assets/js/components/Editor/Blob/index.tsx
+++ b/app/assets/js/components/Editor/Blob/index.tsx
@@ -3,6 +3,7 @@ import { ReactNodeViewRenderer } from "@tiptap/react";
 
 import { DropFilePlugin } from "./DropFilePlugin";
 import { PasteFilePlugin } from "./PasteFilePlugin";
+import { PasteHtmlImagesPlugin } from "./PasteHtmlImagesPlugin";
 import { BlobView } from "./BlobView";
 
 export function isUploadInProgress(doc: any) {
@@ -67,7 +68,7 @@ const BlobExtension = Node.create({
   },
 
   addProseMirrorPlugins() {
-    return [PasteFilePlugin, DropFilePlugin];
+    return [PasteFilePlugin, PasteHtmlImagesPlugin, DropFilePlugin];
   },
 });
 


### PR DESCRIPTION
When some content that contains images is pasted into a document, the images are removed from the content. This prevents TipTap from breaking. 