### PR TITLE
fix: wire upload handler for rich editor toolbar

### DIFF
--- a/turboui/src/RichEditor/EditorContext.tsx
+++ b/turboui/src/RichEditor/EditorContext.tsx
@@ -5,8 +5,8 @@ import { EditorState, Person } from "./useEditor";
 
 export const EditorContext = React.createContext<EditorState | null>(null);
 
-export function useUploadFile(): EditorState["editor"]["uploadFile"] {
-  return useEditorContext().editor.uploadFile;
+export function useUploadFile(): EditorState["uploadFile"] {
+  return useEditorContext().uploadFile;
 }
 
 export function usePerson(id: string): Person | null {


### PR DESCRIPTION
## Summary
- ensure the rich editor context exposes the injected upload handler for attachments

## Testing
- make turboui.build *(fails: docker: command not found)*
- make turboui.test *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d272c55388832a8ea12b08e460e461