### PR TITLE
fix: Keep TaskCreationModal open after Task is created

### DIFF
--- a/turboui/src/MilestonePage/index.tsx
+++ b/turboui/src/MilestonePage/index.tsx
@@ -144,7 +144,6 @@ export function MilestonePage(props: MilestonePage.Props) {
         milestone: milestone,
       });
     }
-    setIsTaskModalOpen(false);
   };
 
   const tabs = useTabs(


### PR DESCRIPTION
Now, the TaskCreationModal stays open after Task is created when "Add more" is selected.