### PR TITLE
chore: Add task_v2 ff to enable new Task page

### DIFF
--- a/app/assets/js/pages/TaskPage/loader.tsx
+++ b/app/assets/js/pages/TaskPage/loader.tsx
@@ -1,11 +1,16 @@
 import * as Pages from "@/components/Pages";
 import * as Tasks from "@/models/tasks";
+import { Paths } from "@/routes/paths";
+import { redirectIfFeatureEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 interface LoaderResult {
   task: Tasks.Task;
 }
 
 export async function loader({ params }): Promise<LoaderResult> {
+  const paths = new Paths({ companyId: params.companyId });
+  await redirectIfFeatureEnabled(params, { feature: "task_v2", path: paths.taskV2Path(params.id) });
+
   return {
     task: await Tasks.getTask({
       id: params.id,

--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -8,7 +8,7 @@ import { parseContextualDate, serializeContextualDate } from "@/models/contextua
 import { parseMilestoneForTurboUi, parseMilestonesForTurboUi } from "@/models/milestones";
 import * as Time from "@/utils/time";
 
-import { usePaths } from "../../routes/paths";
+import { Paths, usePaths } from "../../routes/paths";
 import { showErrorToast, TaskPage } from "turboui";
 import { PageModule } from "../../routes/types";
 import { PageCache } from "@/routes/PageCache";
@@ -17,6 +17,7 @@ import { assertPresent } from "@/utils/assertions";
 import { usePersonFieldContributorsSearch } from "@/models/projectContributors";
 import { projectPageCacheKey } from "../ProjectV2Page";
 import { parseSpaceForTurboUI } from "@/models/spaces";
+import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
 
 type LoaderResult = {
   data: {
@@ -26,6 +27,9 @@ type LoaderResult = {
 };
 
 async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
+  const paths = new Paths({ companyId: params.companyId });
+  await redirectIfFeatureNotEnabled(params, { feature: "task_v2", path: paths.taskPath(params.id) });
+
   return await PageCache.fetch({
     cacheKey: pageCacheKey(params.id),
     refreshCache,

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -440,6 +440,10 @@ export class Paths {
     return this.createCompanyPath(["tasks", taskId]);
   }
 
+  taskV2Path(taskId: string) {
+    return this.createCompanyPath(["tasks", taskId, "v2"]);
+  }
+
   //
   // Private utility methods
   //


### PR DESCRIPTION
We can now use the `task_v2` feature flag to enable the new Task page.