### PR TITLE
feat: Notify mentions on project description updates

### DIFF
--- a/app/assets/js/features/activities/ProjectDescriptionChanged/index.tsx
+++ b/app/assets/js/features/activities/ProjectDescriptionChanged/index.tsx
@@ -53,10 +53,7 @@ const ProjectDescriptionChanged: ActivityHandler = {
     const data = content(activity);
     const { mentionedPersonLookup } = useRichEditorHandlers();
 
-    const rawDescription = data.description ?? data.project?.description;
-    if (!rawDescription) return null;
-
-    const description = typeof rawDescription === "string" ? safeParseDescription(rawDescription) : rawDescription;
+    const description = decodeDescription(data.description ?? data.project?.description);
     if (!description) return null;
 
     return <Summary content={description} characterCount={200} mentionedPersonLookup={mentionedPersonLookup} />;
@@ -79,8 +76,8 @@ const ProjectDescriptionChanged: ActivityHandler = {
     const name = project?.name ?? projectName;
 
     return hasDescription
-      ? `Updated the "${name}" project description`
-      : `Removed the "${name}" project description`;
+      ? `Project "${name}" description was updated`
+      : `Project "${name}" description was removed`;
   },
 
   NotificationLocation({ activity }: { activity: Activity }) {
@@ -90,6 +87,20 @@ const ProjectDescriptionChanged: ActivityHandler = {
 
 function content(activity: Activity): ActivityContentProjectDescriptionChanged {
   return activity.content as ActivityContentProjectDescriptionChanged;
+}
+
+function decodeDescription(description?: unknown) {
+  if (!description) return null;
+
+  if (typeof description === "string") {
+    return safeParseDescription(description);
+  }
+
+  if (typeof description === "object") {
+    return description;
+  }
+
+  return null;
 }
 
 function safeParseDescription(description: string) {

--- a/app/lib/operately/activities/notifications/project_description_changed.ex
+++ b/app/lib/operately/activities/notifications/project_description_changed.ex
@@ -1,5 +1,26 @@
 defmodule Operately.Activities.Notifications.ProjectDescriptionChanged do
-  def dispatch(_activity) do
-    {:ok, []}
+  @moduledoc """
+  Notifies the following people:
+  - People mentioned in the project description
+
+  The author of the activity is excluded from notifications.
+  """
+
+  alias Operately.RichContent
+
+  def dispatch(activity) do
+    people = RichContent.find_mentioned_ids(activity.content["description"], :decode_ids)
+
+    people
+    |> Enum.reject(&(&1 == activity.author_id))
+    |> Enum.uniq()
+    |> Enum.map(fn person_id ->
+      %{
+        person_id: person_id,
+        activity_id: activity.id,
+        should_send_email: true
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately_email/emails/project_description_changed_email.ex
+++ b/app/lib/operately_email/emails/project_description_changed_email.ex
@@ -1,0 +1,44 @@
+defmodule OperatelyEmail.Emails.ProjectDescriptionChangedEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.{Projects, Repo}
+  alias OperatelyWeb.Paths
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    project = Projects.get_project!(activity.content["project_id"])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: project.name, who: author, action: "updated the project description")
+    |> assign(:author, author)
+    |> assign(:project_name, project.name)
+    |> assign(:description, description(activity))
+    |> assign(:cta_url, Paths.project_path(company, project) |> Paths.to_url())
+    |> render("project_description_changed")
+  end
+
+  defp description(activity) do
+    activity.content["description"]
+    |> decode_description()
+    |> case do
+      nil -> decode_description(get_in(activity.content, ["project", "description"]))
+      value -> value
+    end
+  end
+
+  defp decode_description(nil), do: nil
+
+  defp decode_description(description) when is_binary(description) do
+    case Jason.decode(description) do
+      {:ok, decoded} -> decoded
+      _ -> nil
+    end
+  end
+
+  defp decode_description(description) when is_map(description), do: description
+  defp decode_description(_), do: nil
+end

--- a/app/lib/operately_email/templates/project_description_changed.html.eex
+++ b/app/lib/operately_email/templates/project_description_changed.html.eex
@@ -1,0 +1,19 @@
+<%= title("#{short_name(@author)} updated the \"#{@project_name}\" project description") %>
+
+<%= spacer() %>
+
+<%= if @description do %>
+  <%= row do %>
+    <%= rich_text(@description) %>
+  <% end %>
+<% else %>
+  <%= row do %>
+    The description was cleared.
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Project") %>
+<% end %>

--- a/app/lib/operately_email/templates/project_description_changed.text.eex
+++ b/app/lib/operately_email/templates/project_description_changed.text.eex
@@ -1,0 +1,9 @@
+<%= short_name(@author) %> updated the "<%= @project_name %>" project description.
+
+<%= if @description do %>
+View the project to read the updated details.
+<% else %>
+The description was cleared.
+<% end %>
+
+View Project: <%= @cta_url %>

--- a/app/test/features/project_description_test.exs
+++ b/app/test/features/project_description_test.exs
@@ -31,6 +31,21 @@ defmodule Operately.Features.ProjectsDescriptionTest do
     |> Steps.assert_project_description_feed_item(description: "New description")
   end
 
+  @tag login_as: :champion
+  feature "mentioning a person in a project description sends notification and email", ctx do
+    ctx = Steps.given_space_member_exists(ctx)
+
+    ctx
+    |> Steps.visit_project_page()
+    |> Steps.assert_project_description_absent()
+    |> Steps.submit_project_description_mentioning(ctx.space_member)
+
+    ctx
+    |> Steps.assert_space_member_project_description_notification_sent()
+    |> Steps.assert_space_member_project_description_email_sent()
+    |> Steps.assert_author_not_notified_about_project_description()
+  end
+
   defp project_description() do
     """
     SuperPace is an innovative project designed to track and quantify DevOps

--- a/app/test/support/features/projects_steps.ex
+++ b/app/test/support/features/projects_steps.ex
@@ -9,6 +9,7 @@ defmodule Operately.Support.Features.ProjectSteps do
   alias Operately.People.Person
   alias Operately.ContextualDates.ContextualDate
   alias OperatelyWeb.Paths
+  alias Wallaby.QueryError
 
   import Operately.CompaniesFixtures
   import Operately.GroupsFixtures
@@ -55,6 +56,10 @@ defmodule Operately.Support.Features.ProjectSteps do
       })
 
     Map.put(ctx, :goal, goal)
+  end
+
+  step :given_space_member_exists, ctx, opts \\ [] do
+    Factory.add_space_member(ctx, :space_member, :group, opts)
   end
 
   def create_project(ctx, name: name) do
@@ -543,6 +548,13 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.click_button("Save")
   end
 
+  step :submit_project_description_mentioning, ctx, person do
+    ctx
+    |> open_project_description_editor()
+    |> UI.mention_person_in_rich_text(person)
+    |> save_project_description()
+  end
+
   step :expand_project_description, ctx do
     ctx
     |> UI.find(UI.query(testid: "description-section"), fn el ->
@@ -559,6 +571,32 @@ defmodule Operately.Support.Features.ProjectSteps do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> FeedSteps.assert_feed_item_exists(ctx.champion, "updated the project description", description)
+  end
+
+  step :assert_space_member_project_description_notification_sent, ctx do
+    ctx
+    |> UI.login_as(ctx.space_member)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.champion,
+      action: "Project \"#{ctx.project.name}\" description was updated"
+    })
+  end
+
+  step :assert_space_member_project_description_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.space_member,
+      author: ctx.champion,
+      action: "updated the project description"
+    })
+  end
+
+  step :assert_author_not_notified_about_project_description, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.assert_no_unread_notifications()
   end
 
   step :assert_champion_changed, ctx, name: name do
@@ -816,5 +854,26 @@ defmodule Operately.Support.Features.ProjectSteps do
     assert String.contains?(markdown, "Status:")
 
     ctx
+  end
+
+  defp open_project_description_editor(ctx) do
+    ctx =
+      try do
+        UI.click_text(ctx, "Add a project description...")
+      rescue
+        QueryError ->
+          ctx
+          |> UI.find(UI.query(testid: "description-section"), fn el ->
+            UI.click_button(el, "Edit")
+          end)
+      end
+
+    UI.sleep(ctx, 200)
+  end
+
+  defp save_project_description(ctx) do
+    ctx
+    |> UI.click_button("Save")
+    |> UI.sleep(200)
   end
 end


### PR DESCRIPTION
## Summary
- implement mention-based notifications for project description changes
- add project description email pipeline and templates mirroring milestone/goal flows
- enhance the activity handler, feature spec, and test steps to cover mention notifications and emails

## Testing
- `make test.mix.features FILE=app/test/features/project_description_test.exs` *(fails: ./devenv: line 127: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e7ff377ac0832aac527ea6c4227a4c