### PR TITLE
feat: Changin Task assignee sends notifications

### DIFF
--- a/app/assets/js/features/activities/TaskAssigneeUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskAssigneeUpdating/index.tsx
@@ -31,7 +31,7 @@ const TaskAssigneeUpdating: ActivityHandler = {
   FeedItemTitle({ activity, page }: { activity: Activity; page: string }) {
     const { project, task, newAssignee, oldAssignee } = content(activity);
     const assigneeText = newAssignee ? `assigned to ${newAssignee.fullName}` : `unassigned ${oldAssignee.fullName} from`;
-    const message = `${assigneeText} task`;
+    const message = `${assigneeText} the task`;
     const taskName = task ? taskLink(task) : "a task";
 
     if (page === "project") {

--- a/app/lib/operately/activities/notifications/task_assignee_updating.ex
+++ b/app/lib/operately/activities/notifications/task_assignee_updating.ex
@@ -1,5 +1,19 @@
 defmodule Operately.Activities.Notifications.TaskAssigneeUpdating do
-  def dispatch(_activity) do
-    {:ok, []}
+  def dispatch(activity) do
+    old_assignee_id = activity.content["old_assignee_id"]
+    new_assignee_id = activity.content["new_assignee_id"]
+
+    [old_assignee_id, new_assignee_id]
+    |> Enum.uniq_by(& &1)
+    |> Enum.filter(fn id -> id != nil end)
+    |> Enum.filter(fn id -> id != activity.author_id end)
+    |> Enum.map(fn id ->
+      %{
+        person_id: id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately_email/emails/task_assignee_updating_email.ex
+++ b/app/lib/operately_email/emails/task_assignee_updating_email.ex
@@ -1,0 +1,38 @@
+defmodule OperatelyEmail.Emails.TaskAssigneeUpdatingEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Tasks.Task
+  alias Operately.People.Person
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    {:ok, task} = Task.get(:system, id: activity.content["task_id"], opts: [
+      preload: [:project]
+    ])
+    old_assignee = get_person(activity.content["old_assignee_id"])
+    new_assignee = get_person(activity.content["new_assignee_id"])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: task.project.name, who: author, action: "changed the assignee for #{task.name}")
+    |> assign(:author, author)
+    |> assign(:name, task.name)
+    |> assign(:old_assignee, old_assignee)
+    |> assign(:new_assignee, new_assignee)
+    |> assign(:cta_url, Paths.project_task_path(company, task) |> Paths.to_url())
+    |> render("task_assignee_updating")
+  end
+
+  defp get_person(nil), do: nil
+  defp get_person(id) do
+    case Person.get(:system, id: id) do
+      {:ok, person} -> person
+      {:error, _} -> nil
+    end
+  end
+end

--- a/app/lib/operately_email/templates/task_assignee_updating.html.eex
+++ b/app/lib/operately_email/templates/task_assignee_updating.html.eex
@@ -1,0 +1,29 @@
+<%= if @new_assignee do %>
+  <%= title("#{short_name(@author)} changed the assignee for #{@name}") %>
+<% else %>
+  <%= title("#{short_name(@author)} removed the assignee for #{@name}") %>
+<% end %>
+
+<%= spacer() %>
+
+<%= if @new_assignee do %>
+  <%= if @old_assignee do %>
+    <%= row do %>
+      The assignee was changed from <%= short_name(@old_assignee) %> to <%= short_name(@new_assignee) %>
+    <% end %>
+  <% else %>
+    <%= row do %>
+      The assignee is now <%= short_name(@new_assignee) %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= row do %>
+    The assignee was removed. Previously it was <%= short_name(@old_assignee) %>
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Task") %>
+<% end %>

--- a/app/lib/operately_email/templates/task_assignee_updating.text.eex
+++ b/app/lib/operately_email/templates/task_assignee_updating.text.eex
@@ -1,0 +1,3 @@
+<%= short_name(@author) %> changed the assignee for <%= @name %>.
+
+Link: <%= @cta_url %>

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -179,7 +179,7 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.assert_change_in_feed("updated the description")
   end
 
-  @tag login_as: :champion
+  @tag login_as: :reviewer
   feature "edit task assignee", ctx do
     feed_title = "assigned this task to #{Operately.People.Person.short_name(ctx.champion)}"
 
@@ -193,6 +193,31 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.reload_task_page()
     |> Steps.assert_assignee(ctx.champion.full_name)
     |> Steps.assert_change_in_feed(feed_title)
+    |> Steps.assert_task_assignee_change_visible_in_feed()
+  end
+
+  @tag login_as: :reviewer
+  feature "edit task assignee sends notification to assignee", ctx do
+    ctx
+    |> Steps.given_task_exists()
+    |> Steps.visit_task_page()
+    |> Steps.assert_no_assignee()
+    |> Steps.edit_task_assignee(ctx.champion.full_name)
+    |> Steps.assert_assignee(ctx.champion.full_name)
+    |> Steps.assert_assignee_changed_notification_sent()
+    |> Steps.assert_assignee_changed_email_sent()
+  end
+
+  @tag login_as: :reviewer
+  feature "remove task assignee sends notification to assignee", ctx do
+    ctx
+    |> Steps.given_task_exists()
+    |> Steps.given_task_assignee_exists()
+    |> Steps.visit_task_page()
+    |> Steps.assert_assignee(ctx.champion.full_name)
+    |> Steps.remove_task_assignee()
+    |> Steps.assert_assignee_removed_notification_sent()
+    |> Steps.assert_assignee_removed_email_sent()
   end
 
   @tag login_as: :champion


### PR DESCRIPTION
Updating a Task's assignee now sends a notification to the previous and new assignees.