### PR TITLE
feat: Tasks can be created without milestone

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3592,6 +3592,7 @@ export interface ProjectsCreateMilestoneResult {
 }
 
 export interface ProjectsCreateTaskInput {
+  projectId: Id;
   milestoneId: Id | null;
   name: string;
   assigneeId: Id | null;

--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -540,7 +540,8 @@ function useTasks(paths: Paths, backendTasks: Tasks.Task[], project: Projects.Pr
         name: task.title,
         assigneeId: task.assignee,
         dueDate: serializeContextualDate(task.dueDate),
-        milestoneId: task.milestone.id,
+        milestoneId: task.milestone?.id || null,
+        projectId: project.id,
       })
       .then((data) => {
         PageCache.invalidate(pageCacheKey(project.id));

--- a/app/lib/operately/activities/content/task_adding.ex
+++ b/app/lib/operately/activities/content/task_adding.ex
@@ -14,7 +14,7 @@ defmodule Operately.Activities.Content.TaskAdding do
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields))
+    |> validate_required([:company_id, :space_id, :project_id, :task_id, :name])
   end
 
   def build(params) do

--- a/turboui/src/TaskBoard/components/TaskCreationModal.tsx
+++ b/turboui/src/TaskBoard/components/TaskCreationModal.tsx
@@ -36,7 +36,7 @@ export function TaskCreationModal({
   const [milestone, setMilestone] = useState<Types.Milestone | null>(null);
   const [createMore, setCreateMore] = useState(false);
 
-  const disabled = !title.trim() || !milestone;
+  const disabled = !title.trim();
 
   // Default search functions if not provided
   const defaultSearchPeople = async ({ query }: { query: string }) => {

--- a/turboui/src/TaskBoard/types.ts
+++ b/turboui/src/TaskBoard/types.ts
@@ -44,7 +44,7 @@ export interface UpdateMilestonePayload {
 
 export interface NewTaskPayload {
   title: string;
-  milestone: Milestone;
+  milestone: Milestone | null;
   dueDate: DateField.ContextualDate | null;
   assignee: string | null;
 }


### PR DESCRIPTION
We can now create Tasks without specifying a Milestone from the new Project page.