### PR TITLE
feat: Add handler for task_milestone_updating activity

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -825,6 +825,13 @@ export interface ActivityContentTaskDueDateUpdating {
   newDueDate: ContextualDate;
 }
 
+export interface ActivityContentTaskMilestoneUpdating {
+  project: Project;
+  task: Task | null;
+  oldMilestone: Milestone | null;
+  newMilestone: Milestone | null;
+}
+
 export interface ActivityContentTaskNameEditing {
   companyId?: string | null;
   spaceId?: string | null;

--- a/app/assets/js/features/activities/TaskMilestoneUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskMilestoneUpdating/index.tsx
@@ -1,0 +1,89 @@
+import type { ActivityContentTaskMilestoneUpdating } from "@/api";
+import type { Activity } from "@/models/activities";
+import { Paths } from "@/routes/paths";
+import { feedTitle, milestoneLink, projectLink } from "../feedItemLinks";
+import type { ActivityHandler } from "../interfaces";
+
+const TaskMilestoneUpdating: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths: Paths, activity: Activity) {
+    return paths.projectPath(content(activity).project!.id!);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: string }) {
+    const { project, oldMilestone, newMilestone } = content(activity);
+
+    let message: any[];
+
+    if (!oldMilestone && newMilestone) {
+      message = ["assigned task to milestone", milestoneLink(newMilestone)];
+    } else if (oldMilestone && !newMilestone) {
+      message = ["removed task from milestone", milestoneLink(oldMilestone)];
+    } else if (oldMilestone && newMilestone) {
+      message = ["moved task from milestone", milestoneLink(oldMilestone), "to", milestoneLink(newMilestone)];
+    } else {
+      message = ["updated task milestone"];
+    }
+
+    if (page === "project") {
+      return feedTitle(activity, ...message);
+    } else {
+      return feedTitle(activity, ...message, "in", projectLink(project));
+    }
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(props: { activity: Activity }) {
+    const { oldMilestone, newMilestone } = content(props.activity);
+
+    if (!oldMilestone && newMilestone) {
+      return `Task was assigned to milestone "${newMilestone.title}"`;
+    } else if (oldMilestone && !newMilestone) {
+      return `Task was removed from milestone "${oldMilestone.title}"`;
+    } else if (oldMilestone && newMilestone) {
+      return `Task was moved from milestone "${oldMilestone.title}" to "${newMilestone.title}"`;
+    } else {
+      return "Task milestone was updated";
+    }
+  },
+
+  NotificationLocation(props: { activity: Activity }) {
+    return content(props.activity).project!.name!;
+  },
+};
+
+function content(activity: Activity): ActivityContentTaskMilestoneUpdating {
+  return activity.content as ActivityContentTaskMilestoneUpdating;
+}
+
+export default TaskMilestoneUpdating;

--- a/app/assets/js/features/activities/feedItemLinks.tsx
+++ b/app/assets/js/features/activities/feedItemLinks.tsx
@@ -81,6 +81,14 @@ export const linkLink = (link: api.ResourceHubLink) => {
   return <Link to={path}>{name}</Link>;
 };
 
