### PR TITLE
feat: add group edited activity feed support

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -405,7 +405,12 @@ export interface ActivityContentGoalTimeframeEditing {
 }
 
 export interface ActivityContentGroupEdited {
-  exampleField?: string | null;
+  company: Company;
+  space: Space;
+  oldName: string;
+  newName: string;
+  oldMission?: string | null;
+  newMission?: string | null;
 }
 
 export interface ActivityContentMessageArchiving {

--- a/app/assets/js/features/activities/GroupEdited/index.tsx
+++ b/app/assets/js/features/activities/GroupEdited/index.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+
+import type { Activity, ActivityContentGroupEdited } from "@/api";
+import type { ActivityHandler } from "../interfaces";
+
+import { assertPresent } from "@/utils/assertions";
+import { feedTitle, spaceLink } from "../feedItemLinks";
+
+const GroupEdited: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, activity: Activity): string {
+    const data = content(activity);
+    const spaceId = data.space?.id;
+
+    assertPresent(spaceId, "space.id must be present in GroupEdited activity content");
+
+    return paths.spacePath(spaceId);
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const data = content(activity);
+
+    assertPresent(data.space, "space must be present in GroupEdited activity content");
+
+    if (page === "space") {
+      return feedTitle(activity, "updated this space");
+    }
+
+    return feedTitle(activity, "updated the", spaceLink(data.space), "space");
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const data = content(activity);
+
+    const oldName = data.oldName ?? "";
+    const newName = data.newName ?? "";
+    const oldMission = data.oldMission ?? "";
+    const newMission = data.newMission ?? "";
+
+    const nameChanged = oldName !== newName && (oldName !== "" || newName !== "");
+    const missionChanged = oldMission !== newMission && (oldMission !== "" || newMission !== "");
+
+    if (!nameChanged && !missionChanged) {
+      return null;
+    }
+
+    return (
+      <div className="flex flex-col gap-1 text-sm">
+        {nameChanged && (
+          <div>
+            <span className="text-content-subtle">Name:</span> {oldName} → {newName}
+          </div>
+        )}
+        {missionChanged && (
+          <div>
+            <span className="text-content-subtle">Purpose:</span> {oldMission} → {newMission}
+          </div>
+        )}
+      </div>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const data = content(activity);
+
+    const spaceName = data.newName || data.space?.name;
+
+    if (spaceName) {
+      return `Updated the ${spaceName} space`;
+    }
+
+    return "Updated the space";
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).space?.name ?? null;
+  },
+};
+
+function content(activity: Activity): ActivityContentGroupEdited {
+  return activity.content as ActivityContentGroupEdited;
+}
+
+export default GroupEdited;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -153,6 +153,7 @@ export const DISPLAYED_IN_FEED = [
   "resource_hub_link_edited",
   "resource_hub_link_deleted",
   "resource_hub_link_commented",
+  "group_edited",
   "space_added",
   "space_joining",
   "space_member_removed",
@@ -244,6 +245,7 @@ import ResourceHubLinkCommented from "@/features/activities/ResourceHubLinkComme
 import ResourceHubLinkCreated from "@/features/activities/ResourceHubLinkCreated";
 import ResourceHubLinkDeleted from "@/features/activities/ResourceHubLinkDeleted";
 import ResourceHubLinkEdited from "@/features/activities/ResourceHubLinkEdited";
+import GroupEdited from "@/features/activities/GroupEdited";
 import SpaceAdded from "@/features/activities/SpaceAdded";
 import SpaceJoining from "@/features/activities/SpaceJoining";
 import SpaceMemberRemoved from "@/features/activities/SpaceMemberRemoved";
@@ -331,6 +333,7 @@ function handler(activity: Activity) {
     .with("resource_hub_link_edited", () => ResourceHubLinkEdited)
     .with("resource_hub_link_deleted", () => ResourceHubLinkDeleted)
     .with("resource_hub_link_commented", () => ResourceHubLinkCommented)
+    .with("group_edited", () => GroupEdited)
     .with("space_added", () => SpaceAdded)
     .with("space_joining", () => SpaceJoining)
     .with("space_member_removed", () => SpaceMemberRemoved)

--- a/app/lib/operately_web/api/serializers/activity.ex
+++ b/app/lib/operately_web/api/serializers/activity.ex
@@ -162,8 +162,8 @@ defmodule OperatelyWeb.Api.Serializers.Activity do
     }
   end
 
-  def serialize_content("group_edited", _content) do
-    %{}
+  def serialize_content("group_edited", content) do
+    Serializer.serialize(content, level: :essential)
   end
 
   def serialize_content("password_first_time_changed", _content) do

--- a/app/lib/operately_web/api/serializers/activity_content/group_edited.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/group_edited.ex
@@ -1,0 +1,14 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.GroupEdited do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      company: Serializer.serialize(content["company"], level: :essential),
+      space: Serializer.serialize(content["group"], level: :essential),
+      old_name: Serializer.serialize(content["old_name"], level: :essential),
+      new_name: Serializer.serialize(content["new_name"], level: :essential),
+      old_mission: Serializer.serialize(content["old_mission"], level: :essential),
+      new_mission: Serializer.serialize(content["new_mission"], level: :essential)
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1202,7 +1202,12 @@ defmodule OperatelyWeb.Api.Types do
   )
 
   object :activity_content_group_edited do
