### PR TITLE
chore: Add project_id to Tasks

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3021,10 +3021,10 @@ export interface CreateSpaceResult {
 }
 
 export interface CreateTaskInput {
-  name?: string | null;
-  assigneeIds?: string[] | null;
+  name: string;
+  milestoneId: Id;
+  assigneeIds?: Id[] | null;
   description?: string | null;
-  milestoneId?: string | null;
 }
 
 export interface CreateTaskResult {
@@ -3592,7 +3592,7 @@ export interface ProjectsCreateMilestoneResult {
 }
 
 export interface ProjectsCreateTaskInput {
-  milestoneId: Id;
+  milestoneId: Id | null;
   name: string;
   assigneeId: Id | null;
   dueDate: ContextualDate | null;
@@ -3686,7 +3686,7 @@ export interface ProjectsUpdateTaskDueDateResult {
 
 export interface ProjectsUpdateTaskMilestoneInput {
   taskId: Id;
-  milestoneId: Id;
+  milestoneId: Id | null;
 }
 
 export interface ProjectsUpdateTaskMilestoneResult {

--- a/app/lib/operately/data/change_072_populate_project_id_in_tasks.ex
+++ b/app/lib/operately/data/change_072_populate_project_id_in_tasks.ex
@@ -1,0 +1,14 @@
+defmodule Operately.Data.Change072PopulateProjectIdInTasks do
+  def run do
+    sql = """
+    UPDATE tasks
+    SET project_id = project_milestones.project_id
+    FROM project_milestones
+    WHERE tasks.milestone_id = project_milestones.id
+    AND tasks.milestone_id IS NOT NULL
+    AND tasks.project_id IS NULL;
+    """
+
+    Operately.Repo.query!(sql)
+  end
+end

--- a/app/lib/operately/operations/task_adding.ex
+++ b/app/lib/operately/operations/task_adding.ex
@@ -33,6 +33,7 @@ defmodule Operately.Operations.TaskAdding do
         description: Jason.decode!(attrs.description),
         milestone_id: changes.milestone.id,
         creator_id: creator.id,
+        project_id: changes.milestone.project_id,
       })
     end)
   end

--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -21,6 +21,7 @@ defmodule Operately.Projects.Project do
     has_many :key_resources, Operately.Projects.KeyResource, foreign_key: :project_id
     has_many :milestones, Operately.Projects.Milestone, foreign_key: :project_id
     has_many :check_ins, CheckIn, foreign_key: :project_id
+    has_many :tasks, Operately.Tasks.Task, foreign_key: :project_id
 
     has_one :champion_contributor, Contributor, foreign_key: :project_id, where: [role: "champion"]
     has_one :reviewer_contributor, Contributor, foreign_key: :project_id, where: [role: "reviewer"]

--- a/app/lib/operately/tasks/task.ex
+++ b/app/lib/operately/tasks/task.ex
@@ -14,6 +14,7 @@ defmodule Operately.Tasks.Task do
           reopened_at: NaiveDateTime.t() | nil,
           creator_id: Ecto.UUID.t() | nil,
           milestone_id: Ecto.UUID.t() | nil,
+          project_id: Ecto.UUID.t() | nil,
           inserted_at: NaiveDateTime.t() | nil,
           updated_at: NaiveDateTime.t() | nil
         }
@@ -21,10 +22,10 @@ defmodule Operately.Tasks.Task do
   schema "tasks" do
     belongs_to :creator, Operately.People.Person
     belongs_to :milestone, Operately.Projects.Milestone
+    belongs_to :project, Operately.Projects.Project
 
-    has_one :group, through: [:milestone, :project, :group]
+    has_one :group, through: [:project, :group]
     has_one :company, through: [:creator, :company]
-    has_one :project, through: [:milestone, :project]
     has_one :access_context, through: [:project, :access_context]
 
     has_many :assignees, Operately.Tasks.Assignee
@@ -53,9 +54,9 @@ defmodule Operately.Tasks.Task do
 
   def changeset(task, attrs) do
     task
-    |> cast(attrs, [:name, :deprecated_due_date, :description, :size, :priority, :creator_id, :status, :closed_at, :reopened_at, :milestone_id])
+    |> cast(attrs, [:name, :deprecated_due_date, :description, :size, :priority, :creator_id, :status, :closed_at, :reopened_at, :milestone_id, :project_id])
     |> cast_embed(:due_date)
-    |> validate_required([:name, :description, :creator_id, :milestone_id])
+    |> validate_required([:name, :description, :creator_id, :project_id])
   end
 
   #

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -429,7 +429,7 @@ defmodule OperatelyWeb.Api.Projects do
 
     inputs do
       field :task_id, :id, null: false
