### PR TITLE
feat: Enable feed on new Task page

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -134,13 +134,13 @@ export interface Account {
 }
 
 export interface Activity {
-  id?: string | null;
+  id: string;
   scopeType?: string | null;
   scopeId?: string | null;
   resourceId?: string | null;
   resourceType?: string | null;
-  action?: string | null;
-  insertedAt?: string | null;
+  action: string;
+  insertedAt: string;
   updatedAt?: string | null;
   commentThread?: CommentThread | null;
   author?: Person | null;

--- a/app/assets/js/features/activities/TaskAdding/index.tsx
+++ b/app/assets/js/features/activities/TaskAdding/index.tsx
@@ -1,0 +1,69 @@
+import type { ActivityContentTaskAdding } from "@/api";
+import type { Activity } from "@/models/activities";
+import { Paths } from "@/routes/paths";
+import { feedTitle, projectLink, taskLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
+
+const TaskAdding: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths: Paths, activity: Activity) {
+    return paths.taskV2Path(content(activity).task!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: string }) {
+    const { project, taskName, task } = content(activity);
+    const tName = task ? taskLink(task) : `"${taskName}"`;
+
+    if (page === "project" || page === "task") {
+      return feedTitle(activity, "added the task", tName);
+    } else {
+      return feedTitle(activity, "added the task", tName, "in", projectLink(project));
+    }
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(props: { activity: Activity }) {
+    const { taskName } = content(props.activity);
+    return `New task "${taskName}" was created`;
+  },
+
+  NotificationLocation(props: { activity: Activity }) {
+    return content(props.activity).project!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentTaskAdding {
+  return activity.content as ActivityContentTaskAdding;
+}
+
+export default TaskAdding;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -124,6 +124,7 @@ export const DISPLAYED_IN_FEED = [
   "project_timeline_edited",
   "project_retrospective_commented",
   "project_discussion_submitted",
+  "task_adding",
   "task_name_updating",
   "task_status_updating",
   "task_deleting",
@@ -196,6 +197,7 @@ import ProjectContributorRemoved from "@/features/activities/ProjectContributorR
 import ProjectContributorsAddition from "@/features/activities/ProjectContributorsAddition";
 import ProjectCreated from "@/features/activities/ProjectCreated";
 import ProjectDiscussionSubmitted from "@/features/activities/ProjectDiscussionSubmitted";
+import TaskAdding from "@/features/activities/TaskAdding";
 import TaskNameUpdating from "@/features/activities/TaskNameUpdating";
 import TaskStatusUpdating from "@/features/activities/TaskStatusUpdating";
 import TaskDescriptionChange from "@/features/activities/TaskDescriptionChange";
@@ -328,6 +330,7 @@ function handler(activity: Activity) {
     .with("goal_target_deleting", () => GoalTargetDeleting)
     .with("goal_target_updating", () => GoalTargetUpdating)
     .with("project_discussion_submitted", () => ProjectDiscussionSubmitted)
+    .with("task_adding", () => TaskAdding)
     .with("task_name_updating", () => TaskNameUpdating)
     .with("task_status_updating", () => TaskStatusUpdating)
     .with("task_deleting", () => TaskDeleting)

--- a/app/assets/js/models/activities/tasks.tsx
+++ b/app/assets/js/models/activities/tasks.tsx
@@ -1,0 +1,35 @@
+import { Activity } from "@/api";
+import { TaskCreationActivity } from "turboui";
+import { parsePersonForTurboUi } from "../people";
+import { Paths } from "@/routes/paths";
+
+const HANDLED_ACTIVITY_TYPES = ["task_adding"];
+
+type TurboUiPerson = NonNullable<ReturnType<typeof parsePersonForTurboUi>>;
+
+export function parseActivitiesForTurboUi(paths: Paths, activities: Activity[]) {
+  return activities
+    .filter((activity) => HANDLED_ACTIVITY_TYPES.includes(activity.action))
+    .map((activity) => parseActivityForTurboUi(paths, activity))
+    .filter((activity) => activity !== null);
+}
+
+function parseActivityForTurboUi(paths: Paths, activity: Activity) {
+  const author = parsePersonForTurboUi(paths, activity.author);
+
+  switch (activity.action) {
+    case "task_adding":
+      return parseTaskCreationActivity(author!, activity);
+    default:
+      return null;
+  }
+}
+
+function parseTaskCreationActivity(author: TurboUiPerson, activity: Activity): TaskCreationActivity {
+  return {
+    id: activity.id,
+    type: "task_adding",
+    author,
+    insertedAt: activity.insertedAt,
+  };
+}

--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import Api from "@/api";
 
 import { useNavigate } from "react-router-dom";
-import * as Tasks from "../../models/tasks";
-import * as People from "../../models/people";
+import * as Tasks from "@/models/tasks";
+import * as People from "@/models/people";
+import * as Activities from "@/models/activities";
 import { parseContextualDate, serializeContextualDate } from "@/models/contextualDates";
 import { parseMilestoneForTurboUi, parseMilestonesForTurboUi } from "@/models/milestones";
 import * as Time from "@/utils/time";
@@ -18,11 +19,14 @@ import { usePersonFieldContributorsSearch } from "@/models/projectContributors";
 import { projectPageCacheKey } from "../ProjectV2Page";
 import { parseSpaceForTurboUI } from "@/models/spaces";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
+import { parseActivitiesForTurboUi } from "@/models/activities/tasks";
+import { useMe } from "@/contexts/CurrentCompanyContext";
 
 type LoaderResult = {
   data: {
     task: Tasks.Task;
     tasksCount: number;
+    activities: Activities.Activity[];
   };
   cacheVersion: number;
 };
@@ -45,12 +49,17 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
           includeSpace: true,
         }).then((d) => d.task!),
         tasksCount: Api.project_tasks.getOpenTaskCount({ id: params.id, useTaskId: true }).then((d) => d.count!),
+        activities: Api.getActivities({
+          scopeId: params.id,
+          scopeType: "task",
+          actions: ["task_adding"],
+        }).then((d) => d.activities!),
       }),
   });
 }
 
 function pageCacheKey(id: string): string {
-  return `v4-TaskV2Page.task-${id}`;
+  return `v5-TaskV2Page.task-${id}`;
 }
 
 export default { name: "TaskV2Page", loader, Page } as PageModule;
