### PR TITLE
feat: show goal page status banner

### DIFF
--- a/app/test/features/goal_closing_test.exs
+++ b/app/test/features/goal_closing_test.exs
@@ -63,4 +63,21 @@ defmodule Operately.Features.GoalClosingTest do
     |> Steps.reopen_goal()
     |> Steps.assert_goal_is_reopened()
   end
+
+  feature "closing a goal shows the closed status banner", ctx do
+    ctx
+    |> Steps.visit_goal_page()
+    |> Steps.assert_goal_closed_status_banner_not_visible()
+    |> Steps.close_goal()
+    |> Steps.assert_goal_closed_status_banner_visible()
+  end
+
+  feature "reopening a goal hides the closed status banner", ctx do
+    ctx
+    |> Steps.given_closed_goal_exists()
+    |> Steps.visit_goal_page()
+    |> Steps.assert_goal_closed_status_banner_visible()
+    |> Steps.reopen_goal()
+    |> Steps.assert_goal_closed_status_banner_not_visible()
+  end
 end

--- a/app/test/support/features/goal_closing_steps.ex
+++ b/app/test/support/features/goal_closing_steps.ex
@@ -125,6 +125,14 @@ defmodule Operately.Support.Features.GoalClosingSteps do
     |> UI.refute_has(testid: "reopen-goal")
   end
 
+  step :assert_goal_closed_status_banner_visible, ctx do
+    UI.assert_has(ctx, testid: "closed-status-banner")
+  end
+
+  step :assert_goal_closed_status_banner_not_visible, ctx do
+    UI.refute_has(ctx, testid: "closed-status-banner")
+  end
+
   step :assert_closed_projects_not_shown_in_warning, ctx do
     ctx
     # This project was closed and shouldn't appear

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -19,6 +19,7 @@ import { Discussions } from "./Discussions";
 import { Overview } from "./Overview";
 import { PageHeader } from "./PageHeader";
 import { RichEditorHandlers } from "../RichEditor/useEditor";
+import { StatusBanner } from "../ProjectPageLayout/StatusBanner";
 
 export namespace GoalPage {
   export interface Space {
@@ -203,6 +204,13 @@ export function GoalPage(props: GoalPage.Props) {
     <>
       <PageNew title={[state.goalName]} size="fullwidth" testId="goal-page">
         <PageHeader {...state} />
+        <StatusBanner
+          state={state.state === "closed" ? "closed" : null}
+          closedAt={state.closedAt}
+          reopenLink={state.reopenLink}
+          retrospectiveLink={state.retrospective?.link}
+          entityName="goal"
+        />
         <Tabs tabs={tabs} />
 
         <div className="flex-1 overflow-auto">

--- a/turboui/src/ProjectPageLayout/StatusBanner.tsx
+++ b/turboui/src/ProjectPageLayout/StatusBanner.tsx
@@ -5,14 +5,15 @@ import { IconPlayerPauseFilled, IconArchive } from "../icons";
 
 export namespace StatusBanner {
   export interface Props {
-    state: "paused" | "closed";
+    state: "paused" | "closed" | null;
     closedAt?: Date | null;
     reopenLink?: string;
     retrospectiveLink?: string;
+    entityName?: string;
   }
 }
 
-export function StatusBanner({ state, closedAt, reopenLink, retrospectiveLink }: StatusBanner.Props) {
+export function StatusBanner({ state, closedAt, reopenLink, retrospectiveLink, entityName = "project" }: StatusBanner.Props) {
   if (state === "paused") {
     return (
       <div data-test-id="paused-status-banner" className="bg-callout-warning-bg border-y my-2 border-surface-outline">
@@ -20,7 +21,7 @@ export function StatusBanner({ state, closedAt, reopenLink, retrospectiveLink }:
           <div className="flex items-center gap-3">
             <IconPlayerPauseFilled className="w-5 h-5 text-content-accent" />
             <div>
-              <span className="text-content-accent font-medium">This project is paused</span>
+              <span className="text-content-accent font-medium">This {entityName} is paused</span>
             </div>
             {reopenLink && (
               <PrimaryButton linkTo={reopenLink} size="xs">
@@ -48,7 +49,9 @@ export function StatusBanner({ state, closedAt, reopenLink, retrospectiveLink }:
           <div className="flex items-center gap-3 text-callout-info-content">
             <IconArchive className="w-5 h-5" />
             <div>
-              <span>This project was closed on {closedAt ? formatDate(closedAt) : "an unknown date"}.</span>
+              <span>
+                This {entityName} was closed on {closedAt ? formatDate(closedAt) : "an unknown date"}.
+              </span>
               {retrospectiveLink && (
                 <>
                   <span> Read the </span>


### PR DESCRIPTION
## Summary
- render the shared status banner on the goal page when a goal is closed
- generalize the status banner copy so it can reference goals as well as projects
- extend goal closing feature coverage to verify the banner toggles when closing and reopening

## Testing
- npm --prefix turboui run build
- make test FILE=app/test/features/goal_closing_test.exs # fails: docker not found in CI-free environment


------
https://chatgpt.com/codex/tasks/task_b_68d68cb90634832a86cceebfb40c29ee