### PR TITLE
fix: Prevent parent Goal from overflowing Project V2 page

### DIFF
--- a/turboui/src/ProjectPage/OverviewSidebar.tsx
+++ b/turboui/src/ProjectPage/OverviewSidebar.tsx
@@ -272,9 +272,11 @@ function Actions(props: ProjectPage.State) {
 
 function SidebarSection({ title, children }: { title: string | React.ReactNode; children: React.ReactNode }) {
   return (
-    <div>
-      <div className="font-bold text-sm mb-1.5">{title}</div>
-      {children}
+    <div className="overflow-hidden">
+      <div className="font-bold text-sm mb-1.5">
+        <div className="truncate">{title}</div>
+      </div>
+      <div className="overflow-hidden">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
The Project's parent Goal now doesn't overflow the new Project page.