### PR TITLE
fix: Solve error in project_goal_connection activities

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -521,8 +521,11 @@ export interface ActivityContentProjectDueDateUpdating {
 }
 
 export interface ActivityContentProjectGoalConnection {
-  project?: Project | null;
-  goal?: Goal | null;
+  project: Project;
+  goal: Goal | null;
+  goalName: string | null;
+  previousGoal: Goal | null;
+  previousGoalName: string | null;
 }
 
 export interface ActivityContentProjectGoalDisconnection {
@@ -3747,6 +3750,7 @@ export interface ProjectsUpdateMilestoneResult {
 export interface ProjectsUpdateParentGoalInput {
   projectId: Id;
   goalId: Id | null;
+  goalName: string | null;
 }
 
 export interface ProjectsUpdateParentGoalResult {

--- a/app/assets/js/features/activities/ProjectGoalConnection/index.tsx
+++ b/app/assets/js/features/activities/ProjectGoalConnection/index.tsx
@@ -4,7 +4,6 @@ import type { ActivityContentProjectGoalConnection } from "@/api";
 import type { Activity } from "@/models/activities";
 import type { ActivityHandler } from "../interfaces";
 
-
 import { feedTitle, goalLink, projectLink } from "../feedItemLinks";
 
 const ProjectGoalConnection: ActivityHandler = {
@@ -29,15 +28,52 @@ const ProjectGoalConnection: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
-    const project = projectLink(content(activity).project!);
-    const goal = goalLink(content(activity).goal!);
+    const { project: p, goal: g, goalName, previousGoal, previousGoalName } = content(activity);
 
+    const project = projectLink(p);
+
+    if (g) {
+      const goal = goalLink(g);
+
+      if (page === "project") {
+        return feedTitle(activity, "connected the project to the", goal, "goal");
+      } else if (page === "goal") {
+        return feedTitle(activity, "connected the", project, "project to the goal");
+      } else {
+        return feedTitle(activity, "connected the", project, "project to the", goal, "goal");
+      }
+    }
+
+    if (goalName) {
+      if (page === "project") {
+        return feedTitle(activity, "connected the project to the", goalName, "goal");
+      } else {
+        return feedTitle(activity, "connected the", project, "project to the", goalName, "goal");
+      }
+    }
+
+    // Handle cases where a project was disconnected from a goal
+    if (previousGoal) {
+      const prevGoal = goalLink(previousGoal);
+
+      if (page === "project") {
+        return feedTitle(activity, "disconnected the project from the", prevGoal, "goal");
+      } else {
+        return feedTitle(activity, "disconnected the", project, "project from the", prevGoal, "goal");
+      }
+    } else if (previousGoalName) {
+      if (page === "project") {
+        return feedTitle(activity, "disconnected the project from the", previousGoalName, "goal");
+      } else {
+        return feedTitle(activity, "disconnected the", project, "project from the", previousGoalName, "goal");
+      }
+    }
+
+    // Fallback if no previous goal information is available
     if (page === "project") {
-      return feedTitle(activity, "connected the project to the", goal, "goal");
-    } else if (page === "goal") {
-      return feedTitle(activity, "connected the", project, "project to the goal");
+      return feedTitle(activity, "disconnected the project from its parent goal");
     } else {
-      return feedTitle(activity, "connected the", project, "project to the", goal, "goal");
+      return feedTitle(activity, "disconnected the", project, "project from its parent goal");
     }
   },
 

--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -116,7 +116,12 @@ function Page() {
 
   const [parentGoal, setParentGoal] = usePageField({
     value: (data: { project: Projects.Project }) => Goals.parseParentGoalForTurboUi(paths, data.project.goal),
-    update: (v) => Api.projects.updateParentGoal({ projectId: project.id, goalId: v && v.id }),
+    update: (v) =>
+      Api.projects.updateParentGoal({
+        projectId: project.id,
+        goalId: v && v.id,
+        goalName: v && v.name,
+      }),
     onError: () => showErrorToast("Network Error", "Reverted the parent goal to its previous value."),
   });
 

--- a/app/lib/operately/activities/content/project_goal_connection.ex
+++ b/app/lib/operately/activities/content/project_goal_connection.ex
@@ -6,12 +6,16 @@ defmodule Operately.Activities.Content.ProjectGoalConnection do
     belongs_to :space, Operately.Groups.Group
     belongs_to :project, Operately.Projects.Project
     belongs_to :goal, Operately.Goals.Goal
+    belongs_to :previous_goal, Operately.Goals.Goal
+
+    field :goal_name, :string
+    field :previous_goal_name, :string
   end
 
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required(__schema__(:fields) -- [:goal_id])
+    |> validate_required([:company_id, :space_id, :project_id])
   end
 
   def build(params) do

--- a/app/lib/operately/data/change_076_enhance_project_goal_connection_activities.ex
+++ b/app/lib/operately/data/change_076_enhance_project_goal_connection_activities.ex
@@ -1,0 +1,35 @@
+defmodule Operately.Data.Change076EnhanceProjectGoalConnectionActivities do
+  import Ecto.Query, only: [from: 2]
+  alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Goals.Goal
+
+  def run do
+    from(a in Activity, where: a.action == "project_goal_connection")
+    |> Repo.all()
+    |> Enum.each(fn activity ->
+      goal_id = activity.content["goal_id"]
+
+      goal_name = case get_goal(goal_id) do
+        nil -> nil
+        goal -> goal.name
+      end
+
+      new_content = activity.content
+      |> Map.put("goal_name", goal_name)
+
+      {:ok, _updated} = update_activity(activity, new_content)
+    end)
+  end
+
+  defp get_goal(nil), do: nil
+  defp get_goal(goal_id) do
+    Repo.get(Goal, goal_id)
+  end
+
+  defp update_activity(activity, new_content) do
+    activity
+    |> Ecto.Changeset.change(%{content: new_content})
+    |> Repo.update()
+  end
+end

--- a/app/lib/operately_web/api/serializers/activity.ex
+++ b/app/lib/operately_web/api/serializers/activity.ex
@@ -223,13 +223,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_content("project_goal_connection", content) do
-    %{
-      project: Serializer.serialize(content["project"], level: :essential),
-      goal: serialize_goal(content["goal"])
-    }
-  end
-
   def serialize_content("project_goal_disconnection", content) do
     %{
       project: Serializer.serialize(content["project"], level: :essential),

--- a/app/lib/operately_web/api/serializers/activity_content/project_goal_connection.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/project_goal_connection.ex
@@ -1,0 +1,11 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ProjectGoalConnection do
+  def serialize(content, level: :essential) do
+    %{
+      project: OperatelyWeb.Api.Serializer.serialize(content["project"], level: :essential),
+      goal: OperatelyWeb.Api.Serializer.serialize(content["goal"], level: :essential),
+      previous_goal: OperatelyWeb.Api.Serializer.serialize(content["previous_goal"], level: :essential),
+      goal_name: content["goal_name"],
+      previous_goal_name: content["previous_goal_name"],
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -272,8 +272,11 @@ defmodule OperatelyWeb.Api.Types do
   )
 
   object :activity_content_project_goal_connection do
-    field? :project, :project, null: true
-    field? :goal, :goal, null: true
+    field :project, :project, null: false
+    field :goal, :goal, null: true
+    field :goal_name, :string, null: true
+    field :previous_goal, :goal, null: true
+    field :previous_goal_name, :string, null: true
   end
 
   object :update_content_project_discussion do

--- a/app/priv/repo/migrations/20250819142041_populate_project_goal_connection_activity_with_missing_fields.exs
+++ b/app/priv/repo/migrations/20250819142041_populate_project_goal_connection_activity_with_missing_fields.exs
@@ -1,0 +1,7 @@
+defmodule Operately.Repo.Migrations.PopulateProjectGoalConnectionActivityWithMissingFields do
+  use Ecto.Migration
+
+  def change do
+    Operately.Data.Change076EnhanceProjectGoalConnectionActivities.run()
+  end
+end

--- a/app/test/operately/data/change_076_enhance_project_goal_connection_activities_test.exs
+++ b/app/test/operately/data/change_076_enhance_project_goal_connection_activities_test.exs
@@ -1,0 +1,69 @@
+defmodule Operately.Data.Change076EnhanceProjectGoalConnectionActivitiesTest do
+  use Operately.DataCase
+
+  alias Operately.Activities.Activity
+  alias Operately.Repo
+  alias Operately.Data.Change076EnhanceProjectGoalConnectionActivities
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_project(:project, :space, name: "Test Project")
+    |> Factory.add_goal(:goal, :space, name: "Test Goal")
+  end
+
+  test "adds goal_name to project_goal_connection activities when goal exists", ctx do
+    activity = create_test_activity(ctx.creator, ctx.project.id, ctx.goal.id)
+
+    assert activity.content["goal_name"] == nil
+
+    Change076EnhanceProjectGoalConnectionActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["goal_name"] == "Test Goal"
+  end
+
+  test "sets goal_name to nil for project_goal_connection activities when goal doesn't exist", ctx do
+    # Create activity with non-existent goal_id
+    activity = create_test_activity(ctx.creator, ctx.project.id, Ecto.UUID.generate())
+
+    assert activity.content["goal_name"] == nil
+
+    Change076EnhanceProjectGoalConnectionActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["goal_name"] == nil
+  end
+
+  test "handles case where goal_id is nil", ctx do
+    activity = create_test_activity(ctx.creator, ctx.project.id, nil)
+
+    assert activity.content["goal_name"] == nil
+
+    Change076EnhanceProjectGoalConnectionActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["goal_name"] == nil
+  end
+
+  defp create_test_activity(person, project_id, goal_id) do
+    attrs = %{
+      action: "project_goal_connection",
+      author_id: person.id,
+      content: %{
+        "company_id" => Ecto.UUID.generate(),
+        "space_id" => Ecto.UUID.generate(),
+        "project_id" => project_id,
+        "goal_id" => goal_id
+      }
+    }
+
+    {:ok, activity} = Repo.insert(struct(Activity, attrs))
+
+    activity
+  end
+end


### PR DESCRIPTION
This is an attempt to solve https://github.com/operately/operately/issues/3153.

Unfortunately, the error message doesn't specify which activity caused the error. However, I managed to reproduce the same error in the activity `ProjectGoalConnection`. Now, the feed doesn't break if some information in the activity is missing.