### PR TITLE
fix: resolve project due date template warnings

### DIFF
--- a/app/lib/operately_email/templates/project_due_date_updating.text.eex
+++ b/app/lib/operately_email/templates/project_due_date_updating.text.eex
@@ -1,15 +1,15 @@
-<% if @new_date do %>
-<%   if @previous_date do %>
+<%= if @new_date do %>
+  <%= if @previous_date do %>
 <%= short_name(@author) %> changed the due date for <%= @project.name %> from <%= @previous_date %> to <%= @new_date %>.
-<%   else %>
+  <% else %>
 <%= short_name(@author) %> set the due date for <%= @project.name %> to <%= @new_date %>.
-<%   end %>
+  <% end %>
 <% else %>
-<%   if @previous_date do %>
+  <%= if @previous_date do %>
 <%= short_name(@author) %> removed the due date for <%= @project.name %>. It was previously <%= @previous_date %>.
-<%   else %>
+  <% else %>
 <%= short_name(@author) %> removed the due date for <%= @project.name %>.
-<%   end %>
+  <% end %>
 <% end %>
 
 Link: <%= @cta_url %>


### PR DESCRIPTION
## Summary
- adjust the project due date email template to remove nested EEx indentation that triggered warnings

## Testing
- mix compile *(fails: Hex is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e50dd7e5d0832abf253060a51bea42