### PR TITLE
fix: Remove constraint that causes Space deletion to fail

### DIFF
--- a/app/priv/repo/migrations/20251007112431_fix_goals_parent_goal_id_constraint_set_null.exs
+++ b/app/priv/repo/migrations/20251007112431_fix_goals_parent_goal_id_constraint_set_null.exs
@@ -1,0 +1,19 @@
+defmodule Operately.Repo.Migrations.FixGoalsParentGoalIdConstraintSetNull do
+  use Ecto.Migration
+
+  def up do
+    drop constraint(:goals, :goals_parent_goal_id_fkey)
+
+    alter table(:goals) do
+      modify :parent_goal_id, references(:goals, on_delete: :nilify_all, type: :binary_id)
+    end
+  end
+
+  def down do
+    drop constraint(:goals, :goals_parent_goal_id_fkey)
+
+    alter table(:goals) do
+      modify :parent_goal_id, references(:goals, on_delete: :nothing, type: :binary_id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/3601.

The problem was:
```
11:20:38.223 [error] 
Erorr while processing delete_space 

11:20:38.223 [error] ** (Ecto.ConstraintError) constraint error when attempting to delete struct:

    * "goals_parent_goal_id_fkey" (foreign_key_constraint)

If you would like to stop this constraint violation from raising an
exception and instead add it as an error to your changeset, please
call `foreign_key_constraint/3` on your changeset with the constraint
`:name` as an option.

The changeset has not defined any constraint.
```

I've fixed it by changing the constraint.