### PR TITLE
feat: Changing Project due date sends notifications 

### DIFF
--- a/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
@@ -1,6 +1,5 @@
 import type { ActivityContentProjectDueDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
-import { Paths } from "@/routes/paths";
 import React from "react";
 import { FormattedTime } from "turboui";
 import { feedTitle, projectLink } from "../feedItemLinks";
@@ -11,8 +10,8 @@ const ProjectDueDateUpdating: ActivityHandler = {
     throw new Error("Not implemented");
   },
 
-  pagePath(_paths: Paths, _activity: Activity) {
-    throw new Error("Not implemented");
+  pagePath(paths, activity: Activity) {
+    return paths.projectPath(content(activity).project!.id!);
   },
 
   PageTitle(_props: { activity: any }) {

--- a/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
@@ -69,12 +69,24 @@ const ProjectDueDateUpdating: ActivityHandler = {
     throw new Error("Not implemented");
   },
 
-  NotificationTitle(_props: { activity: Activity }) {
-    return <></>;
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const { project, newDueDate } = content(activity);
+    const projectName = project?.name ?? "the project";
+
+    if (newDueDate) {
+      return (
+        <>
+          Updated due date for {projectName} to <FormattedTime time={newDueDate} format="short-date" />
+        </>
+      );
+    } else {
+      return <>Cleared due date for {projectName}</>;
+    }
   },
 
-  NotificationLocation(_props: { activity: Activity }) {
-    return null;
+  NotificationLocation({ activity }: { activity: Activity }) {
+    const { space } = content(activity);
+    return space?.name || null;
   },
 };
 

--- a/app/lib/operately/activities/notifications/project_due_date_updating.ex
+++ b/app/lib/operately/activities/notifications/project_due_date_updating.ex
@@ -1,5 +1,32 @@
 defmodule Operately.Activities.Notifications.ProjectDueDateUpdating do
-  def dispatch(_activity) do
-    {:ok, []}
+  @moduledoc """
+  Notifies the following people:
+  - Project champion
+  - Project reviewer
+
+  The person who authored the comment is excluded from notifications.
+  """
+
+  alias Operately.Projects.Project
+
+  def dispatch(activity) do
+    project = Project.get!(:system, id: activity.content["project_id"], opts: [preload: [:champion_contributor, :reviewer_contributor]])
+
+    champion_id = if project.champion_contributor, do: project.champion_contributor.person_id, else: nil
+    reviewer_id = if project.reviewer_contributor, do: project.reviewer_contributor.person_id, else: nil
+
+    [champion_id, reviewer_id]
+    |> Enum.filter(& &1)
+    |> Enum.map(& &1)
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 == activity.author_id))
+    |> Enum.map(fn person_id ->
+      %{
+        person_id: person_id,
+        activity_id: activity.id,
+        should_send_email: true
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately_email/emails/project_due_date_updating_email.ex
+++ b/app/lib/operately_email/emails/project_due_date_updating_email.ex
@@ -1,0 +1,36 @@
+defmodule OperatelyEmail.Emails.ProjectDueDateUpdatingEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Projects.Project
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+    project = Project.get!(:system, id: activity.content["project_id"])
+
+    previous_date = get_date_value(activity.content["old_due_date"])
+    new_date = get_date_value(activity.content["new_due_date"])
+    action = subject_action(previous_date, new_date)
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: project.name, who: author, action: action)
+    |> assign(:author, author)
+    |> assign(:project, project)
+    |> assign(:previous_date, previous_date)
+    |> assign(:new_date, new_date)
+    |> assign(:cta_url, Paths.project_path(company, project) |> Paths.to_url())
+    |> render("project_due_date_updating")
+  end
+
+  defp get_date_value(nil), do: nil
+  defp get_date_value(%Operately.ContextualDates.ContextualDate{value: value}), do: value
+  defp get_date_value(date), do: Calendar.strftime(date, "%b %-d, %Y")
+
+  defp subject_action(_old, nil), do: "removed the due date"
+  defp subject_action(nil, _new), do: "set the due date"
+  defp subject_action(_old, _new), do: "changed the due date"
+end

--- a/app/lib/operately_email/templates/project_due_date_updating.html.eex
+++ b/app/lib/operately_email/templates/project_due_date_updating.html.eex
@@ -1,0 +1,37 @@
+<%= if @new_date do %>
+  <%= if @previous_date do %>
+    <%= title("#{short_name(@author)} changed the due date for #{@project.name}") %>
+  <% else %>
+    <%= title("#{short_name(@author)} set the due date for #{@project.name}") %>
+  <% end %>
+<% else %>
+  <%= title("#{short_name(@author)} removed the due date for #{@project.name}") %>
+<% end %>
+
+<%= spacer() %>
+
+<%= if @new_date do %>
+  <%= if @previous_date do %>
+    <%= row do %>
+      The due date was changed from <%= @previous_date %> to <%= @new_date %>.
+    <% end %>
+  <% else %>
+    <%= row do %>
+      The due date is now <%= @new_date %>.
+    <% end %>
+  <% end %>
+<% else %>
+  <%= row do %>
+    <%= if @previous_date do %>
+      The due date was removed. Previously it was <%= @previous_date %>.
+    <% else %>
+      The due date was removed.
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Project") %>
+<% end %>

--- a/app/lib/operately_email/templates/project_due_date_updating.text.eex
+++ b/app/lib/operately_email/templates/project_due_date_updating.text.eex
@@ -1,0 +1,15 @@
+<% if @new_date do %>
+<%   if @previous_date do %>
+<%= short_name(@author) %> changed the due date for <%= @project.name %> from <%= @previous_date %> to <%= @new_date %>.
+<%   else %>
+<%= short_name(@author) %> set the due date for <%= @project.name %> to <%= @new_date %>.
+<%   end %>
+<% else %>
+<%   if @previous_date do %>
+<%= short_name(@author) %> removed the due date for <%= @project.name %>. It was previously <%= @previous_date %>.
+<%   else %>
+<%= short_name(@author) %> removed the due date for <%= @project.name %>.
+<%   end %>
+<% end %>
+
+Link: <%= @cta_url %>

--- a/app/test/features/projects_test.exs
+++ b/app/test/features/projects_test.exs
@@ -69,6 +69,46 @@ defmodule Operately.Features.ProjectsTest do
     end
 
     @tag login_as: :champion
+    feature "edit project due date", ctx do
+      next_friday = Operately.Support.Time.next_friday()
+      formatted_date = Operately.Support.Time.format_month_day(next_friday)
+
+      ctx
+      |> Steps.visit_project_page()
+      |> Steps.edit_project_due_date(next_friday)
+      |> Steps.assert_project_due_date(formatted_date)
+      |> Steps.reload_project_page()
+      |> Steps.assert_project_due_date(formatted_date)
+      |> Steps.assert_project_due_date_change_visible_in_feed(formatted_date)
+      |> Steps.assert_project_due_date_notification_sent(formatted_date)
+      |> Steps.assert_project_due_date_set_email_sent()
+    end
+
+    @tag login_as: :reviewer
+    feature "edit project due date sends notification to champion", ctx do
+      next_friday = Operately.Support.Time.next_friday()
+      formatted_date = Operately.Support.Time.format_month_day(next_friday)
+
+      ctx
+      |> Steps.visit_project_page()
+      |> Steps.edit_project_due_date(next_friday)
+      |> Steps.assert_project_due_date(formatted_date)
+      |> Steps.assert_project_due_date_changed_notification_sent(formatted_date)
+      |> Steps.assert_project_due_date_changed_email_sent()
+    end
+
+    @tag login_as: :reviewer
+    feature "remove project due date sends notification to champion", ctx do
+      ctx
+      |> Steps.given_project_due_date_exists()
+      |> Steps.visit_project_page()
+      |> Steps.remove_project_due_date()
+      |> Steps.assert_no_project_due_date()
+      |> Steps.assert_project_due_date_removed_notification_sent()
+      |> Steps.assert_project_due_date_removed_email_sent()
+    end
+
+    @tag login_as: :champion
     feature "export project as markdown", ctx do
       ctx
       |> Steps.visit_project_page()

--- a/app/test/support/features/projects_steps.ex
+++ b/app/test/support/features/projects_steps.ex
@@ -7,6 +7,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   alias Operately.Support.Features.NotificationsSteps
   alias Operately.Support.Features.FeedSteps
   alias Operately.People.Person
+  alias Operately.ContextualDates.ContextualDate
   alias OperatelyWeb.Paths
 
   import Operately.CompaniesFixtures
@@ -59,8 +60,16 @@ defmodule Operately.Support.Features.ProjectSteps do
   def create_project(ctx, name: name) do
     company = company_fixture(%{name: "Test Org"})
     champion = person_fixture_with_account(%{company_id: company.id, full_name: "John Champion"})
-    reviewer = person_fixture_with_account(%{company_id: company.id, full_name: "Leonardo Reviewer"})
-    group = group_fixture(champion, %{company_id: company.id, name: "Test Group", company_permissions: Binding.view_access()})
+
+    reviewer =
+      person_fixture_with_account(%{company_id: company.id, full_name: "Leonardo Reviewer"})
+
+    group =
+      group_fixture(champion, %{
+        company_id: company.id,
+        name: "Test Group",
+        company_permissions: Binding.view_access()
+      })
 
     params = %Operately.Operations.ProjectCreation{
       company_id: company.id,
@@ -77,7 +86,13 @@ defmodule Operately.Support.Features.ProjectSteps do
 
     {:ok, project} = Operately.Projects.create_project(params)
 
-    Map.merge(ctx, %{company: company, champion: champion, project: project, reviewer: reviewer, group: group})
+    Map.merge(ctx, %{
+      company: company,
+      champion: champion,
+      project: project,
+      reviewer: reviewer,
+      group: group
+    })
   end
 
   def login(ctx) do
@@ -217,7 +232,8 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.login_as(ctx.reviewer)
     |> NotificationsSteps.assert_activity_notification(%{
       author: ctx.champion,
-      action: "Disconnected the #{ctx.project.name} project from the Improve support first response time goal"
+      action:
+        "Disconnected the #{ctx.project.name} project from the Improve support first response time goal"
     })
   end
 
@@ -237,13 +253,138 @@ defmodule Operately.Support.Features.ProjectSteps do
   step :assert_project_moved_notification_sent, ctx do
     ctx
     |> UI.login_as(ctx.reviewer)
-    |> NotificationsSteps.assert_project_moved_sent(author: ctx.champion, old_space: ctx.group, new_space: ctx.new_space)
+    |> NotificationsSteps.assert_project_moved_sent(
+      author: ctx.champion,
+      old_space: ctx.group,
+      new_space: ctx.new_space
+    )
   end
 
   step :assert_project_moved_feed_item_exists, ctx do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
-    |> FeedSteps.assert_project_moved(author: ctx.champion, old_space: ctx.group, new_space: ctx.new_space)
+    |> FeedSteps.assert_project_moved(
+      author: ctx.champion,
+      old_space: ctx.group,
+      new_space: ctx.new_space
+    )
+  end
+
+  step :reload_project_page, ctx do
+    ctx |> UI.visit(Paths.project_path(ctx.company, ctx.project))
+  end
+
+  step :edit_project_due_date, ctx, date do
+    ctx
+    |> UI.select_day_in_date_field(testid: "project-due-date", date: date)
+    |> UI.sleep(300)
+  end
+
+  step :remove_project_due_date, ctx do
+    UI.clear_date_in_date_field(ctx, testid: "project-due-date")
+  end
+
+  step :assert_project_due_date, ctx, formatted_date do
+    ctx |> UI.assert_text(formatted_date, testid: "project-due-date")
+  end
+
+  step :assert_no_project_due_date, ctx do
+    ctx |> UI.assert_text("Set due date", testid: "project-due-date")
+  end
+
+  step :assert_project_due_date_change_visible_in_feed, ctx, date_text do
+    short = "#{Person.first_name(ctx.champion)} changed the due date to #{date_text}"
+    long = "#{Person.first_name(ctx.champion)} changed the due date to #{date_text} on the #{ctx.project.name}"
+
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> UI.find(UI.query(testid: "project-feed"), fn el ->
+      UI.assert_text(el, short)
+    end)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> UI.find(UI.query(testid: "space-feed"), fn el ->
+      UI.assert_text(el, long)
+    end)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.find(UI.query(testid: "company-feed"), fn el ->
+      UI.assert_text(el, long)
+    end)
+  end
+
+  step :assert_project_due_date_set_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.reviewer,
+      author: ctx.champion,
+      action: "set the due date"
+    })
+  end
+
+  step :assert_project_due_date_notification_sent, ctx, date_text do
+    ctx
+    |> UI.login_as(ctx.reviewer)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.champion,
+      action: "Updated due date for #{ctx.project.name} to #{date_text}"
+    })
+  end
+
+  step :assert_project_due_date_changed_notification_sent, ctx, date_text do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.reviewer,
+      action: "Updated due date for #{ctx.project.name} to #{date_text}"
+    })
+  end
+
+  step :assert_project_due_date_removed_notification_sent, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.reviewer,
+      action: "Cleared due date for #{ctx.project.name}"
+    })
+  end
+
+  step :assert_project_due_date_changed_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.champion,
+      author: ctx.reviewer,
+      action: "set the due date"
+    })
+  end
+
+  step :assert_project_due_date_removed_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.champion,
+      author: ctx.reviewer,
+      action: "removed the due date"
+    })
+  end
+
+  step :given_project_due_date_exists, ctx do
+    due_date = Operately.Support.Time.next_friday()
+    contextual_end_date = ContextualDate.create_day_date(due_date)
+
+    timeframe =
+      if ctx.project.timeframe do
+        %{
+          contextual_start_date: ctx.project.timeframe.contextual_start_date,
+          contextual_end_date: contextual_end_date
+        }
+      else
+        %{contextual_start_date: nil, contextual_end_date: contextual_end_date}
+      end
+
+    {:ok, project} = Operately.Projects.update_project(ctx.project, %{timeframe: timeframe})
+
+    Map.put(ctx, :project, project)
   end
 
   #
