### PR TITLE
feat: Click anywhere on the Rich Text area to focus it

### DIFF
--- a/turboui/src/RichEditor/index.tsx
+++ b/turboui/src/RichEditor/index.tsx
@@ -40,11 +40,8 @@ function EditorContent(props: EditorProps): JSX.Element {
   const handleClick = useLinkEditFormClose();
   const editor = props.editor.editor;
 
-  const handleEditorAreaClick = (e: React.MouseEvent) => {
-    // First handle the existing link edit form close functionality
-    handleClick(e);
-
-    // Then focus the editor if it's not already focused and is editable
+  const handleFocus = () => {
+    // Focus the editor if it's not already focused and is editable
     if (editor && !editor.isFocused && editor.isEditable) {
       editor.commands.focus();
     }
@@ -54,16 +51,15 @@ function EditorContent(props: EditorProps): JSX.Element {
     {
       "border border-surface-outline rounded-lg": !props.hideBorder,
     },
-    "cursor-pointer",
     props.className,
   );
   const contentClassName = classNames("min-h-[100px]", props.padding ?? "p-3");
 
   return (
-    <div onClick={handleEditorAreaClick} className={className}>
+    <div onClick={handleClick} className={className}>
       {!props.hideToolbar && <Toolbar />}
 
-      <div className="ProseMirror text-content-accent relative">
+      <div onClick={handleFocus} className="ProseMirror cursor-pointer text-content-accent relative">
         <TipTapEditorContent className={contentClassName} />
       </div>
     </div>


### PR DESCRIPTION
Previously, the Rich Text editor only gained focus when clicking directly on the text input. This commit updates the behavior so that clicking anywhere within the Rich Text area will focus the editor.
