### PR TITLE
feat: enable project milestone drag reordering

### DIFF
--- a/app/assets/js/pages/ProjectPage/index.tsx
+++ b/app/assets/js/pages/ProjectPage/index.tsx
@@ -263,6 +263,8 @@ function Page() {
     milestones,
     onMilestoneCreate: createMilestone,
     onMilestoneUpdate: updateMilestone,
+    onMilestoneReorder: (milestoneId: string, destinationIndex: number) =>
+      reorderMilestones({ sourceId: milestoneId, destinationIndex }),
     contributors: prepareContributors(paths, project.contributors),
     checkIns: parseCheckInsForTurboUi(paths, checkIns),
     discussions: prepareDiscussions(paths, discussions),

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -132,6 +132,7 @@ export namespace ProjectPage {
     onTaskMilestoneChange?: (taskId: string, milestoneId: string, index: number) => void;
     onMilestoneCreate: (milestone: NewMilestonePayload) => void;
     onMilestoneUpdate: (milestoneId: string, updates: TaskBoardTypes.UpdateMilestonePayload) => void;
+    onMilestoneReorder?: (milestoneId: string, destinationIndex: number) => Promise<unknown> | void;
     searchPeople: SearchFn;
     filters?: TaskBoardTypes.FilterCondition[];
     onFiltersChange?: (filters: TaskBoardTypes.FilterCondition[]) => void;

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -304,7 +304,7 @@ const getMilestonesWithStats = (allMilestones: Types.Milestone[] | undefined, or
     });
     milestonesToProcess = Array.from(milestoneMap.values());
   } else {
-    milestonesToProcess = allMilestones;
+    milestonesToProcess = [...allMilestones];
   }
 
   return milestonesToProcess
@@ -341,22 +341,6 @@ const getMilestonesWithStats = (allMilestones: Types.Milestone[] | undefined, or
         stats,
         hasTasks,
       };
-    })
-    .sort((a, b) => {
-      const dateA = a.milestone.dueDate?.date;
-      const dateB = b.milestone.dueDate?.date;
-
-      // If both have due dates, sort by date (earlier dates first)
-      if (dateA && dateB) {
-        return new Date(dateA).getTime() - new Date(dateB).getTime();
-      }
-
-      // If only one has a due date, prioritize the one with a due date
-      if (dateA && !dateB) return -1;
-      if (!dateA && dateB) return 1;
-
-      // If neither has a due date, sort by milestone ID for consistency
-      return a.milestone.id.localeCompare(b.milestone.id);
     });
 };
 


### PR DESCRIPTION
## Summary
- enable drag-and-drop milestone ordering on the Project overview timeline with visible handles and shared drop zone state
- plumb the new milestone reorder callback through the Project page props so the Phoenix layer invokes the ordering hook
- respect provided milestone order within the TaskBoard milestone prep while still filtering out completed milestones

## Testing
- npm --prefix turboui run build
- npm --prefix app run build

------
https://chatgpt.com/codex/tasks/task_b_68ed083695e8832aad3eea34ed7fcc95