### PR TITLE
chore: Add useProjectMilestoneOrdering for optimistically updating Milestones order

### DIFF
--- a/app/assets/js/models/milestones/index.test.tsx
+++ b/app/assets/js/models/milestones/index.test.tsx
@@ -1,0 +1,49 @@
+import { parseMilestonesForTurboUi } from "./index";
+
+describe("parseMilestonesForTurboUi", () => {
+  const paths = {
+    projectMilestonePath: (id: string) => `/milestones/${id}`,
+  } as any;
+
+  it("orders milestones according to ordering state", () => {
+    const result = parseMilestonesForTurboUi(
+      paths,
+      [
+        { id: "m1", title: "First", status: "pending" },
+        { id: "m2", title: "Second", status: "pending" },
+        { id: "m3", title: "Third", status: "pending" },
+      ] as any,
+      ["m3", "m1"],
+    );
+
+    expect(result.orderingState).toEqual(["m3", "m1", "m2"]);
+    expect(result.orderedMilestones.map((m) => m.id)).toEqual(["m3", "m1", "m2"]);
+  });
+
+  it("filters out unknown ids and removes duplicates", () => {
+    const result = parseMilestonesForTurboUi(
+      paths,
+      [
+        { id: "m1", title: "First", status: "pending" },
+        { id: "m2", title: "Second", status: "pending" },
+      ] as any,
+      ["m2", "unknown", "m2", "m1"],
+    );
+
+    expect(result.orderingState).toEqual(["m2", "m1"]);
+    expect(Object.keys(result.milestonesById)).toEqual(["m1", "m2"]);
+  });
+
+  it("falls back to natural order when no ordering is provided", () => {
+    const result = parseMilestonesForTurboUi(
+      paths,
+      [
+        { id: "m1", title: "First", status: "pending" },
+        { id: "m2", title: "Second", status: "done" },
+      ] as any,
+    );
+
+    expect(result.orderingState).toEqual(["m1", "m2"]);
+    expect(result.orderedMilestones.map((m) => m.id)).toEqual(["m1", "m2"]);
+  });
+});

--- a/app/assets/js/models/milestones/index.tsx
+++ b/app/assets/js/models/milestones/index.tsx
@@ -5,11 +5,38 @@ import { CommentSection } from "turboui";
 import { Paths } from "@/routes/paths";
 import { parseContextualDate } from "../contextualDates";
 
+interface ParsedMilestonesForTurboUi {
+  orderedMilestones: ReturnType<typeof parseMilestoneForTurboUi>[];
+  milestonesById: Record<string, ReturnType<typeof parseMilestoneForTurboUi>>;
+  orderingState: string[];
+}
+
 export type { Milestone, MilestoneComment };
 export { getMilestone, usePostMilestoneComment } from "@/api";
 
