### PR TITLE
feat: Add handler for task_assignee_updating activity

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -147,7 +147,7 @@ export interface Activity {
   resource?: ActivityResourceUnion | null;
   person?: Person | null;
   eventData?: ActivityDataUnion | null;
-  content?: ActivityContent | null;
+  content: ActivityContent;
   notifications?: Notification[] | null;
   permissions?: ActivityPermissions | null;
 }
@@ -187,7 +187,6 @@ export interface ActivityContentCompanyOwnerRemoving {
   companyId?: string | null;
   personId?: string | null;
   person?: Person | null;
-  company?: Company | null;
 }
 
 export interface ActivityContentCompanyOwnersAdding {
@@ -792,6 +791,13 @@ export interface ActivityContentTaskAssigneeAssignment {
   spaceId?: string | null;
   taskId?: string | null;
   personId?: string | null;
+}
+
+export interface ActivityContentTaskAssigneeUpdating {
+  project: Project;
+  task: Task;
+  oldAssignee: Person;
+  newAssignee: Person;
 }
 
 export interface ActivityContentTaskClosing {

--- a/app/assets/js/features/activities/TaskAssigneeUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskAssigneeUpdating/index.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+
+import type { ActivityContentTaskAssigneeUpdating } from "@/api";
+import type { Activity } from "@/models/activities";
+import { Paths } from "@/routes/paths";
+import { feedTitle, projectLink, taskLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
+import { AvatarWithName } from "turboui";
+
+const TaskAssigneeUpdating: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths: Paths, activity: Activity) {
+    return paths.projectPath(content(activity).project!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: string }) {
+    const { project, task, newAssignee, oldAssignee } = content(activity);
+    const assigneeText = newAssignee ? `assigned to ${newAssignee.fullName}` : `unassigned ${oldAssignee.fullName} from`;
+    const message = `${assigneeText} task`;
+
+    if (page === "project") {
+      return feedTitle(activity, message, taskLink(task));
+    } else {
+      return feedTitle(activity, message, taskLink(task), "in", projectLink(project));
+    }
+  },
+
+  FeedItemContent({ activity }: { activity: Activity; page: any }) {
+    const { oldAssignee, newAssignee } = content(activity);
+
+    if (!newAssignee) return null;
+
+    return (
+      <div className="flex items-center gap-2">
+        {oldAssignee ? (
+          <>
+            <span>Previously assigned to:</span>
+            <div className="flex items-center gap-1">
+              <AvatarWithName person={oldAssignee} size="tiny" />
+            </div>
+          </>
+        ) : (
+          <span>Previously it was unassigned</span>
+        )}
+      </div>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(props: { activity: Activity }) {
+    const { task, newAssignee } = content(props.activity);
+    const assigneeText = newAssignee ? `assigned to ${newAssignee.fullName}` : "unassigned";
+
+    return `Task "${task.name}" was ${assigneeText}`;
+  },
+
+  NotificationLocation(props: { activity: Activity }) {
+    return content(props.activity).project!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentTaskAssigneeUpdating {
+  return activity.content as ActivityContentTaskAssigneeUpdating;
+}
+
+export default TaskAssigneeUpdating;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -130,6 +130,7 @@ export const DISPLAYED_IN_FEED = [
   "task_deleting",
   "task_description_change",
   "task_due_date_updating",
+  "task_assignee_updating",
   "resource_hub_document_created",
   "resource_hub_document_edited",
   "resource_hub_document_commented",
@@ -203,6 +204,7 @@ import TaskStatusUpdating from "@/features/activities/TaskStatusUpdating";
 import TaskDescriptionChange from "@/features/activities/TaskDescriptionChange";
 import TaskDueDateUpdating from "@/features/activities/TaskDueDateUpdating";
 import TaskDeleting from "@/features/activities/TaskDeleting";
+import TaskAssigneeUpdating from "@/features/activities/TaskAssigneeUpdating";
 import ProjectGoalConnection from "@/features/activities/ProjectGoalConnection";
 import ProjectGoalDisconnection from "@/features/activities/ProjectGoalDisconnection";
 import ProjectKeyResourceAdded from "@/features/activities/ProjectKeyResourceAdded";
@@ -336,6 +338,7 @@ function handler(activity: Activity) {
     .with("task_deleting", () => TaskDeleting)
     .with("task_description_change", () => TaskDescriptionChange)
     .with("task_due_date_updating", () => TaskDueDateUpdating)
+    .with("task_assignee_updating", () => TaskAssigneeUpdating)
     .with("project_champion_updating", () => ProjectChampionUpdating)
     .with("project_due_date_updating", () => ProjectDueDateUpdating)
     .with("project_reviewer_updating", () => ProjectReviewerUpdating)

--- a/app/assets/js/models/activities/tasks.tsx
+++ b/app/assets/js/models/activities/tasks.tsx
@@ -1,9 +1,9 @@
-import { Activity, ActivityContentTaskNameUpdating } from "@/api";
-import { TaskCreationActivity, TaskTitleActivity, TaskDescriptionActivity } from "turboui";
+import { Activity, ActivityContentTaskNameUpdating, ActivityContentTaskAssigneeUpdating } from "@/api";
+import { TaskCreationActivity, TaskTitleActivity, TaskDescriptionActivity, TaskAssignmentActivity } from "turboui";
 import { parsePersonForTurboUi } from "../people";
 import { Paths } from "@/routes/paths";
 
-export const SUPPORTED_ACTIVITY_TYPES = ["task_adding", "task_name_updating", "task_description_change"];
+export const SUPPORTED_ACTIVITY_TYPES = ["task_adding", "task_name_updating", "task_description_change", "task_assignee_updating"];
 
 type TurboUiPerson = NonNullable<ReturnType<typeof parsePersonForTurboUi>>;
 
@@ -23,10 +23,9 @@ function parseActivityForTurboUi(paths: Paths, activity: Activity) {
     case "task_name_updating":
       return parseTaskNameUpdatingActivity(author!, activity, activity.content as ActivityContentTaskNameUpdating);
     case "task_description_change":
-      return parseTaskDescriptionChangeActivity(
-        author!,
-        activity,
-      );
+      return parseTaskDescriptionChangeActivity(author!, activity);
+    case "task_assignee_updating":
+      return parseTaskAssigneeUpdatingActivity(paths, author!, activity, activity.content as ActivityContentTaskAssigneeUpdating);
     default:
       return null;
   }
@@ -66,5 +65,21 @@ function parseTaskDescriptionChangeActivity(
     author,
     insertedAt: activity.insertedAt,
     hasContent: true,
+  };
+}
+
+function parseTaskAssigneeUpdatingActivity(
+  paths: Paths,
+  author: TurboUiPerson,
+  activity: Activity,
+  content: ActivityContentTaskAssigneeUpdating,
+): TaskAssignmentActivity {
+  return {
+    id: activity.id,
+    type: "task_assignee_updating",
+    author,
+    insertedAt: activity.insertedAt,
+    assignee: parsePersonForTurboUi(paths, content.newAssignee || content.oldAssignee)!,
+    action: content.newAssignee ? "assigned" : "unassigned",
   };
 }

--- a/app/lib/operately_web/api/project_tasks.ex
+++ b/app/lib/operately_web/api/project_tasks.ex
@@ -229,7 +229,7 @@ defmodule OperatelyWeb.Api.ProjectTasks do
     def call(conn, inputs) do
       conn
       |> Steps.start_transaction()
-      |> Steps.find_task(inputs.task_id)
+      |> Steps.find_task(inputs.task_id, [:assigned_people])
       |> Steps.check_task_permissions(:can_edit_task)
       |> Steps.update_task_assignee(inputs.assignee_id)
       |> Steps.save_activity(:task_assignee_updating, fn changes ->
@@ -389,9 +389,11 @@ defmodule OperatelyWeb.Api.ProjectTasks do
       end)
     end
 
-    def find_task(multi, task_id) do
+    def find_task(multi, task_id, preloads \\ []) do
       Ecto.Multi.run(multi, :task, fn _repo, %{me: me} ->
-        case Operately.Tasks.Task.get(me, id: task_id, opts: [preload: [:project]]) do
+        preloads = [:project] ++ preloads
+
+        case Operately.Tasks.Task.get(me, id: task_id, opts: [preload: preloads]) do
           {:ok, task} -> {:ok, task}
           {:error, _} -> {:error, {:not_found, "Task not found"}}
         end

--- a/app/lib/operately_web/api/serializers/activity_content/task_assignee_updating.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/task_assignee_updating.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.TaskAssigneeUpdating do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      project: Serializer.serialize(content["project"], level: :essential),
+      task: Serializer.serialize(content["task"], level: :essential),
+      old_assignee: Serializer.serialize(content["old_assignee"], level: :essential),
+      new_assignee: Serializer.serialize(content["new_assignee"], level: :essential),
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -790,6 +790,13 @@ defmodule OperatelyWeb.Api.Types do
     field :task_name, :string
   end
 
+  object :activity_content_task_assignee_updating do
+    field :project, :project
+    field :task, :task
+    field :old_assignee, :person
+    field :new_assignee, :person
+  end
+
   object :activity_content_task_deleting do
     field :company, :company
     field :space, :space

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -222,7 +222,7 @@ export function createActiveTaskTimeline(): TimelineItemType[] {
       fromStatus: "not_started",
       toStatus: "in_progress",
     }), // 2 hours ago
-    createTaskActivity("task-assignment", alice, 3 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }), // 3 hours ago
+    createTaskActivity("task_assignee_updating", alice, 3 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }), // 3 hours ago
     createTaskActivity("task-milestone", alice, 4 * 60 * 60 * 1000, {
       milestone: { id: "milestone-1", title: "Beta Release", status: "pending" },
       action: "attached",
@@ -244,7 +244,7 @@ export function createCompletedTaskTimeline(): TimelineItemType[] {
     createTaskActivity("task-status-change", bob, 60 * 60 * 1000, { fromStatus: "in_progress", toStatus: "done" }),
     createComment(bob, "All tests are passing and the feature is ready for release!", 2 * 60 * 60 * 1000),
     createComment(charlie, "The design looks perfect. Nice work on the animations!", 4 * 60 * 60 * 1000),
-    createTaskActivity("task-assignment", alice, 2 * 24 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
+    createTaskActivity("task_assignee_updating", alice, 2 * 24 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
     createTaskActivity("task_adding", alice, 3 * 24 * 60 * 60 * 1000),
   ];
 }
@@ -256,7 +256,7 @@ export function createOverdueTaskTimeline(): TimelineItemType[] {
       fromDueDate: null,
       toDueDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     }),
-    createTaskActivity("task-assignment", alice, 5 * 24 * 60 * 60 * 1000, { assignee: charlie, action: "assigned" }),
+    createTaskActivity("task_assignee_updating", alice, 5 * 24 * 60 * 60 * 1000, { assignee: charlie, action: "assigned" }),
     createTaskActivity("task_adding", alice, 7 * 24 * 60 * 60 * 1000),
   ];
 }
@@ -280,7 +280,7 @@ export function createLongContentTimeline(): TimelineItemType[] {
     ),
     createTaskActivity("task_description_change", alice, 6 * 60 * 60 * 1000, { hasContent: true }),
     createTaskActivity("task-status-change", bob, 8 * 60 * 60 * 1000, { fromStatus: "todo", toStatus: "in_progress" }),
-    createTaskActivity("task-assignment", alice, 12 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
+    createTaskActivity("task_assignee_updating", alice, 12 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
     createTaskActivity("task_adding", alice, 24 * 60 * 60 * 1000),
   ];
 }

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -59,7 +59,7 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
   const iconProps = { size: 12, className: "text-content-subtle" };
 
   switch (activity.type) {
-    case "task-assignment":
+    case "task_assignee_updating":
       return <IconUserPlus {...iconProps} className="text-blue-500" />;
     case "task-status-change":
       return getStatusIcon(activity.toStatus);
@@ -101,7 +101,7 @@ function getStatusIcon(status: string) {
 
 function ActivityText({ activity }: { activity: TaskActivity }) {
   switch (activity.type) {
-    case "task-assignment":
+    case "task_assignee_updating":
       if (activity.action === "assigned") {
         return (
           <span className="text-content-dimmed">

--- a/turboui/src/Timeline/index.stories.tsx
+++ b/turboui/src/Timeline/index.stories.tsx
@@ -66,7 +66,7 @@ const mockTaskAssignment: TimelineItem = {
   type: "task-activity",
   value: {
     id: "activity-1",
-    type: "task-assignment",
+    type: "task_assignee_updating",
     author: mockAuthor,
     insertedAt: new Date(Date.now() - 3600000).toISOString(), // 1 hour ago
     assignee: mockAssignee,

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -3,7 +3,7 @@ import { Person, Comment, CommentActivity } from "../CommentSection/types";
 // Task-specific activity types
 export interface TaskAssignmentActivity {
   id: string;
-  type: "task-assignment";
+  type: "task_assignee_updating";
   author: Person;
   insertedAt: string;
   assignee: Person;


### PR DESCRIPTION
The `task_assignee_updating` activity is now displayed on the new Task page and in the feed.