### PR TITLE
chore: Add has_description field to task_description_change activity

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -815,6 +815,7 @@ export interface ActivityContentTaskDeleting {
 export interface ActivityContentTaskDescriptionChange {
   task: Task;
   projectName: string;
+  hasDescription: boolean;
 }
 
 export interface ActivityContentTaskDueDateUpdating {
@@ -2906,8 +2907,8 @@ export interface ChangePasswordInput {
 export interface ChangePasswordResult {}
 
 export interface ChangeTaskDescriptionInput {
-  taskId?: string | null;
-  description?: string | null;
+  taskId: Id;
+  description: Json;
 }
 
 export interface ChangeTaskDescriptionResult {

--- a/app/assets/js/models/activities/tasks.tsx
+++ b/app/assets/js/models/activities/tasks.tsx
@@ -5,6 +5,7 @@ import {
   ActivityContentTaskDueDateUpdating,
   ActivityContentTaskMilestoneUpdating,
   ActivityContentTaskStatusUpdating,
+  ActivityContentTaskDescriptionChange,
 } from "@/api";
 import {
   TaskCreationActivity,
@@ -49,7 +50,11 @@ function parseActivityForTurboUi(paths: Paths, activity: Activity) {
     case "task_name_updating":
       return parseTaskNameUpdatingActivity(author!, activity, activity.content as ActivityContentTaskNameUpdating);
     case "task_description_change":
-      return parseTaskDescriptionChangeActivity(author!, activity);
+      return parseTaskDescriptionChangeActivity(
+        author!,
+        activity,
+        activity.content as ActivityContentTaskDescriptionChange,
+      );
     case "task_assignee_updating":
       return parseTaskAssigneeUpdatingActivity(
         paths,
@@ -101,13 +106,17 @@ function parseTaskNameUpdatingActivity(
   };
 }
 
-function parseTaskDescriptionChangeActivity(author: TurboUiPerson, activity: Activity): TaskDescriptionActivity {
+function parseTaskDescriptionChangeActivity(
+  author: TurboUiPerson,
+  activity: Activity,
+  content: ActivityContentTaskDescriptionChange,
+): TaskDescriptionActivity {
   return {
     id: activity.id,
     type: "task_description_change",
     author,
     insertedAt: activity.insertedAt,
-    hasContent: true,
+    hasContent: content.hasDescription,
   };
 }
 

--- a/app/lib/operately/activities/content/task_description_change.ex
+++ b/app/lib/operately/activities/content/task_description_change.ex
@@ -9,6 +9,7 @@ defmodule Operately.Activities.Content.TaskDescriptionChange do
 
     field :task_name, :string
     field :project_name, :string
+    field :has_description, :boolean
   end
 
   def changeset(attrs) do

--- a/app/lib/operately/data/change_078_enhance_task_description_change_activities.ex
+++ b/app/lib/operately/data/change_078_enhance_task_description_change_activities.ex
@@ -1,0 +1,52 @@
+defmodule Operately.Data.Change078EnhanceTaskDescriptionChangeActivities do
+  import Ecto.Query, only: [from: 2]
+  alias Operately.{Repo, Tasks}
+  alias Operately.Tasks.Task
+  alias __MODULE__.Activity
+
+  def run do
+    from(a in Activity, where: a.action == "task_description_change")
+    |> Repo.all()
+    |> Enum.each(fn activity ->
+      task_id = activity.content["task_id"]
+
+      has_description = case get_task(task_id) do
+        nil -> false
+        task -> Tasks.has_description?(task)
+      end
+
+      new_content = activity.content
+      |> Map.put("has_description", has_description)
+
+      {:ok, _updated} = update_activity(activity, new_content)
+    end)
+  end
+
+  defp get_task(nil), do: nil
+  defp get_task(task_id) do
+    Repo.get(Task, task_id)
+  end
+
+  defp update_activity(activity, new_content) do
+    activity
+    |> Ecto.Changeset.change(%{content: new_content})
+    |> Repo.update()
+  end
+
+  defmodule Activity do
+    use Operately.Schema
+
+    schema "activities" do
+      field :action, :string
+      field :content, :map
+    end
+
+    def changeset(attrs) do
+      changeset(%__MODULE__{}, attrs)
+    end
+
+    def changeset(activity, attrs) do
+      activity |> cast(attrs, [:action, :content])
+    end
+  end
+end

--- a/app/lib/operately/operations/task_description_change.ex
+++ b/app/lib/operately/operations/task_description_change.ex
@@ -17,7 +17,8 @@ defmodule Operately.Operations.TaskDescriptionChange do
         project_id: task.project_id,
         task_id: task.id,
         task_name: task.name,
-        project_name: task.project.name
+        project_name: task.project.name,
+        has_description: Operately.Tasks.has_description?(description)
       }
     end)
     |> Repo.transaction()

--- a/app/lib/operately/tasks.ex
+++ b/app/lib/operately/tasks.ex
@@ -6,6 +6,8 @@ defmodule Operately.Tasks do
   alias Operately.Tasks.Assignee
   alias Operately.Access.Fetch
 
+  defdelegate has_description?(task_or_description), to: Operately.Tasks.Description
+
   def get_task!(id), do: Repo.get!(Task, id)
 
   def get_task_with_access_level(id, requester_id) do

--- a/app/lib/operately/tasks/description.ex
+++ b/app/lib/operately/tasks/description.ex
@@ -1,0 +1,70 @@
+defmodule Operately.Tasks.Description do
+  alias Operately.Tasks.Task
+
+  @doc """
+  Determines if a task or description has meaningful content.
+
+  Returns `true` if the task has a non-empty description, `false` otherwise.
+  Handles TipTap editor format, empty maps, and nil values.
+
+  ## Examples
+
+      iex> Operately.Tasks.Description.has_description?(%Task{description: nil})
+      false
+
+      iex> Operately.Tasks.Description.has_description?(%Task{description: %{}})
+      false
+
+      iex> Operately.Tasks.Description.has_description?(%{"content" => [%{"type" => "paragraph"}], "type" => "doc"})
+      false
+
+      iex> Operately.Tasks.Description.has_description?(%{"content" => [%{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Hello"}]}], "type" => "doc"})
+      true
+  """
+  def has_description?(task = %Task{}) do
+    has_description?(task.description)
+  end
+
+  def has_description?(description) do
+    case description do
+      nil -> false
+
+      description when description == %{} -> false
+
+      %{"type" => "doc", "content" => content} when is_list(content) ->
+        # Convert TipTap content to string and check if it's meaningful
+        content
+        |> rich_content_to_string()
+        |> String.trim()
+        |> case do
+          "" -> false
+          _non_empty -> true
+        end
+
+      _ -> false
+    end
+  end
+
+  @doc """
+  Converts TipTap rich content to a plain string, similar to the JavaScript richContentToString function.
+  """
+  def rich_content_to_string(content) when is_list(content) do
+    content
+    |> Enum.map(&rich_content_to_string/1)
+    |> Enum.join(" ")
+  end
+
+  def rich_content_to_string(%{"type" => "text", "text" => text}) when is_binary(text) do
+    text
+  end
+
+  def rich_content_to_string(%{"type" => "mention", "attrs" => %{"label" => label}}) when is_binary(label) do
+    label
+  end
+
+  def rich_content_to_string(%{"content" => content}) when is_list(content) do
+    rich_content_to_string(content)
+  end
+
+  def rich_content_to_string(_), do: ""
+end

--- a/app/lib/operately_web/api/mutations/change_task_description.ex
+++ b/app/lib/operately_web/api/mutations/change_task_description.ex
@@ -8,8 +8,8 @@ defmodule OperatelyWeb.Api.Mutations.ChangeTaskDescription do
   alias Operately.Repo
 
   inputs do
-    field? :task_id, :string, null: true
-    field? :description, :string, null: true
+    field :task_id, :id, null: false
+    field :description, :json, null: false
   end
 
   outputs do
@@ -18,16 +18,14 @@ defmodule OperatelyWeb.Api.Mutations.ChangeTaskDescription do
 
   def call(conn, inputs) do
     author = me(conn)
-    {:ok, task_id} = decode_id(inputs.task_id)
 
-    case load_task(author, task_id) do
+    case load_task(author, inputs.task_id) do
       nil ->
-        query(task_id)
+        query(inputs.task_id)
         |> forbidden_or_not_found(author.id, join_parent: :project)
 
       task ->
-        description = inputs.description && Jason.decode!(inputs.description)
-        {:ok, task} = Operately.Operations.TaskDescriptionChange.run(author, task, description)
+        {:ok, task} = Operately.Operations.TaskDescriptionChange.run(author, task, inputs.description)
 
         {:ok, %{task: Serializer.serialize(task, level: :essential)}}
     end

--- a/app/lib/operately_web/api/project_tasks.ex
+++ b/app/lib/operately_web/api/project_tasks.ex
@@ -131,6 +131,7 @@ defmodule OperatelyWeb.Api.ProjectTasks do
           task_id: changes.task.id,
           project_name: changes.project.name,
           task_name: changes.task.name,
+          has_description: Operately.Tasks.has_description?(inputs.description)
         }
       end)
       |> Steps.commit()

--- a/app/lib/operately_web/api/serializers/activity_content/task_description_change.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/task_description_change.ex
@@ -5,6 +5,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.TaskDes
     %{
       task: Serializer.serialize(content["task"], level: :full),
       project_name: Serializer.serialize(content["project_name"], level: :essential),
+      has_description: content["has_description"]
     }
   end
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -764,6 +764,7 @@ defmodule OperatelyWeb.Api.Types do
   object :activity_content_task_description_change do
     field :task, :task, null: false
     field :project_name, :string, null: false
+    field :has_description, :boolean, null: false
   end
 
   object :activity_content_task_due_date_updating do

--- a/app/priv/repo/migrations/20250822164615_add_has_description_field_to_task_description_change_activity.exs
+++ b/app/priv/repo/migrations/20250822164615_add_has_description_field_to_task_description_change_activity.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddHasDescriptionFieldToTaskDescriptionChangeActivity do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change078EnhanceTaskDescriptionChangeActivities.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/access/activity_context_assigner_test.exs
+++ b/app/test/operately/access/activity_context_assigner_test.exs
@@ -158,6 +158,7 @@ defmodule Operately.AccessActivityContextAssignerTest do
           project_name: "-",
           task_id: "-",
           task_name: "-",
+          has_description: false
         }
       }
 

--- a/app/test/operately/data/change_078_enhance_task_description_change_activities_test.exs
+++ b/app/test/operately/data/change_078_enhance_task_description_change_activities_test.exs
@@ -1,0 +1,115 @@
+defmodule Operately.Data.Change078EnhanceTaskDescriptionChangeActivitiesTest do
+  use Operately.DataCase
+
+  alias Operately.Activities.Activity
+  alias Operately.Repo
+  alias Operately.Data.Change078EnhanceTaskDescriptionChangeActivities
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_project(:project, :space, name: "Test Project")
+    |> Factory.add_project_milestone(:project_milestone, :project)
+    |> Factory.add_project_task(:task, :project_milestone, name: "Test Task")
+  end
+
+  test "adds has_description as true when task exists and has meaningful TipTap description", ctx do
+    # Update task to have a meaningful TipTap description
+    {:ok, task_with_description} = Repo.update(
+      Ecto.Changeset.change(ctx.task, %{
+        description: %{
+          "content" => [
+            %{
+              "type" => "paragraph",
+              "content" => [%{"type" => "text", "text" => "This is a meaningful description"}]
+            }
+          ],
+          "type" => "doc"
+        }
+      })
+    )
+
+    activity = create_test_activity(ctx.creator, ctx.project.id, task_with_description.id)
+
+    assert activity.content["has_description"] == nil
+
+    Change078EnhanceTaskDescriptionChangeActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["has_description"] == true
+  end
+
+  test "adds has_description as false when task exists but has no description", ctx do
+    activity = create_test_activity(ctx.creator, ctx.project.id, ctx.task.id)
+
+    assert activity.content["has_description"] == nil
+
+    Change078EnhanceTaskDescriptionChangeActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["has_description"] == false
+  end
+
+  test "adds has_description as false when task exists but has empty map description", ctx do
+    # Update task to have an empty map description
+    {:ok, task_with_empty_description} = Repo.update(
+      Ecto.Changeset.change(ctx.task, %{description: %{}})
+    )
+
+    activity = create_test_activity(ctx.creator, ctx.project.id, task_with_empty_description.id)
+
+    assert activity.content["has_description"] == nil
+
+    Change078EnhanceTaskDescriptionChangeActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["has_description"] == false
+  end
+
+  test "sets has_description to false when task doesn't exist", ctx do
+    activity = create_test_activity(ctx.creator, ctx.project.id, Ecto.UUID.generate())
+
+    assert activity.content["has_description"] == nil
+
+    Change078EnhanceTaskDescriptionChangeActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["has_description"] == false
+  end
+
+  test "handles case where task_id is nil", ctx do
+    activity = create_test_activity(ctx.creator, ctx.project.id, nil)
+
+    assert activity.content["has_description"] == nil
+
+    Change078EnhanceTaskDescriptionChangeActivities.run()
+
+    updated_activity = Repo.get!(Activity, activity.id)
+
+    assert updated_activity.content["has_description"] == false
+  end
+
+  defp create_test_activity(person, project_id, task_id) do
+    attrs = %{
+      action: "task_description_change",
+      author_id: person.id,
+      content: %{
+        "company_id" => Ecto.UUID.generate(),
+        "space_id" => Ecto.UUID.generate(),
+        "project_id" => project_id,
+        "task_id" => task_id,
+        "task_name" => "Test Task",
+        "project_name" => "Test Project"
+      }
+    }
+
+    {:ok, activity} = Repo.insert(struct(Activity, attrs))
+
+    activity
+  end
+end


### PR DESCRIPTION
I've added the had_description field to the `task_description_change` activity which is necessary for the new feed.