### PR TITLE
fix: Don't throw 404 error when Task is deleted

### DIFF
--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -188,6 +188,13 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     |> UI.sleep(300)
   end
 
+  step :delete_task, ctx do
+    ctx
+    |> UI.click(testid: "delete-task")
+    |> UI.click_button("Delete Forever")
+    |> UI.assert_page(Paths.project_path(ctx.company, ctx.project))
+  end
+
   #
   # Assertions
   #
@@ -265,6 +272,12 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
 
   step :refute_task_description, ctx, description do
     UI.refute_text(ctx, description)
+  end
+
+  step :assert_task_not_in_list, ctx do
+    ctx
+    |> UI.click(testid: "tab-tasks")
+    |> UI.refute_text(ctx.task.name)
   end
 
   step :assert_change_in_feed, ctx, title do
@@ -358,9 +371,9 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     end)
   end
 
-  step :assert_task_comment_visible_in_feed, ctx do
-    short = "#{Operately.People.Person.first_name(ctx.champion)} commented on #{ctx.task.name}"
-    long = "#{Operately.People.Person.first_name(ctx.champion)} commented on #{ctx.task.name} in the #{ctx.project.name} project"
+  step :assert_task_comment_visible_in_feed, ctx, person: person, task_name: task_name do
+    short = "#{Operately.People.Person.first_name(person)} commented on #{task_name}"
+    long = "#{Operately.People.Person.first_name(person)} commented on #{task_name} in the #{ctx.project.name} project"
 
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
@@ -471,12 +484,12 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     })
   end
 
-  step :assert_comment_posted_notification_sent, ctx do
+  step :assert_comment_posted_notification_sent, ctx, task_name: task_name do
     ctx
     |> UI.login_as(ctx.champion)
     |> NotificationsSteps.assert_activity_notification(%{
       author: ctx.reviewer,
-      action: "Re: #{ctx.task.name}"
+      action: "Re: #{task_name}"
     })
   end
 

--- a/turboui/src/TaskPage/Sidebar.tsx
+++ b/turboui/src/TaskPage/Sidebar.tsx
@@ -194,6 +194,7 @@ function Actions(props: TaskPage.State) {
       icon: IconTrash,
       show: props.canEdit,
       danger: true,
+      testId: "delete-task",
     },
   ].filter((action) => action.show);
 
@@ -209,6 +210,7 @@ function Actions(props: TaskPage.State) {
             className={`flex items-center gap-2 text-xs hover:bg-surface-highlight rounded px-2 py-1 -mx-2 w-full text-left ${
               action.danger ? "text-content-error hover:bg-red-50" : ""
             }`}
+            data-test-id={action.testId}
           >
             <action.icon size={16} className={action.danger ? "text-content-error" : "text-content-dimmed"} />
             <span>{action.label}</span>


### PR DESCRIPTION
`PageCache` was triggering the loader when a page unmounts, which was causing unnecesary requests to be fired. 

Also, when a Task was deleted, we were getting a 404 error in the console. The user wasn't being affected by this error, but feature tests for deleting a Task wouldn't work because of this error.