### PR TITLE
feat: Add optimistic behavior to Milestone closing and reopening

### DIFF
--- a/app/assets/js/models/milestones/index.tsx
+++ b/app/assets/js/models/milestones/index.tsx
@@ -1,11 +1,11 @@
 import * as Time from "@/utils/time";
 import * as People from "@/models/people";
-import { Milestone, MilestoneComment } from "@/api";
+import { Milestone, MilestoneComment, MilestoneStatus } from "@/api";
 import { CommentSection, DateField } from "turboui";
 import { Paths } from "@/routes/paths";
 import { parseContextualDate } from "../contextualDates";
 
-export type { Milestone, MilestoneComment };
+export type { Milestone, MilestoneComment, MilestoneStatus };
 export {
   getMilestone,
   useUpdateMilestone,

--- a/app/assets/js/pages/MilestoneV2Page/useComments.tsx
+++ b/app/assets/js/pages/MilestoneV2Page/useComments.tsx
@@ -49,5 +49,5 @@ export function useComments(paths: Paths, milestone: Milestones.Milestone) {
     PageCache.invalidate(pageCacheKey(milestone.id));
   }, [paths, me, milestone.id]);
 
-  return { comments, handleCreateComment };
+  return { comments, setComments, handleCreateComment };
 }


### PR DESCRIPTION
Now, when a Milestone is closed or reopened, the activity is instantly added to the feed.