### PR TITLE
chore: Cover mentioning people in task comments

### DIFF
--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -375,13 +375,20 @@ defmodule Operately.Features.ProjectTasksTest do
       ctx
       |> Steps.given_task_exists()
       |> Steps.given_space_member_exists()
+      |> Steps.visit_task_page()
+      |> Steps.post_comment("This is a comment without mentions")
 
     ctx
+    |> Steps.assert_space_member_not_notified()
+
+    ctx
+    |> Steps.login_as_champion()
     |> Steps.visit_task_page()
-    |> Steps.post_comment("This is a comment without mentions")
-    |> Steps.assert_space_member_not_mentioned()
     |> Steps.post_comment_mentioning(ctx.space_member)
-    |> Steps.assert_space_member_mentioned()
+
+    ctx
+    |> Steps.assert_space_member_notified()
+    |> Steps.assert_space_member_mentioned_email_sent()
   end
 
   @tag login_as: :reviewer

--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -200,44 +200,13 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
       el
       |> UI.click_text("Write a comment here...")
       |> UI.mention_person_in_rich_text(person)
-      |> UI.send_keys(" Thanks for your help!")
       |> UI.click_button("Post")
     end)
     |> UI.sleep(300)
   end
 
-  step :assert_space_member_not_mentioned, ctx do
-    ctx =
-      ctx
-      |> UI.login_as(ctx.space_member)
-      |> NotificationsSteps.assert_no_unread_notifications()
-      |> UI.login_as(ctx.champion)
-      |> UI.visit(Paths.project_task_path(ctx.company, ctx.task))
-
-    emails = UI.list_sent_emails(ctx)
-
-    refute Enum.any?(emails, fn email -> ctx.space_member.email in email.to end)
-
-    ctx
-  end
-
-  step :assert_space_member_mentioned, ctx do
-    ctx =
-      ctx
-      |> UI.login_as(ctx.space_member)
-      |> NotificationsSteps.assert_activity_notification(%{
-        author: ctx.champion,
-        action: "Re: #{ctx.task.name}"
-      })
-      |> UI.login_as(ctx.champion)
-
-    ctx
-    |> EmailSteps.assert_activity_email_sent(%{
-      where: ctx.project.name,
-      to: ctx.space_member,
-      author: ctx.champion,
-      action: "commented on: #{ctx.task.name}"
-    })
+  step :login_as_champion, ctx do
+    UI.login_as(ctx, ctx.champion)
   end
 
   step :delete_task, ctx do
@@ -547,6 +516,16 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     })
   end
 
+  step :assert_space_member_mentioned_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.space_member,
+      author: ctx.champion,
+      action: "commented on: #{ctx.task.name}"
+    })
+  end
+
   #
   # Notifications
   #
@@ -615,6 +594,23 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
     |> UI.login_as(recipient)
     |> NotificationsSteps.visit_notifications_page()
     |> UI.refute_text("New task \"#{ctx.task.name}\" was created")
+  end
+
+  step :assert_space_member_not_notified, ctx do
+    ctx
+    |> UI.login_as(ctx.space_member)
+    |> UI.visit(Paths.home_path(ctx.company))
+    |> UI.click(testid: "notifications-bell")
+    |> UI.refute_text("Re: #{ctx.task.name}")
+  end
+
+  step :assert_space_member_notified, ctx do
+    ctx
+    |> UI.login_as(ctx.space_member)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.champion,
+      action: "Re: #{ctx.task.name}"
+    })
   end
 
   #

--- a/app/test/support/features/ui.ex
+++ b/app/test/support/features/ui.ex
@@ -117,10 +117,17 @@ defmodule Operately.Support.Features.UI do
 
   def mention_person_in_rich_text(state, person_or_name) do
     name = mention_name(person_or_name)
+    query = Query.css(".ProseMirror[contenteditable=true]")
 
-    state
-    |> send_keys(["@", name])
-    |> send_keys([:enter])
+    execute("mention_person_in_rich_text", state, fn session ->
+      session
+      |> Browser.find(query, fn element ->
+        element
+        |> Browser.send_keys(["@", name])
+        |> sleep(500)
+        |> Browser.send_keys([:enter])
+      end)
+    end)
   end
 
   defp mention_name(%Person{} = person), do: Person.first_name(person)


### PR DESCRIPTION
## Summary
- add a UI helper to mention people in rich text while driving feature tests
- extend project task feature steps to post mention comments and assert notifications/emails
- add a feature test that exercises mentioning a space member in a task comment

## Testing
- make test FILE=test/features/project_tasks_test.exs # fails: docker: command not found

------
https://chatgpt.com/codex/tasks/task_b_68e676b620c4832a86aa6a81c97e04eb