-      field :milestone_id, :id, null: false
+      field :milestone_id, :id, null: true
     end
 
     outputs do
@@ -841,11 +841,16 @@ defmodule OperatelyWeb.Api.Projects do
 
     def validate_milestone_belongs_to_project(multi, milestone_id) do
       Ecto.Multi.run(multi, :validate_milestone, fn _repo, %{project: project} ->
-        milestone = Operately.Projects.get_milestone!(milestone_id)
-        if milestone.project_id == project.id do
-          {:ok, milestone}
-        else
-          {:error, "Milestone must belong to the same project as the task"}
+        case milestone_id do
+          nil ->
+            {:ok, nil}
+          _ ->
+            milestone = Operately.Projects.get_milestone!(milestone_id)
+            if milestone.project_id == project.id do
+              {:ok, milestone}
+            else
+              {:error, "Milestone must belong to the same project as the task"}
+            end
         end
       end)
     end
@@ -869,6 +874,7 @@ defmodule OperatelyWeb.Api.Projects do
           name: inputs.name,
           description: %{},
           milestone_id: milestone.id,
+          project_id: milestone.project_id,
           creator_id: me.id,
           due_date: inputs.due_date
         })

--- a/app/priv/repo/migrations/20250813170624_add_project_id_to_tasks_schema.exs
+++ b/app/priv/repo/migrations/20250813170624_add_project_id_to_tasks_schema.exs
@@ -3,7 +3,7 @@ defmodule Operately.Repo.Migrations.AddProjectIdToTasksSchema do
 
   def change do
     alter table(:tasks) do
-      add :project_id, references(:projects, type: :binary_id)
+      add :project_id, references(:projects, type: :binary_id, on_delete: :delete_all)
     end
 
     create index(:tasks, [:project_id])

--- a/app/priv/repo/migrations/20250813170624_add_project_id_to_tasks_schema.exs
+++ b/app/priv/repo/migrations/20250813170624_add_project_id_to_tasks_schema.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddProjectIdToTasksSchema do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tasks) do
+      add :project_id, references(:projects, type: :binary_id)
+    end
+
+    create index(:tasks, [:project_id])
+  end
+end

--- a/app/priv/repo/migrations/20250813171118_populate_project_id_in_tasks_schema.exs
+++ b/app/priv/repo/migrations/20250813171118_populate_project_id_in_tasks_schema.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.PopulateProjectIdInTasksSchema do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change072PopulateProjectIdInTasks.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/access/activity_context_assigner_test.exs
+++ b/app/test/operately/access/activity_context_assigner_test.exs
@@ -581,7 +581,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
   describe "assigns access_context to task activities" do
     setup ctx do
       milestone = milestone_fixture(%{project_id: ctx.project.id})
-      task = task_fixture(%{space_id: ctx.group.id, creator_id: ctx.author.id, milestone_id: milestone.id})
+      task = task_fixture(%{space_id: ctx.group.id, creator_id: ctx.author.id, milestone_id: milestone.id, project_id: ctx.project.id})
 
       Map.merge(ctx, %{milestone: milestone, task: task})
     end

--- a/app/test/operately/data/change_013_create_activities_access_context_test.exs
+++ b/app/test/operately/data/change_013_create_activities_access_context_test.exs
@@ -737,7 +737,7 @@ defmodule Operately.Data.Change013CreateActivitiesAccessContextTest do
       project = Repo.preload(project, :access_context)
 
       milestone = milestone_fixture(%{project_id: project.id})
-      task = task_fixture(%{ space_id: group.id, creator_id: ctx.author.id, milestone_id: milestone.id})
+      task = task_fixture(%{ space_id: group.id, creator_id: ctx.author.id, milestone_id: milestone.id, project_id: project.id})
 
       Map.merge(ctx, %{project: project, task: task})
     end

