### PR TITLE
feat: Add handler for task_status_updating activity

### DIFF
--- a/app/assets/js/models/tasks/index.tsx
+++ b/app/assets/js/models/tasks/index.tsx
@@ -47,7 +47,7 @@ export function parseTaskForTurboUi(paths: Paths, task: BackendTask) {
   };
 }
 
-function parseTaskStatus(status: string | null | undefined): Status {
+export function parseTaskStatus(status: string | null | undefined): Status {
   const validStatuses: Status[] = ["pending", "in_progress", "done", "canceled"];
 
   if (status && validStatuses.includes(status as Status)) {

--- a/turboui/src/MilestonePage/mockData.ts
+++ b/turboui/src/MilestonePage/mockData.ts
@@ -30,7 +30,7 @@ export const createMockTimelineItems = (): any[] => [
     type: "task-activity" as const,
     value: {
       id: "activity-3",
-      type: "task-status-change" as const,
+      type: "task_status_updating" as const,
       author: mockPeople[0],
       insertedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000).toISOString(), // 4 days ago
       fromStatus: "pending" as const,
@@ -46,7 +46,7 @@ export const createMockTimelineItems = (): any[] => [
     type: "task-activity" as const,
     value: {
       id: "activity-4",
-      type: "task-status-change" as const,
+      type: "task_status_updating" as const,
       author: mockPeople[2],
       insertedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days ago
       fromStatus: "pending" as const,
@@ -97,7 +97,7 @@ export const createMockTimelineItems = (): any[] => [
     type: "task-activity" as const,
     value: {
       id: "activity-6",
-      type: "task-status-change" as const,
+      type: "task_status_updating" as const,
       author: mockPeople[0],
       insertedAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(), // 6 hours ago
       fromStatus: "in_progress" as const,

--- a/turboui/src/TaskPage/mockData.ts
+++ b/turboui/src/TaskPage/mockData.ts
@@ -218,7 +218,7 @@ export function createActiveTaskTimeline(): TimelineItemType[] {
       "I've started working on the login component. Should have a first version ready by tomorrow.",
       30 * 60 * 1000,
     ), // 30 min ago
-    createTaskActivity("task-status-change", alice, 2 * 60 * 60 * 1000, {
+    createTaskActivity("task_status_updating", alice, 2 * 60 * 60 * 1000, {
       fromStatus: "not_started",
       toStatus: "in_progress",
     }), // 2 hours ago
@@ -241,7 +241,7 @@ export function createMinimalTaskTimeline(): TimelineItemType[] {
 export function createCompletedTaskTimeline(): TimelineItemType[] {
   return [
     createComment(alice, "Great work everyone! This turned out really well.", 30 * 60 * 1000),
-    createTaskActivity("task-status-change", bob, 60 * 60 * 1000, { fromStatus: "in_progress", toStatus: "done" }),
+    createTaskActivity("task_status_updating", bob, 60 * 60 * 1000, { fromStatus: "in_progress", toStatus: "done" }),
     createComment(bob, "All tests are passing and the feature is ready for release!", 2 * 60 * 60 * 1000),
     createComment(charlie, "The design looks perfect. Nice work on the animations!", 4 * 60 * 60 * 1000),
     createTaskActivity("task_assignee_updating", alice, 2 * 24 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
@@ -279,7 +279,7 @@ export function createLongContentTimeline(): TimelineItemType[] {
       4 * 60 * 60 * 1000,
     ),
     createTaskActivity("task_description_change", alice, 6 * 60 * 60 * 1000, { hasContent: true }),
-    createTaskActivity("task-status-change", bob, 8 * 60 * 60 * 1000, { fromStatus: "todo", toStatus: "in_progress" }),
+    createTaskActivity("task_status_updating", bob, 8 * 60 * 60 * 1000, { fromStatus: "todo", toStatus: "in_progress" }),
     createTaskActivity("task_assignee_updating", alice, 12 * 60 * 60 * 1000, { assignee: bob, action: "assigned" }),
     createTaskActivity("task_adding", alice, 24 * 60 * 60 * 1000),
   ];

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -18,6 +18,7 @@ import {
 } from "../icons";
 import { TaskActivityProps, TaskActivity } from "./types";
 import { DateField } from "../DateField";
+import { capitalizeFirstLetter } from "../utils/strings";
 
 export function TaskActivityItem({ activity }: TaskActivityProps) {
   return (
@@ -62,7 +63,7 @@ function ActivityIcon({ activity }: { activity: TaskActivity }) {
   switch (activity.type) {
     case "task_assignee_updating":
       return <IconUserPlus {...iconProps} className="text-blue-500" />;
-    case "task-status-change":
+    case "task_status_updating":
       return getStatusIcon(activity.toStatus);
     case "task_milestone_updating":
       return activity.action === "attached" ? (
@@ -140,7 +141,7 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
         );
       }
 
-    case "task-status-change":
+    case "task_status_updating":
       return (
         <span className="text-content-dimmed">
           changed status{activity.task ? ` of "${activity.task.title}"` : ""} from{" "}
@@ -226,6 +227,6 @@ function formatStatus(status: string): string {
     case "done":
       return "Done";
     default:
-      return status;
+      return capitalizeFirstLetter(status);
   }
 }

--- a/turboui/src/Timeline/index.stories.tsx
+++ b/turboui/src/Timeline/index.stories.tsx
@@ -78,7 +78,7 @@ const mockStatusChange: TimelineItem = {
   type: "task-activity",
   value: {
     id: "activity-2",
-    type: "task-status-change",
+    type: "task_status_updating",
     author: mockUser,
     insertedAt: new Date(Date.now() - 7200000).toISOString(), // 2 hours ago
     fromStatus: "todo",

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -1,5 +1,6 @@
 import { DateField } from "../DateField";
 import { Person, Comment, CommentActivity } from "../CommentSection/types";
+import { Status } from "../TaskBoard/types";
 
 // Task-specific activity types
 export interface TaskAssignmentActivity {
@@ -13,12 +14,12 @@ export interface TaskAssignmentActivity {
 
 export interface TaskStatusChangeActivity {
   id: string;
-  type: "task-status-change";
+  type: "task_status_updating";
   author: Person;
   insertedAt: string;
-  fromStatus: TaskStatus;
-  toStatus: TaskStatus;
-  task?: Task; // Optional for backward compatibility
+  fromStatus: Status;
+  toStatus: Status;
+  task?: Task;
 }
 
 export interface TaskMilestoneActivity {
@@ -73,7 +74,6 @@ export interface TaskCreationActivity {
 }
 
 // Supporting types
-export type TaskStatus = "todo" | "in_progress" | "done";
 export type TaskPriority = "low" | "normal" | "high" | "urgent";
 
 export interface Milestone {
@@ -86,7 +86,7 @@ export interface Milestone {
 export interface Task {
   id: string;
   title: string;
-  status?: TaskStatus;
+  status?: Status;
 }
 
 // Union type for all activities

--- a/turboui/src/utils/strings.tsx
+++ b/turboui/src/utils/strings.tsx
@@ -2,3 +2,7 @@ export function truncate(text: string, maxLength: number) {
   if (text.length <= maxLength) return text;
   return text.substring(0, maxLength) + "...";
 }
+
+export function capitalizeFirstLetter(text: string) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}


### PR DESCRIPTION
The `task_status_updating` activity is now displayed on the new Task page and in the feed.