@@ -58,7 +67,8 @@ export default { name: "TaskV2Page", loader, Page } as PageModule;
 function Page() {
   const paths = usePaths();
   const navigate = useNavigate();
-  const { task, tasksCount } = PageCache.useData(loader).data;
+  const currentUser = useMe();
+  const { task, tasksCount, activities } = PageCache.useData(loader).data;
 
   assertPresent(task.project, "Task must have a project");
   assertPresent(task.space, "Task must have a space");
@@ -144,6 +154,10 @@ function Page() {
     searchPeople: assigneeSearch,
     updateProjectName: setProjectName,
 
+    // Timeline
+    currentUser: People.parsePersonForTurboUi(paths, currentUser)!,
+    timelineItems: prepareTimelineItems(paths, activities), 
+
     // Milestone selection
     milestone: milestone as TaskPage.Milestone | null,
     onMilestoneChange: setMilestone,
@@ -151,20 +165,13 @@ function Page() {
 
     // Core task data
     name: name as string,
-    onNameChange: (newName) => {
-      setName(newName);
-      return Promise.resolve(true);
-    },
-
+    onNameChange: setName,
     description,
     onDescriptionChange: setDescription,
-
     status,
     onStatusChange: setStatus,
-
     dueDate: dueDate || undefined,
     onDueDateChange: setDueDate,
-
     assignee,
     onAssigneeChange: setAssignee,
 
@@ -271,4 +278,13 @@ function useMilestonesSearch(projectId): TaskPage.Props["searchMilestones"] {
 
     return parseMilestonesForTurboUi(paths, data.milestones || []);
   };
+}
+
+function prepareTimelineItems(paths: Paths, activities: Activities.Activity[]) {
+  const parsedActivities = parseActivitiesForTurboUi(paths, activities);
+
+  return parsedActivities.map((activity) => ({
+    type: "task-activity" as const,
+    value: activity,
+  }));
 }

--- a/app/lib/operately_web/api/serializers/activity.ex
+++ b/app/lib/operately_web/api/serializers/activity.ex
@@ -284,10 +284,6 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_content("task_adding", _content) do
-    %{}
-  end
-
   def serialize_content("task_assignee_assignment", _content) do
     %{}
   end

--- a/app/lib/operately_web/api/serializers/activity_content/task_adding.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/task_adding.ex
@@ -1,0 +1,14 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.TaskAdding do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      company: Serializer.serialize(content["company"], level: :essential),
+      space: Serializer.serialize(content["space"], level: :essential),
+      project: Serializer.serialize(content["project"], level: :essential),
+      milestone: Serializer.serialize(content["milestone"], level: :essential),
+      task: Serializer.serialize(content["task"], level: :essential),
+      task_name: content["name"]
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -440,20 +440,20 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :activity do
-    field? :id, :string, null: true
+    field :id, :string, null: false
     field? :scope_type, :string, null: true
     field? :scope_id, :string, null: true
     field? :resource_id, :string, null: true
     field? :resource_type, :string, null: true
-    field? :action, :string, null: true
-    field? :inserted_at, :datetime, null: true
+    field :action, :string, null: false
+    field :inserted_at, :datetime, null: false
     field? :updated_at, :datetime, null: true
     field? :comment_thread, :comment_thread, null: true
     field? :author, :person, null: true
     field? :resource, :activity_resource_union, null: true
     field? :person, :person, null: true
     field? :event_data, :activity_data_union, null: true
-    field? :content, :activity_content, null: true
+    field :content, :activity_content, null: false
     field? :notifications, list_of(:notification), null: true
     field? :permissions, :activity_permissions, null: true
   end

--- a/turboui/src/TaskPage/index.tsx
+++ b/turboui/src/TaskPage/index.tsx
@@ -81,9 +81,9 @@ export namespace TaskPage {
     onArchive?: () => void;
 
     // Search functionality for assignees
-    searchPeople?: (params: { query: string }) => Promise<Person[]>;
+    searchPeople: (params: { query: string }) => Promise<Person[]>;
     // Search functionality for rich editor mentions
-    peopleSearch?: SearchFn;
+    peopleSearch: SearchFn;
     // Person lookup for rich content mentions
     mentionedPersonLookup: MentionedPersonLookupFn;
 

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -228,13 +228,13 @@ export function createActiveTaskTimeline(): TimelineItemType[] {
       action: "attached",
     }),
     createComment(alice, "This is a critical feature for the beta release. Let's prioritize it.", 6.5 * 60 * 60 * 1000),
-    createTaskActivity("task-creation", alice, 24 * 60 * 60 * 1000), // 1 day ago
+    createTaskActivity("task_adding", alice, 24 * 60 * 60 * 1000), // 1 day ago
   ];
 }
 
 export function createMinimalTaskTimeline(): TimelineItemType[] {
   return [
-    createTaskActivity("task-creation", alice, 2 * 60 * 60 * 1000), // 2 hours ago
+    createTaskActivity("task_adding", alice, 2 * 60 * 60 * 1000), // 2 hours ago
   ];
 }
 
