### PR TITLE
fix: Handle flushSync error when editing description on Task page

### DIFF
--- a/turboui/src/RichContent/index.tsx
+++ b/turboui/src/RichContent/index.tsx
@@ -18,7 +18,10 @@ export default function RichContent({ content, className, mentionedPersonLookup 
   });
 
   React.useEffect(() => {
-    editor.setContent(content);
+    // Use setTimeout to avoid flushSync warning by deferring the update
+    setTimeout(() => {
+      editor.setContent(content);
+    }, 0);
   }, [content]);
 
   return <Content editor={editor} className={className} />;


### PR DESCRIPTION
We were getting the following error when editing a Task description which included mentioned people:

```
Warning: flushSync was called from inside a lifecycle method. React cannot flush when React is already rendering. Consider moving this call to a scheduler task or micro task.
```

That's now fixed.