@@ -372,11 +513,22 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> FeedSteps.assert_project_goal_connection(author: ctx.champion, goal_name: goal_name)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
-    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name, goal_name: goal_name)
+    |> FeedSteps.assert_project_goal_connection(
+      author: ctx.champion,
+      project_name: ctx.project.name,
+      goal_name: goal_name
+    )
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name, goal_name: goal_name)
+    |> FeedSteps.assert_project_goal_connection(
+      author: ctx.champion,
+      project_name: ctx.project.name,
+      goal_name: goal_name
+    )
     |> UI.visit(Paths.goal_path(ctx.company, ctx.goal, tab: "activity"))
-    |> FeedSteps.assert_project_goal_connection(author: ctx.champion, project_name: ctx.project.name)
+    |> FeedSteps.assert_project_goal_connection(
+      author: ctx.champion,
+      project_name: ctx.project.name
+    )
   end
 
   step :assert_project_description_absent, ctx do
@@ -411,8 +563,8 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_champion_changed_feed_posted, ctx, champion: champion do
-    title = "assigned #{Person.short_name((champion))} as the champion"
-    title_long = "assigned #{Person.short_name((champion))} as the champion on #{ctx.project.name}"
+    title = "assigned #{Person.short_name(champion)} as the champion"
+    title_long = "assigned #{Person.short_name(champion)} as the champion on #{ctx.project.name}"
 
     assert_feed(ctx, title, title_long)
   end
