### PR TITLE
fix: Solve issues in Tasks reordering

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3785,6 +3785,7 @@ export interface ProjectTasksCreateInput {
 
 export interface ProjectTasksCreateResult {
   task: Task;
+  updatedMilestone: Milestone | null;
 }
 
 export interface ProjectTasksDeleteInput {
@@ -3793,6 +3794,7 @@ export interface ProjectTasksDeleteInput {
 
 export interface ProjectTasksDeleteResult {
   success: boolean;
+  updatedMilestone: Milestone | null;
 }
 
 export interface ProjectTasksUpdateAssigneeInput {
@@ -3830,6 +3832,7 @@ export interface ProjectTasksUpdateMilestoneInput {
 
 export interface ProjectTasksUpdateMilestoneResult {
   task: Task;
+  updatedMilestones: Milestone[];
 }
 
 export interface ProjectTasksUpdateNameInput {
@@ -3848,6 +3851,7 @@ export interface ProjectTasksUpdateStatusInput {
 
 export interface ProjectTasksUpdateStatusResult {
   task: Task;
+  updatedMilestone: Milestone | null;
 }
 
 export interface ProjectsCreateMilestoneInput {

--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3824,13 +3824,13 @@ export interface ProjectTasksUpdateDueDateResult {
   task: Task;
 }
 
-export interface ProjectTasksUpdateMilestoneInput {
+export interface ProjectTasksUpdateMilestoneAndOrderingInput {
   taskId: Id;
   milestoneId: Id | null;
   milestonesOrderingState: EditMilestoneOrderingStateInput[];
 }
 
-export interface ProjectTasksUpdateMilestoneResult {
+export interface ProjectTasksUpdateMilestoneAndOrderingResult {
   task: Task;
   updatedMilestones: Milestone[];
 }
@@ -4803,8 +4803,10 @@ class ApiNamespaceProjectTasks {
     return this.client.post("/project_tasks/update_due_date", input);
   }
 
-  async updateMilestone(input: ProjectTasksUpdateMilestoneInput): Promise<ProjectTasksUpdateMilestoneResult> {
-    return this.client.post("/project_tasks/update_milestone", input);
+  async updateMilestoneAndOrdering(
+    input: ProjectTasksUpdateMilestoneAndOrderingInput,
+  ): Promise<ProjectTasksUpdateMilestoneAndOrderingResult> {
+    return this.client.post("/project_tasks/update_milestone_and_ordering", input);
   }
 
   async updateName(input: ProjectTasksUpdateNameInput): Promise<ProjectTasksUpdateNameResult> {
@@ -7419,13 +7421,6 @@ export default {
         defaultApiClient.apiNamespaceProjectTasks.updateDueDate,
       ),
 
-    updateMilestone: (input: ProjectTasksUpdateMilestoneInput) =>
-      defaultApiClient.apiNamespaceProjectTasks.updateMilestone(input),
-    useUpdateMilestone: () =>
-      useMutation<ProjectTasksUpdateMilestoneInput, ProjectTasksUpdateMilestoneResult>(
-        defaultApiClient.apiNamespaceProjectTasks.updateMilestone,
-      ),
-
     updateName: (input: ProjectTasksUpdateNameInput) => defaultApiClient.apiNamespaceProjectTasks.updateName(input),
     useUpdateName: () =>
       useMutation<ProjectTasksUpdateNameInput, ProjectTasksUpdateNameResult>(
@@ -7441,6 +7436,13 @@ export default {
     useUpdateDescription: () =>
       useMutation<ProjectTasksUpdateDescriptionInput, ProjectTasksUpdateDescriptionResult>(
         defaultApiClient.apiNamespaceProjectTasks.updateDescription,
+      ),
+
+    updateMilestoneAndOrdering: (input: ProjectTasksUpdateMilestoneAndOrderingInput) =>
+      defaultApiClient.apiNamespaceProjectTasks.updateMilestoneAndOrdering(input),
+    useUpdateMilestoneAndOrdering: () =>
+      useMutation<ProjectTasksUpdateMilestoneAndOrderingInput, ProjectTasksUpdateMilestoneAndOrderingResult>(
+        defaultApiClient.apiNamespaceProjectTasks.updateMilestoneAndOrdering,
       ),
 
     updateAssignee: (input: ProjectTasksUpdateAssigneeInput) =>

--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3824,6 +3824,15 @@ export interface ProjectTasksUpdateDueDateResult {
   task: Task;
 }
 
+export interface ProjectTasksUpdateMilestoneInput {
+  taskId: Id;
+  milestoneId: Id | null;
+}
+
+export interface ProjectTasksUpdateMilestoneResult {
+  task: Task;
+}
+
 export interface ProjectTasksUpdateMilestoneAndOrderingInput {
   taskId: Id;
   milestoneId: Id | null;
@@ -4801,6 +4810,10 @@ class ApiNamespaceProjectTasks {
 
   async updateDueDate(input: ProjectTasksUpdateDueDateInput): Promise<ProjectTasksUpdateDueDateResult> {
     return this.client.post("/project_tasks/update_due_date", input);
+  }
+
+  async updateMilestone(input: ProjectTasksUpdateMilestoneInput): Promise<ProjectTasksUpdateMilestoneResult> {
+    return this.client.post("/project_tasks/update_milestone", input);
   }
 
   async updateMilestoneAndOrdering(
@@ -7419,6 +7432,13 @@ export default {
     useUpdateDueDate: () =>
       useMutation<ProjectTasksUpdateDueDateInput, ProjectTasksUpdateDueDateResult>(
         defaultApiClient.apiNamespaceProjectTasks.updateDueDate,
+      ),
+
+    updateMilestone: (input: ProjectTasksUpdateMilestoneInput) =>
+      defaultApiClient.apiNamespaceProjectTasks.updateMilestone(input),
+    useUpdateMilestone: () =>
+      useMutation<ProjectTasksUpdateMilestoneInput, ProjectTasksUpdateMilestoneResult>(
+        defaultApiClient.apiNamespaceProjectTasks.updateMilestone,
       ),
 
     updateName: (input: ProjectTasksUpdateNameInput) => defaultApiClient.apiNamespaceProjectTasks.updateName(input),

--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1108,6 +1108,11 @@ export interface EditMemberPermissionsInput {
   accessLevel?: number | null;
 }
 
+export interface EditMilestoneOrderingStateInput {
+  milestoneId: Id;
+  orderingState: string[];
+}
+
 export interface EditProjectTimelineMilestoneUpdateInput {
   id: string;
   title: string;
@@ -3820,7 +3825,7 @@ export interface ProjectTasksUpdateDueDateResult {
 export interface ProjectTasksUpdateMilestoneInput {
   taskId: Id;
   milestoneId: Id | null;
-  index?: number;
+  milestonesOrderingState: EditMilestoneOrderingStateInput[];
 }
 
 export interface ProjectTasksUpdateMilestoneResult {

--- a/app/assets/js/models/milestones/index.tsx
+++ b/app/assets/js/models/milestones/index.tsx
@@ -1,7 +1,7 @@
 import * as Time from "@/utils/time";
 import * as People from "@/models/people";
 import { Milestone, MilestoneComment } from "@/api";
-import { CommentSection, DateField, TaskBoard } from "turboui";
+import { CommentSection, DateField } from "turboui";
 import { Paths } from "@/routes/paths";
 import { parseContextualDate } from "../contextualDates";
 
@@ -19,11 +19,11 @@ export interface ParsedMilestone extends Pick<Milestone, "id" | "title" | "descr
   deadline: DateField.ContextualDate | null;
 }
 
-export function parseMilestonesForTurboUi(paths: Paths, milestones: Milestone[]): TaskBoard.Milestone[] {
+export function parseMilestonesForTurboUi(paths: Paths, milestones: Milestone[]) {
   return milestones.map((m) => parseMilestoneForTurboUi(paths, m));
 }
 
-export function parseMilestoneForTurboUi(paths: Paths, milestone: Milestone): TaskBoard.Milestone {
+export function parseMilestoneForTurboUi(paths: Paths, milestone: Milestone) {
   return {
     id: milestone.id,
     name: milestone.title,

--- a/app/assets/js/models/milestones/index.tsx
+++ b/app/assets/js/models/milestones/index.tsx
@@ -1,7 +1,7 @@
 import * as Time from "@/utils/time";
 import * as People from "@/models/people";
 import { Milestone, MilestoneComment } from "@/api";
-import { CommentSection, DateField } from "turboui";
+import { CommentSection, DateField, TaskBoard } from "turboui";
 import { Paths } from "@/routes/paths";
 import { parseContextualDate } from "../contextualDates";
 
@@ -19,11 +19,11 @@ export interface ParsedMilestone extends Pick<Milestone, "id" | "title" | "descr
   deadline: DateField.ContextualDate | null;
 }
 
-export function parseMilestonesForTurboUi(paths: Paths, milestones: Milestone[]) {
+export function parseMilestonesForTurboUi(paths: Paths, milestones: Milestone[]): TaskBoard.Milestone[] {
   return milestones.map((m) => parseMilestoneForTurboUi(paths, m));
 }
 
-export function parseMilestoneForTurboUi(paths: Paths, milestone: Milestone) {
+export function parseMilestoneForTurboUi(paths: Paths, milestone: Milestone): TaskBoard.Milestone {
   return {
     id: milestone.id,
     name: milestone.title,

--- a/app/assets/js/models/tasks/index.tsx
+++ b/app/assets/js/models/tasks/index.tsx
@@ -5,7 +5,7 @@ import { parseMilestoneForTurboUi } from "../milestones";
 import { Status } from "turboui/src/TaskBoard/types";
 import { parseContent, richContentToString } from "turboui/RichContent";
 
-export type { Task } from "@/api";
+export type { Task, EditMilestoneOrderingStateInput } from "@/api";
 export { useTasksForTurboUi } from "./useTasksForTurboUi";
 
 export {

--- a/app/assets/js/models/tasks/index.tsx
+++ b/app/assets/js/models/tasks/index.tsx
@@ -4,6 +4,7 @@ import { Paths } from "@/routes/paths";
 import { parseMilestoneForTurboUi } from "../milestones";
 import { Status } from "turboui/src/TaskBoard/types";
 import { parseContent, richContentToString } from "turboui/RichContent";
+import { TaskBoard } from "turboui";
 
 export type { Task, EditMilestoneOrderingStateInput } from "@/api";
 export { useTasksForTurboUi } from "./useTasksForTurboUi";
@@ -25,11 +26,11 @@ export {
  * @param tasks - Array of backend Task objects
  * @returns Array of TurboUI Task objects
  */
-export function parseTasksForTurboUi(paths: Paths, tasks: BackendTask[]) {
+export function parseTasksForTurboUi(paths: Paths, tasks: BackendTask[]): TaskBoard.Task[] {
   return tasks.map((task) => parseTaskForTurboUi(paths, task));
 }
 
-export function parseTaskForTurboUi(paths: Paths, task: BackendTask) {
+export function parseTaskForTurboUi(paths: Paths, task: BackendTask): TaskBoard.Task {
   const description = parseContent(task.description || "{}");
 
   return {

--- a/app/assets/js/models/tasks/milestoneOrdering.test.tsx
+++ b/app/assets/js/models/tasks/milestoneOrdering.test.tsx
@@ -1,0 +1,147 @@
+import { TaskBoard } from "turboui";
+import { buildMilestonesOrderingState } from "./milestoneOrdering";
+
+describe("buildMilestonesOrderingState", () => {
+  test("should handle moving task from one milestone to another", () => {
+    // Create milestones with ordering states
+    const milestones = [
+      createMilestone("milestone-1", ["task-1", "task-2"]),
+      createMilestone("milestone-2", ["task-3"]),
+    ];
+    
+    // Create the task being moved
+    const task = createTask("task-1", "milestone-1");
+
+    const result = buildMilestonesOrderingState(
+      milestones,
+      task,
+      "milestone-2",
+      1
+    );
+
+    // Should update both source and target milestone ordering states
+    expect(result).toHaveLength(2);
+    
+    // Source milestone should only have task-2
+    expect(result[0]).toEqual({
+      milestoneId: "milestone-1",
+      orderingState: ["task-2"]
+    });
+    
+    // Target milestone should have task-3 and task-1 (inserted at index 1)
+    expect(result[1]).toEqual({
+      milestoneId: "milestone-2",
+      orderingState: ["task-3", "task-1"]
+    });
+  });
+
+  test("should handle moving task within the same milestone", () => {
+    // Create milestones with ordering states
+    const milestones = [
+      createMilestone("milestone-1", ["task-1", "task-2", "task-3"]),
+    ];
+    
+    // Create the task being moved
+    const task = createTask("task-1", "milestone-1");
+
+    const result = buildMilestonesOrderingState(
+      milestones,
+      task,
+      "milestone-1",
+      2
+    );
+
+    // Should update only one milestone
+    expect(result).toHaveLength(1);
+    
+    // Milestone should have task-2, task-3, task-1 (task-1 moved to end)
+    expect(result[0]).toEqual({
+      milestoneId: "milestone-1",
+      orderingState: ["task-2", "task-3", "task-1"]
+    });
+  });
+
+  test("should handle moving task to no-milestone", () => {
+    // Create milestones with ordering states
+    const milestones = [
+      createMilestone("milestone-1", ["task-1", "task-2"]),
+    ];
+    
+    // Create the task being moved
+    const task = createTask("task-1", "milestone-1");
+
+    const result = buildMilestonesOrderingState(
+      milestones,
+      task,
+      "no-milestone",
+      0
+    );
+
+    // Should only update source milestone
+    expect(result).toHaveLength(1);
+    
+    // Source milestone should only have task-2
+    expect(result[0]).toEqual({
+      milestoneId: "milestone-1",
+      orderingState: ["task-2"]
+    });
+  });
+
+  test("should handle moving task from no-milestone to a milestone", () => {
+    // Create milestones with ordering states
+    const milestones = [
+      createMilestone("milestone-1", ["task-2"]),
+    ];
+    
+    // Create the task being moved (with no milestone)
+    const task = createTask("task-1", null);
+
+    const result = buildMilestonesOrderingState(
+      milestones,
+      task,
+      "milestone-1",
+      1
+    );
+
+    // Should only update target milestone
+    expect(result).toHaveLength(1);
+    
+    // Target milestone should have task-2 and task-1
+    expect(result[0]).toEqual({
+      milestoneId: "milestone-1",
+      orderingState: ["task-2", "task-1"]
+    });
+  });
+});
+
+const createTask = (id: string, milestoneId: string | null): TaskBoard.Task => ({
+    id,
+    title: `Task ${id}`,
+    status: "todo" as const,
+    description: null,
+    link: "",
+    assignees: [],
+    milestone: milestoneId ? { 
+      id: milestoneId, 
+      name: `Milestone ${milestoneId}`,
+      status: "pending" as const, 
+      dueDate: null, 
+      link: "#",
+      tasksOrderingState: []
+    } : null,
+    dueDate: null,
+    hasDescription: false,
+    hasComments: false,
+    commentCount: 0,
+    comments: undefined,
+    _isHelperTask: false,
+  });
+
+const createMilestone = (id: string, taskIds: string[]): TaskBoard.Milestone => ({
+    id, 
+    name: `Milestone ${id}`,
+    status: "pending" as const, 
+    dueDate: null, 
+    link: "#",
+    tasksOrderingState: taskIds
+  });

--- a/app/assets/js/models/tasks/milestoneOrdering.tsx
+++ b/app/assets/js/models/tasks/milestoneOrdering.tsx
@@ -1,0 +1,81 @@
+import { TaskBoard } from "turboui";
+import { EditMilestoneOrderingStateInput } from "@/api";
+
+/**
+ * Builds milestone ordering state arrays for the task milestone update mutation
+ * 
+ * @param milestones - List of all milestones with their current ordering states
+ * @param task - The task being moved
+ * @param targetMilestoneId - ID of the milestone where the task is being moved to
+ * @param indexInTargetMilestone - Position in the target milestone
+ * @returns Array of milestone ordering states that need to be updated
+ */
+export const buildMilestonesOrderingState = (
+  milestones: TaskBoard.Milestone[],
+  task: TaskBoard.Task,
+  targetMilestoneId: string | null,
+  indexInTargetMilestone: number
+): EditMilestoneOrderingStateInput[] => {
+  const sourceMilestoneId = task.milestone?.id || null;
+  
+  const milestonesOrderingState: EditMilestoneOrderingStateInput[] = [];
+  
+  // Check if the milestone has changed
+  if (sourceMilestoneId !== targetMilestoneId) {
+    // Update source milestone (if it exists) by removing the task
+    if (sourceMilestoneId) {
+      const sourceMilestone = milestones.find(m => m.id === sourceMilestoneId);
+
+      if (sourceMilestone && sourceMilestone.tasksOrderingState) {
+        // Create a new ordering state without the task
+        const newSourceOrderingState = sourceMilestone.tasksOrderingState.filter(
+          taskId => taskId !== task.id
+        );
+        
+        milestonesOrderingState.push({
+          milestoneId: sourceMilestoneId,
+          orderingState: newSourceOrderingState,
+        });
+      }
+    }
+    
+    // Update target milestone (if it exists) by adding the task
+    if (targetMilestoneId) {
+      const targetMilestone = milestones.find(m => m.id === targetMilestoneId);
+
+      if (targetMilestone) {
+        // Create a copy of the current ordering state or initialize empty array
+        const newTargetOrderingState = [...(targetMilestone.tasksOrderingState || [])];
+        
+        // Insert task at the specified index
+        newTargetOrderingState.splice(indexInTargetMilestone, 0, task.id);
+        
+        milestonesOrderingState.push({
+          milestoneId: targetMilestoneId,
+          orderingState: newTargetOrderingState,
+        });
+      }
+    }
+  } else {
+    // Milestone hasn't changed - just update the ordering in the current milestone
+    if (targetMilestoneId) {
+      const milestone = milestones.find(m => m.id === targetMilestoneId);
+
+      if (milestone) {
+        // Remove the task from its current position
+        const currentOrderingState = [...(milestone.tasksOrderingState || [])];
+        const filteredOrderingState = currentOrderingState.filter(taskId => taskId !== task.id);
+        
+        // Insert the task at the new position
+        filteredOrderingState.splice(indexInTargetMilestone, 0, task.id);
+        
+        milestonesOrderingState.push({
+          milestoneId: targetMilestoneId,
+          orderingState: filteredOrderingState,
+        });
+      }
+    }
+  }
+  
+  return milestonesOrderingState;
+};

--- a/app/assets/js/models/tasks/useTasksForTurboUi.tsx
+++ b/app/assets/js/models/tasks/useTasksForTurboUi.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import Api from "@/api";
+import * as Milestones from "../milestones";
 import * as Tasks from "./index";
 
 import { compareIds, usePaths } from "@/routes/paths";
@@ -9,6 +10,11 @@ import { serializeContextualDate } from "../contextualDates";
 
 import { DateField, showErrorToast, TaskBoard } from "turboui";
 import { buildMilestonesOrderingState } from "./milestoneOrdering";
+
+interface TasksSnapshot {
+  tasks: TaskBoard.Task[];
+  milestones?: TaskBoard.Milestone[];
+}
 
 interface Attrs {
   backendTasks: Tasks.Task[];
@@ -27,28 +33,119 @@ export function useTasksForTurboUi({ backendTasks, projectId, cacheKey, mileston
     setTasks(Tasks.parseTasksForTurboUi(paths, backendTasks));
   }, [backendTasks, paths]);
 
+  const createSnapshot = React.useCallback((): TasksSnapshot => ({
+    tasks: [...tasks],
+    milestones: setMilestones ? [...milestones] : undefined,
+  }), [tasks, milestones, setMilestones]);
+
+  const restoreSnapshot = React.useCallback((snapshot: TasksSnapshot) => {
+    setTasks(snapshot.tasks);
+    if (setMilestones && snapshot.milestones) {
+      setMilestones(snapshot.milestones);
+    }
+  }, [setMilestones]);
+
+  const updateMilestonesFromServer = React.useCallback((
+    updatedMilestone: Milestones.Milestone | null,
+    updatedMilestones: Milestones.Milestone[] | null
+  ) => {
+    if (!setMilestones) return;
+
+    setMilestones(prev => {
+      let newMilestones = [...prev];
+
+      // Handle single milestone update
+      if (updatedMilestone) {
+        const index = newMilestones.findIndex(m => compareIds(m.id, updatedMilestone.id));
+        if (index >= 0) {
+          newMilestones[index] = Milestones.parseMilestoneForTurboUi(paths, updatedMilestone);
+        }
+      }
+
+      // Handle multiple milestones update (takes precedence)
+      if (updatedMilestones && updatedMilestones.length > 0) {
+        const parsedMilestones = Milestones.parseMilestonesForTurboUi(paths, updatedMilestones); 
+
+        parsedMilestones.forEach(updatedMilestone => {
+          const index = newMilestones.findIndex(m => compareIds(m.id, updatedMilestone.id));
+          if (index >= 0) {
+            newMilestones[index] = updatedMilestone;
+          }
+        });
+      }
+
+      return newMilestones;
+    });
+  }, [setMilestones]);
+
   const createTask = async (task: TaskBoard.NewTaskPayload) => {
-    return Api.project_tasks
-      .create({
+    const snapshot = createSnapshot();
+    const tempId = `temp-${Date.now()}`;
+
+    const optimisticTask: TaskBoard.Task = {
+      id: tempId,
+      title: task.title,
+      description: "",
+      link: "#",
+      status: "pending" as TaskBoard.Status,
+      assignees: task.assignee ? [{ id: task.assignee, fullName: "Loading...", avatarUrl: "" }] : [],
+      dueDate: task.dueDate || null,
+      milestone: task.milestone,
+    };
+
+    setTasks(prev => [...prev, optimisticTask]);
+
+    // Update milestone ordering if task has a milestone
+    if (task.milestone && setMilestones) {
+      setMilestones(prev => prev.map(m => {
+        if (compareIds(m.id, task.milestone!.id)) {
+          return {
+            ...m,
+            tasksOrderingState: m.tasksOrderingState ? [...m.tasksOrderingState, tempId] : [tempId]
+          };
+        }
+        return m;
+      }));
+    }
+
+    try {
+      const res = await Api.project_tasks.create({
         name: task.title,
         assigneeId: task.assignee,
         dueDate: serializeContextualDate(task.dueDate),
         milestoneId: task.milestone?.id || null,
         projectId: projectId,
-      })
-      .then((data) => {
-        PageCache.invalidate(cacheKey);
-
-        setTasks((prev) => [...prev, Tasks.parseTaskForTurboUi(paths, data.task)]);
-
-        return { success: true };
-      })
-      .catch((e) => {
-        console.error("Failed to create task", e);
-        showErrorToast("Error", "Failed to create task");
-
-        return { success: false };
       });
+
+      // Replace temporary task with real task
+      const realTask = Tasks.parseTaskForTurboUi(paths, res.task);
+      setTasks(prev => prev.map(t => t.id === tempId ? realTask : t));
+
+      // Update milestones with server response
+      updateMilestonesFromServer(res.updatedMilestone, null);
+
+      // Replace temp ID in milestone ordering
+      if (task.milestone && setMilestones) {
+        setMilestones(prev => prev.map(m => {
+          if (compareIds(m.id, task.milestone!.id)) {
+            return {
+              ...m,
+              tasksOrderingState: m.tasksOrderingState ? m.tasksOrderingState.map(id => id === tempId ? realTask.id : id) : [],
+            };
+          }
+          return m;
+        }));
+      }
+
+      PageCache.invalidate(cacheKey);
+      return { success: true };
+
+    } catch (e) {
+      console.error("Failed to create task", e);
+      showErrorToast("Error", "Failed to create task");
+      restoreSnapshot(snapshot);
+      return { success: false };
+    }
   };
 
   const updateTaskDueDate = async (taskId: string, dueDate: DateField.ContextualDate | null) => {

--- a/app/assets/js/models/tasks/useTasksForTurboUi.tsx
+++ b/app/assets/js/models/tasks/useTasksForTurboUi.tsx
@@ -277,7 +277,7 @@ export function useTasksForTurboUi({ backendTasks, projectId, cacheKey, mileston
         });
       }
 
-      const res = await Api.project_tasks.updateMilestone({
+      const res = await Api.project_tasks.updateMilestoneAndOrdering({
         taskId,
         milestoneId: normalizedMilestoneId,
         milestonesOrderingState,

--- a/app/assets/js/pages/MilestoneV2Page/index.tsx
+++ b/app/assets/js/pages/MilestoneV2Page/index.tsx
@@ -115,11 +115,12 @@ function Page() {
     onError: (e: string) => showErrorToast(e, "Failed to update milestone due date."),
   });
 
-  const { tasks, createTask, updateTaskAssignee, updateTaskDueDate, updateTaskStatus } = Tasks.useTasksForTurboUi(
-    data.tasks,
-    milestone.project.id,
-    pageCacheKey(milestone.id),
-  );
+  const { tasks, createTask, updateTaskAssignee, updateTaskDueDate, updateTaskStatus } = Tasks.useTasksForTurboUi({
+    backendTasks: data.tasks,
+    projectId: milestone.project.id,
+    cacheKey: pageCacheKey(milestone.id),
+    milestones: [],
+  });
   const { comments, setComments, handleCreateComment } = useComments(paths, milestone);
   const [status, setStatus] = useStatusField(paths, pageData, setComments);
 

--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -78,7 +78,8 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
 
 function Page() {
   const paths = usePaths();
-  const { project, checkIns, discussions, company, backendTasks } = PageCache.useData(loader).data;
+  const { data, refresh } = PageCache.useData(loader);
+  const { project, checkIns, discussions, company, backendTasks } = data;
   const navigate = useNavigate();
 
   const mentionedPersonLookup = useMentionedPersonLookupFn();
@@ -149,8 +150,16 @@ function Page() {
 
   const { milestones, setMilestones, createMilestone, updateMilestone } = useMilestones(paths, project);
   const { resources, createResource, updateResource, removeResource } = useResources(project);
+
   const { tasks, createTask, updateTaskDueDate, updateTaskAssignee, updateTaskStatus, updateTaskMilestone } =
-    Tasks.useTasksForTurboUi(backendTasks, project.id, pageCacheKey(project.id), setMilestones);
+    Tasks.useTasksForTurboUi({
+      backendTasks,
+      projectId: project.id,
+      cacheKey: pageCacheKey(project.id),
+      milestones,
+      setMilestones,
+      refresh,
+    });
 
   const parentGoalSearch = useParentGoalSearch(project);
   const spaceSearch = useSpaceSearch();

--- a/app/lib/operately/data/change_079_update_milestone_tasks_ordering_state.ex
+++ b/app/lib/operately/data/change_079_update_milestone_tasks_ordering_state.ex
@@ -1,0 +1,68 @@
+defmodule Operately.Data.Change079UpdateMilestoneTasksOrderingState do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias __MODULE__.{Milestone, Task}
+
+  def run do
+    Repo.transaction(fn ->
+      from(m in Milestone,
+        preload: [:tasks]
+      )
+      |> Repo.all()
+      |> Enum.each(&update_milestone_ordering/1)
+    end)
+  end
+
+  defp update_milestone_ordering(milestone) do
+    active_tasks = Enum.filter(milestone.tasks, fn task ->
+      task.status != "done" && task.status != "canceled"
+    end)
+
+    task_short_ids = Enum.map(active_tasks, &OperatelyWeb.Paths.task_id/1)
+
+    Repo.update_all(
+      from(m in Milestone, where: m.id == ^milestone.id),
+      set: [tasks_ordering_state: task_short_ids]
+    )
+  end
+
+  defmodule Milestone do
+    use Operately.Schema
+
+    schema "project_milestones" do
+      field :tasks_ordering_state, {:array, :string}, default: Operately.Tasks.OrderingState.initialize()
+      has_many :tasks, Task
+    end
+
+    def changeset(attrs) do
+      changeset(%__MODULE__{}, attrs)
+    end
+
+    def changeset(milestone, attrs) do
+      milestone
+      |> cast(attrs, [:tasks_ordering_state])
+    end
+  end
+
+  defmodule Task do
+    use Operately.Schema
+
+    schema "tasks" do
+      belongs_to :milestone, Milestone
+      field :name, :string
+      field :status, :string
+
+      timestamps()
+    end
+
+    def changeset(attrs) do
+      changeset(%__MODULE__{}, attrs)
+    end
+
+    def changeset(task, attrs) do
+      task
+      |> cast(attrs, [:milestone_id, :status])
+    end
+  end
+end

--- a/app/lib/operately/tasks/milestone_sync.ex
+++ b/app/lib/operately/tasks/milestone_sync.ex
@@ -1,0 +1,243 @@
+defmodule Operately.Tasks.MilestoneSync do
+  @moduledoc """
+  Handles synchronization between tasks and milestone ordering state.
+  """
+
+  import Ecto.Query, only: [from: 2]
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Tasks.{Task, OrderingState}
+  alias Operately.Projects.Milestone
+
+  @doc """
+  Handles milestone sync after task creation
+  """
+  def sync_after_task_create(multi, milestone_id) when is_nil(milestone_id), do: multi
+  def sync_after_task_create(multi, milestone_id) do
+    Multi.run(multi, :milestone_sync_create, fn _repo, changes ->
+      with_milestone_lock(milestone_id, fn milestone ->
+        task = get_task_from_changes(changes)
+        ordering_state = OrderingState.load(milestone.tasks_ordering_state)
+        updated_ordering = OrderingState.add_task(ordering_state, task)
+
+        update_milestone_ordering(milestone, updated_ordering)
+      end)
+    end)
+    |> Multi.run(:updated_milestone, &extract_milestone_from_sync/2)
+  end
+
+  @doc """
+  Handles milestone sync after task status update
+  """
+  def sync_after_status_update(multi) do
+    Multi.run(multi, :milestone_sync_status, fn _repo, changes ->
+      task = Map.get(changes, :task) || Map.get(changes, :updated_task)
+      updated_task = Map.get(changes, :updated_task)
+
+      case task.milestone_id do
+        nil -> {:ok, nil}
+        milestone_id -> sync_status_change(milestone_id, task, updated_task)
+      end
+    end)
+    |> Multi.run(:updated_milestone, &extract_milestone_from_sync/2)
+  end
+
+  @doc """
+  Handles milestone sync after task deletion
+  """
+  def sync_after_task_delete(multi) do
+    Multi.run(multi, :milestone_sync_delete, fn _repo, changes ->
+      task = Map.get(changes, :task) || Map.get(changes, :delete_task)
+
+      case task.milestone_id do
+        nil -> {:ok, nil}
+        milestone_id ->
+          with_milestone_lock(milestone_id, fn milestone ->
+            ordering_state = OrderingState.load(milestone.tasks_ordering_state)
+            updated_ordering = OrderingState.remove_task(ordering_state, task)
+
+            update_milestone_ordering(milestone, updated_ordering)
+          end)
+      end
+    end)
+    |> Multi.run(:updated_milestone, &extract_milestone_from_sync/2)
+  end
+
+  @doc """
+  Handles milestone sync after task milestone change (move between milestones)
+  """
+  def sync_after_milestone_change(multi, new_milestone_id) do
+    multi
+    |> sync_remove_from_old_milestone(new_milestone_id)
+    |> sync_add_to_new_milestone(new_milestone_id)
+    |> Multi.run(:milestone_change_sync, &collect_updated_milestones/2)
+  end
+
+  @doc """
+  Handles milestone sync for manual ordering updates
+  """
+  def sync_manual_ordering(multi, ordering_states) do
+    Multi.run(multi, :milestone_sync_manual, fn _repo, _changes ->
+      updated_milestones =
+        ordering_states
+        |> validate_and_filter_ordering_states()
+        |> update_multiple_milestone_orderings()
+
+      {:ok, updated_milestones}
+    end)
+  end
+
+  #
+  # Helpers
+  #
+
+  defp sync_remove_from_old_milestone(multi, nil), do: multi
+  defp sync_remove_from_old_milestone(multi, new_milestone_id) do
+    Multi.run(multi, :sync_remove_old, fn _repo, changes ->
+      task = get_task_from_changes(changes)
+
+      if task.milestone_id != new_milestone_id do
+        with_milestone_lock(task.milestone_id, fn milestone ->
+          ordering_state = OrderingState.load(milestone.tasks_ordering_state)
+          updated_ordering = OrderingState.remove_task(ordering_state, task)
+
+          update_milestone_ordering(milestone, updated_ordering)
+        end)
+      else
+        {:ok, nil}
+      end
+    end)
+  end
+
+  defp sync_add_to_new_milestone(multi, nil), do: multi
+  defp sync_add_to_new_milestone(multi, new_milestone_id) do
+    Multi.run(multi, :sync_add_new, fn _repo, changes ->
+      task = get_updated_task_from_changes(changes)
+
+      if task.milestone_id != new_milestone_id do
+        with_milestone_lock(new_milestone_id, fn milestone ->
+          ordering_state = OrderingState.load(milestone.tasks_ordering_state)
+          updated_ordering = OrderingState.add_task(ordering_state, task)
+
+          update_milestone_ordering(milestone, updated_ordering)
+        end)
+      else
+        {:ok, nil}
+      end
+    end)
+  end
+
+  defp sync_status_change(milestone_id, original_task, updated_task) do
+    with_milestone_lock(milestone_id, fn milestone ->
+      ordering_state = OrderingState.load(milestone.tasks_ordering_state)
+
+      updated_ordering =
+        case {task_should_be_in_ordering?(original_task), task_should_be_in_ordering?(updated_task)} do
+          {true, false} ->
+            OrderingState.remove_task(ordering_state, updated_task)
+
+          {false, true} ->
+            OrderingState.add_task(ordering_state, updated_task)
+
+          _ ->
+            # No change in ordering relevance
+            ordering_state
+        end
+
+      update_milestone_ordering(milestone, updated_ordering)
+    end)
+  end
+
+  defp task_should_be_in_ordering?(%{status: status}) when status in ["done", "canceled"], do: false
+  defp task_should_be_in_ordering?(_task), do: true
+
+  defp with_milestone_lock(milestone_id, callback) do
+    query = from(m in Milestone, where: m.id == ^milestone_id, lock: "FOR UPDATE")
+
+    case Repo.one(query) do
+      nil -> {:ok, nil}
+      milestone -> callback.(milestone)
+    end
+  end
+
+  defp update_milestone_ordering(milestone, new_ordering_state) do
+    changeset = Milestone.changeset(milestone, %{tasks_ordering_state: new_ordering_state})
+    Repo.update(changeset)
+  end
+
+  defp validate_and_filter_ordering_states(ordering_states) do
+    Enum.map(ordering_states, fn state ->
+      case state.ordering_state do
+        nil -> state
+        [] -> state
+        ordering ->
+          {:ok, task_ids} = OperatelyWeb.Api.Helpers.decode_id(ordering)
+
+          valid_tasks =
+            from(t in Task,
+              where: t.id in ^task_ids,
+              where: t.milestone_id == ^state.milestone_id and t.status not in ["done", "canceled"]
+            )
+            |> Repo.all()
+
+          valid_encoded_ids = Enum.map(valid_tasks, &OperatelyWeb.Paths.task_id/1) |> MapSet.new()
+          filtered_ordering = Enum.filter(ordering, &MapSet.member?(valid_encoded_ids, &1))
+
+          %{state | ordering_state: filtered_ordering}
+      end
+    end)
+  end
+
+  defp update_multiple_milestone_orderings(filtered_states) do
+    milestone_ids = Enum.map(filtered_states, & &1.milestone_id)
+
+    # Lock all milestones at once
+    milestones =
+      from(m in Milestone, where: m.id in ^milestone_ids, lock: "FOR UPDATE")
+      |> Repo.all()
+      |> Enum.reduce(%{}, fn milestone, acc ->
+        Map.put(acc, milestone.id, milestone)
+      end)
+
+    # Update each milestone
+    Enum.map(filtered_states, fn state ->
+      milestone = Map.get(milestones, state.milestone_id)
+      {:ok, updated_milestone} = update_milestone_ordering(milestone, state.ordering_state)
+      updated_milestone
+    end)
+  end
+
+  # Helper functions to extract the right task from Multi changes
+  defp get_task_from_changes(changes) do
+    Map.get(changes, :task) || Map.get(changes, :new_task)
+  end
+
+  defp get_updated_task_from_changes(changes) do
+    Map.get(changes, :updated_task) || get_task_from_changes(changes)
+  end
+
+  defp extract_milestone_from_sync(_repo, changes) do
+    milestone = case changes do
+      %{milestone_sync_create: milestone} -> milestone
+      %{milestone_sync_status: milestone} -> milestone
+      %{milestone_sync_delete: milestone} -> milestone
+      _ -> nil
+    end
+
+    {:ok, milestone}
+  end
+
+  defp collect_updated_milestones(_repo, changes) do
+    milestones = [
+      Map.get(changes, :sync_remove_old),
+      Map.get(changes, :sync_add_new)
+    ]
+    |> Enum.filter(fn
+      {:ok, milestone} when not is_nil(milestone) -> true
+      _ -> false
+    end)
+    |> Enum.map(fn {:ok, milestone} -> milestone end)
+
+    {:ok, milestones}
+  end
+end

--- a/app/lib/operately/tasks/ordering_state.ex
+++ b/app/lib/operately/tasks/ordering_state.ex
@@ -23,4 +23,9 @@ defmodule Operately.Tasks.OrderingState do
       idx -> List.insert_at(ordering_state, idx, task_short_id)
     end
   end
+
+  def remove_task(ordering_state, task) do
+    task_short_id = OperatelyWeb.Paths.task_id(task)
+    List.delete(ordering_state, task_short_id)
+  end
 end

--- a/app/lib/operately/tasks/ordering_state.ex
+++ b/app/lib/operately/tasks/ordering_state.ex
@@ -1,7 +1,6 @@
 defmodule Operately.Tasks.OrderingState do
   @moduledoc """
   Manages the ordering of tasks within a milestone using a simple list of short task IDs.
-  This is a simplified version of KanbanState that only tracks order, not status.
   """
 
   def load(nil), do: initialize()
@@ -12,35 +11,16 @@ defmodule Operately.Tasks.OrderingState do
     []
   end
 
-  def add_task(ordering_state, task, index \\ 0) do
+  def add_task(ordering_state, task, index \\ nil) do
     task_short_id = OperatelyWeb.Paths.task_id(task)
 
     # Remove task if it already exists to avoid duplicates
-    ordering_state = remove_task(ordering_state, task)
+    ordering_state = List.delete(ordering_state, task_short_id)
 
-    # Insert at the specified index
-    List.insert_at(ordering_state, index, task_short_id)
-  end
-
-  def remove_task(ordering_state, task) do
-    task_short_id = OperatelyWeb.Paths.task_id(task)
-    List.delete(ordering_state, task_short_id)
-  end
-
-  def move_task(ordering_state, task, new_index) do
-    task_short_id = OperatelyWeb.Paths.task_id(task)
-    ordering_state
-    |> List.delete(task_short_id)
-    |> List.insert_at(new_index, task_short_id)
-  end
-
-  def get_task_index(ordering_state, task) do
-    task_short_id = OperatelyWeb.Paths.task_id(task)
-    Enum.find_index(ordering_state, &(&1 == task_short_id))
-  end
-
-  def contains_task?(ordering_state, task) do
-    task_short_id = OperatelyWeb.Paths.task_id(task)
-    task_short_id in ordering_state
+    # Insert at the specified index, or at the end if no index provided
+    case index do
+      nil -> ordering_state ++ [task_short_id]
+      idx -> List.insert_at(ordering_state, idx, task_short_id)
+    end
   end
 end

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -102,6 +102,7 @@ defmodule OperatelyWeb.Api do
     mutation(:update_status, OperatelyWeb.Api.ProjectTasks.UpdateStatus)
     mutation(:update_due_date, OperatelyWeb.Api.ProjectTasks.UpdateDueDate)
     mutation(:update_assignee, OperatelyWeb.Api.ProjectTasks.UpdateAssignee)
+    mutation(:update_milestone, OperatelyWeb.Api.ProjectTasks.UpdateMilestone)
     mutation(:update_milestone_and_ordering, OperatelyWeb.Api.ProjectTasks.UpdateMilestoneAndOrdering)
     mutation(:update_description, OperatelyWeb.Api.ProjectTasks.UpdateDescription)
   end

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -102,7 +102,7 @@ defmodule OperatelyWeb.Api do
     mutation(:update_status, OperatelyWeb.Api.ProjectTasks.UpdateStatus)
     mutation(:update_due_date, OperatelyWeb.Api.ProjectTasks.UpdateDueDate)
     mutation(:update_assignee, OperatelyWeb.Api.ProjectTasks.UpdateAssignee)
-    mutation(:update_milestone, OperatelyWeb.Api.ProjectTasks.UpdateMilestone)
+    mutation(:update_milestone_and_ordering, OperatelyWeb.Api.ProjectTasks.UpdateMilestoneAndOrdering)
     mutation(:update_description, OperatelyWeb.Api.ProjectTasks.UpdateDescription)
   end
 

--- a/app/lib/operately_web/api/project_tasks.ex
+++ b/app/lib/operately_web/api/project_tasks.ex
@@ -271,7 +271,7 @@ defmodule OperatelyWeb.Api.ProjectTasks do
     end
   end
 
-  defmodule UpdateMilestone do
+  defmodule UpdateMilestoneAndOrdering do
     use TurboConnect.Mutation
     use OperatelyWeb.Api.Helpers
 

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -502,6 +502,11 @@ defmodule OperatelyWeb.Api.Types do
     field? :value, :float, null: true
   end
 
+  object :edit_milestone_ordering_state_input do
+    field :milestone_id, :id, null: false
+    field :ordering_state, list_of(:string), null: false
+  end
+
   enum(:milestone_comment_action, values: Operately.Comments.MilestoneComment.valid_actions())
 
   object :milestone_comment do

--- a/app/priv/repo/migrations/20250905101847_update_milestone_tasks_ordering_with_valid_tasks_list.exs
+++ b/app/priv/repo/migrations/20250905101847_update_milestone_tasks_ordering_with_valid_tasks_list.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.UpdateMilestoneTasksOrderingWithValidTasksList do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change079UpdateMilestoneTasksOrderingState.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/data/change_079_update_milestone_tasks_ordering_state_test.exs
+++ b/app/test/operately/data/change_079_update_milestone_tasks_ordering_state_test.exs
@@ -1,0 +1,119 @@
+defmodule Operately.Data.Change079UpdateMilestoneTasksOrderingStateTest do
+  use Operately.DataCase
+
+  alias Operately.Repo
+  alias Operately.Projects.Milestone
+  alias Operately.Data.Change079UpdateMilestoneTasksOrderingState
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+  end
+
+  test "updates tasks_ordering_state with only active tasks", ctx do
+    ctx = Factory.add_space(ctx, :space)
+    ctx = Factory.add_project(ctx, :project, :space)
+    ctx = Factory.add_project_milestone(ctx, :milestone, :project)
+
+    active_task1 = create_test_task(ctx.creator, ctx.milestone, "Active Task 1", "todo")
+    active_task2 = create_test_task(ctx.creator, ctx.milestone, "Active Task 2", "in_progress")
+    done_task = create_test_task(ctx.creator, ctx.milestone, "Done Task", "done")
+    canceled_task = create_test_task(ctx.creator, ctx.milestone, "Canceled Task", "canceled")
+
+    Change079UpdateMilestoneTasksOrderingState.run()
+
+    updated_milestone = Repo.get!(Milestone, ctx.milestone.id)
+    expected_task_ids = [
+      OperatelyWeb.Paths.task_id(active_task1),
+      OperatelyWeb.Paths.task_id(active_task2)
+    ]
+
+    # Sort both lists for consistent comparison
+    assert Enum.sort(updated_milestone.tasks_ordering_state) == Enum.sort(expected_task_ids)
+
+    # Verify excluded tasks are not in the ordering state
+    refute Enum.member?(updated_milestone.tasks_ordering_state, OperatelyWeb.Paths.task_id(done_task))
+    refute Enum.member?(updated_milestone.tasks_ordering_state, OperatelyWeb.Paths.task_id(canceled_task))
+  end
+
+  test "handles milestones with no active tasks", ctx do
+    ctx = Factory.add_space(ctx, :space)
+    ctx = Factory.add_project(ctx, :project, :space)
+    ctx = Factory.add_project_milestone(ctx, :milestone, :project)
+
+    _done_task = create_test_task(ctx.creator, ctx.milestone, "Done Task", "done")
+    _canceled_task = create_test_task(ctx.creator, ctx.milestone, "Canceled Task", "canceled")
+
+    Change079UpdateMilestoneTasksOrderingState.run()
+
+    updated_milestone = Repo.get!(Milestone, ctx.milestone.id)
+    assert updated_milestone.tasks_ordering_state == []
+  end
+
+  test "handles milestones with mixed tasks", ctx do
+    ctx = Factory.add_space(ctx, :space)
+    ctx = Factory.add_project(ctx, :project, :space)
+    ctx = Factory.add_project_milestone(ctx, :milestone1, :project)
+    ctx = Factory.add_project_milestone(ctx, :milestone2, :project)
+
+    # Milestone 1 with mixed tasks
+    active_task1 = create_test_task(ctx.creator, ctx.milestone1, "Active Task 1", "todo")
+    _done_task1 = create_test_task(ctx.creator, ctx.milestone1, "Done Task", "done")
+    active_task2 = create_test_task(ctx.creator, ctx.milestone1, "Active Task 2", "in_progress")
+
+    # Milestone 2 with only inactive tasks
+    _done_task2 = create_test_task(ctx.creator, ctx.milestone2, "Done Task", "done")
+    _canceled_task2 = create_test_task(ctx.creator, ctx.milestone2, "Canceled Task", "canceled")
+
+    Change079UpdateMilestoneTasksOrderingState.run()
+
+    updated_milestone1 = Repo.get!(Milestone, ctx.milestone1.id)
+    updated_milestone2 = Repo.get!(Milestone, ctx.milestone2.id)
+
+    expected_milestone1_ids = [
+      OperatelyWeb.Paths.task_id(active_task1),
+      OperatelyWeb.Paths.task_id(active_task2)
+    ]
+
+    # Sort for consistent comparison
+    assert Enum.sort(updated_milestone1.tasks_ordering_state) == Enum.sort(expected_milestone1_ids)
+    assert updated_milestone2.tasks_ordering_state == []
+  end
+
+  test "preserves existing tasks_ordering_state structure", ctx do
+    ctx = Factory.add_space(ctx, :space)
+    ctx = Factory.add_project(ctx, :project, :space)
+    ctx = Factory.add_project_milestone(ctx, :milestone, :project)
+
+    active_task1 = create_test_task(ctx.creator, ctx.milestone, "Active Task 1", "todo")
+    active_task2 = create_test_task(ctx.creator, ctx.milestone, "Active Task 2", "in_progress")
+    done_task = create_test_task(ctx.creator, ctx.milestone, "Done Task", "done")
+
+    # Verify migration works correctly
+    Change079UpdateMilestoneTasksOrderingState.run()
+
+    updated_milestone = Repo.get!(Milestone, ctx.milestone.id)
+    expected_task_ids = [
+      OperatelyWeb.Paths.task_id(active_task1),
+      OperatelyWeb.Paths.task_id(active_task2)
+    ]
+
+    assert Enum.sort(updated_milestone.tasks_ordering_state) == Enum.sort(expected_task_ids)
+    refute Enum.member?(updated_milestone.tasks_ordering_state, OperatelyWeb.Paths.task_id(done_task))
+  end
+
+  defp create_test_task(creator, milestone, name, status) do
+    attrs = %{
+      name: name,
+      description: Operately.Support.RichText.rich_text("Test task description"),
+      milestone_id: milestone.id,
+      status: status,
+      creator_id: creator.id,
+      assignee_id: creator.id,
+      project_id: milestone.project_id
+    }
+
+    {:ok, task} = Operately.Tasks.create_task(attrs)
+    task
+  end
+end

--- a/app/test/operately_web/api/project_tasks_test.exs
+++ b/app/test/operately_web/api/project_tasks_test.exs
@@ -584,13 +584,13 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
 
   describe "update task milestone" do
     test "it requires authentication", ctx do
-      assert {401, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{})
+      assert {401, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{})
     end
 
     test "it requires a task_id", ctx do
       ctx = Factory.log_in_person(ctx, :creator)
 
-      assert {400, res} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {400, res} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         milestone_id: Paths.milestone_id(ctx.milestone),
         milestones_ordering_state: []
       })
@@ -605,7 +605,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.log_in_person(:creator)
 
       # Moving task from milestone to milestone2, updating ordering for both
-      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone2),
         milestones_ordering_state: [
@@ -637,7 +637,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.add_project_task(:task2, :milestone)
         |> Factory.log_in_person(:creator)
 
-      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: nil,
         milestones_ordering_state: [
@@ -664,7 +664,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
 
       before_count = count_activities(ctx.project.id, "task_milestone_updating")
 
-      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone2),
         milestones_ordering_state: [
@@ -690,7 +690,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.add_project_milestone(:milestone2, :project2)
         |> Factory.log_in_person(:creator)
 
-      assert {400, res} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {400, res} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone2),
         milestones_ordering_state: [
@@ -712,7 +712,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.log_in_person(:creator)
 
       # Task stays in same milestone, but ordering changes
-      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone),  # Same milestone
         milestones_ordering_state: [
@@ -741,7 +741,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.log_in_person(:creator)
 
       # Task moves from milestone to milestone2, affecting both ordering states
-      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, _} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone2),
         milestones_ordering_state: [
@@ -777,7 +777,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.log_in_person(:creator)
 
       # Move task to another milestone and include all tasks in the ordering state
-      assert {200, res} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, res} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone2),
         milestones_ordering_state: [
@@ -819,7 +819,7 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
         |> Factory.log_in_person(:creator)
 
       # Try to include a task from milestone2 in milestone's ordering state
-      assert {200, res} = mutation(ctx.conn, [:project_tasks, :update_milestone], %{
+      assert {200, res} = mutation(ctx.conn, [:project_tasks, :update_milestone_and_ordering], %{
         task_id: Paths.task_id(ctx.task),
         milestone_id: Paths.milestone_id(ctx.milestone),  # Same milestone
         milestones_ordering_state: [

--- a/turboui/src/TaskBoard/components/EmptyMilestoneDropZone.tsx
+++ b/turboui/src/TaskBoard/components/EmptyMilestoneDropZone.tsx
@@ -19,7 +19,7 @@ export interface EmptyMilestoneDropZoneProps {
  */
 export function EmptyMilestoneDropZone({ milestoneId, onTaskCreation }: EmptyMilestoneDropZoneProps) {
   // Set up drop zone with the same ID pattern as TaskList
-  const { ref } = useDropZone({ id: `milestone-${milestoneId}`, dependencies: [] });
+  const { ref } = useDropZone({ id: milestoneId, dependencies: [] });
 
   return (
     <div

--- a/turboui/src/TaskBoard/components/TaskItem.tsx
+++ b/turboui/src/TaskBoard/components/TaskItem.tsx
@@ -26,7 +26,7 @@ export function TaskItem({ task, milestoneId, itemStyle, onTaskDueDateChange, on
   const [currentStatus, setCurrentStatus] = useState<TaskWithIndex["status"]>(task.status);
 
   // Set up draggable behavior
-  const { ref, isDragging } = useDraggable({ id: task.id, zoneId: `milestone-${milestoneId}` });
+  const { ref, isDragging } = useDraggable({ id: task.id, zoneId: milestoneId });
 
   const itemClasses = classNames(isDragging ? "opacity-50 bg-surface-accent" : "");
 

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -52,12 +52,12 @@ export function TaskList({
 
   // Set up drop zone for this list of tasks
   const { ref } = useDropZone({
-    id: `milestone-${milestoneId}`,
+    id: milestoneId,
     dependencies: [tasksWithIndex],
   });
 
   // Get the animation styles for the container and items
-  const { containerStyle, itemStyle } = useDraggingAnimation(`milestone-${milestoneId}`, tasksWithIndex);
+  const { containerStyle, itemStyle } = useDraggingAnimation(milestoneId, tasksWithIndex);
 
   // Count hidden tasks for the ghost row
   const totalHiddenCount = hiddenTasks.length;


### PR DESCRIPTION
The drag-and-drop feature to reorder tasks and update their milestones has several issues. This PR attempts to fix them.