### PR TITLE
feat: Add handler for task_due_date_updating activity

### DIFF
--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -252,7 +252,7 @@ export function createCompletedTaskTimeline(): TimelineItemType[] {
 export function createOverdueTaskTimeline(): TimelineItemType[] {
   return [
     createComment(alice, "This is overdue. Can we get an update on the progress?", 60 * 60 * 1000),
-    createTaskActivity("task-due-date", alice, 3 * 24 * 60 * 60 * 1000, {
+    createTaskActivity("task_due_date_updating", alice, 3 * 24 * 60 * 60 * 1000, {
       fromDueDate: null,
       toDueDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
     }),

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -17,6 +17,7 @@ import {
   IconClockPlay,
 } from "../icons";
 import { TaskActivityProps, TaskActivity } from "./types";
+import { DateField } from "../DateField";
 
 export function TaskActivityItem({ activity }: TaskActivityProps) {
   return (
@@ -69,7 +70,7 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
       ) : (
         <IconFlagX {...iconProps} className="text-orange-500" />
       );
-    case "task-due-date":
+    case "task_due_date_updating":
       return activity.toDueDate ? (
         <IconCalendarPlus {...iconProps} className="text-blue-500" />
       ) : (
@@ -165,13 +166,13 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
         );
       }
 
-    case "task-due-date":
+    case "task_due_date_updating":
       if (activity.toDueDate && !activity.fromDueDate) {
         return (
-          <span className="text-content-dimmed">
+          <span className="text-content-dimmed flex items-center gap-1">
             set due date to{" "}
             <span className="font-medium text-content-dimmed">
-              <FormattedTime time={activity.toDueDate} format="short-date" />
+              <DateField date={activity.toDueDate} readonly hideCalendarIcon  />
             </span>
           </span>
         );
@@ -179,14 +180,14 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
         return <span className="text-content-subtle">removed due date</span>;
       } else if (activity.toDueDate && activity.fromDueDate) {
         return (
-          <span className="text-content-subtle">
+          <span className="text-content-dimmed flex items-center gap-1">
             changed due date from{" "}
             <span className="font-medium text-content-dimmed">
-              <FormattedTime time={activity.fromDueDate} format="short-date" />
+              <DateField date={activity.fromDueDate} readonly hideCalendarIcon />
             </span>{" "}
             to{" "}
             <span className="font-medium text-content-dimmed">
-              <FormattedTime time={activity.toDueDate} format="short-date" />
+              <DateField date={activity.toDueDate} readonly hideCalendarIcon />
             </span>
           </span>
         );

--- a/turboui/src/Timeline/index.stories.tsx
+++ b/turboui/src/Timeline/index.stories.tsx
@@ -119,11 +119,15 @@ const mockDueDateChange: TimelineItem = {
   type: "task-activity",
   value: {
     id: "activity-5",
-    type: "task-due-date",
+    type: "task_due_date_updating",
     author: mockAuthor,
     insertedAt: new Date(Date.now() - 18000000).toISOString(), // 5 hours ago
     fromDueDate: null,
-    toDueDate: "2024-01-30",
+    toDueDate: {
+      date: new Date("2024-01-30"),
+      dateType: "day",
+      value: "Jan 30, 2024"
+    },
   } as TaskActivity,
 };
 

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -1,3 +1,4 @@
+import { DateField } from "../DateField";
 import { Person, Comment, CommentActivity } from "../CommentSection/types";
 
 // Task-specific activity types
@@ -40,11 +41,11 @@ export interface TaskPriorityActivity {
 
 export interface TaskDueDateActivity {
   id: string;
-  type: "task-due-date";
+  type: "task_due_date_updating";
   author: Person;
   insertedAt: string;
-  fromDueDate: string | null;
-  toDueDate: string | null;
+  fromDueDate: DateField.ContextualDate | null;
+  toDueDate: DateField.ContextualDate | null;
 }
 
 export interface TaskDescriptionActivity {


### PR DESCRIPTION
The `task_due_date_updating`  activity is now displayed on the new Task page and in the feed.