--- a/app/test/operately/data/change_072_populate_project_id_in_tasks_test.exs
+++ b/app/test/operately/data/change_072_populate_project_id_in_tasks_test.exs
@@ -1,0 +1,85 @@
+defmodule Operately.Data.Change072PopulateProjectIdInTasksTest do
+  use Operately.DataCase
+
+  alias Operately.Tasks
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.ProjectsFixtures
+  import Operately.TasksFixtures
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    group = group_fixture(creator)
+    project = project_fixture(%{company_id: company.id, creator_id: creator.id, group_id: group.id})
+    milestone = milestone_fixture(%{project_id: project.id, creator_id: creator.id})
+
+    %{
+      company: company,
+      creator: creator,
+      group: group,
+      project: project,
+      milestone: milestone
+    }
+  end
+
+  test "populates project_id for tasks that belong to milestones", %{creator: creator, project: project, milestone: milestone} do
+    task1 = task_fixture(%{
+      creator_id: creator.id,
+      milestone_id: milestone.id,
+      project_id: project.id
+    })
+    task2 = task_fixture(%{
+      creator_id: creator.id,
+      milestone_id: milestone.id,
+      project_id: project.id
+    })
+
+    task3 = task_fixture(%{
+      creator_id: creator.id,
+      milestone_id: nil,
+      project_id: project.id
+    })
+
+    # Use raw query to set project_id to NULL to simulate pre-migration state
+    task1_binary = Ecto.UUID.dump!(task1.id)
+    task2_binary = Ecto.UUID.dump!(task2.id)
+    task3_binary = Ecto.UUID.dump!(task3.id)
+
+    Operately.Repo.query!("UPDATE tasks SET project_id = NULL WHERE id IN ($1, $2, $3)", [task1_binary, task2_binary, task3_binary])
+
+    # Verify initial state
+    assert Tasks.get_task!(task1.id).project_id == nil
+    assert Tasks.get_task!(task2.id).project_id == nil
+    assert Tasks.get_task!(task3.id).project_id == nil
+
+    Operately.Data.Change072PopulateProjectIdInTasks.run()
+
+    assert Tasks.get_task!(task1.id).project_id == project.id
+    assert Tasks.get_task!(task2.id).project_id == project.id
+
+    assert Tasks.get_task!(task3.id).project_id == nil
+  end
+
+  test "does not update tasks that already have project_id set", %{company: company, creator: creator, group: group} do
+    project1 = project_fixture(%{company_id: company.id, creator_id: creator.id, group_id: group.id})
+    project2 = project_fixture(%{company_id: company.id, creator_id: creator.id, group_id: group.id})
+
+    milestone = milestone_fixture(%{project_id: project1.id, creator_id: creator.id})
+
+    task = task_fixture(%{
+      creator_id: creator.id,
+      milestone_id: milestone.id,
+      project_id: project2.id
+    })
+
+    # Verify initial state
+    assert Tasks.get_task!(task.id).project_id == project2.id
+
+    Operately.Data.Change072PopulateProjectIdInTasks.run()
+
+    assert Tasks.get_task!(task.id).project_id == project2.id
+  end
+end

--- a/app/test/operately/operations/task_description_change_test.exs
+++ b/app/test/operately/operations/task_description_change_test.exs
@@ -20,7 +20,7 @@ defmodule Operately.Operations.TaskDescriptionChangeTest do
     project = project_fixture(%{company_id: company.id, creator_id: person.id, group_id: group.id})
     milestone = milestone_fixture(%{project_id: project.id, title: "Some milestone"})
 
-    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, name: "name"})
+    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, project_id: project.id, name: "name"})
       |> Repo.preload(:group)
 
     {:ok, person: person, task: task, group: group}

--- a/app/test/operately/operations/task_status_change_test.exs
+++ b/app/test/operately/operations/task_status_change_test.exs
@@ -18,7 +18,7 @@ defmodule Operately.Operations.TaskStatusChangeTest do
     group = group_fixture(person)
     project = project_fixture(%{company_id: company.id, creator_id: person.id, group_id: group.id})
     milestone = milestone_fixture(%{project_id: project.id, title: "Some milestone"})
-    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, name: "name"})
+    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, project_id: project.id, name: "name"})
     assignee_fixture(%{task_id: task.id, person_id: person.id})
 
     {:ok, person: person, milestone: milestone, task: task}

--- a/app/test/operately/operations/task_update_test.exs
+++ b/app/test/operately/operations/task_update_test.exs
@@ -22,7 +22,7 @@ defmodule Operately.Operations.TaskUpdateTest do
     group = group_fixture(person)
     project = project_fixture(%{company_id: company.id, creator_id: person.id, group_id: group.id})
     milestone = milestone_fixture(%{project_id: project.id, title: "Some milestone"})
-    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, name: @prev_name})
+    task = task_fixture(%{creator_id: person.id, milestone_id: milestone.id, project_id: project.id, name: @prev_name})
     assignee_fixture(%{task_id: task.id, person_id: person.id})
 
     {:ok, company: company, person: person, task: task}

--- a/app/test/operately/tasks_test.exs
+++ b/app/test/operately/tasks_test.exs
@@ -29,6 +29,7 @@ defmodule Operately.TasksTest do
       space_id: space.id,
       creator_id: person.id,
       milestone_id: milestone.id,
