### PR TITLE
feat: Update Task activities message on Milestone V2 page

### DIFF
--- a/app/assets/js/pages/MilestoneV2Page/index.tsx
+++ b/app/assets/js/pages/MilestoneV2Page/index.tsx
@@ -254,7 +254,7 @@ function usePageField<T>(
 }
 
 function prepareTimelineItems(paths: Paths, activities: Activities.Activity[], comments: TurboUiComment[]) {
-  const parsedActivities: MilestonePage.TimelineItemType[] = parseActivitiesForTurboUi(paths, activities)
+  const parsedActivities: MilestonePage.TimelineItemType[] = parseActivitiesForTurboUi(paths, activities, "milestone")
     .filter((activity): activity is NonNullable<typeof activity> => activity !== null)
     .map((activity) => {
       if (activity.type.startsWith("task_")) {

--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -312,7 +312,7 @@ function useMilestonesSearch(projectId): TaskPage.Props["searchMilestones"] {
 }
 
 function prepareTimelineItems(paths: Paths, activities: Activities.Activity[], comments: Comments.Comment[]) {
-  const parsedActivities = parseActivitiesForTurboUi(paths, activities).map((activity) => ({
+  const parsedActivities = parseActivitiesForTurboUi(paths, activities, "task").map((activity) => ({
     type: "task-activity",
     value: activity,
   }));

--- a/turboui/src/Timeline/TaskActivities.tsx
+++ b/turboui/src/Timeline/TaskActivities.tsx
@@ -102,12 +102,14 @@ function getStatusIcon(status: string) {
 }
 
 function ActivityText({ activity }: { activity: TaskActivity }) {
+  const taskName = formatTaskName(activity);
+
   switch (activity.type) {
     case "task_assignee_updating":
       if (activity.action === "assigned") {
         return (
           <span className="text-content-dimmed">
-            assigned this task to{" "}
+            assigned {taskName} to{" "}
             {activity.assignee.profileLink ? (
               <BlackLink
                 to={activity.assignee.profileLink}
@@ -136,7 +138,7 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
             ) : (
               <span className="font-medium text-content-dimmed">{shortName(activity.assignee.fullName)}</span>
             )}{" "}
-            from this task
+            from {taskName}
           </span>
         );
       }
@@ -144,7 +146,7 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
     case "task_status_updating":
       return (
         <span className="text-content-dimmed">
-          changed status{activity.task ? ` of "${activity.task.title}"` : ""} from{" "}
+          changed status of {taskName} from{" "}
           <span className="font-medium text-content-dimmed">{formatStatus(activity.fromStatus)}</span> to{" "}
           <span className="font-medium text-content-dimmed">{formatStatus(activity.toStatus)}</span>
         </span>
@@ -154,14 +156,14 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
       if (activity.action === "attached") {
         return (
           <span className="text-content-dimmed">
-            attached this task to milestone{" "}
+            attached {taskName} to milestone{" "}
             <span className="font-medium text-content-dimmed">{activity.milestone.name}</span>
           </span>
         );
       } else {
         return (
           <span className="text-content-dimmed">
-            detached this task from milestone{" "}
+            detached {taskName} from milestone{" "}
             <span className="font-medium text-content-dimmed">{activity.milestone.name}</span>
           </span>
         );
@@ -171,18 +173,18 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
       if (activity.toDueDate && !activity.fromDueDate) {
         return (
           <span className="text-content-dimmed flex items-center gap-1">
-            set due date to{" "}
+            set due date for {taskName} to{" "}
             <span className="font-medium text-content-dimmed">
-              <DateField date={activity.toDueDate} readonly hideCalendarIcon  />
+              <DateField date={activity.toDueDate} readonly hideCalendarIcon />
             </span>
           </span>
         );
       } else if (!activity.toDueDate && activity.fromDueDate) {
-        return <span className="text-content-subtle">removed due date</span>;
+        return <span className="text-content-subtle">removed due date from {taskName}</span>;
       } else if (activity.toDueDate && activity.fromDueDate) {
         return (
           <span className="text-content-dimmed flex items-center gap-1">
-            changed due date from{" "}
+            changed due date of {taskName} from{" "}
             <span className="font-medium text-content-dimmed">
               <DateField date={activity.fromDueDate} readonly hideCalendarIcon />
             </span>{" "}
@@ -198,23 +200,36 @@ function ActivityText({ activity }: { activity: TaskActivity }) {
     case "task_description_change":
       return (
         <span className="text-content-dimmed">
-          {activity.hasContent ? "updated the description" : "removed the description"}
+          {activity.hasContent
+            ? `updated the description ${activity.page === "task" ? "" : "of " + taskName}`
+            : `removed the description ${activity.page === "task" ? "" : "from " + taskName}`}
         </span>
       );
 
     case "task_name_updating":
       return (
         <span className="text-content-dimmed">
-          changed title from <span className="font-medium text-content-dimmed">"{activity.fromTitle}"</span> to{" "}
+          changed title of {activity.page === "task" ? "this task" : "a task"} from{" "}
+          <span className="font-medium text-content-dimmed">"{activity.fromTitle}"</span> to{" "}
           <span className="font-medium text-content-dimmed">"{activity.toTitle}"</span>
         </span>
       );
 
     case "task_adding":
-      return <span className="text-content-dimmed">created this task</span>;
+      return <span className="text-content-dimmed">created {taskName}</span>;
 
     default:
       return <span className="text-content-dimmed">performed an action</span>;
+  }
+}
+
+function formatTaskName(activity: TaskActivity): string {
+  if (activity.page === "task") {
+    return "this task";
+  } else if ("taskName" in activity) {
+    return `"${activity.taskName}"`;
+  } else {
+    return `"${activity.toTitle}"`;
   }
 }
 

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -4,6 +4,8 @@ import { Status } from "../TaskBoard/types";
 import { MentionedPersonLookupFn } from "../RichEditor";
 import { SearchFn } from "../RichEditor/extensions/MentionPeople";
 
+export type ActivityPageContext = "task" | "milestone";
+
 // Task-specific activity types
 export interface TaskAssignmentActivity {
   id: string;
@@ -12,6 +14,8 @@ export interface TaskAssignmentActivity {
   insertedAt: string;
   assignee: Person;
   action: "assigned" | "unassigned";
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskStatusChangeActivity {
@@ -21,6 +25,8 @@ export interface TaskStatusChangeActivity {
   insertedAt: string;
   fromStatus: Status;
   toStatus: Status;
+  taskName: string;
+  page: ActivityPageContext;
   task?: Task;
 }
 
@@ -31,6 +37,8 @@ export interface TaskMilestoneActivity {
   insertedAt: string;
   milestone: Milestone;
   action: "attached" | "detached";
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskPriorityActivity {
@@ -40,6 +48,8 @@ export interface TaskPriorityActivity {
   insertedAt: string;
   fromPriority: TaskPriority;
   toPriority: TaskPriority;
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskDueDateActivity {
@@ -49,6 +59,8 @@ export interface TaskDueDateActivity {
   insertedAt: string;
   fromDueDate: DateField.ContextualDate | null;
   toDueDate: DateField.ContextualDate | null;
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskDescriptionActivity {
@@ -57,6 +69,8 @@ export interface TaskDescriptionActivity {
   author: Person;
   insertedAt: string;
   hasContent: boolean; // Whether description was added/updated vs removed
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskTitleActivity {
@@ -66,6 +80,7 @@ export interface TaskTitleActivity {
   insertedAt: string;
   fromTitle: string;
   toTitle: string;
+  page: ActivityPageContext;
 }
 
 export interface TaskCreationActivity {
@@ -73,6 +88,8 @@ export interface TaskCreationActivity {
   type: "task_adding";
   author: Person;
   insertedAt: string;
+  taskName: string;
+  page: ActivityPageContext;
 }
 
 // Supporting types


### PR DESCRIPTION
Most of the Task activities were using the text "this task" in the message. This made sense in the Task page, but it was confusing in the Milestone page. Now, in the Milestone page, we show the task name instead of "this task".