### PR TITLE
fix: Hide bullet points in hidden Tasks list

### DIFF
--- a/app/assets/js/pages/MilestoneV2Page/index.tsx
+++ b/app/assets/js/pages/MilestoneV2Page/index.tsx
@@ -63,7 +63,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
 }
 
 export function pageCacheKey(id: string): string {
-  return `v11-MilestoneV2Page.task-${id}`;
+  return `v12-MilestoneV2Page.task-${id}`;
 }
 
 function Page() {

--- a/app/assets/js/pages/ProjectV2Page/index.tsx
+++ b/app/assets/js/pages/ProjectV2Page/index.tsx
@@ -28,7 +28,7 @@ export default { name: "ProjectV2Page", loader, Page } as PageModule;
 export { pageCacheKey as projectPageCacheKey };
 
 function pageCacheKey(id: string): string {
-  return `v5-ProjectV2Page.project-${id}`;
+  return `v6-ProjectV2Page.project-${id}`;
 }
 
 type LoaderResult = {

--- a/app/assets/js/pages/TaskV2Page/index.tsx
+++ b/app/assets/js/pages/TaskV2Page/index.tsx
@@ -64,7 +64,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
 }
 
 export function pageCacheKey(id: string): string {
-  return `v6-TaskV2Page.task-${id}`;
+  return `v7-TaskV2Page.task-${id}`;
 }
 
 export default { name: "TaskV2Page", loader, Page } as PageModule;

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -117,7 +117,7 @@ export function TaskList({
       {/* Hidden tasks that are expanded with animation */}
       {hiddenTasksExpanded &&
         hiddenTasks.map((task, index) => (
-          <div
+          <ul
             key={`hidden-${task.id}`}
             className="animate-fadeIn"
             style={{
@@ -134,7 +134,7 @@ export function TaskList({
               searchPeople={searchPeople}
               draggingDisabled
             />
-          </div>
+          </ul>
         ))}
     </>
   );


### PR DESCRIPTION
On the Milestones page, bullet points were being displayed in the hidden Tasks list:
![1](https://github.com/user-attachments/assets/70761fe2-5d0c-4831-90de-b8733cddbb27)


That's now fixed:
![2](https://github.com/user-attachments/assets/20f4eb2b-7e43-4d2a-986d-6f3951d4a9c3)
