### PR TITLE
fix: MilestoneCommented event doesn't break feed when Milestone is deleted

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -572,11 +572,10 @@ export interface ActivityContentProjectKeyResourceDeleted {
 }
 
 export interface ActivityContentProjectMilestoneCommented {
-  projectId?: string | null;
-  project?: Project | null;
-  milestone?: Milestone | null;
-  commentAction?: string | null;
-  comment?: Comment | null;
+  project: Project;
+  milestone: Milestone | null;
+  commentAction: string;
+  comment: Comment;
 }
 
 export interface ActivityContentProjectMilestoneCreation {

--- a/app/assets/js/features/activities/ProjectMilestoneCommented/index.tsx
+++ b/app/assets/js/features/activities/ProjectMilestoneCommented/index.tsx
@@ -7,9 +7,7 @@ import type { ActivityHandler } from "../interfaces";
 
 import { Summary } from "@/components/RichContent";
 
-import { usePaths } from "@/routes/paths";
-import { Link } from "turboui";
-import { feedTitle, projectLink } from "../feedItemLinks";
+import { feedTitle, milestoneLink, projectLink } from "../feedItemLinks";
 
 const ProjectMilestoneCommented: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -33,17 +31,14 @@ const ProjectMilestoneCommented: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
-    const paths = usePaths();
-    const project = content(activity).project!;
-    const milestone = content(activity).milestone!;
-    const path = paths.projectMilestonePath(milestone.id!);
-    const link = <Link to={path}>{milestone!.title!}</Link>;
+    const { milestone, project } = content(activity);
+    const milestoneName = milestone ? milestoneLink(milestone) : "a milestone";
     const what = didWhat(content(activity).commentAction!);
 
     if (page === "project") {
-      return feedTitle(activity, what, "the", link, "milestone");
+      return feedTitle(activity, what, "the", milestoneName, "milestone");
     } else {
-      return feedTitle(activity, what, "the", link, "milestone in the", projectLink(project), "project");
+      return feedTitle(activity, what, "the", milestoneName, "milestone in the", projectLink(project), "project");
     }
   },
 

--- a/app/lib/operately_web/api/serializers/activity_content/project_milestone_commented.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/project_milestone_commented.ex
@@ -1,14 +1,10 @@
 defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ProjectMilestoneCommented do
   def serialize(content, level: :essential) do
     %{
-      comment: OperatelyWeb.Api.Serializer.serialize(content.comment),
       comment_action: content.comment_action,
-      milestone: %{
-        id: OperatelyWeb.Paths.milestone_id(content.milestone),
-        title: content.milestone.title,
-      },
+      comment: OperatelyWeb.Api.Serializer.serialize(content.comment),
+      milestone: OperatelyWeb.Api.Serializer.serialize(content.milestone),
       project: OperatelyWeb.Api.Serializer.serialize(content.project),
-      project_id: OperatelyWeb.Paths.project_id(content.project),
     }
   end
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1607,11 +1607,10 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   object :activity_content_project_milestone_commented do
-    field? :project_id, :string, null: true
-    field? :project, :project, null: true
-    field? :milestone, :milestone, null: true
-    field? :comment_action, :string, null: true
-    field? :comment, :comment, null: true
+    field :project, :project, null: false
+    field :milestone, :milestone, null: true
+    field :comment_action, :string, null: false
+    field :comment, :comment, null: false
   end
 
   object :activity_content_project_review_submitted do


### PR DESCRIPTION
MilestoneCommented events no longer break the feed when the Milestone is deleted.