### PR TITLE
fix: Show only contributors in contributors list on Project V2 page

### DIFF
--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -327,7 +327,7 @@ function prepareContributor(
   }
 
   return {
-    id: contributor.id,
+    id: contributor.person.id,
     fullName: contributor.person.fullName,
     avatarUrl: contributor.person.avatarUrl || "",
     title: contributor.person.title || "",

--- a/turboui/src/MilestonePage/InProjectContextStory.tsx
+++ b/turboui/src/MilestonePage/InProjectContextStory.tsx
@@ -111,6 +111,7 @@ export function InProjectContextStory() {
     setParentGoal: () => {},
     parentGoal: null,
     parentGoalSearch: parentGoalSearchFn,
+    contributors: [],
   };
 
   const tabs = useTabs("tasks", [
@@ -266,6 +267,7 @@ export function EmptyMilestoneInProjectContextStory() {
     setParentGoal: () => {},
     parentGoal: null,
     parentGoalSearch: parentGoalSearchFn,
+    contributors: [],
   };
 
   const tabs = useTabs("tasks", [

--- a/turboui/src/ProjectPage/OverviewSidebar.tsx
+++ b/turboui/src/ProjectPage/OverviewSidebar.tsx
@@ -166,8 +166,8 @@ function Reviewer(props: ProjectPage.State) {
   );
 }
 
-function Contributors(props: any) {
-  const contributors = props.contributors || [];
+function Contributors(props: ProjectPage.State) {
+  const contributors = props.contributors.filter((c) => ![props.champion?.id, props.reviewer?.id].includes(c.id));
 
   return (
     <SidebarSection title="Contributors">

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -106,7 +106,7 @@ export namespace ProjectPage {
     filters?: TaskBoardTypes.FilterCondition[];
     onFiltersChange?: (filters: TaskBoardTypes.FilterCondition[]) => void;
 
-    contributors?: any[];
+    contributors: Person[];
     manageTeamLink?: string;
     checkIns?: CheckIn[];
     mentionedPersonLookup?: MentionedPersonLookupFn;

--- a/turboui/src/TaskPage/InProjectContextStory.tsx
+++ b/turboui/src/TaskPage/InProjectContextStory.tsx
@@ -76,6 +76,7 @@ export function InProjectContextStory() {
     setParentGoal: () => {},
     parentGoal: null,
     parentGoalSearch: parentGoalSearchFn,
+    contributors: [],
   };
 
   // Show TaskPage within the Tasks tab - simulates navigating to a specific task


### PR DESCRIPTION
The Project's champion and reviewer are no longer displayed in the contributors list.