### PR TITLE
fix: Created by link redirects to correct page on Task V2 page

### DIFF
--- a/turboui/src/TaskPage/Sidebar.tsx
+++ b/turboui/src/TaskPage/Sidebar.tsx
@@ -79,7 +79,7 @@ function CreatedBy(props: TaskPage.State) {
           person={props.createdBy}
           size={"tiny"}
           nameFormat="short"
-          link={`/people/${props.createdBy.id}`}
+          link={props.createdBy.profileLink}
         />
         <div className="flex items-center gap-1.5 ml-1 text-content-dimmed text-xs">
           <IconCalendar size={14} />

--- a/turboui/src/TaskPage/index.tsx
+++ b/turboui/src/TaskPage/index.tsx
@@ -25,6 +25,7 @@ export namespace TaskPage {
     id: string;
     fullName: string;
     avatarUrl: string | null;
+    profileLink: string;
   }
 
   export interface Milestone {

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -34,6 +34,7 @@ export const mockTaskPeople: TaskPage.Person[] = timelinePeople.map(p => ({
   id: p.id,
   fullName: p.fullName,
   avatarUrl: p.avatarUrl || null,
+  profileLink: "#",
 }));
 
 // Mock milestone data for TaskPage - sorted by due date (earliest first), with some without due dates


### PR DESCRIPTION
The "created by" link was redirecting to an inexistent page.