### PR TITLE
fix: Solve li within li error in Tasks tab

### DIFF
--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -117,7 +117,7 @@ export function TaskList({
       {/* Hidden tasks that are expanded with animation */}
       {hiddenTasksExpanded &&
         hiddenTasks.map((task, index) => (
-          <li
+          <div
             key={`hidden-${task.id}`}
             className="animate-fadeIn"
             style={{
@@ -133,7 +133,7 @@ export function TaskList({
               onTaskStatusChange={onTaskStatusChange}
               searchPeople={searchPeople}
             />
-          </li>
+          </div>
         ))}
     </ul>
   );


### PR DESCRIPTION
There were some <li> tags within other <li> tags which were raising errors in the console. That's now fixed. 