@@ -469,9 +621,15 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> FeedSteps.assert_project_key_resource_added(author: ctx.champion)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
-    |> FeedSteps.assert_project_key_resource_added(author: ctx.champion, project_name: ctx.project.name)
+    |> FeedSteps.assert_project_key_resource_added(
+      author: ctx.champion,
+      project_name: ctx.project.name
+    )
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_project_key_resource_added(author: ctx.champion, project_name: ctx.project.name)
+    |> FeedSteps.assert_project_key_resource_added(
+      author: ctx.champion,
+      project_name: ctx.project.name
+    )
   end
 
   step :assert_key_resource_added_notification_sent, ctx do
@@ -513,9 +671,15 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> FeedSteps.assert_project_key_resource_deleted(author: ctx.champion)
     |> UI.visit(Paths.space_path(ctx.company, ctx.group))
-    |> FeedSteps.assert_project_key_resource_deleted(author: ctx.champion, project_name: ctx.project.name)
+    |> FeedSteps.assert_project_key_resource_deleted(
+      author: ctx.champion,
+      project_name: ctx.project.name
+    )
     |> UI.visit(Paths.feed_path(ctx.company))
-    |> FeedSteps.assert_project_key_resource_deleted(author: ctx.champion, project_name: ctx.project.name)
+    |> FeedSteps.assert_project_key_resource_deleted(
+      author: ctx.champion,
+      project_name: ctx.project.name
+    )
   end
 
   #

--- a/turboui/src/ProjectPage/OverviewSidebar.tsx
+++ b/turboui/src/ProjectPage/OverviewSidebar.tsx
@@ -123,6 +123,7 @@ function ProjectDates(props: ProjectPage.State) {
           placeholder="Set start date"
           showOverdueWarning={false}
           useStartOfPeriod={true}
+          testId="project-start-date"
         />
       </SidebarSection>
       <SidebarSection title="Due date">
@@ -131,6 +132,7 @@ function ProjectDates(props: ProjectPage.State) {
           onDateSelect={props.setDueAt || (() => {})}
           readonly={!props.canEdit}
           placeholder="Set due date"
+          testId="project-due-date"
         />
       </SidebarSection>
     </div>


### PR DESCRIPTION
## Summary
- notify only the project champion and reviewer about due date updates
- read contextual date values in the project due date email handler for accurate messaging

## Testing
- mix format app/lib/operately/activities/notifications/project_due_date_updating.ex app/lib/operately_email/emails/project_due_date_updating_email.ex

------
https://chatgpt.com/codex/tasks/task_b_68dbd7d10828832abcccdeeed4f71735