### PR TITLE
chore: Update ProjectDueDateUpdating and ProjectMilestoneCreation notifications

### DIFF
--- a/app/lib/operately/activities/notifications/project_champion_updating.ex
+++ b/app/lib/operately/activities/notifications/project_champion_updating.ex
@@ -3,7 +3,7 @@ defmodule Operately.Activities.Notifications.ProjectChampionUpdating do
   Notifies the following people:
   - Project subscribers: People subscribed to notifications for the project
 
-  The person who authored the comment is excluded from notifications.
+  The person who authored the activity is excluded from notifications.
   """
 
   alias Operately.Projects.{Project, Notifications}

--- a/app/lib/operately/activities/notifications/project_due_date_updating.ex
+++ b/app/lib/operately/activities/notifications/project_due_date_updating.ex
@@ -1,30 +1,26 @@
 defmodule Operately.Activities.Notifications.ProjectDueDateUpdating do
   @moduledoc """
   Notifies the following people:
-  - Project champion
-  - Project reviewer
+  - Project subscribers: People subscribed to notifications for the project
 
-  The person who authored the comment is excluded from notifications.
+  The person who authored the activity is excluded from notifications.
   """
 
-  alias Operately.Projects.Project
+  alias Operately.Projects.{Project, Notifications}
 
   def dispatch(activity) do
-    project = Project.get!(:system, id: activity.content["project_id"], opts: [preload: [:champion_contributor, :reviewer_contributor]])
+    {:ok, project} = Project.get(:system, id: activity.content["project_id"])
+    subscriber_ids = Notifications.get_project_subscribers(project)
 
-    champion_id = if project.champion_contributor, do: project.champion_contributor.person_id, else: nil
-    reviewer_id = if project.reviewer_contributor, do: project.reviewer_contributor.person_id, else: nil
-
-    [champion_id, reviewer_id]
-    |> Enum.filter(& &1)
-    |> Enum.map(& &1)
-    |> Enum.uniq()
-    |> Enum.reject(&(&1 == activity.author_id))
-    |> Enum.map(fn person_id ->
+    subscriber_ids
+    |> Enum.uniq_by(& &1)
+    |> Enum.filter(fn id -> id != nil end)
+    |> Enum.filter(fn id -> id != activity.author_id end)
+    |> Enum.map(fn id ->
       %{
-        person_id: person_id,
+        person_id: id,
         activity_id: activity.id,
-        should_send_email: true
+        should_send_email: true,
       }
     end)
     |> Operately.Notifications.bulk_create()

--- a/app/lib/operately/activities/notifications/project_milestone_creation.ex
+++ b/app/lib/operately/activities/notifications/project_milestone_creation.ex
@@ -1,5 +1,28 @@
 defmodule Operately.Activities.Notifications.ProjectMilestoneCreation do
-  def dispatch(_activity) do
-    {:ok, []}
+  @moduledoc """
+  Notifies the following people:
+  - Project subscribers: People subscribed to notifications for the project
+
+  The person who authored the activity is excluded from notifications.
+  """
+
+  alias Operately.Projects.{Project, Notifications}
+
+  def dispatch(activity) do
+    {:ok, project} = Project.get(:system, id: activity.content["project_id"])
+    subscriber_ids = Notifications.get_project_subscribers(project)
+
+    subscriber_ids
+    |> Enum.uniq_by(& &1)
+    |> Enum.filter(fn id -> id != nil end)
+    |> Enum.filter(fn id -> id != activity.author_id end)
+    |> Enum.map(fn id ->
+      %{
+        person_id: id,
+        activity_id: activity.id,
+        should_send_email: true,
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
   end
 end

--- a/app/lib/operately/activities/notifications/project_reviewer_updating.ex
+++ b/app/lib/operately/activities/notifications/project_reviewer_updating.ex
@@ -3,7 +3,7 @@ defmodule Operately.Activities.Notifications.ProjectReviewerUpdating do
   Notifies the following people:
   - Project subscribers: People subscribed to notifications for the project
 
-  The person who authored the comment is excluded from notifications.
+  The person who authored the activity is excluded from notifications.
   """
 
   alias Operately.Projects.{Project, Notifications}

--- a/app/lib/operately_email/emails/project_milestone_creation_email.ex
+++ b/app/lib/operately_email/emails/project_milestone_creation_email.ex
@@ -1,0 +1,41 @@
+defmodule OperatelyEmail.Emails.ProjectMilestoneCreationEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias Operately.Repo
+  alias Operately.Projects.Milestone
+  alias Operately.ContextualDates.ContextualDate
+  alias OperatelyWeb.Paths
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    {:ok, milestone} = Milestone.get(:system, id: activity.content["milestone_id"], opts: [preload: [:project]])
+    project = milestone.project
+    due_date = milestone_due_date(milestone)
+    link = Paths.project_milestone_path(company, milestone) |> Paths.to_url()
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: project.name, who: author, action: "created the \"#{milestone.title}\" milestone")
+    |> assign(:author, author)
+    |> assign(:project, project)
+    |> assign(:milestone, milestone)
+    |> assign(:due_date, due_date)
+    |> assign(:cta_url, link)
+    |> render("project_milestone_creation")
+  end
+
+  defp milestone_due_date(%{timeframe: nil}), do: nil
+
+  defp milestone_due_date(%{timeframe: timeframe}) do
+    case Map.get(timeframe, :contextual_end_date) || Map.get(timeframe, "contextual_end_date") do
+      nil -> nil
+      %ContextualDate{value: value} -> value
+      %{value: value} -> value
+      %{"value" => value} -> value
+      _ -> nil
+    end
+  end
+end

--- a/app/lib/operately_email/templates/project_milestone_creation.html.eex
+++ b/app/lib/operately_email/templates/project_milestone_creation.html.eex
@@ -1,0 +1,20 @@
+<%= title("#{short_name(@author)} created the #{@milestone.title} milestone") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  A new milestone was added to <%= @project.name %>.
+<% end %>
+
+<%= if @due_date do %>
+  <%= spacer() %>
+  <%= row do %>
+    It is scheduled for <%= @due_date %>.
+  <% end %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Milestone") %>
+<% end %>

--- a/app/lib/operately_email/templates/project_milestone_creation.text.eex
+++ b/app/lib/operately_email/templates/project_milestone_creation.text.eex
@@ -1,0 +1,6 @@
+<%= short_name(@author) %> created the <%= @milestone.title %> milestone for <%= @project.name %>.
+<%= if @due_date do %>
+It is scheduled for <%= @due_date %>.
+<% end %>
+
+Link: <%= @cta_url %>


### PR DESCRIPTION
Both `ProjectDueDateUpdating` and `ProjectMilestoneCreation` notifications now rely on the project subscriptions.