### PR TITLE
feat: Changing Milestone due date sends notifications

### DIFF
--- a/app/assets/js/features/activities/MilestoneDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/MilestoneDueDateUpdating/index.tsx
@@ -33,7 +33,7 @@ const MilestoneDueDateUpdating: ActivityHandler = {
     const { project, milestone, milestoneName, newDueDate } = content(activity);
     const title = milestone ? milestoneLink(milestone, milestoneName) : `"${milestoneName}"`;
 
-    const message = newDueDate ? ["updated milestone", title, "due date"] : ["removed due date from milestone", title];
+    const message = newDueDate ? ["updated the due date for the", title, "milestone"] : ["removed due date from the", title, "milestone"];
 
     if (page === "project") {
       return feedTitle(activity, ...message);
@@ -104,9 +104,9 @@ const MilestoneDueDateUpdating: ActivityHandler = {
     const { milestone, newDueDate } = content(props.activity);
 
     if (newDueDate) {
-      return `Milestone "${milestone?.title}" due date was updated`;
+      return `The "${milestone?.title}" milestone due date was updated`;
     } else {
-      return `Milestone "${milestone?.title}" due date was removed`;
+      return `The "${milestone?.title}" milestone due date was removed`;
     }
   },
 

--- a/app/lib/operately/activities/notifications/milestone_due_date_updating.ex
+++ b/app/lib/operately/activities/notifications/milestone_due_date_updating.ex
@@ -1,6 +1,28 @@
 defmodule Operately.Activities.Notifications.MilestoneDueDateUpdating do
-  def dispatch(_activity) do
-    # Notification dispatcher for MilestoneDueDateUpdating not implemented yet
-    {:ok, []}
+  @moduledoc """
+  Notifies the following people:
+  - Project champion
+
+  The person who authored the comment is excluded from notifications.
+  """
+
+  alias Operately.Projects.Project
+
+  def dispatch(activity) do
+    project = Project.get!(:system, id: activity.content["project_id"], opts: [preload: :champion_contributor])
+
+    champion_id = if project.champion_contributor, do: project.champion_contributor.person_id, else: nil
+
+    [champion_id]
+    |> Enum.filter(fn id -> id != nil end)
+    |> Enum.filter(fn id -> id != activity.author_id end)
+    |> Enum.map(fn id ->
+      %{
+        person_id: id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately/activities/notifications/task_assignee_updating.ex
+++ b/app/lib/operately/activities/notifications/task_assignee_updating.ex
@@ -1,4 +1,12 @@
 defmodule Operately.Activities.Notifications.TaskAssigneeUpdating do
+  @moduledoc """
+  Notifies the following people:
+  - Previous assignee: Person who was assigned to work on the task
+  - New assignee: Person who is assigned to work on the task
+
+  The person who authored the comment is excluded from notifications.
+  """
+
   def dispatch(activity) do
     old_assignee_id = activity.content["old_assignee_id"]
     new_assignee_id = activity.content["new_assignee_id"]

--- a/app/lib/operately_email/emails/milestone_due_date_updating_email.ex
+++ b/app/lib/operately_email/emails/milestone_due_date_updating_email.ex
@@ -1,0 +1,32 @@
+defmodule OperatelyEmail.Emails.MilestoneDueDateUpdatingEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Projects.Milestone
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    {:ok, milestone} = Milestone.get(:system, id: activity.content["milestone_id"], opts: [
+      preload: [:project]
+    ])
+    previous_date = get_date_value(activity.content["old_due_date"])
+    new_date = get_date_value(activity.content["new_due_date"])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: milestone.project.name, who: author, action: "changed the due date for \"#{milestone.title}\"")
+    |> assign(:author, author)
+    |> assign(:name, milestone.title)
+    |> assign(:previous_date, previous_date)
+    |> assign(:new_date, new_date)
+    |> assign(:cta_url, Paths.project_path(company, milestone.project) |> Paths.to_url())
+    |> render("milestone_due_date_updating")
+  end
+
+  defp get_date_value(nil), do: nil
+  defp get_date_value(date), do: date.value
+end

--- a/app/lib/operately_email/templates/milestone_due_date_updating.html.eex
+++ b/app/lib/operately_email/templates/milestone_due_date_updating.html.eex
@@ -1,0 +1,29 @@
+<%= if @new_date do %>
+  <%= title("#{short_name(@author)} changed the due date for #{@name}") %>
+<% else %>
+  <%= title("#{short_name(@author)} removed the due date for #{@name}") %>
+<% end %>
+
+<%= spacer() %>
+
+<%= if @new_date do %>
+  <%= if @previous_date do %>
+    <%= row do %>
+      The due date was changed from <%= @previous_date %> to <%= @new_date %>.
+    <% end %>
+  <% else %>
+    <%= row do %>
+      The due date is now <%= @new_date %>.
+    <% end %>
+  <% end %>
+<% else %>
+  <%= row do %>
+    The due date was removed. Previously it was <%= @previous_date %>.
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Project") %>
+<% end %>

--- a/app/lib/operately_email/templates/milestone_due_date_updating.text.eex
+++ b/app/lib/operately_email/templates/milestone_due_date_updating.text.eex
@@ -1,0 +1,3 @@
+<%= short_name(@author) %> changed the due date for <%= @name %>.
+
+Link: <%= @cta_url %>

--- a/app/test/features/project_milestones_test.exs
+++ b/app/test/features/project_milestones_test.exs
@@ -110,6 +110,30 @@ defmodule Operately.Features.ProjectMilestonesTest do
       |> Steps.reload_milestone_page()
       |> Steps.assert_milestone_due_date(formatted_date)
       |> Steps.assert_activity_added_to_feed("updated the milestone")
+      |> Steps.assert_milestone_due_date_change_visible_in_feed()
+    end
+
+    feature "edit milestone due date sends notification to champion", ctx do
+      next_friday = Operately.Support.Time.next_friday()
+      formatted_date = Operately.Support.Time.format_month_day(next_friday)
+
+      ctx
+      |> UI.login_as(ctx.reviewer)
+      |> Steps.visit_milestone_page()
+      |> Steps.edit_milestone_due_date(next_friday)
+      |> Steps.assert_milestone_due_date(formatted_date)
+      |> Steps.assert_due_date_changed_notification_sent()
+      |> Steps.assert_due_date_changed_email_sent()
+    end
+
+    feature "remove milestone due date sends notification to champion", ctx do
+      ctx
+      |> UI.login_as(ctx.reviewer)
+      |> Steps.visit_milestone_page()
+      |> Steps.remove_milestone_due_date()
+      |> Steps.assert_no_due_date()
+      |> Steps.assert_due_date_removed_notification_sent()
+      |> Steps.assert_due_date_changed_email_sent()
     end
 
     feature "mark milestone as completed", ctx do


### PR DESCRIPTION
Updating a milestone's due date now notifies the project champion.