### PR TITLE
feat: enable editing draft resource hub subscriptions

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3452,6 +3452,8 @@ export interface EditResourceHubDocumentInput {
   documentId?: Id | null;
   name?: string | null;
   content?: string | null;
+  sendNotificationsToEveryone?: boolean | null;
+  subscriberIds?: Id[] | null;
 }
 
 export interface EditResourceHubDocumentResult {
@@ -4070,6 +4072,8 @@ export interface PublishResourceHubDocumentInput {
   documentId?: Id | null;
   name?: string | null;
   content?: string | null;
+  sendNotificationsToEveryone?: boolean | null;
+  subscriberIds?: Id[] | null;
 }
 
 export interface PublishResourceHubDocumentResult {

--- a/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx
@@ -8,12 +8,40 @@ import { useFormContext } from "@/components/Forms/FormContext";
 
 import { usePaths } from "@/routes/paths";
 import { areRichTextObjectsEqual } from "turboui";
+import { DimmedSection } from "@/components/PaperContainer";
+import { Spacer } from "@/components/Spacer";
+import { Options, SubscribersSelector, useSubscriptions } from "@/features/Subscriptions";
+import { assertPresent } from "@/utils/assertions";
 
 export function Form({ document }: { document: ResourceHubDocument }) {
   const paths = usePaths();
   const navigate = useNavigate();
   const [edit] = useEditResourceHubDocument();
   const [publish] = usePublishResourceHubDocument();
+
+  const isDraft = document.state === "draft";
+
+  if (isDraft) {
+    assertPresent(document.potentialSubscribers, "potentialSubscribers must be present in document");
+    assertPresent(document.subscriptionList, "subscriptionList must be present in document");
+    assertPresent(document.resourceHub, "resourceHub must be present in document");
+  }
+
+  const subscriptionsState = useSubscriptions(document.potentialSubscribers ?? [], {
+    ignoreMe: true,
+    sendNotificationsToEveryone: document.subscriptionList?.sendToEveryone ?? undefined,
+  });
+
+  const initialSubscriptionTypeRef = React.useRef<Options | null>(null);
+  const initialSubscriberIdsRef = React.useRef<string[] | null>(null);
+
+  if (initialSubscriptionTypeRef.current === null) {
+    initialSubscriptionTypeRef.current = subscriptionsState.subscriptionType;
+  }
+
+  if (initialSubscriberIdsRef.current === null) {
+    initialSubscriberIdsRef.current = [...subscriptionsState.currentSubscribersList];
+  }
 
   const form = Forms.useForm({
     fields: {
@@ -31,20 +59,33 @@ export function Form({ document }: { document: ResourceHubDocument }) {
     cancel: () => navigate(paths.resourceHubDocumentPath(document.id!)),
     submit: async (type: "save" | "publish-draft") => {
       const { title, content } = form.values;
+      const serializedContent = JSON.stringify(content);
+      const subscriptionPayload = isDraft
+        ? {
+            sendNotificationsToEveryone: subscriptionsState.subscriptionType === Options.ALL,
+            subscriberIds: subscriptionsState.currentSubscribersList,
+          }
+        : null;
+      const subscriptionsChanged =
+        isDraft &&
+        (initialSubscriptionTypeRef.current !== subscriptionsState.subscriptionType ||
+          !areIdListsEqual(initialSubscriberIdsRef.current, subscriptionsState.currentSubscribersList));
 
       if (type === "save") {
-        if (documentHasChanged(document, title, content)) {
+        if (documentHasChanged(document, title, content) || subscriptionsChanged) {
           await edit({
             documentId: document.id,
             name: title,
-            content: JSON.stringify(content),
+            content: serializedContent,
+            ...(subscriptionPayload ? subscriptionPayload : {}),
           });
         }
       } else if (type === "publish-draft") {
         await publish({
           documentId: document.id,
           name: title,
-          content: JSON.stringify(content),
+          content: serializedContent,
+          ...(subscriptionPayload ? subscriptionPayload : {}),
         });
       }
 
@@ -66,7 +107,16 @@ export function Form({ document }: { document: ResourceHubDocument }) {
         />
       </Forms.FieldGroup>
 
-      <FormActions document={document} />
+      {isDraft ? (
+        <DimmedSection>
+          <Spacer size={4} />
+          <SubscribersSelector state={subscriptionsState} resourceHubName={document.resourceHub!.name!} />
+
+          <FormActions document={document} />
+        </DimmedSection>
+      ) : (
+        <FormActions document={document} />
+      )}
     </Forms.Form>
   );
 }
@@ -100,4 +150,14 @@ function documentHasChanged(document: ResourceHubDocument, name: string, content
   if (document.name !== name) return true;
   if (!areRichTextObjectsEqual(JSON.parse(document.content!), content)) return true;
   return false;
+}
+
+function areIdListsEqual(initialIds: string[] | null, currentIds: string[]) {
+  if (!initialIds) return currentIds.length === 0;
+  if (initialIds.length !== currentIds.length) return false;
+
+  const sortedInitial = [...initialIds].sort();
+  const sortedCurrent = [...currentIds].sort();
+
+  return sortedInitial.every((id, index) => id === sortedCurrent[index]);
 }

--- a/app/assets/js/pages/ResourceHubEditDocumentPage/loader.tsx
+++ b/app/assets/js/pages/ResourceHubEditDocumentPage/loader.tsx
@@ -13,6 +13,8 @@ export async function loader({ params }): Promise<LoaderResult> {
       includeResourceHub: true,
       includeParentFolder: true,
       includePathToDocument: true,
+      includeSubscriptionsList: true,
+      includePotentialSubscribers: true,
     }).then((res) => res.document!),
   };
 }

--- a/app/lib/operately/operations/resource_hub_document_editing.ex
+++ b/app/lib/operately/operations/resource_hub_document_editing.ex
@@ -3,6 +3,8 @@ defmodule Operately.Operations.ResourceHubDocumentEditing do
   alias Operately.{Repo, Activities}
   alias Operately.ResourceHubs.{Document, Node}
   alias Operately.Notifications.SubscriptionList
+  alias Operately.Operations.Notifications.Subscription
+  alias Operately.Operations.SubscriptionsListEditing
 
   def run(author, document, attrs) do
     Multi.new()
@@ -14,14 +16,16 @@ defmodule Operately.Operations.ResourceHubDocumentEditing do
       })
     end)
     |> Multi.run(:subscription_list, fn _, changes ->
-      SubscriptionList.get(:system,
-        parent_id: changes.document.id,
-        opts: [
-          preload: :subscriptions
-        ]
-      )
+      with {:ok, subscription_list} <-
+             SubscriptionList.get(:system,
+               parent_id: changes.document.id,
+               opts: [preload: :subscriptions]
+             ),
+           {:ok, subscription_list} <- maybe_update_subscriptions(subscription_list, attrs) do
+        {:ok, subscription_list}
+      end
     end)
-    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(attrs.content)
+    |> Subscription.update_mentioned_people(attrs.content)
     |> Activities.insert_sync(author.id, :resource_hub_document_edited, fn _changes ->
       %{
         company_id: author.company_id,
@@ -33,5 +37,25 @@ defmodule Operately.Operations.ResourceHubDocumentEditing do
     end)
     |> Repo.transaction()
     |> Repo.extract_result(:document)
+  end
+
+  defp maybe_update_subscriptions(subscription_list, attrs) do
+    if should_update_subscriptions?(attrs) do
+      attrs_for_update = %{
+        send_notifications_to_everyone: attrs[:send_to_everyone],
+        subscriber_ids: attrs[:subscriber_ids] || [],
+      }
+
+      case SubscriptionsListEditing.run(subscription_list, attrs_for_update) do
+        {:ok, _} -> SubscriptionList.get(:system, id: subscription_list.id, opts: [preload: :subscriptions])
+        {:error, _operation, reason, _changes} -> {:error, reason}
+      end
+    else
+      {:ok, subscription_list}
+    end
+  end
+
+  defp should_update_subscriptions?(attrs) do
+    not is_nil(attrs[:subscriber_ids]) or not is_nil(attrs[:send_to_everyone])
   end
 end

--- a/app/lib/operately/operations/resource_hub_document_publishing.ex
+++ b/app/lib/operately/operations/resource_hub_document_publishing.ex
@@ -2,10 +2,24 @@ defmodule Operately.Operations.ResourceHubDocumentPublishing do
   alias Ecto.Multi
   alias Operately.{Activities, Repo}
   alias Operately.ResourceHubs.{Document, Node}
+  alias Operately.Notifications.SubscriptionList
+  alias Operately.Operations.Notifications.Subscription
+  alias Operately.Operations.SubscriptionsListEditing
 
   def run(author, document, attrs) do
     Multi.new()
     |> update_document(document, attrs[:content])
+    |> Multi.run(:subscription_list, fn _, changes ->
+      with {:ok, subscription_list} <-
+             SubscriptionList.get(:system,
+               parent_id: changes.document.id,
+               opts: [preload: :subscriptions]
+             ),
+           {:ok, subscription_list} <- maybe_update_subscriptions(subscription_list, attrs) do
+        {:ok, subscription_list}
+      end
+    end)
+    |> Subscription.update_mentioned_people(attrs[:content] || document.content)
     |> update_node(document.node, attrs[:name])
     |> insert_activity(author, document)
     |> Repo.transaction()
@@ -45,5 +59,25 @@ defmodule Operately.Operations.ResourceHubDocumentPublishing do
       document = Map.put(changes.document, :node, changes.node)
       {:ok, document}
     end)
+  end
+
+  defp maybe_update_subscriptions(subscription_list, attrs) do
+    if should_update_subscriptions?(attrs) do
+      attrs_for_update = %{
+        send_notifications_to_everyone: attrs[:send_to_everyone],
+        subscriber_ids: attrs[:subscriber_ids] || [],
+      }
+
+      case SubscriptionsListEditing.run(subscription_list, attrs_for_update) do
+        {:ok, _} -> SubscriptionList.get(:system, id: subscription_list.id, opts: [preload: :subscriptions])
+        {:error, _operation, reason, _changes} -> {:error, reason}
+      end
+    else
+      {:ok, subscription_list}
+    end
+  end
+
+  defp should_update_subscriptions?(attrs) do
+    not is_nil(attrs[:subscriber_ids]) or not is_nil(attrs[:send_to_everyone])
   end
 end

--- a/app/lib/operately_web/api/mutations/edit_resource_hub_document.ex
+++ b/app/lib/operately_web/api/mutations/edit_resource_hub_document.ex
@@ -9,6 +9,8 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocument do
     field? :document_id, :id, null: true
     field? :name, :string, null: true
     field? :content, :string, null: true
+    field? :send_notifications_to_everyone, :boolean, null: true
+    field? :subscriber_ids, list_of(:id), null: true
   end
 
   outputs do
@@ -39,7 +41,12 @@ defmodule OperatelyWeb.Api.Mutations.EditResourceHubDocument do
 
   defp parse_attrs(inputs) do
     content = Jason.decode!(inputs.content)
-    {:ok, Map.put(inputs, :content, content)}
+    {:ok,
+      Map.merge(inputs, %{
+        content: content,
+        send_to_everyone: inputs[:send_notifications_to_everyone],
+        subscriber_ids: inputs[:subscriber_ids],
+      })}
   end
 
   defp find_document(me, inputs) do

--- a/app/lib/operately_web/api/mutations/publish_resource_hub_document.ex
+++ b/app/lib/operately_web/api/mutations/publish_resource_hub_document.ex
@@ -9,6 +9,8 @@ defmodule OperatelyWeb.Api.Mutations.PublishResourceHubDocument do
     field? :document_id, :id, null: true
     field? :name, :string, null: true
     field? :content, :string, null: true
+    field? :send_notifications_to_everyone, :boolean, null: true
+    field? :subscriber_ids, list_of(:id), null: true
   end
 
   outputs do
@@ -38,11 +40,17 @@ defmodule OperatelyWeb.Api.Mutations.PublishResourceHubDocument do
   end
 
   defp parse_attrs(inputs) do
+    attrs =
+      Map.merge(inputs, %{
+        send_to_everyone: inputs[:send_notifications_to_everyone],
+        subscriber_ids: inputs[:subscriber_ids],
+      })
+
     if inputs[:content] do
       content = Jason.decode!(inputs.content)
-      {:ok, Map.put(inputs, :content, content)}
+      {:ok, Map.put(attrs, :content, content)}
     else
-      {:ok, inputs}
+      {:ok, attrs}
     end
   end
 


### PR DESCRIPTION
## Summary
- expose the subscriber selector when editing draft resource hub documents and preload the current selections
- adjust the subscriptions hook and loader so draft edits reflect existing subscription state
- allow edit/publish mutations to accept subscription updates and sync the underlying subscription list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68efc08286b8832ab2b16c9187f70c89