### PR TITLE
fix: Ensure all fields are cleared after adding task

### DIFF
--- a/app/test/features/project_milestones_test.exs
+++ b/app/test/features/project_milestones_test.exs
@@ -171,7 +171,7 @@ defmodule Operately.Features.ProjectMilestonesTest do
       |> Steps.assert_activity_added_to_feed("created \"My task\"")
     end
 
-    feature "add multiple tasks with 'Create more' toggle on", ctx do
+    feature "add multiple tasks", ctx do
       ctx
       |> Steps.visit_milestone_page()
       |> Steps.add_multiple_tasks(names: ["1st task", "2nd task"])

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -97,6 +97,57 @@ defmodule Operately.Features.ProjectTasksTest do
   end
 
   @tag login_as: :champion
+  feature "create task with due date, assignee and milestone", ctx do
+    next_friday = Operately.Support.Time.next_friday()
+    formatted_date = Operately.Support.Time.format_month_day(next_friday)
+
+    attrs = %{
+      name: "Task 1",
+      assignee: ctx.champion.full_name,
+      due_date: next_friday,
+      milestone: ctx.milestone.title
+    }
+
+    ctx
+    |> Steps.visit_project_page()
+    |> Steps.go_to_tasks_tab()
+    |> Steps.add_task_from_tasks_board(attrs)
+    |> Steps.assert_task_added(attrs.name)
+    |> Steps.go_to_task_page()
+    |> Steps.assert_assignee(attrs.assignee)
+    |> Steps.assert_task_due_date(formatted_date)
+    |> Steps.assert_task_milestone(attrs.milestone)
+  end
+
+  @tag login_as: :champion
+  feature "add multiple tasks with 'Create more' toggle on", ctx do
+    ctx
+    |> Steps.visit_project_page()
+    |> Steps.go_to_tasks_tab()
+    |> Steps.add_multiple_tasks(names: ["1st task", "2nd task"])
+    |> Steps.assert_task_added("1st task")
+    |> Steps.assert_task_added("2nd task")
+  end
+
+  @tag login_as: :champion
+  feature "all form fields are cleared after task is added", ctx do
+    attrs = %{
+      name: "Task 1",
+      assignee: ctx.champion.full_name,
+      due_date: Operately.Support.Time.next_friday(),
+      milestone: ctx.milestone.title
+    }
+
+    ctx
+    |> Steps.visit_project_page()
+    |> Steps.go_to_tasks_tab()
+    |> Steps.open_task_form_and_fill_out_all_fields(attrs)
+    |> Steps.toggle_create_more_switch()
+    |> Steps.click_create_task_button()
+    |> Steps.assert_form_fields_are_empty()
+  end
+
+  @tag login_as: :champion
   feature "edit task name", ctx do
     new_name = "New task name"
     feed_title = "changed the title of this task from \"My task\" to \"#{new_name}\""

--- a/turboui/src/DateField/index.tsx
+++ b/turboui/src/DateField/index.tsx
@@ -13,6 +13,7 @@ import { QuarterSelector } from "./components/QuarterSelector";
 import { YearSelector } from "./components/YearSelector";
 import { getDateWithoutCurrentYear } from "./utils";
 import { usePopoverPositioning } from "./hooks/usePopoverPositioning";
+import { useEffect } from "react";
 
 const DATE_TYPES = [
   { value: "day" as const, label: "Day" },
@@ -94,9 +95,15 @@ export function DateField({
   const [previousSelectedDate, setPreviousSelectedDate] = useState<DateField.ContextualDate | null>(date || null);
 
   // If calendarOnly is true, we only show the calendar and only "day" is accepted
-  const [dateType, setDateType] = useState<DateField.DateType>(calendarOnly ? "day" : (date?.dateType || "day"));
+  const [dateType, setDateType] = useState<DateField.DateType>(calendarOnly ? "day" : date?.dateType || "day");
 
   const { useSidePositioning, triggerRef, side } = usePopoverPositioning({ open });
+
+  useEffect(() => {
+    setSelectedDate(date || null);
+    setPreviousSelectedDate(date || null);
+    setDateType(calendarOnly ? "day" : date?.dateType || "day");
+  }, [date]);
 
   const yearOptions = Array.from({ length: maxYear - minYear + 1 }, (_, i) => minYear + i);
 
@@ -105,6 +112,9 @@ export function DateField({
 
     if (isOpen && selectedDate) {
       setPreviousSelectedDate(selectedDate);
+    } else if (!isOpen && selectedDate) {
+      // When closing the popover with a selected date, behave like clicking "Confirm"
+      onDateSelect?.(selectedDate);
     }
   };
 
@@ -153,13 +163,13 @@ export function DateField({
             readonly={readonly}
             showOverdueWarning={showOverdueWarning}
             variant={variant}
-          hideCalendarIcon={hideCalendarIcon}
-          testId={testId}
-          size={size}
-          error={error}
-          ariaLabel={ariaLabel}
-          className={className}
-        />
+            hideCalendarIcon={hideCalendarIcon}
+            testId={testId}
+            size={size}
+            error={error}
+            ariaLabel={ariaLabel}
+            className={className}
+          />
         </div>
       </Popover.Trigger>
 
@@ -328,9 +338,7 @@ function DatePickerContent(props: DatePickerContentProps) {
         {selectedDate && <ClearButton onClear={onClearDate} testId={testId} />}
       </div>
 
-      {!calendarOnly && (
-        <DateTypeSelector dateType={dateType} dateTypes={DATE_TYPES} setDateType={setDateType} />
-      )}
+      {!calendarOnly && <DateTypeSelector dateType={dateType} dateTypes={DATE_TYPES} setDateType={setDateType} />}
 
       {dateType === "day" && (
         <div className="mb-3">


### PR DESCRIPTION
After adding a task with the "Create more" toggle on, all the fields are cleared. 

Previously, the DateField was not in sync with the parent component's date. When the form was submitted, the date value was reset to null, but the form didn't show it. As a result, the date was still shown in the form, but the submitted value was null.