### PR TITLE
fix: Add feed handler for ProjectTaskCommented event

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -667,6 +667,12 @@ export interface ActivityContentProjectStartDateUpdating {
   newStartDate: string | null;
 }
 
+export interface ActivityContentProjectTaskCommented {
+  project: Project;
+  task: Task | null;
+  comment: Comment | null;
+}
+
 export interface ActivityContentProjectTimelineEdited {
   project?: Project | null;
   oldStartDate?: string | null;

--- a/app/assets/js/features/activities/ProjectTaskCommented/index.tsx
+++ b/app/assets/js/features/activities/ProjectTaskCommented/index.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+
+import type { ActivityContentProjectTaskCommented } from "@/api";
+import type { Activity } from "@/models/activities";
+import type { ActivityHandler } from "../interfaces";
+
+import { usePaths } from "@/routes/paths";
+import { Link, Summary } from "turboui";
+import { feedTitle, projectLink } from "./../feedItemLinks";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+
+const ProjectTaskCommented: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, activity: Activity): string {
+    const { task, project } = content(activity);
+    const path = task ? paths.taskPath(task.id) : paths.projectPath(project.id);
+
+    return path;
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const paths = usePaths();
+    const { project, task } = content(activity);
+
+    const taskPath = task ? paths.taskPath(task.id) : null;
+    const taskLink = (taskPath && task) ? <Link to={taskPath}>{task.name}</Link> : "a task";
+
+    if (page === "project") {
+      return feedTitle(activity, "commented on", taskLink);
+    } else {
+      return feedTitle(activity, "commented on", taskLink, "in the", projectLink(project), "project");
+    }
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const { mentionedPersonLookup } = useRichEditorHandlers();
+    const { comment } = content(activity);
+    const commentContent = comment?.content ? JSON.parse(comment.content)["message"] : "";
+
+    return <Summary content={commentContent} characterCount={200} mentionedPersonLookup={mentionedPersonLookup} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const { task } = content(activity);
+    const taskName = task ? task.name : "a task";
+    return "Re: " + taskName;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).project.name;
+  },
+};
+
+function content(activity: Activity): ActivityContentProjectTaskCommented {
+  return activity.content as ActivityContentProjectTaskCommented;
+}
+
+export default ProjectTaskCommented;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -123,6 +123,7 @@ export const DISPLAYED_IN_FEED = [
   "project_resuming",
   "project_timeline_edited",
   "project_retrospective_commented",
+  "project_task_commented",
   "project_discussion_submitted",
   "task_adding",
   "task_name_updating",
@@ -225,6 +226,7 @@ import ProjectPausing from "@/features/activities/ProjectPausing";
 import ProjectRenamed from "@/features/activities/ProjectRenamed";
 import ProjectResuming from "@/features/activities/ProjectResuming";
 import ProjectRetrospectiveCommented from "@/features/activities/ProjectRetrospectiveCommented";
+import ProjectTaskCommented from "@/features/activities/ProjectTaskCommented";
 import ProjectTimelineEdited from "@/features/activities/ProjectTimelineEdited";
 import ResourceHubDocumentCommented from "@/features/activities/ResourceHubDocumentCommented";
 import ResourceHubDocumentCreated from "@/features/activities/ResourceHubDocumentCreated";
@@ -311,6 +313,7 @@ function handler(activity: Activity) {
     .with("project_renamed", () => ProjectRenamed)
     .with("project_resuming", () => ProjectResuming)
     .with("project_retrospective_commented", () => ProjectRetrospectiveCommented)
+    .with("project_task_commented", () => ProjectTaskCommented)
     .with("project_timeline_edited", () => ProjectTimelineEdited)
     .with("resource_hub_document_created", () => ResourceHubDocumentCreated)
     .with("resource_hub_document_edited", () => ResourceHubDocumentEdited)

--- a/app/lib/operately_web/api/serializers/activity_content/project_task_commented.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/project_task_commented.ex
@@ -1,0 +1,11 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.ProjectTaskCommented do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      project: Serializer.serialize(content.project, level: :essential),
+      task: Serializer.serialize(content.task, level: :essential),
+      comment: OperatelyWeb.Api.Serializer.serialize(content.comment),
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -373,6 +373,12 @@ defmodule OperatelyWeb.Api.Types do
     field? :new_priority, :string, null: true
   end
 
+  object :activity_content_project_task_commented do
+    field :project, :project, null: false
+    field :task, :task, null: true
+    field :comment, :comment, null: true
+  end
+
   object :goal_editing_updated_target do
     field? :id, :string, null: true
     field? :old_name, :string, null: true

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -293,6 +293,19 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.assert_comment("This is a comment")
     |> Steps.reload_task_page()
     |> Steps.assert_comment("This is a comment")
+    |> Steps.assert_task_comment_visible_in_feed()
+  end
+
+  @tag login_as: :reviewer
+  feature "post comment to task sends notification to assignee", ctx do
+    ctx
+    |> Steps.given_task_exists()
+    |> Steps.given_task_assignee_exists()
+    |> Steps.visit_task_page()
+    |> Steps.post_comment("This is a comment")
+    |> Steps.assert_comment("This is a comment")
+    |> Steps.assert_comment_posted_notification_sent()
+    |> Steps.assert_comment_posted_email_sent()
   end
 
   @tag login_as: :champion


### PR DESCRIPTION
The feed handler for ProjectTaskCommented was missing.