### PR TITLE
fix: Fix project name in TaskDueDateChanged feed item

### DIFF
--- a/app/assets/js/features/activities/TaskDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskDueDateUpdating/index.tsx
@@ -44,23 +44,21 @@ const TaskDueDateUpdating: ActivityHandler = {
       taskElement = "a task";
     }
     
-    const projectElement = project ? ` in ${projectLink(project)}` : '';
-    
     if (newDueDate) {
       // When showing a date, need to include the DateField component after the message
       const dateField = <span style={{ display: "inline-flex" }}><DateField date={parseContextualDate(newDueDate)} readonly hideCalendarIcon /></span>;
       
       if (props.page === "project") {
-        return feedTitle(props.activity, message, dateField, " on", taskElement);
+        return feedTitle(props.activity, message, dateField, "on", taskElement);
       } else {
-        return feedTitle(props.activity, message, dateField, " on", taskElement, projectElement);
+        return feedTitle(props.activity, message, dateField, "on", taskElement, "in", projectLink(project));
       }
     } else {
       // For cleared date, no DateField needed
       if (props.page === "project") {
-        return feedTitle(props.activity, message, " on", taskElement);
+        return feedTitle(props.activity, message, "on", taskElement);
       } else {
-        return feedTitle(props.activity, message, " on", taskElement, projectElement);
+        return feedTitle(props.activity, message, "on", taskElement, "in", projectLink(project));
       }
     }
   },

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -99,7 +99,7 @@ defmodule Operately.Features.ProjectTasksTest do
   @tag login_as: :champion
   feature "edit task name", ctx do
     new_name = "New task name"
-    feed_title = "changed the title of this task from \"some name\" to \"#{new_name}\""
+    feed_title = "changed the title of this task from \"My task\" to \"#{new_name}\""
 
     ctx
     |> Steps.given_task_exists()

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -159,6 +159,7 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.reload_task_page()
     |> Steps.assert_task_due_date(formatted_date)
     |> Steps.assert_change_in_feed(feed_title)
+    |> Steps.assert_task_due_date_change_visible_in_feed(formatted_date)
   end
 
   @tag login_as: :champion

--- a/app/test/support/factory/projects.ex
+++ b/app/test/support/factory/projects.ex
@@ -318,7 +318,7 @@ defmodule Operately.Support.Factory.Projects do
       creator_id: ctx.creator.id,
       milestone_id: milestone_id,
       project_id: project_id,
-      title: Keyword.get(opts, :title, "Task #{testid}")
+      name: Keyword.get(opts, :name, "Task #{testid}")
     })
 
     task = Operately.TasksFixtures.task_fixture(attrs)

--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -5,7 +5,7 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
   step :given_task_exists, ctx do
     ctx
     |> Factory.add_space_member(:creator, :group)
-    |> Factory.add_project_task(:task, :milestone)
+    |> Factory.add_project_task(:task, :milestone, name: "My task")
   end
 
   step :given_another_milestone_exists, ctx do
@@ -242,6 +242,34 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     # This could verify no error messages are displayed and key elements are present
     ctx
     |> UI.assert_has(testid: "task-name")
+  end
+
+  step :assert_task_due_date_change_visible_in_feed, ctx, date do
+    part1 = "#{Operately.People.Person.first_name(ctx.champion)} changed the due date to"
+    part2 = "on #{ctx.task.name} in #{ctx.project.name}"
+
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> UI.find(UI.query(testid: "project-feed"), fn el ->
+      el
+      |> UI.assert_text(part1)
+      |> UI.assert_text(date)
+      |> UI.assert_text("on #{ctx.task.name}")
+    end)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> UI.find(UI.query(testid: "space-feed"), fn el ->
+      el
+      |> UI.assert_text(part1)
+      |> UI.assert_text(date)
+      |> UI.assert_text(part2)
+    end)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.find(UI.query(testid: "company-feed"), fn el ->
+      el
+      |> UI.assert_text(part1)
+      |> UI.assert_text(date)
+      |> UI.assert_text(part2)
+    end)
   end
 
   #


### PR DESCRIPTION
The project name was not displayed correctly in the TaskDueDateChanged feed item:

![tmp](https://github.com/user-attachments/assets/4a3b6ed8-a889-4925-b0dd-639b706996fc)

That's now fixed. I've also added some tests to check this feed item.