### PR TITLE
feat: Add handler for task_name_updating activity

### DIFF
--- a/app/assets/js/models/activities/tasks.tsx
+++ b/app/assets/js/models/activities/tasks.tsx
@@ -1,15 +1,15 @@
-import { Activity } from "@/api";
-import { TaskCreationActivity } from "turboui";
+import { Activity, ActivityContentTaskNameUpdating } from "@/api";
+import { TaskCreationActivity, TaskTitleActivity, TaskDescriptionActivity } from "turboui";
 import { parsePersonForTurboUi } from "../people";
 import { Paths } from "@/routes/paths";
 
-const HANDLED_ACTIVITY_TYPES = ["task_adding"];
+export const SUPPORTED_ACTIVITY_TYPES = ["task_adding", "task_name_updating", "task_description_change"];
 
 type TurboUiPerson = NonNullable<ReturnType<typeof parsePersonForTurboUi>>;
 
 export function parseActivitiesForTurboUi(paths: Paths, activities: Activity[]) {
   return activities
-    .filter((activity) => HANDLED_ACTIVITY_TYPES.includes(activity.action))
+    .filter((activity) => SUPPORTED_ACTIVITY_TYPES.includes(activity.action))
     .map((activity) => parseActivityForTurboUi(paths, activity))
     .filter((activity) => activity !== null);
 }
@@ -20,6 +20,13 @@ function parseActivityForTurboUi(paths: Paths, activity: Activity) {
   switch (activity.action) {
     case "task_adding":
       return parseTaskCreationActivity(author!, activity);
+    case "task_name_updating":
+      return parseTaskNameUpdatingActivity(author!, activity, activity.content as ActivityContentTaskNameUpdating);
+    case "task_description_change":
+      return parseTaskDescriptionChangeActivity(
+        author!,
+        activity,
+      );
     default:
       return null;
   }
@@ -31,5 +38,33 @@ function parseTaskCreationActivity(author: TurboUiPerson, activity: Activity): T
     type: "task_adding",
     author,
     insertedAt: activity.insertedAt,
+  };
+}
+
+function parseTaskNameUpdatingActivity(
+  author: TurboUiPerson,
+  activity: Activity,
+  content: ActivityContentTaskNameUpdating,
+): TaskTitleActivity {
+  return {
+    id: activity.id,
+    type: "task_name_updating",
+    author,
+    insertedAt: activity.insertedAt,
+    fromTitle: content.oldName,
+    toTitle: content.newName,
+  };
+}
+
+function parseTaskDescriptionChangeActivity(
+  author: TurboUiPerson,
+  activity: Activity,
+): TaskDescriptionActivity {
+  return {
+    id: activity.id,
+    type: "task_description_change",
+    author,
+    insertedAt: activity.insertedAt,
+    hasContent: true,
   };
 }

--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -7,6 +7,7 @@ import * as People from "@/models/people";
 import * as Activities from "@/models/activities";
 import { parseContextualDate, serializeContextualDate } from "@/models/contextualDates";
 import { parseMilestoneForTurboUi, parseMilestonesForTurboUi } from "@/models/milestones";
+import { parseActivitiesForTurboUi, SUPPORTED_ACTIVITY_TYPES } from "@/models/activities/tasks";
 import * as Time from "@/utils/time";
 
 import { Paths, usePaths } from "../../routes/paths";
@@ -19,7 +20,6 @@ import { usePersonFieldContributorsSearch } from "@/models/projectContributors";
 import { projectPageCacheKey } from "../ProjectV2Page";
 import { parseSpaceForTurboUI } from "@/models/spaces";
 import { redirectIfFeatureNotEnabled } from "@/routes/redirectIfFeatureEnabled";
-import { parseActivitiesForTurboUi } from "@/models/activities/tasks";
 import { useMe } from "@/contexts/CurrentCompanyContext";
 
 type LoaderResult = {
@@ -52,7 +52,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
         activities: Api.getActivities({
           scopeId: params.id,
           scopeType: "task",
-          actions: ["task_adding"],
+          actions: SUPPORTED_ACTIVITY_TYPES,
         }).then((d) => d.activities!),
       }),
   });

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -278,7 +278,7 @@ export function createLongContentTimeline(): TimelineItemType[] {
       "I've implemented all the requirements from the spec. The authentication flow now supports both email/password and social login.",
       4 * 60 * 60 * 1000,
     ),
-    createTaskActivity("task-description", alice, 6 * 60 * 60 * 1000, { hasContent: true }),
+    createTaskActivity("task_description_change", alice, 6 * 60 * 60 * 1000, { hasContent: true }),
     createTaskActivity("task-status-change", bob, 8 * 60 * 60 * 1000, { fromStatus: "todo", toStatus: "in_progress" }),
     createTaskActivity("task-assignment", alice, 12 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
     createTaskActivity("task_adding", alice, 24 * 60 * 60 * 1000),

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -75,9 +75,9 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
       ) : (
         <IconCalendarMinus {...iconProps} className="text-orange-500" />
       );
-    case "task-description":
+    case "task_description_change":
       return <IconFileText {...iconProps} className="text-purple-500" />;
-    case "task-title":
+    case "task_name_updating":
       return <IconEdit {...iconProps} className="text-gray-500" />;
     case "task_adding":
       return <IconPlus {...iconProps} className="text-green-500" />;
@@ -193,14 +193,14 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
       }
       return <span className="text-content-dimmed">updated due date</span>;
 
-    case "task-description":
+    case "task_description_change":
       return (
         <span className="text-content-dimmed">
           {activity.hasContent ? "updated the description" : "removed the description"}
         </span>
       );
 
-    case "task-title":
+    case "task_name_updating":
       return (
         <span className="text-content-dimmed">
           changed title from <span className="font-medium text-content-dimmed">"{activity.fromTitle}"</span> to{" "}

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -49,7 +49,7 @@ export interface TaskDueDateActivity {
 
 export interface TaskDescriptionActivity {
   id: string;
-  type: "task-description";
+  type: "task_description_change";
   author: Person;
   insertedAt: string;
   hasContent: boolean; // Whether description was added/updated vs removed
@@ -57,7 +57,7 @@ export interface TaskDescriptionActivity {
 
 export interface TaskTitleActivity {
   id: string;
-  type: "task-title";
+  type: "task_name_updating";
   author: Person;
   insertedAt: string;
   fromTitle: string;


### PR DESCRIPTION
The `task_name_updating` activity is now displayed on the new Task page.