+      project_id: project.id,
       status: "todo",
     })
 

--- a/app/test/operately_web/api/mutations/change_task_description_test.exs
+++ b/app/test/operately_web/api/mutations/change_task_description_test.exs
@@ -216,6 +216,7 @@ defmodule OperatelyWeb.Api.Mutations.ChangeTaskDescriptionTest do
     task_fixture(%{
       creator_id: ctx[:creator_id] || ctx.person.id,
       milestone_id: milestone.id,
+      project_id: project.id,
     })
   end
 

--- a/app/test/operately_web/api/mutations/update_task_status_test.exs
+++ b/app/test/operately_web/api/mutations/update_task_status_test.exs
@@ -102,6 +102,6 @@ defmodule OperatelyWeb.Api.Mutations.UpdateTaskStatusTest do
   end
 
   def create_task(ctx, milestone) do
-    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: ctx.project.id, name: "Example task"})
+    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: milestone.project_id, name: "Example task"})
   end
 end

--- a/app/test/operately_web/api/mutations/update_task_status_test.exs
+++ b/app/test/operately_web/api/mutations/update_task_status_test.exs
@@ -102,6 +102,6 @@ defmodule OperatelyWeb.Api.Mutations.UpdateTaskStatusTest do
   end
 
   def create_task(ctx, milestone) do
-    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, name: "Example task"})
+    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: ctx.project.id, name: "Example task"})
   end
 end

--- a/app/test/operately_web/api/mutations/update_task_test.exs
+++ b/app/test/operately_web/api/mutations/update_task_test.exs
@@ -107,6 +107,6 @@ defmodule OperatelyWeb.Api.Mutations.UpdateTaskTest do
   end
 
   def create_task(ctx, milestone) do
-    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, name: "Example task"})
+    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: ctx.project.id, name: "Example task"})
   end
 end

--- a/app/test/operately_web/api/mutations/update_task_test.exs
+++ b/app/test/operately_web/api/mutations/update_task_test.exs
@@ -107,6 +107,6 @@ defmodule OperatelyWeb.Api.Mutations.UpdateTaskTest do
   end
 
   def create_task(ctx, milestone) do
-    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: ctx.project.id, name: "Example task"})
+    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: milestone.project_id, name: "Example task"})
   end
 end

--- a/app/test/operately_web/api/queries/get_task_test.exs
+++ b/app/test/operately_web/api/queries/get_task_test.exs
@@ -157,7 +157,7 @@ defmodule OperatelyWeb.Api.Queries.GetTaskTest do
     })
     milestone = milestone_fixture(%{ project_id: project.id })
 
-    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id})
+    task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: project.id})
   end
 
   defp add_person_to_space(ctx) do

--- a/app/test/operately_web/api/queries/get_tasks_test.exs
+++ b/app/test/operately_web/api/queries/get_tasks_test.exs
@@ -147,7 +147,7 @@ defmodule OperatelyWeb.Api.Queries.GetTasksTest do
     })
     milestone = milestone_fixture(%{ project_id: project.id })
     tasks = Enum.map(1..3, fn _ ->
-      task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id})
+      task_fixture(%{creator_id: ctx.creator.id, milestone_id: milestone.id, project_id: project.id})
     end)
 
     {Paths.milestone_id(milestone), tasks}

--- a/app/test/support/factory/projects.ex
+++ b/app/test/support/factory/projects.ex
@@ -307,6 +307,7 @@ defmodule Operately.Support.Factory.Projects do
     attrs = Enum.into(opts, %{
       creator_id: ctx.creator.id,
       milestone_id: milestone.id,
+      project_id: milestone.project_id,
       title: Keyword.get(opts, :title, "Task #{testid}")
     })
 

--- a/turboui/src/TaskBoard/types.ts
+++ b/turboui/src/TaskBoard/types.ts
@@ -152,7 +152,7 @@ export interface TaskBoardProps {
   onTaskAssigneeChange: (taskId: string, assignee: Person | null) => void;
   onTaskDueDateChange: (taskId: string, dueDate: DateField.ContextualDate | null) => void;
   onTaskStatusChange: (taskId: string, status: string) => void;
-  onTaskMilestoneChange?: (taskId: string, milestoneId: string) => void;
+  onTaskMilestoneChange?: (taskId: string, milestoneId: string | null) => void;
   onMilestoneUpdate?: (milestoneId: string, updates: Partial<Milestone>) => void;
   searchPeople?: (params: { query: string }) => Promise<Person[]>;
 


### PR DESCRIPTION
I've added a `project_id` field to Tasks. This will be necessary for us to be able to create Tasks which don't belong to any milestone.