### PR TITLE
fix: Use separate prop for Project status on new Task page

### DIFF
--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -147,6 +147,7 @@ function Page() {
   const props: TaskPage.Props = {
     projectName,
     projectLink: paths.projectV2Path(task.project.id),
+    projectStatus: task.project.status,
     workmapLink,
     tasksCount,
     space: parseSpaceForTurboUI(paths, task.space),

--- a/turboui/src/TaskPage/InProjectContextStory.tsx
+++ b/turboui/src/TaskPage/InProjectContextStory.tsx
@@ -131,6 +131,7 @@ export function InProjectContextStory() {
             <TaskPage
               // Navigation
               projectName="Mobile App V2"
+              projectStatus="on_track"
               projectLink="#"
               workmapLink="#"
               space={{

--- a/turboui/src/TaskPage/index.stories.tsx
+++ b/turboui/src/TaskPage/index.stories.tsx
@@ -50,6 +50,7 @@ function Component(props: Partial<TaskPage.Props>) {
 
     // Navigation
     projectName: props.projectName ?? "Mobile App V2",
+    projectStatus: props.projectStatus ?? "on_track",
     projectLink: "#",
     workmapLink: "#",
 

--- a/turboui/src/TaskPage/index.tsx
+++ b/turboui/src/TaskPage/index.tsx
@@ -44,6 +44,7 @@ export namespace TaskPage {
     projectLink: string;
     workmapLink: string;
     tasksCount?: number;
+    projectStatus: string;
 
     space: Space;
 
@@ -145,7 +146,7 @@ export function TaskPage(props: TaskPage.Props) {
   );
 
   return (
-    <ProjectPageLayout title={[state.projectName]} testId="project-page" tabs={tabs} {...state}>
+    <ProjectPageLayout {...state} title={[state.projectName]} testId="project-page" tabs={tabs} status={state.projectStatus}>
       <div className="px-4 py-4">
         <PageHeader {...state} />
         <div className="flex-1 overflow-scroll">


### PR DESCRIPTION
The Project status was using the Task status prop on the new Task page, so the project status was not shown correctly. That's now fixed.