### PR TITLE
fix: Task without milestone doesn't return 404

### DIFF
--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -62,7 +62,6 @@ function Page() {
 
   assertPresent(task.project, "Task must have a project");
   assertPresent(task.space, "Task must have a space");
-  assertPresent(task.milestone, "Task must have a milestone");
 
   const workmapLink = paths.spaceWorkMapPath(task.space.id, "projects" as const);
 

--- a/app/lib/operately_web/api/queries/get_task.ex
+++ b/app/lib/operately_web/api/queries/get_task.ex
@@ -34,8 +34,7 @@ defmodule OperatelyWeb.Api.Queries.GetTask do
     include_filters = extract_include_filters(inputs)
 
     from(t in Task,
-      join: m in assoc(t, :milestone),
-      join: p in assoc(m, :project), as: :project,
+      join: p in assoc(t, :project), as: :project,
       where: t.id == ^inputs.id
     )
     |> Task.scope_company(person.company_id)
@@ -48,7 +47,7 @@ defmodule OperatelyWeb.Api.Queries.GetTask do
     Enum.reduce(requested, query, fn include, q ->
       case include do
         :include_assignees -> from t in q, preload: [:assigned_people]
-        :include_milestone -> from [_, m, p] in q, preload: [milestone: {m, [project: p]}]
+        :include_milestone -> from t in q, preload: [milestone: :project]
         :include_project -> from [project: p] in q, preload: [project: p]
         :include_creator -> from t in q, preload: [:creator]
         :include_space -> from t in q, preload: :group


### PR DESCRIPTION
The Task page no longer shows 404 if the Task doesn't have a milestone.