### PR TITLE
feat: Notify mentions on task description updates

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -853,6 +853,7 @@ export interface ActivityContentTaskDescriptionChange {
   task: Task | null;
   projectName: string;
   hasDescription: boolean;
+  description: string | null;
 }
 
 export interface ActivityContentTaskDueDateUpdating {
@@ -1055,6 +1056,7 @@ export interface Company {
   id?: string | null;
   name?: string | null;
   mission?: string | null;
+  setupCompleted?: boolean | null;
   trustedEmailDomains?: string[] | null;
   enabledExperimentalFeatures?: string[] | null;
   companySpaceId?: string | null;
@@ -1386,6 +1388,7 @@ export interface Project {
   accessLevels?: AccessLevels | null;
   potentialSubscribers?: Subscriber[] | null;
   notifications?: Notification[] | null;
+  milestonesOrderingState?: string[] | null;
 }
 
 export interface ProjectCheckIn {
@@ -1700,6 +1703,11 @@ export interface SpacePermissions {
   canViewMessage?: boolean | null;
   canAddMembers?: boolean | null;
   canDelete?: boolean | null;
+}
+
+export interface SpaceSetupInput {
+  name: string;
+  description: string;
 }
 
 export interface SpaceTools {
@@ -3088,6 +3096,12 @@ export interface CloseProjectResult {
   retrospective: ProjectRetrospective;
 }
 
+export interface CompleteCompanySetupInput {
+  spaces: SpaceSetupInput[];
+}
+
+export interface CompleteCompanySetupResult {}
+
 export interface CopyResourceHubFolderInput {
   folderName?: string | null;
   folderId?: Id | null;
@@ -3845,6 +3859,15 @@ export interface ProjectMilestonesUpdateDueDateResult {
   milestone: Milestone;
 }
 
+export interface ProjectMilestonesUpdateOrderingInput {
+  projectId: Id;
+  orderingState: string[];
+}
+
+export interface ProjectMilestonesUpdateOrderingResult {
+  project: Project;
+}
+
 export interface ProjectMilestonesUpdateTitleInput {
   milestoneId: Id;
   title: string;
@@ -4468,6 +4491,10 @@ class ApiNamespaceRoot {
     return this.client.post("/close_project", input);
   }
 
+  async completeCompanySetup(input: CompleteCompanySetupInput): Promise<CompleteCompanySetupResult> {
+    return this.client.post("/complete_company_setup", input);
+  }
+
   async copyResourceHubFolder(input: CopyResourceHubFolderInput): Promise<CopyResourceHubFolderResult> {
     return this.client.post("/copy_resource_hub_folder", input);
   }
@@ -4888,6 +4915,10 @@ class ApiNamespaceProjectMilestones {
 
   async updateDueDate(input: ProjectMilestonesUpdateDueDateInput): Promise<ProjectMilestonesUpdateDueDateResult> {
     return this.client.post("/project_milestones/update_due_date", input);
+  }
+
+  async updateOrdering(input: ProjectMilestonesUpdateOrderingInput): Promise<ProjectMilestonesUpdateOrderingResult> {
+    return this.client.post("/project_milestones/update_ordering", input);
   }
 
   async updateTitle(input: ProjectMilestonesUpdateTitleInput): Promise<ProjectMilestonesUpdateTitleResult> {
@@ -5444,6 +5475,10 @@ export class ApiClient {
     return this.apiNamespaceRoot.closeProject(input);
   }
 
+  completeCompanySetup(input: CompleteCompanySetupInput): Promise<CompleteCompanySetupResult> {
+    return this.apiNamespaceRoot.completeCompanySetup(input);
+  }
+
   copyResourceHubFolder(input: CopyResourceHubFolderInput): Promise<CopyResourceHubFolderResult> {
     return this.apiNamespaceRoot.copyResourceHubFolder(input);
   }
@@ -5946,6 +5981,9 @@ export async function closeGoal(input: CloseGoalInput): Promise<CloseGoalResult>
 }
 export async function closeProject(input: CloseProjectInput): Promise<CloseProjectResult> {
   return defaultApiClient.closeProject(input);
+}
+export async function completeCompanySetup(input: CompleteCompanySetupInput): Promise<CompleteCompanySetupResult> {
+  return defaultApiClient.completeCompanySetup(input);
 }
 export async function copyResourceHubFolder(input: CopyResourceHubFolderInput): Promise<CopyResourceHubFolderResult> {
   return defaultApiClient.copyResourceHubFolder(input);
@@ -6525,6 +6563,15 @@ export function useCloseGoal(): UseMutationHookResult<CloseGoalInput, CloseGoalR
 
 export function useCloseProject(): UseMutationHookResult<CloseProjectInput, CloseProjectResult> {
   return useMutation<CloseProjectInput, CloseProjectResult>((input) => defaultApiClient.closeProject(input));
+}
+
+export function useCompleteCompanySetup(): UseMutationHookResult<
+  CompleteCompanySetupInput,
+  CompleteCompanySetupResult
+> {
+  return useMutation<CompleteCompanySetupInput, CompleteCompanySetupResult>((input) =>
+    defaultApiClient.completeCompanySetup(input),
+  );
 }
 
 export function useCopyResourceHubFolder(): UseMutationHookResult<
@@ -7138,6 +7185,8 @@ export default {
   useCloseGoal,
   closeProject,
   useCloseProject,
+  completeCompanySetup,
+  useCompleteCompanySetup,
   copyResourceHubFolder,
   useCopyResourceHubFolder,
   createAccount,
@@ -7453,6 +7502,13 @@ export default {
     useUpdateTitle: () =>
       useMutation<ProjectMilestonesUpdateTitleInput, ProjectMilestonesUpdateTitleResult>((input) =>
         defaultApiClient.apiNamespaceProjectMilestones.updateTitle(input),
+      ),
+
+    updateOrdering: (input: ProjectMilestonesUpdateOrderingInput) =>
+      defaultApiClient.apiNamespaceProjectMilestones.updateOrdering(input),
+    useUpdateOrdering: () =>
+      useMutation<ProjectMilestonesUpdateOrderingInput, ProjectMilestonesUpdateOrderingResult>((input) =>
+        defaultApiClient.apiNamespaceProjectMilestones.updateOrdering(input),
       ),
   },
 

--- a/app/assets/js/features/activities/TaskDescriptionChange/index.tsx
+++ b/app/assets/js/features/activities/TaskDescriptionChange/index.tsx
@@ -47,10 +47,11 @@ const TaskDescriptionChange: ActivityHandler = {
     const data = content(activity);
     const { mentionedPersonLookup } = useRichEditorHandlers();
 
-    if (!data.task?.description) return null;
+    const rawDescription = data.description ?? data.task?.description;
 
-    const description =
-      typeof data.task.description === "string" ? JSON.parse(data.task.description) : data.task.description;
+    if (!rawDescription) return null;
+
+    const description = typeof rawDescription === "string" ? JSON.parse(rawDescription) : rawDescription;
 
     return <Summary content={description} characterCount={200} mentionedPersonLookup={mentionedPersonLookup} />;
   },

--- a/app/lib/operately/activities/content/task_description_change.ex
+++ b/app/lib/operately/activities/content/task_description_change.ex
@@ -11,12 +11,22 @@ defmodule Operately.Activities.Content.TaskDescriptionChange do
     field :task_name, :string
     field :project_name, :string
     field :has_description, :boolean
+    field :description, :map
   end
 
   def changeset(attrs) do
     %__MODULE__{}
     |> cast(attrs, __schema__(:fields))
-    |> validate_required([:company_id, :space_id, :project_id, :task_id, :task_name, :project_name, :has_description])
+    |> validate_required([
+      :company_id,
+      :space_id,
+      :project_id,
+      :task_id,
+      :task_name,
+      :project_name,
+      :has_description,
+      :description
+    ])
   end
 
   def build(params) do

--- a/app/lib/operately/activities/notifications/task_description_change.ex
+++ b/app/lib/operately/activities/notifications/task_description_change.ex
@@ -1,6 +1,25 @@
 defmodule Operately.Activities.Notifications.TaskDescriptionChange do
-  def dispatch(_activity) do
-    # Notification dispatcher for TaskDescriptionChange not implemented yet
-    {:ok, []}
+  @moduledoc """
+  Notifies the following people:
+  - People mentioned in the Task description
+
+  The person who authored the comment is excluded from notifications.
+  """
+
+  alias Operately.RichContent
+
+  def dispatch(activity) do
+    people = RichContent.find_mentioned_ids(activity.content["description"], :decode_ids)
+
+    people
+    |> Enum.reject(&(&1 == activity.author_id))
+    |> Enum.map(fn person_id ->
+      %{
+        person_id: person_id,
+        activity_id: activity.id,
+        should_send_email: true
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately/activities/preloader.ex
+++ b/app/lib/operately/activities/preloader.ex
@@ -153,10 +153,14 @@ defmodule Operately.Activities.Preloader do
   end
 
   defp is_field_an_embed(object, key, value) when is_map(value) do
-    value_type = value.__struct__
-    embeds = object.__struct__.__schema__(:embeds)
+    if Map.has_key?(value, :__struct__) do
+      value_type = value.__struct__
+      embeds = object.__struct__.__schema__(:embeds)
 
-    key in embeds && object.__struct__.__schema__(:embed, key).related == value_type
+      key in embeds && object.__struct__.__schema__(:embed, key).related == value_type
+    else
+      false
+    end
   end
 
   #

--- a/app/lib/operately_email/emails/task_description_change_email.ex
+++ b/app/lib/operately_email/emails/task_description_change_email.ex
@@ -1,5 +1,37 @@
 defmodule OperatelyEmail.Emails.TaskDescriptionChangeEmail do
-  def send(_person, _activity) do
-    raise "Email for TaskDescriptionChange not implemented"
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.Repo
+  alias OperatelyWeb.Paths
+  alias Operately.Tasks.Task
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    {:ok, task} =
+      Task.get(:system, id: activity.content["task_id"], opts: [preload: [:project]])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: task.project.name, who: author, action: "updated the description for \"#{task.name}\"")
+    |> assign(:author, author)
+    |> assign(:task_name, task.name)
+    |> assign(:description, decode_description(activity.content["description"]))
+    |> assign(:cta_url, Paths.project_task_path(company, task) |> Paths.to_url())
+    |> render("task_description_change")
   end
+
+  defp decode_description(nil), do: nil
+
+  defp decode_description(description) when is_binary(description) do
+    case Jason.decode(description) do
+      {:ok, decoded} -> decoded
+      _ -> nil
+    end
+  end
+
+  defp decode_description(description) when is_map(description), do: description
+  defp decode_description(_), do: nil
 end

--- a/app/lib/operately_email/templates/task_description_change.html.eex
+++ b/app/lib/operately_email/templates/task_description_change.html.eex
@@ -1,1 +1,19 @@
-<%= raise "HTML Email for TaskDescriptionChange not implemented" %>
+<%= title("#{short_name(@author)} updated the description for \"#{@task_name}\"") %>
+
+<%= spacer() %>
+
+<%= if @description do %>
+  <%= row do %>
+    <%= rich_text(@description) %>
+  <% end %>
+<% else %>
+  <%= row do %>
+    The description was cleared.
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Task") %>
+<% end %>

--- a/app/lib/operately_web/api/project_tasks.ex
+++ b/app/lib/operately_web/api/project_tasks.ex
@@ -101,7 +101,8 @@ defmodule OperatelyWeb.Api.ProjectTasks do
           task_id: changes.task.id,
           project_name: changes.project.name,
           task_name: changes.task.name,
-          has_description: Operately.RichContent.empty?(inputs.description)
+          has_description: Operately.RichContent.empty?(inputs.description),
+          description: inputs.description
         }
       end)
       |> Steps.commit()

--- a/app/lib/operately_web/api/serializers/activity_content/task_description_change.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/task_description_change.ex
@@ -5,7 +5,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.TaskDes
     %{
       task: Serializer.serialize(content["task"], level: :full),
       project_name: Serializer.serialize(content["project_name"], level: :essential),
-      has_description: content["has_description"]
+      has_description: content["has_description"],
+      description: Jason.encode!(content["description"]),
     }
   end
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -846,6 +846,7 @@ defmodule OperatelyWeb.Api.Types do
     field :task, :task, null: true
     field :project_name, :string, null: false
     field :has_description, :boolean, null: false
+    field :description, :string, null: true
   end
 
   object :activity_content_task_due_date_updating do

--- a/app/test/features/project_tasks_test.exs
+++ b/app/test/features/project_tasks_test.exs
@@ -241,6 +241,24 @@ defmodule Operately.Features.ProjectTasksTest do
     |> Steps.assert_change_in_feed("updated the description")
   end
 
+  @tag login_as: :champion
+  feature "mentioning a person in a task description sends notification and email", ctx do
+    ctx =
+      ctx
+      |> Steps.given_task_exists()
+      |> Steps.given_space_member_exists()
+      |> Steps.assert_space_member_task_description_not_notified()
+
+    ctx
+    |> Steps.login_as_champion()
+    |> Steps.visit_task_page()
+    |> Steps.edit_task_description_mentioning(ctx.space_member)
+
+    ctx
+    |> Steps.assert_space_member_task_description_notification_sent()
+    |> Steps.assert_space_member_task_description_email_sent()
+  end
+
   @tag login_as: :reviewer
   feature "edit task assignee", ctx do
     feed_title = "assigned this task to #{Operately.People.Person.short_name(ctx.champion)}"


### PR DESCRIPTION
## Summary
- Add a persisted description field to task description change activities and expose it across the API
- Deliver mention notifications and emails when task descriptions include mentions
- Cover the new behaviour with feature specs and update the UI to render stored descriptions

## Testing
- make test FILE=app/test/features/project_tasks_test.exs *(fails: ./devenv: line 127: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e7915369f8832a9eb07a0bb5515ac2