### PR TITLE
chore: Add task scope to get_activities query

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1880,6 +1880,8 @@ export type UpdateContent =
   | UpdateContentProjectDiscussion
   | UpdateContentMessage;
 
+export type ActivityScopeType = "person" | "company" | "space" | "project" | "task" | "goal";
+
 export type AgentMessageSender = "user" | "ai";
 
 export type AgentMessageStatus = "pending" | "done";
@@ -1981,13 +1983,13 @@ export interface GetAccountResult {
 }
 
 export interface GetActivitiesInput {
-  scopeId?: string | null;
-  scopeType?: string | null;
-  actions?: string[] | null;
+  scopeId: string;
+  scopeType: ActivityScopeType;
+  actions: string[];
 }
 
 export interface GetActivitiesResult {
-  activities?: Activity[] | null;
+  activities: Activity[];
 }
 
 export interface GetActivityInput {

--- a/app/lib/operately_web/api/queries/get_activities.ex
+++ b/app/lib/operately_web/api/queries/get_activities.ex
@@ -65,7 +65,7 @@ defmodule OperatelyWeb.Api.Queries.GetActivities do
     from a in query, where: fragment("? ->> ? = ?", a.content, "company_id", ^company_id)
   end
 
-  def scope_query(query, "person", scope_id) do
+  def scope_query(query, :person, scope_id) do
     from a in query, where: a.author_id == ^scope_id
   end
 

--- a/app/lib/operately_web/api/queries/get_activities.ex
+++ b/app/lib/operately_web/api/queries/get_activities.ex
@@ -11,49 +11,35 @@ defmodule OperatelyWeb.Api.Queries.GetActivities do
   import Ecto.Query, only: [from: 2, limit: 2, preload: 2]
 
   inputs do
-    field? :scope_id, :string, null: true
-    field? :scope_type, :string, null: true
-    field? :actions, list_of(:string), null: true
+    field :scope_id, :string, null: false
+    field :scope_type, :activity_scope_type, null: false
+    field :actions, list_of(:string), null: false
   end
 
   outputs do
-    field? :activities, list_of(:activity), null: true
+    field :activities, list_of(:activity), null: false
   end
 
   def call(conn, inputs) do
     actions = inputs[:actions] || []
-    {:ok, scope_type, scope_id} = decode_scope(inputs)
-    activities = load_activities(me(conn), scope_type, scope_id, actions)
+    {:ok, scope_id} = decode_scope_id(inputs)
+
+    activities = load_activities(me(conn), inputs.scope_type, scope_id, actions)
 
     {:ok, %{activities: OperatelyWeb.Api.Serializers.Activity.serialize(activities)}}
   end
 
-  def decode_scope(inputs) do
-    scope_id = inputs[:scope_id]
-    scope_type = inputs[:scope_type]
-
-    case scope_type do
-      "space" ->
-        {:ok, id} = decode_id(scope_id)
-        {:ok, scope_type, id}
-
-      "company" ->
-        scope_id = id_without_comments(scope_id)
+  def decode_scope_id(inputs) do
+    case inputs[:scope_type] do
+      :company ->
+        scope_id = id_without_comments(inputs[:scope_id])
         {:ok, id} = ShortId.decode(scope_id)
         company = Operately.Repo.get_by(Operately.Companies.Company, short_id: id)
-        {:ok, scope_type, company.id}
-
-      "project" ->
-        {:ok, id} = decode_id(scope_id)
-        {:ok, scope_type, id}
-
-      "goal" ->
-        {:ok, id} = decode_id(scope_id)
-        {:ok, scope_type, id}
+        {:ok, company.id}
 
       _ ->
-        {:ok, id} = decode_id(scope_id)
-        {:ok, scope_type, id}
+        {:ok, scope_id} = decode_id(inputs.scope_id)
+        {:ok, scope_id}
     end
   end
 

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -458,6 +458,8 @@ defmodule OperatelyWeb.Api.Types do
     field? :permissions, :activity_permissions, null: true
   end
 
+  enum(:activity_scope_type, values: [:person, :company, :space, :project, :task, :goal])
+
   object :activity_permissions do
     field? :can_comment_on_thread, :boolean, null: true
     field? :can_view, :boolean, null: true


### PR DESCRIPTION
We can now use `OperatelyWeb.Api.Queries.GetActivities` to get the `Task` activities.