### PR TITLE
feat: Always show 'Last update' section with 'Check in' button in Goal and Project sidebars

### DIFF
--- a/app/assets/js/pages/GoalPage/index.tsx
+++ b/app/assets/js/pages/GoalPage/index.tsx
@@ -28,6 +28,7 @@ import { Paths, usePaths } from "@/routes/paths";
 import { useAiSidebar } from "../../features/AiSidebar";
 import { useChecklists } from "./useChecklists";
 import { useRichEditorHandlers } from "@/features/richtexteditor";
+import { useMe } from "@/contexts/CurrentCompanyContext";
 export default { name: "GoalPage", loader, Page } as PageModule;
 
 function pageCacheKey(id: string): string {
@@ -76,6 +77,7 @@ function Page() {
   const paths = usePaths();
   const navigate = useNavigate();
   const { goal, workMap, checkIns, discussions } = PageCache.useData(loader).data;
+  const currentUser = useMe();
 
   assertPresent(goal.space);
   assertPresent(goal.privacy);
@@ -227,6 +229,7 @@ function Page() {
     discussions: prepareDiscussions(paths, discussions),
     contributors: [],
     relatedWorkItems: prepareWorkMapData(workMap),
+    currentUser: currentUser ? People.parsePersonForTurboUi(paths, currentUser) : null,
 
     richTextHandlers: richEditorHandlers,
 

--- a/app/assets/js/pages/ProjectCheckInsPage/CheckInButton.tsx
+++ b/app/assets/js/pages/ProjectCheckInsPage/CheckInButton.tsx
@@ -10,5 +10,5 @@ export function CheckInButton({ project }: { project: Projects.Project }) {
 
   const path = paths.projectCheckInNewPath(project.id!);
 
-  return <PrimaryButton linkTo={path}>Check-In Now</PrimaryButton>;
+  return <PrimaryButton linkTo={path}>Check in</PrimaryButton>;
 }

--- a/app/assets/js/pages/ProjectPage/index.tsx
+++ b/app/assets/js/pages/ProjectPage/index.tsx
@@ -23,6 +23,7 @@ import { Paths, usePaths } from "@/routes/paths";
 import { useAiSidebar } from "../../features/AiSidebar";
 import { parseContextualDate, serializeContextualDate } from "../../models/contextualDates";
 import { useRichEditorHandlers } from "@/features/richtexteditor";
+import { useMe } from "@/contexts/CurrentCompanyContext";
 
 export default { name: "ProjectV2Page", loader, Page } as PageModule;
 export { pageCacheKey as projectPageCacheKey };
@@ -76,6 +77,7 @@ function Page() {
   const { data, refresh } = PageCache.useData(loader);
   const { project, checkIns, discussions, backendTasks, childrenCount } = data;
   const navigate = useNavigate();
+  const currentUser = useMe();
 
   useAiSidebar({
     conversationContext: {
@@ -266,6 +268,7 @@ function Page() {
     discussions: prepareDiscussions(paths, discussions),
     newCheckInLink: paths.projectCheckInNewPath(project.id),
     newDiscussionLink: paths.projectDiscussionNewPath(project.id),
+    currentUser: currentUser ? People.parsePersonForTurboUi(paths, currentUser) : null,
     searchPeople: assigneeSearch,
 
     richTextHandlers: richEditorHandlers,

--- a/turboui/src/GoalPage/CheckIns.tsx
+++ b/turboui/src/GoalPage/CheckIns.tsx
@@ -18,14 +18,18 @@ export function CheckIns(props: GoalPage.State) {
 
         {showCheckInButton && (
           <PrimaryButton linkTo={props.newCheckInLink} size="xs" testId="check-in-button">
-            Check-In Now
+            Post check-in
           </PrimaryButton>
         )}
       </div>
 
       <div className="mt-8">
         {props.checkIns.map((checkIn) => (
-          <CheckInCard key={checkIn.id} checkIn={checkIn} mentionedPersonLookup={props.richTextHandlers.mentionedPersonLookup} />
+          <CheckInCard
+            key={checkIn.id}
+            checkIn={checkIn}
+            mentionedPersonLookup={props.richTextHandlers.mentionedPersonLookup}
+          />
         ))}
       </div>
     </div>

--- a/turboui/src/GoalPage/index.stories.tsx
+++ b/turboui/src/GoalPage/index.stories.tsx
@@ -53,6 +53,7 @@ function Component(props: Partial<GoalPage.Props>) {
       space: "view",
     },
   );
+  const currentUser = React.useMemo(() => props.currentUser || genPerson(), [props.currentUser]);
 
   React.useEffect(() => {
     setChecklistItems(props.checklistItems || []);
@@ -159,6 +160,7 @@ function Component(props: Partial<GoalPage.Props>) {
       {...checklistHandlers}
       deleteGoal={deleteGoal}
       richTextHandlers={createMockRichEditorHandlers()}
+      currentUser={currentUser}
     />
   );
 }

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -117,6 +117,7 @@ export namespace GoalPage {
     relatedWorkItems: MiniWorkMap.WorkItem[];
     checkIns: CheckIn[];
     discussions: Discussion[];
+    currentUser?: Person | null;
     status: BadgeStatus;
     state: "active" | "closed";
 

--- a/turboui/src/ProjectPage/CheckIns.tsx
+++ b/turboui/src/ProjectPage/CheckIns.tsx
@@ -18,14 +18,18 @@ export function CheckIns(props: ProjectPage.State) {
 
         {showCheckInButton && (
           <PrimaryButton linkTo={props.newCheckInLink} size="xs" testId="check-in-button">
-            Check-In Now
+            Post check-in
           </PrimaryButton>
         )}
       </div>
 
       <div className="mt-8">
         {props.checkIns.map((checkIn) => (
-          <CheckInCard key={checkIn.id} checkIn={checkIn} mentionedPersonLookup={props.richTextHandlers.mentionedPersonLookup} />
+          <CheckInCard
+            key={checkIn.id}
+            checkIn={checkIn}
+            mentionedPersonLookup={props.richTextHandlers.mentionedPersonLookup}
+          />
         ))}
       </div>
     </div>

--- a/turboui/src/ProjectPage/OverviewSidebar.tsx
+++ b/turboui/src/ProjectPage/OverviewSidebar.tsx
@@ -23,7 +23,7 @@ export function OverviewSidebar(props: ProjectPage.State) {
   return (
     <div className="sm:col-span-4 sm:pl-8">
       <div className="space-y-6">
-        <LastCheckInSection {...props} />
+        <CheckInsSection {...props} />
         <ParentGoal {...props} />
         <ProjectDates {...props} />
       </div>
@@ -47,14 +47,50 @@ export function OverviewSidebar(props: ProjectPage.State) {
   );
 }
 
-function LastCheckInSection(props: any) {
-  if (!props.checkIns || props.checkIns.length === 0) {
-    return null;
+function CheckInsSection(props: ProjectPage.State) {
+  const checkIns = props.checkIns || [];
+  const isClosed = props.state === "closed";
+  const lastCheckInState: "active" | "closed" | undefined = isClosed ? "closed" : "active";
+  const viewerCanCheckIn = props.canEdit && !isClosed;
+  const isChampion = !!props.currentUser?.id && !!props.champion?.id && props.currentUser.id === props.champion.id;
+  const championFirstName = props.champion?.fullName?.split(" ")[0];
+
+  let zeroStateCopy = "Weekly check-ins keep everyone in the loop. Updates will appear here.";
+
+  if (isClosed) {
+    zeroStateCopy = "This project is closed. Earlier check-ins stay available for reference.";
+  } else if (viewerCanCheckIn && isChampion) {
+    zeroStateCopy = "Share the first update to set the project status and start the weekly cadence.";
+  } else if (championFirstName) {
+    zeroStateCopy = `${championFirstName} hasn't shared a check-in yet. Updates will land here soon.`;
   }
 
+  const header = (
+    <div className="flex items-center gap-2">
+      <span>Last update</span>
+      {viewerCanCheckIn && (
+        <span className="shrink-0">
+          <SecondaryButton size="xxs" linkTo={props.newCheckInLink} testId="sidebar-check-in-button">
+            Check in
+          </SecondaryButton>
+        </span>
+      )}
+    </div>
+  );
+
   return (
-    <SidebarSection title="Last check-in">
-      <LastCheckIn checkIns={props.checkIns} state={props.state} mentionedPersonLookup={props.mentionedPersonLookup} />
+    <SidebarSection title={header} className="pt-4 sm:pt-0">
+      <div className="space-y-3">
+        {checkIns.length > 0 ? (
+          <LastCheckIn
+            checkIns={checkIns}
+            state={lastCheckInState}
+            mentionedPersonLookup={props.richTextHandlers.mentionedPersonLookup}
+          />
+        ) : (
+          <p className="text-sm text-content-dimmed">{zeroStateCopy}</p>
+        )}
+      </div>
     </SidebarSection>
   );
 }

--- a/turboui/src/ProjectPage/index.stories.tsx
+++ b/turboui/src/ProjectPage/index.stories.tsx
@@ -41,6 +41,7 @@ function daysAgo(days: number): Date {
 }
 
 const people = genPeople(5);
+const currentViewer = people[0]!;
 
 const meta: Meta<typeof ProjectPage> = {
   title: "Pages/ProjectPage",
@@ -387,6 +388,7 @@ export const Default: Story = {
         newCheckInLink="#"
         checkIns={mockCheckIns}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={mockDiscussions}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -469,6 +471,7 @@ export const ReadOnly: Story = {
         newCheckInLink="#"
         checkIns={mockCheckIns}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -595,6 +598,7 @@ export const EmptyTasks: Story = {
         newCheckInLink="#"
         checkIns={mockCheckIns}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -706,6 +710,7 @@ export const EmptyProject: Story = {
         newCheckInLink="#"
         checkIns={[]}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -777,6 +782,7 @@ export const EmptyProjectReadOnly: Story = {
         newCheckInLink="#"
         checkIns={[]}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -931,6 +937,7 @@ export const PausedProject: Story = {
         newCheckInLink="#"
         checkIns={mockCheckIns}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}
@@ -1017,6 +1024,7 @@ export const ClosedProject: Story = {
         newCheckInLink="#"
         checkIns={mockCheckIns}
         newDiscussionLink="#"
+        currentUser={currentViewer}
         discussions={[]}
         onProjectDelete={() => {}}
         canDelete={true}

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -138,6 +138,8 @@ export namespace ProjectPage {
     checkIns: CheckIn[];
     discussions: Discussion[];
 
+    currentUser?: Person | null;
+
     richTextHandlers: RichEditorHandlers;
 
     // Resource management

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -111,7 +111,7 @@ export function TaskBoard({
   );
 
   return (
-    <div className="flex flex-col flex-1 w-full max-w-6xl mx-auto">
+    <div className="flex flex-col flex-1 w-full max-w-6xl mx-auto pb-8">
       <TaskCreationModal
         isOpen={isTaskModalOpen}
         onClose={() => setIsTaskModalOpen(false)}


### PR DESCRIPTION
- Replace 'Check-In Now' with simpler 'Check in' (plus we capitalize only first character in buttons now)
- Rename subsection header from 'Check-ins' to 'Last update' to avoid repeating the term and reflect presence of only the last one
- Being always present and providing zero-state microcopy will help educate new users about this core feature

Resolves #3170.