### PR TITLE
chore: Add DateDisplay component to turboui

### DIFF
--- a/app/assets/js/features/activities/TaskDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskDueDateUpdating/index.tsx
@@ -2,7 +2,7 @@ import type { ActivityContentTaskDueDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
 import React from "react";
-import { DateField } from "turboui";
+import { DateDisplay } from "turboui";
 import { feedTitle, taskLink, projectLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
 import { parseContextualDate } from "@/models/contextualDates";
@@ -46,7 +46,7 @@ const TaskDueDateUpdating: ActivityHandler = {
     
     if (newDueDate) {
       // When showing a date, need to include the DateField component after the message
-      const dateField = <span style={{ display: "inline-flex" }}><DateField date={parseContextualDate(newDueDate)} readonly hideCalendarIcon /></span>;
+      const dateField = <DateDisplay date={parseContextualDate(newDueDate)} />;
       
       if (props.page === "project") {
         return feedTitle(props.activity, message, dateField, "on", taskElement);
@@ -68,7 +68,7 @@ const TaskDueDateUpdating: ActivityHandler = {
 
     if (oldDueDate) {
       return (
-        <span>Previously the due date was <span style={{ display: "inline-flex" }}><DateField date={parseContextualDate(oldDueDate)} readonly hideCalendarIcon /></span></span>
+        <span>Previously the due date was <DateDisplay date={parseContextualDate(oldDueDate)} /></span>
       );
     } else {
       return <>Previously had no due date</>;
@@ -93,7 +93,7 @@ const TaskDueDateUpdating: ActivityHandler = {
     
     if (newDueDate) {
       return (
-        <span>Updated due date for {name} to <span style={{ display: "inline-flex" }}><DateField date={parseContextualDate(newDueDate)} readonly hideCalendarIcon /></span></span>
+        <span>Updated due date for {name} to <DateDisplay date={parseContextualDate(newDueDate)} /></span>
       );
     } else {
       return <span>Cleared due date for {name}</span>;

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -224,7 +224,7 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.visit_task_page()
     |> Steps.edit_task_due_date(next_friday)
     |> Steps.assert_task_due_date(formatted_date)
-    |> Steps.assert_due_date_changed_notification_sent()
+    |> Steps.assert_due_date_changed_notification_sent(formatted_date)
     |> Steps.assert_due_date_changed_email_sent()
   end
 

--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -309,30 +309,21 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
   end
 
   step :assert_task_due_date_change_visible_in_feed, ctx, date do
-    part1 = "#{Operately.People.Person.first_name(ctx.champion)} changed the due date to"
-    part2 = "on #{ctx.task.name} in #{ctx.project.name}"
+    short = "#{Operately.People.Person.first_name(ctx.champion)} changed the due date to #{date} on #{ctx.task.name}"
+    long = "#{Operately.People.Person.first_name(ctx.champion)} changed the due date to #{date} on #{ctx.task.name} in #{ctx.project.name}"
 
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> UI.find(UI.query(testid: "project-feed"), fn el ->
-      el
-      |> UI.assert_text(part1)
-      |> UI.assert_text(date)
-      |> UI.assert_text("on #{ctx.task.name}")
+      UI.assert_text(el, short)
     end)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
     |> UI.find(UI.query(testid: "space-feed"), fn el ->
-      el
-      |> UI.assert_text(part1)
-      |> UI.assert_text(date)
-      |> UI.assert_text(part2)
+      UI.assert_text(el, long)
     end)
     |> UI.visit(Paths.feed_path(ctx.company))
     |> UI.find(UI.query(testid: "company-feed"), fn el ->
-      el
-      |> UI.assert_text(part1)
-      |> UI.assert_text(date)
-      |> UI.assert_text(part2)
+      UI.assert_text(el, long)
     end)
   end
 
@@ -364,12 +355,12 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
   # Notifications
   #
 
-  step :assert_due_date_changed_notification_sent, ctx do
+  step :assert_due_date_changed_notification_sent, ctx, date do
     ctx
     |> UI.login_as(ctx.champion)
     |> NotificationsSteps.assert_activity_notification(%{
       author: ctx.reviewer,
-      action: "Updated due date for #{ctx.task.name} to"
+      action: "Updated due date for #{ctx.task.name} to #{date}"
     })
   end
 

--- a/turboui/src/DateField/DateDisplay.tsx
+++ b/turboui/src/DateField/DateDisplay.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { getDateWithoutCurrentYear } from "./utils";
+
+/**
+ * DateDisplay renders a contextual date in the same format as DateField,
+ * but without wrapper elements or styling. Useful for inline text where
+ * DateField would break the line and cause feature test issues.
+ */
+export namespace DateDisplay {
+  export interface Props {
+    date: ContextualDate | null;
+    placeholder?: string;
+  }
+
+  export type DateType = "day" | "month" | "quarter" | "year";
+
+  export interface ContextualDate {
+    date: Date;
+    dateType: DateType;
+    value: string;
+  }
+}
+
+export function DateDisplay({ date, placeholder = "Date" }: DateDisplay.Props) {
+  const displayText = date ? getDateWithoutCurrentYear(date) : placeholder;
+  
+  return <>{displayText}</>;
+}

--- a/turboui/src/DateField/index.tsx
+++ b/turboui/src/DateField/index.tsx
@@ -22,6 +22,8 @@ const DATE_TYPES = [
   { value: "year" as const, label: "Year" },
 ];
 
+export { DateDisplay } from "./DateDisplay";
+
 export namespace DateField {
   export interface Props extends TestableElement {
     onDateSelect?: (selectedDate: ContextualDate | null) => void;

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -25,7 +25,7 @@ export { Checkbox } from "./Checkbox";
 export { Checklist } from "./Checklist";
 export { CompanySetupPage, CompanySetupStepsReminder } from "./CompanySetupPage";
 export { Conversations, useConversations } from "./Conversations";
-export { DateField } from "./DateField";
+export { DateField, DateDisplay } from "./DateField";
 export { FloatingActionButton } from "./FloatingActionButton";
 export { FormattedTime } from "./FormattedTime";
 export { GlobalSearch } from "./GlobalSearch";


### PR DESCRIPTION
DateField was not working well when it was used with other text. It would require complex workarounds to avoid line breaks and it was causing problems in feature tests.

So, I've added the `DateDisplay` component, which ensures contextual dates are displayed consistently exactly like when using DateField, but without extra elements or styles.