### PR TITLE
fix: Handle nil in query when reordering Task without Milestone

### DIFF
--- a/app/lib/operately/tasks/milestone_sync.ex
+++ b/app/lib/operately/tasks/milestone_sync.ex
@@ -151,6 +151,7 @@ defmodule Operately.Tasks.MilestoneSync do
   defp task_should_be_in_ordering?(%{status: status}) when status in ["done", "canceled"], do: false
   defp task_should_be_in_ordering?(_task), do: true
 
+  defp with_milestone_lock(nil, _callback), do: {:ok, nil}
   defp with_milestone_lock(milestone_id, callback) do
     query = from(m in Milestone, where: m.id == ^milestone_id, lock: "FOR UPDATE")
 


### PR DESCRIPTION
When a Task didn't have a Milestone, trying to drag and drop it to a Milestone was raising an error because `nil` was not handled in the Milestone query. Now, `nil` values are handled.