-export function parseMilestonesForTurboUi(paths: Paths, milestones: Milestone[]) {
-  return milestones.map((m) => parseMilestoneForTurboUi(paths, m));
+export function parseMilestonesForTurboUi(
+  paths: Paths,
+  milestones: Milestone[],
+  orderingState: string[] = [],
+): ParsedMilestonesForTurboUi {
+  const parsedMilestones = milestones.map((m) => parseMilestoneForTurboUi(paths, m));
+  const milestonesById: Record<string, ReturnType<typeof parseMilestoneForTurboUi>> = {};
+
+  parsedMilestones.forEach((milestone) => {
+    milestonesById[milestone.id] = milestone;
+  });
+
+  const normalizedOrdering = normalizeOrderingState(orderingState, parsedMilestones.map((milestone) => milestone.id));
+
+  const orderedMilestones = normalizedOrdering
+    .map((id) => milestonesById[id])
+    .filter((milestone): milestone is ReturnType<typeof parseMilestoneForTurboUi> => Boolean(milestone));
+
+  return {
+    orderedMilestones,
+    milestonesById,
+    orderingState: normalizedOrdering,
+  };
 }
 
 export function parseMilestoneForTurboUi(paths: Paths, milestone: Milestone) {
@@ -62,4 +89,31 @@ export function splitByStatus(milestones: Milestone[]) {
     pending: milestones.filter((m) => m.status === "pending"),
     done: milestones.filter((m) => m.status === "done"),
   };
+}
+
+function normalizeOrderingState(orderingState: string[], milestoneIds: string[]): string[] {
+  if (milestoneIds.length === 0) {
+    return [];
+  }
+
+  const knownMilestoneIds = new Set(milestoneIds);
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  (orderingState || []).forEach((id) => {
+    if (!knownMilestoneIds.has(id)) return;
+    if (seen.has(id)) return;
+
+    normalized.push(id);
+    seen.add(id);
+  });
+
+  milestoneIds.forEach((id) => {
+    if (seen.has(id)) return;
+
+    normalized.push(id);
+    seen.add(id);
+  });
+
+  return normalized;
 }

--- a/app/assets/js/models/projects/index.tsx
+++ b/app/assets/js/models/projects/index.tsx
@@ -1,6 +1,7 @@
 import * as api from "@/api";
 import { assertPresent } from "@/utils/assertions";
 import * as Time from "@/utils/time";
+export { useProjectMilestoneOrdering } from "./useProjectMilestoneOrdering";
 
 export type Project = api.Project;
 export type ProjectContributor = api.ProjectContributor;

--- a/app/assets/js/models/projects/useProjectMilestoneOrdering.ts
+++ b/app/assets/js/models/projects/useProjectMilestoneOrdering.ts
@@ -1,0 +1,206 @@
+import * as React from "react";
+
+import Api, * as api from "@/api";
+import { PageCache } from "@/routes/PageCache";
+import { showErrorToast, TaskBoard } from "turboui";
+
+interface UseProjectMilestoneOrderingOptions {
+  projectId: string;
+  cacheKey: string;
+  refresh?: () => Promise<void>;
+  initialMilestones: TaskBoard.Milestone[];
+  initialOrderingState: string[];
+}
+
+interface UseProjectMilestoneOrderingResult {
+  milestones: TaskBoard.Milestone[];
+  setMilestones: React.Dispatch<React.SetStateAction<TaskBoard.Milestone[]>>;
+  orderingState: string[];
+  reorderMilestones: (
+    params: { sourceId: string; destinationIndex: number },
+  ) => Promise<{ success: boolean; project?: api.Project }>;
+}
+
+// useProjectMilestoneOrdering does the following: 
+//    1) caches the original milestones/order in a ref so normalization only happens once, 
+//       then seeds React state for ordered milestones and the current ordering array.
+//    2) orderingRef mirrors the latest order to keep synchronous reads in callbacks aligned with async React updates, 
+//       while setMilestones normalizes incoming lists and only mutates ordering state when values actually change.
+//    3) reorderMilestones performs optimistic moves: it shifts the requested id, updates UI state immediately, calls the API, 
+//       reconciles with the server response, and rolls back with a toast on failure while also invalidating cache/refreshing 
+//       when successful.
+export function useProjectMilestoneOrdering({
+  projectId,
+  cacheKey,
+  refresh,
+  initialMilestones,
+  initialOrderingState,
+}: UseProjectMilestoneOrderingOptions): UseProjectMilestoneOrderingResult {
+  const initialDataRef = React.useRef<{ milestones: TaskBoard.Milestone[]; ordering: string[] } | null>(null);
+
+  if (!initialDataRef.current) {
+    const ordering = normalizeMilestoneOrdering(initialOrderingState, initialMilestones);
+    initialDataRef.current = {
+      milestones: reorderMilestonesByIds(initialMilestones, ordering),
+      ordering,
+    };
+  }
+
+  const [milestones, setMilestonesState] = React.useState<TaskBoard.Milestone[]>(initialDataRef.current.milestones);
+  const [orderingState, setOrderingState] = React.useState<string[]>(initialDataRef.current.ordering);
+
+  const orderingRef = React.useRef(orderingState);
+
+  React.useEffect(() => {
+    orderingRef.current = orderingState;
+  }, [orderingState]);
+
+  const setMilestones = React.useCallback<React.Dispatch<React.SetStateAction<TaskBoard.Milestone[]>>>(
+    (update) => {
+      setMilestonesState((prev) => {
+        const next =
+          typeof update === "function" ? (update as (value: TaskBoard.Milestone[]) => TaskBoard.Milestone[])(prev) : update;
+        const normalized = normalizeMilestoneOrdering(orderingRef.current, next);
+
+        setOrderingState((prevOrdering) => (arraysEqual(prevOrdering, normalized) ? prevOrdering : normalized));
+
+        return reorderMilestonesByIds(next, normalized);
+      });
+    },
+  []);
+
+  const reorderMilestones = React.useCallback(
+    async ({ sourceId, destinationIndex }: { sourceId: string; destinationIndex: number }) => {
+      const currentOrder = orderingRef.current;
+      const updatedOrder = moveMilestoneId(currentOrder, sourceId, destinationIndex);
+
+      if (!updatedOrder) {
+        return { success: false };
+      }
+
+      const snapshotOrder = currentOrder.slice();
+      const snapshotMilestones = milestones.slice();
+
+      setOrderingState(updatedOrder);
+      setMilestonesState((prev) => reorderMilestonesByIds(prev, updatedOrder));
+
+      try {
+        const response = await Api.project_milestones.updateOrdering({
+          projectId,
+          orderingState: updatedOrder,
+        });
+
+        const serverOrdering = response.project?.milestonesOrderingState || updatedOrder;
+
+        setMilestonesState((prev) => {
+          const normalized = normalizeMilestoneOrdering(serverOrdering, prev);
+          setOrderingState((prevOrdering) => (arraysEqual(prevOrdering, normalized) ? prevOrdering : normalized));
+          return reorderMilestonesByIds(prev, normalized);
+        });
+
+        PageCache.invalidate(cacheKey);
+
+        if (refresh) {
+          await refresh();
+        }
+
+        return { success: true, project: response.project };
+      } catch (error) {
+        showErrorToast("Error", "Failed to reorder milestones");
+        setOrderingState(snapshotOrder);
+        setMilestonesState(snapshotMilestones);
+        return { success: false };
+      }
+    },
+    [cacheKey, milestones, projectId, refresh],
+  );
+
+  return {
+    milestones,
+    setMilestones,
+    orderingState,
+    reorderMilestones,
+  };
+}
+
+// Builds a deduped sequence that preserves known ids, discards stale ones, 
+// and appends unseen milestones at the end so data is never dropped.
+function normalizeMilestoneOrdering(ordering: string[] | undefined, milestones: TaskBoard.Milestone[]): string[] {
+  if (milestones.length === 0) {
+    return [];
+  }
+
+  const milestoneIds = milestones.map((milestone) => milestone.id);
+  const idSet = new Set(milestoneIds);
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  (ordering || []).forEach((id) => {
+    if (!idSet.has(id)) return;
+    if (seen.has(id)) return;
+
+    normalized.push(id);
+    seen.add(id);
+  });
+
+  milestoneIds.forEach((id) => {
+    if (seen.has(id)) return;
+
+    normalized.push(id);
+    seen.add(id);
+  });
+
+  return normalized;
+}
+
+// Converts the normalized ordering back into milestone objects, 
+// skipping ids that are no longer present in the map.
+function reorderMilestonesByIds(
+  milestones: TaskBoard.Milestone[],
+  ordering: string[],
+): TaskBoard.Milestone[] {
+  if (milestones.length === 0) {
+    return [];
+  }
+
+  const map = new Map(milestones.map((milestone) => [milestone.id, milestone] as const));
+  const normalized = normalizeMilestoneOrdering(ordering, milestones);
+
+  return normalized
+    .map((id) => map.get(id))
+    .filter((milestone): milestone is TaskBoard.Milestone => Boolean(milestone));
+}
+
+// moveMilestoneId returns a new ordering with the requested id moved to a bounded destination index, or null when the source id cannot be found or removed.
+function moveMilestoneId(order: string[], sourceId: string, destinationIndex: number): string[] | null {
+  const currentIndex = order.indexOf(sourceId);
+  if (currentIndex === -1) {
+    return null;
+  }
+
+  const nextOrder = order.slice();
+  const [removed] = nextOrder.splice(currentIndex, 1);
+  if (!removed) {
+    return null;
+  }
+  const boundedIndex = Math.min(Math.max(destinationIndex, 0), nextOrder.length);
+  nextOrder.splice(boundedIndex, 0, removed);
+
+  return nextOrder;
+}
+
+// arraysEqual performs an element-wise comparison so callers can avoid redundant ordering state updates when nothing actually changed.
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+export const __testExports = {
+  normalizeMilestoneOrdering,
+  reorderMilestonesByIds,
+  moveMilestoneId,
+};

--- a/app/assets/js/models/tasks/useTasksForTurboUi.tsx
+++ b/app/assets/js/models/tasks/useTasksForTurboUi.tsx
@@ -64,7 +64,7 @@ export function useTasksForTurboUi({ backendTasks, projectId, cacheKey, mileston
 
       // Handle multiple milestones update (takes precedence)
       if (updatedMilestones && updatedMilestones.length > 0) {
-        const parsedMilestones = Milestones.parseMilestonesForTurboUi(paths, updatedMilestones); 
+        const parsedMilestones = Milestones.parseMilestonesForTurboUi(paths, updatedMilestones).orderedMilestones;
 
         parsedMilestones.forEach(updatedMilestone => {
           const index = newMilestones.findIndex(m => compareIds(m.id, updatedMilestone.id));

--- a/app/assets/js/pages/MilestonePage/index.tsx
+++ b/app/assets/js/pages/MilestonePage/index.tsx
@@ -349,7 +349,7 @@ function useStatusField(
 function useMilestones(pageData, milestone: Milestones.Milestone) {
   const paths = usePaths();
   const [milestones, setMilestones] = React.useState<MilestonePage.Milestone[]>(
-    Milestones.parseMilestonesForTurboUi(paths, [milestone]),
+    Milestones.parseMilestonesForTurboUi(paths, [milestone]).orderedMilestones,
   );
 
   const parsedMilestone = milestones[0]!;

--- a/app/assets/js/pages/TaskPage/index.tsx
+++ b/app/assets/js/pages/TaskPage/index.tsx
@@ -306,7 +306,7 @@ function useMilestonesSearch(projectId): TaskPage.Props["searchMilestones"] {
   return async ({ query }: { query: string }): Promise<TaskPage.Milestone[]> => {
     const data = await Api.projects.getMilestones({ projectId: projectId, query: query.trim() });
 
-    return parseMilestonesForTurboUi(paths, data.milestones || []);
+    return parseMilestonesForTurboUi(paths, data.milestones || []).orderedMilestones;
   };
 }
 


### PR DESCRIPTION
## Summary
- add the milestone ordering mutation and ordering payload to the generated API client
- parse milestone ordering data for the UI, move the project-level ordering hook into its own module with brief documentation comments, and keep optimistic updates intact
- keep project page consumers in sync with manual ordering and cover the helpers with new tests
- elaborate the milestone ordering hook comments to document caching, normalization, and optimistic update behavior

## Testing
- npm --prefix app test -- models/projects/index.test.tsx
- npm --prefix app test -- models/milestones/index.test.tsx

------
https://chatgpt.com/codex/tasks/task_b_68e697b6f8cc832a812413503cff75cc