@@ -245,7 +245,7 @@ export function createCompletedTaskTimeline(): TimelineItemType[] {
     createComment(bob, "All tests are passing and the feature is ready for release!", 2 * 60 * 60 * 1000),
     createComment(charlie, "The design looks perfect. Nice work on the animations!", 4 * 60 * 60 * 1000),
     createTaskActivity("task-assignment", alice, 2 * 24 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
-    createTaskActivity("task-creation", alice, 3 * 24 * 60 * 60 * 1000),
+    createTaskActivity("task_adding", alice, 3 * 24 * 60 * 60 * 1000),
   ];
 }
 
@@ -257,7 +257,7 @@ export function createOverdueTaskTimeline(): TimelineItemType[] {
       toDueDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     }),
     createTaskActivity("task-assignment", alice, 5 * 24 * 60 * 60 * 1000, { assignee: charlie, action: "assigned" }),
-    createTaskActivity("task-creation", alice, 7 * 24 * 60 * 60 * 1000),
+    createTaskActivity("task_adding", alice, 7 * 24 * 60 * 60 * 1000),
   ];
 }
 
@@ -281,6 +281,6 @@ export function createLongContentTimeline(): TimelineItemType[] {
     createTaskActivity("task-description", alice, 6 * 60 * 60 * 1000, { hasContent: true }),
     createTaskActivity("task-status-change", bob, 8 * 60 * 60 * 1000, { fromStatus: "todo", toStatus: "in_progress" }),
     createTaskActivity("task-assignment", alice, 12 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
-    createTaskActivity("task-creation", alice, 24 * 60 * 60 * 1000),
+    createTaskActivity("task_adding", alice, 24 * 60 * 60 * 1000),
   ];
 }

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -79,7 +79,7 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
       return <IconFileText {...iconProps} className="text-purple-500" />;
     case "task-title":
       return <IconEdit {...iconProps} className="text-gray-500" />;
-    case "task-creation":
+    case "task_adding":
       return <IconPlus {...iconProps} className="text-green-500" />;
     default:
       return <IconActivity {...iconProps} />;
@@ -208,7 +208,7 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
         </span>
       );
 
-    case "task-creation":
+    case "task_adding":
       return <span className="text-content-dimmed">created this task</span>;
 
     default:

--- a/turboui/src/Timeline/index.stories.tsx
+++ b/turboui/src/Timeline/index.stories.tsx
@@ -131,7 +131,7 @@ const mockTaskCreation: TimelineItem = {
   type: "task-activity",
   value: {
     id: "activity-6",
-    type: "task-creation",
+    type: "task_adding",
     author: mockUser,
     insertedAt: new Date(Date.now() - 86400000).toISOString(), // 1 day ago
   } as TaskActivity,

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -66,7 +66,7 @@ export interface TaskTitleActivity {
 
 export interface TaskCreationActivity {
   id: string;
-  type: "task-creation";
+  type: "task_adding";
   author: Person;
   insertedAt: string;
 }


### PR DESCRIPTION
The feed is now displayed on the Task page. Currently, only the TaskAdding activity is handled.