+export const milestoneLink = (milestone: api.Milestone) => {
+  const paths = usePaths();
+  const path = paths.projectMilestonePath(milestone.id!);
+  const name = milestone.title;
+
+  return <Link to={path}>{name}</Link>;
+};
+
 export const taskLink = (task: api.Task, taskName?: string) => {
   const paths = usePaths();
   const path = paths.taskPath(task.id);

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -131,6 +131,7 @@ export const DISPLAYED_IN_FEED = [
   "task_description_change",
   "task_due_date_updating",
   "task_assignee_updating",
+  "task_milestone_updating",
   "resource_hub_document_created",
   "resource_hub_document_edited",
   "resource_hub_document_commented",
@@ -205,6 +206,7 @@ import TaskDescriptionChange from "@/features/activities/TaskDescriptionChange";
 import TaskDueDateUpdating from "@/features/activities/TaskDueDateUpdating";
 import TaskDeleting from "@/features/activities/TaskDeleting";
 import TaskAssigneeUpdating from "@/features/activities/TaskAssigneeUpdating";
+import TaskMilestoneUpdating from "@/features/activities/TaskMilestoneUpdating";
 import ProjectGoalConnection from "@/features/activities/ProjectGoalConnection";
 import ProjectGoalDisconnection from "@/features/activities/ProjectGoalDisconnection";
 import ProjectKeyResourceAdded from "@/features/activities/ProjectKeyResourceAdded";
@@ -339,6 +341,7 @@ function handler(activity: Activity) {
     .with("task_description_change", () => TaskDescriptionChange)
     .with("task_due_date_updating", () => TaskDueDateUpdating)
     .with("task_assignee_updating", () => TaskAssigneeUpdating)
+    .with("task_milestone_updating", () => TaskMilestoneUpdating)
     .with("project_champion_updating", () => ProjectChampionUpdating)
     .with("project_due_date_updating", () => ProjectDueDateUpdating)
     .with("project_reviewer_updating", () => ProjectReviewerUpdating)

--- a/app/lib/operately_web/api/serializers/activity_content/task_milestone_updating.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/task_milestone_updating.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.TaskMilestoneUpdating do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      project: Serializer.serialize(content["project"], level: :essential),
+      task: Serializer.serialize(content["task"], level: :essential),
+      old_milestone: Serializer.serialize(content["old_milestone"], level: :essential),
+      new_milestone: Serializer.serialize(content["new_milestone"], level: :essential),
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -344,6 +344,13 @@ defmodule OperatelyWeb.Api.Types do
     field? :new_name, :string, null: true
   end
 
+  object :activity_content_task_milestone_updating do
+    field :project, :project, null: false
+    field :task, :task, null: true
+    field :old_milestone, :milestone, null: true
+    field :new_milestone, :milestone, null: true
+  end
+
   object :activity_content_task_priority_change do
     field? :company_id, :string, null: true
     field? :space_id, :string, null: true

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -223,7 +223,7 @@ export function createActiveTaskTimeline(): TimelineItemType[] {
       toStatus: "in_progress",
     }), // 2 hours ago
     createTaskActivity("task_assignee_updating", alice, 3 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }), // 3 hours ago
-    createTaskActivity("task-milestone", alice, 4 * 60 * 60 * 1000, {
+    createTaskActivity("task_milestone_updating", alice, 4 * 60 * 60 * 1000, {
       milestone: { id: "milestone-1", title: "Beta Release", status: "pending" },
       action: "attached",
     }),

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -64,7 +64,7 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
       return <IconUserPlus {...iconProps} className="text-blue-500" />;
     case "task-status-change":
       return getStatusIcon(activity.toStatus);
-    case "task-milestone":
+    case "task_milestone_updating":
       return activity.action === "attached" ? (
         <IconFlag {...iconProps} className="text-green-500" />
       ) : (
@@ -149,19 +149,19 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
         </span>
       );
 
-    case "task-milestone":
+    case "task_milestone_updating":
       if (activity.action === "attached") {
         return (
           <span className="text-content-dimmed">
             attached this task to milestone{" "}
-            <span className="font-medium text-content-dimmed">{activity.milestone.title}</span>
+            <span className="font-medium text-content-dimmed">{activity.milestone.name}</span>
           </span>
         );
       } else {
         return (
           <span className="text-content-dimmed">
             detached this task from milestone{" "}
-            <span className="font-medium text-content-dimmed">{activity.milestone.title}</span>
+            <span className="font-medium text-content-dimmed">{activity.milestone.name}</span>
           </span>
         );
       }

--- a/turboui/src/Timeline/index.stories.tsx
+++ b/turboui/src/Timeline/index.stories.tsx
@@ -90,13 +90,17 @@ const mockMilestoneAttachment: TimelineItem = {
   type: "task-activity",
   value: {
     id: "activity-3",
-    type: "task-milestone",
+    type: "task_milestone_updating",
     author: mockAuthor,
     insertedAt: new Date(Date.now() - 10800000).toISOString(), // 3 hours ago
     milestone: {
       id: "milestone-1",
-      title: "Beta Release",
-      dueDate: "2024-02-15",
+      name: "Beta Release",
+      dueDate: {
+        date: new Date("2024-02-15"),
+        dateType: "day",
+        value: "Feb 15, 2024",
+      },
       status: "pending",
     },
     action: "attached",

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -23,7 +23,7 @@ export interface TaskStatusChangeActivity {
 
 export interface TaskMilestoneActivity {
   id: string;
-  type: "task-milestone";
+  type: "task_milestone_updating";
   author: Person;
   insertedAt: string;
   milestone: Milestone;
@@ -78,9 +78,9 @@ export type TaskPriority = "low" | "normal" | "high" | "urgent";
 
 export interface Milestone {
   id: string;
-  title: string;
-  dueDate?: string;
-  status: "pending" | "complete";
+  name: string;
+  dueDate: DateField.ContextualDate | null;
+  status: "pending" | "done";
 }
 
 export interface Task {


### PR DESCRIPTION
The `task_milestone_updating` activity is now displayed on the new Task page and in the feed.