### PR TITLE
fix: Clicking on contributor redirects to profile page

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1216,11 +1216,11 @@ export interface ProjectCheckIn {
 }
 
 export interface ProjectContributor {
-  id?: string | null;
-  responsibility?: string | null;
-  role?: string | null;
+  id: string;
+  responsibility: string | null;
+  role: string | null;
   person?: Person | null;
-  accessLevel?: number | null;
+  accessLevel: number | null;
   project?: Project | null;
 }
 

--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -322,16 +322,16 @@ function prepareContributor(
   paths: Paths,
   contributor: Projects.ProjectContributor | null | undefined,
 ): ProjectPage.Person | null {
-  if (!contributor) {
+  if (!contributor?.person) {
     return null;
   }
 
   return {
-    id: contributor.id!,
-    fullName: contributor.person!.fullName!,
-    avatarUrl: contributor.person!.avatarUrl || "",
-    title: contributor.person!.title || "",
-    profileLink: paths.profilePath(contributor.id!),
+    id: contributor.id,
+    fullName: contributor.person.fullName,
+    avatarUrl: contributor.person.avatarUrl || "",
+    title: contributor.person.title || "",
+    profileLink: paths.profilePath(contributor.person.id),
   };
 }
 

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1585,11 +1585,11 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :project_contributor do
-    field? :id, :string, null: true
-    field? :responsibility, :string, null: true
-    field? :role, :string, null: true
+    field :id, :string
+    field :responsibility, :string, null: true
+    field :role, :string, null: true
     field? :person, :person, null: true
-    field? :access_level, :integer, null: true
+    field :access_level, :integer, null: true
     field? :project, :project, null: true
   end
 


### PR DESCRIPTION
Now, clicking on contributor on the new Project page redirects to the contributor's profile page.