### PR TITLE
fix: MilestoneCard redirects to Milestone page correctly

### DIFF
--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -85,7 +85,7 @@ export function MilestoneCard({
               ]}
             />
             <BlackLink
-              to={`/milestones/${milestone.id}`}
+              to={milestone.link || ""}
               className="text-sm font-semibold text-content-base hover:text-link-hover transition-colors"
               underline="hover"
             >


### PR DESCRIPTION
Clicking on Milestone title in the MilestoneCard component no longer redirects to inexistent page.