-    field? :example_field, :string, null: true
+    field :company, :company
+    field :space, :space
+    field :old_name, :string
+    field :new_name, :string
+    field :old_mission, :string, null: true
+    field :new_mission, :string, null: true
   end
 
   object :activity_content_project_review_request_submitted do

--- a/app/test/features/spaces_test.exs
+++ b/app/test/features/spaces_test.exs
@@ -89,6 +89,7 @@ defmodule Operately.Features.SpacesTest do
     |> Steps.click_edit_space()
     |> Steps.change_space_name_and_purpose()
     |> Steps.assert_space_name_and_purpose_changed()
+    |> Steps.assert_space_edit_visible_in_activity_feed()
   end
 
   feature "adding space members", ctx do

--- a/app/test/support/features/spaces_steps.ex
+++ b/app/test/support/features/spaces_steps.ex
@@ -269,17 +269,32 @@ defmodule Operately.Support.Features.SpacesSteps do
   end
 
   step :change_space_name_and_purpose, ctx do
+    updated_attrs = %{name: "Marketing 2", mission: "Let the world know about our products 2"}
+
     ctx
-    |> UI.fill(testid: "name", with: "Marketing 2")
-    |> UI.fill(testid: "purpose", with: "Let the world know about our products 2")
+    |> UI.fill(testid: "name", with: updated_attrs.name)
+    |> UI.fill(testid: "purpose", with: updated_attrs.mission)
     |> UI.click(testid: "submit")
     |> UI.assert_has(testid: "space-page")
+    |> Map.put(:updated_space_attrs, updated_attrs)
   end
 
   step :assert_space_name_and_purpose_changed, ctx do
     ctx
-    |> UI.assert_text("Marketing 2")
-    |> UI.assert_text("Let the world know about our products 2")
+    |> UI.assert_text(ctx.updated_space_attrs.name)
+    |> UI.assert_text(ctx.updated_space_attrs.mission)
+  end
+
+  step :assert_space_edit_visible_in_activity_feed, ctx do
+    updated = ctx.updated_space_attrs
+
+    ctx
+    |> UI.visit(Paths.space_path(ctx.company, ctx.marketing))
+    |> UI.assert_feed_item(ctx.creator, "updated this space", "Name: #{ctx.marketing.name} → #{updated.name}")
+    |> UI.assert_text("Purpose: #{ctx.marketing.mission} → #{updated.mission}")
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.assert_feed_item(ctx.creator, "updated the #{updated.name} space", "Name: #{ctx.marketing.name} → #{updated.name}")
+    |> UI.assert_text("Purpose: #{ctx.marketing.mission} → #{updated.mission}")
   end
 
   step :given_a_completed_project_exists, ctx do


### PR DESCRIPTION
## Summary
- add API serialization for group_edited activities and expose proper fields
- register a new frontend feed handler to render renamed space details
- extend the space feature scenario to assert company and space feeds include the update

## Testing
- make test FILE=app/test/features/spaces_test.exs:85 *(fails: docker unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e67069c3a4832aae1a989fa0ef9dbf