### PR TITLE
fix: Milestone can be created when project has no champion

### DIFF
--- a/app/lib/operately_web/api/project_milestones.ex
+++ b/app/lib/operately_web/api/project_milestones.ex
@@ -127,6 +127,7 @@ defmodule OperatelyWeb.Api.ProjectMilestones do
         }
       end)
       |> Steps.commit()
+      |> Steps.broadcast_review_count_update()
       |> Steps.respond(fn changes ->
         %{milestone: Serializer.serialize(changes.updated_milestone)}
       end)

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -831,7 +831,7 @@ defmodule OperatelyWeb.Api.Projects do
 
     def broadcast_review_count_update(result) do
       with {:ok, changes} <- result,
-           project = Operately.Repo.preload(changes.milestone.project, :champion),
+           project = Operately.Repo.preload(changes.project, :champion),
            %Operately.People.Person{id: champion_id} <- project.champion
       do
         OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -830,11 +830,13 @@ defmodule OperatelyWeb.Api.Projects do
     end
 
     def broadcast_review_count_update(result) do
-      case result do
-        {:ok, changes} ->
-          OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: changes.project.champion.id)
-
-        _result -> :ok
+      with {:ok, changes} <- result,
+           project = Operately.Repo.preload(changes.milestone.project, :champion),
+           %Operately.People.Person{id: champion_id} <- project.champion
+      do
+        OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+      else
+        _ -> :ok
       end
 
       result

--- a/app/test/features/project_milestones_test.exs
+++ b/app/test/features/project_milestones_test.exs
@@ -40,6 +40,17 @@ defmodule Operately.Features.ProjectMilestonesTest do
       |> Steps.assert_milestone_created(name: "2nd milestone")
     end
 
+    feature "add milestone to project that doesn't have a champion", ctx do
+      ctx
+      |> Steps.given_that_milestone_project_doesnt_have_champion()
+      |> Steps.visit_project_page()
+      |> Steps.add_milestone(name: "My milestone")
+      |> Steps.assert_add_milestone_form_closed()
+      |> Steps.assert_milestone_created(name: "My milestone")
+      |> Steps.reload_project_page()
+      |> Steps.assert_milestone_created(name: "My milestone")
+    end
+
     feature "add multiple milestone with 'Create more' toggle on", ctx do
       ctx
       |> Steps.visit_project_page()

--- a/app/test/features/project_milestones_test.exs
+++ b/app/test/features/project_milestones_test.exs
@@ -124,6 +124,19 @@ defmodule Operately.Features.ProjectMilestonesTest do
       |> Steps.assert_milestone_due_date_change_visible_in_feed()
     end
 
+    feature "edit milestone due date when project doesn't have a champion", ctx do
+      next_friday = Operately.Support.Time.next_friday()
+      formatted_date = Operately.Support.Time.format_month_day(next_friday)
+
+      ctx
+      |> Steps.given_that_milestone_project_doesnt_have_champion()
+      |> Steps.visit_milestone_page()
+      |> Steps.edit_milestone_due_date(next_friday)
+      |> Steps.assert_milestone_due_date(formatted_date)
+      |> Steps.reload_milestone_page()
+      |> Steps.assert_milestone_due_date(formatted_date)
+    end
+
     feature "edit milestone due date sends notification to champion", ctx do
       next_friday = Operately.Support.Time.next_friday()
       formatted_date = Operately.Support.Time.format_month_day(next_friday)


### PR DESCRIPTION
Previously, we were getting a 500 the user tried to create a Milestone in a Project that doesn't have a Champion.