### PR TITLE
feat: Add assignments email v2 which mirrors Review V2 page

### DIFF
--- a/app/lib/operately/companies.ex
+++ b/app/lib/operately/companies.ex
@@ -146,6 +146,11 @@ defmodule Operately.Companies do
     |> Repo.update()
   end
 
+  def has_experimental_feature?(%Company{} = company, feature) do
+    features = company.enabled_experimental_features || []
+    Enum.member?(features, feature)
+  end
+
   def add_person_to_general_space(%Operately.People.Person{} = person) do
     AddPersonToGeneralSpace.run(person)
   end

--- a/app/lib/operately_email/emails/assignments_email.ex
+++ b/app/lib/operately_email/emails/assignments_email.ex
@@ -1,8 +1,17 @@
 defmodule OperatelyEmail.Emails.AssignmentsEmail do
   import OperatelyEmail.Mailers.NotificationMailer
 
+  alias Operately.Assignments.{Loader, LoaderV2}
+  alias Operately.Assignments.LoaderV2.AssignmentV2
+  alias Operately.Companies
   alias Operately.Repo
+  alias OperatelyWeb.Paths
+
   require Logger
+
+  @due_soon_window_in_days 1
+  @far_future_tuple {9999, 12, 31}
+  @due_status_rank %{overdue: 0, due_today: 1, due_soon: 2, upcoming: 3, none: 4}
 
   #
   # Sending out an email to remind people of their assignments.
@@ -11,19 +20,207 @@ defmodule OperatelyEmail.Emails.AssignmentsEmail do
 
   def send(person) do
     company = Repo.preload(person, [:company]).company
-    assignments = Operately.Assignments.Loader.load(person, company)
 
-    if assignments != [] do
-      company
-      |> new()
-      |> from("Operately")
-      |> to(person)
-      |> subject("#{company.name}: Your assignments for today")
-      |> assign(:company, company)
-      |> assign(:assignments, assignments)
-      |> render("assignments")
-    else
-      Logger.info("No assignments for #{person.full_name}")
+    case load_assignments_payload(person, company) do
+      {:ok, %{template: template, assigns: assigns}} ->
+        email =
+          company
+          |> new()
+          |> from("Operately")
+          |> to(person)
+          |> subject("#{company.name}: Your assignments for today")
+          |> assign(:company, company)
+
+        email =
+          Enum.reduce(assigns, email, fn {key, value}, acc ->
+            assign(acc, key, value)
+          end)
+
+        render(email, template)
+
+      :no_assignments ->
+        Logger.info("No assignments for #{person.full_name}")
     end
   end
+
+  defp load_assignments_payload(_person, nil), do: :no_assignments
+
+  defp load_assignments_payload(person, company) do
+    if Companies.has_experimental_feature?(company, "review_v2") do
+      v2_payload(person, company)
+    else
+      v1_payload(person, company)
+    end
+  end
+
+  defp v1_payload(person, company) do
+    assignments = Loader.load(person, company)
+
+    if assignments == [] do
+      :no_assignments
+    else
+      {:ok,
+       %{
+         template: "assignments",
+         assigns: %{assignments: assignments}
+       }}
+    end
+  end
+
+  defp v2_payload(person, company) do
+    assignments = LoaderV2.load(person, company)
+
+    if assignments == [] do
+      :no_assignments
+    else
+      categorized = categorize_assignments(assignments)
+
+      if Enum.empty?(categorized.urgent_groups) do
+        :no_assignments
+      else
+        {:ok,
+         %{
+           template: "assignments_v2",
+           assigns: %{
+             urgent_groups: categorized.urgent_groups
+           }
+         }}
+      end
+    end
+  end
+
+  defp categorize_assignments(assignments) do
+    enriched =
+      assignments
+      |> Enum.map(&enrich_assignment/1)
+      |> Enum.map(&assign_category/1)
+
+    due_soon_assignments = Enum.filter(enriched, &(&1.category == :due_soon))
+    review_assignments = Enum.filter(enriched, &(&1.category == :needs_review))
+    urgent_assignments = due_soon_assignments ++ review_assignments
+
+    urgent_groups = group_assignments_by_origin(urgent_assignments)
+
+    %{
+      urgent_groups: urgent_groups
+    }
+  end
+
+  defp enrich_assignment(%AssignmentV2{} = assignment) do
+    due_date = normalize_due_date(assignment.due)
+    {due_status, due_status_label} = resolve_due_status(due_date)
+
+    assignment
+    |> Map.from_struct()
+    |> Map.put(:origin, format_origin(assignment.origin))
+    |> Map.put(:due_date, due_date)
+    |> Map.put(:due_status, due_status)
+    |> Map.put(:due_status_label, due_status_label)
+    |> Map.put(:display_label, assignment.action_label || assignment.name)
+    |> Map.put(:badge_label, due_status_label)
+    |> Map.put(:url, Paths.to_url(assignment.path))
+  end
+
+  defp assign_category(assignment) do
+    category =
+      cond do
+        assignment.role == :reviewer -> :needs_review
+        due_soon?(assignment.due_status) -> :due_soon
+        upcoming?(assignment.due_status) -> :upcoming
+        true -> :none
+      end
+
+    assignment
+    |> Map.put(:category, category)
+    |> Map.put(:badge_label, assignment.due_status_label)
+  end
+
+  defp group_assignments_by_origin([]), do: []
+
+  defp group_assignments_by_origin(assignments) do
+    assignments
+    |> Enum.group_by(fn assignment ->
+      "#{assignment.origin.type}:#{assignment.origin.id}"
+    end)
+    |> Enum.map(fn {_key, grouped} ->
+      sorted_assignments = Enum.sort_by(grouped, &assignment_sort_key/1)
+      first = List.first(sorted_assignments)
+
+      %{
+        origin: first.origin,
+        assignments: sorted_assignments
+      }
+    end)
+    |> Enum.sort_by(&group_sort_key/1)
+  end
+
+  defp normalize_due_date(%Date{} = date), do: date
+  defp normalize_due_date(%DateTime{} = datetime), do: DateTime.to_date(datetime)
+  defp normalize_due_date(%NaiveDateTime{} = datetime), do: NaiveDateTime.to_date(datetime)
+  defp normalize_due_date(_), do: nil
+
+  defp format_origin(origin) do
+    origin
+    |> Map.from_struct()
+    |> Map.put(:url, Paths.to_url(origin.path))
+  end
+
+  defp assignment_sort_key(assignment) do
+    due_tuple =
+      case assignment.due_date do
+        nil -> @far_future_tuple
+        %Date{} = date -> Date.to_erl(date)
+      end
+
+    {
+      rank(assignment.due_status),
+      due_tuple,
+      String.downcase(assignment.display_label || "")
+    }
+  end
+
+  defp group_sort_key(%{assignments: []}) do
+    {{rank(:none), @far_future_tuple, ""}, ""}
+  end
+
+  defp group_sort_key(%{assignments: [first | _], origin: origin}) do
+    {assignment_sort_key(first), String.downcase(origin.name || "")}
+  end
+
+  defp resolve_due_status(nil), do: {:none, "No due date"}
+
+  defp resolve_due_status(%Date{} = due_date) do
+    today = Date.utc_today()
+    diff = Date.diff(due_date, today)
+
+    cond do
+      diff < 0 ->
+        days = abs(diff)
+        label = if days == 1, do: "Overdue by 1 day", else: "Overdue by #{days} days"
+        {:overdue, label}
+
+      diff == 0 ->
+        {:due_today, "Due today"}
+
+      diff == 1 ->
+        {:due_soon, "Due tomorrow"}
+
+      diff <= @due_soon_window_in_days ->
+        {:due_soon, "Due in #{diff} days"}
+
+      true ->
+        {:upcoming, "Due in #{diff} days"}
+    end
+  end
+
+  defp due_soon?(:overdue), do: true
+  defp due_soon?(:due_today), do: true
+  defp due_soon?(:due_soon), do: true
+  defp due_soon?(_), do: false
+
+  defp upcoming?(:upcoming), do: true
+  defp upcoming?(:none), do: true
+  defp upcoming?(_), do: false
+
+  defp rank(status), do: Map.fetch!(@due_status_rank, status)
 end

--- a/app/lib/operately_email/templates/assignments_v2.html.eex
+++ b/app/lib/operately_email/templates/assignments_v2.html.eex
@@ -1,0 +1,36 @@
+<%= title(@company.name) %>
+<%= title("Here are your assignments") %>
+
+<%= spacer() %>
+<%= line() %>
+
+<%= Enum.map(@urgent_groups, fn group -> %>
+  <%= spacer() %>
+  <%= row(%{padding_top: 8, padding_bottom: 4}) do %>
+    <div style="font-family: sans-serif;">
+      <div style="font-weight: 700; font-size: 16px;">
+        <%= link(group.origin.url, group.origin.name) %>
+      </div>
+      <%= if group.origin.space_name do %>
+        <div style="margin-top: 4px; color: #6b6b6b; font-size: 12px;">
+          Space: <%= group.origin.space_name %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= Enum.map(group.assignments, fn assignment -> %>
+    <%= row(%{padding_top: 2, padding_bottom: 6}) do %>
+      <div style="font-family: sans-serif; padding-left: 16px;">
+        <div style="font-weight: 600;">
+          <%= link(assignment.url, assignment.display_label) %>
+        </div>
+        <%= if assignment.badge_label do %>
+          <div style="margin-top: 2px; color: #6b6b6b; font-size: 13px;">
+            <span><%= assignment.badge_label %></span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  <% end) %>
+<% end) %>

--- a/app/lib/operately_email/templates/assignments_v2.text.eex
+++ b/app/lib/operately_email/templates/assignments_v2.text.eex
@@ -1,0 +1,10 @@
+<%= @company.name %> - Assignments
+
+<%= Enum.map(@urgent_groups, fn group -> %>
+- <%= group.origin.name %><%= if group.origin.space_name do %> — Space: <%= group.origin.space_name %><% end %>
+<%= Enum.map(group.assignments, fn assignment -> %>
+  * <%= assignment.display_label %><%= if assignment.badge_label do %> — <%= assignment.badge_label %><% end %>
+    <%= assignment.url %>
+<% end) %>
+
+<% end) %>

--- a/app/test/features/assignments_email_test.exs
+++ b/app/test/features/assignments_email_test.exs
@@ -2,6 +2,7 @@ defmodule Operately.Features.AssignmentsEmailTest do
   use Operately.FeatureCase
 
   alias Operately.Support.Features.ProjectSteps
+  alias Operately.Support.Features.AssignmentsEmailSteps, as: Steps
 
   setup ctx do
     ctx = ProjectSteps.create_project(ctx, name: "Test Project")
@@ -27,5 +28,28 @@ defmodule Operately.Features.AssignmentsEmailTest do
     ctx
     |> UI.visit(link)
     |> UI.assert_text("What's new since the last check-in?")
+  end
+
+  describe "assignments email v2" do
+    setup _ctx do
+      {:ok, Steps.setup_review_v2()}
+    end
+
+    feature "groups champion assignments by origin with urgent items", ctx do
+      ctx
+      |> Steps.prepare_champion_work()
+      |> Steps.prepare_champion_reviews()
+      |> Steps.reload_person(:champion)
+      |> Steps.send_assignments_email_to_champion()
+      |> Steps.assert_champion_email_contains_urgent_work()
+    end
+
+    feature "includes reviewer assignments with clear review labels", ctx do
+      ctx
+      |> Steps.prepare_reviewer_reviews()
+      |> Steps.reload_person(:reviewer)
+      |> Steps.send_assignments_email_to_reviewer()
+      |> Steps.assert_reviewer_email_contains_review_assignments()
+    end
   end
 end

--- a/app/test/support/features/assignments_email_steps.ex
+++ b/app/test/support/features/assignments_email_steps.ex
@@ -1,0 +1,201 @@
+defmodule Operately.Support.Features.AssignmentsEmailSteps do
+  use Operately.FeatureCase
+
+  alias Operately.ContextualDates.{ContextualDate, Timeframe}
+  alias Operately.Support.Factory
+  alias Operately.{Goals, Repo}
+
+  def setup_review_v2 do
+    %{}
+    |> Factory.setup()
+    |> Factory.enable_feature("review_v2")
+    |> Factory.add_space(:product_space, name: "Product Space")
+    |> Factory.add_space_member(:champion, :product_space, name: "Casey Champion")
+    |> Factory.add_space_member(:reviewer, :product_space, name: "Riley Reviewer")
+    |> Factory.add_space_member(:teammate, :product_space, name: "Taylor Teammate")
+  end
+
+  def prepare_champion_work(ctx) do
+    ctx
+    |> add_champion_project_work()
+    |> add_champion_goal_work()
+  end
+
+  def prepare_champion_reviews(ctx) do
+    ctx
+    |> add_champion_project_review()
+    |> add_champion_goal_review()
+  end
+
+  def prepare_reviewer_reviews(ctx) do
+    ctx
+    |> add_reviewer_project_review()
+    |> add_reviewer_goal_review()
+  end
+
+  def reload_person(ctx, key) do
+    person =
+      ctx
+      |> Map.fetch!(key)
+      |> Repo.preload(:account)
+
+    Map.put(ctx, key, person)
+  end
+
+  defp add_champion_project_work(ctx) do
+    ctx =
+      ctx
+      |> Factory.add_project(:project_alpha, :product_space, [
+        champion: :champion,
+        reviewer: :reviewer,
+        name: "Project Atlas"
+      ])
+      |> Factory.set_project_next_check_in_date(:project_alpha, hours_ago(6))
+
+    timeframe =
+      %Timeframe{
+        contextual_start_date: nil,
+        contextual_end_date: ContextualDate.create_day_date(days_from_today(-1))
+      }
+
+    ctx =
+      ctx
+      |> Factory.add_project_milestone(:project_alpha_milestone, :project_alpha, [
+        title: "Milestone Alpha",
+        timeframe: timeframe
+      ])
+      |> Factory.add_project_task(:project_alpha_task_due, :project_alpha_milestone, [
+        name: "Prepare weekly update",
+        due_date: ContextualDate.create_day_date(days_from_today(-1))
+      ])
+      |> Factory.add_task_assignee(:project_alpha_task_due_assignee, :project_alpha_task_due, :champion)
+      |> Factory.add_project_task(:project_alpha_task_future, :project_alpha_milestone, [
+        name: "Draft planning outline",
+        due_date: ContextualDate.create_day_date(days_from_today(5))
+      ])
+      |> Factory.add_task_assignee(:project_alpha_task_future_assignee, :project_alpha_task_future, :champion)
+
+    ctx
+  end
+
+  defp add_champion_goal_work(ctx) do
+    ctx = Factory.add_goal(ctx, :growth_goal, :product_space, [
+      name: "Improve Activation",
+      champion: :champion,
+      reviewer: :reviewer,
+      timeframe: Timeframe.current_year()
+    ])
+
+    goal = Map.fetch!(ctx, :growth_goal)
+    {:ok, goal} = Goals.update_goal(goal, %{next_update_scheduled_at: hours_ago(12)})
+
+    Map.put(ctx, :growth_goal, goal)
+  end
+
+  defp add_champion_project_review(ctx) do
+    Factory.add_project_check_in(ctx, :project_alpha_review_check_in, :project_alpha, :teammate, status: "off_track")
+  end
+
+  defp add_champion_goal_review(ctx) do
+    Factory.add_goal_update(ctx, :growth_goal_update, :growth_goal, :teammate)
+  end
+
+  defp add_reviewer_project_review(ctx) do
+    ctx =
+      ctx
+      |> Factory.add_project(:project_beta, :product_space, [
+        champion: :teammate,
+        reviewer: :reviewer,
+        name: "Project Beacon"
+      ])
+      |> Factory.set_project_next_check_in_date(:project_beta, hours_ago(4))
+
+    Factory.add_project_check_in(ctx, :project_beta_check_in, :project_beta, :teammate, status: "caution")
+  end
+
+  defp add_reviewer_goal_review(ctx) do
+    ctx = Factory.add_goal(ctx, :feedback_goal, :product_space, [
+      name: "Feedback Program",
+      champion: :teammate,
+      reviewer: :reviewer,
+      timeframe: Timeframe.current_year()
+    ])
+
+    goal = Map.fetch!(ctx, :feedback_goal)
+    {:ok, goal} = Goals.update_goal(goal, %{next_update_scheduled_at: hours_ago(3)})
+
+    ctx = Map.put(ctx, :feedback_goal, goal)
+
+    Factory.add_goal_update(ctx, :feedback_goal_update, :feedback_goal, :teammate)
+  end
+
+  defp hours_ago(hours) do
+    seconds = hours * 3600
+    DateTime.utc_now() |> DateTime.add(-seconds, :second)
+  end
+
+  defp days_from_today(offset) do
+    Date.utc_today() |> Date.add(offset)
+  end
+
+  step :send_assignments_email_to_champion, ctx do
+    OperatelyEmail.Emails.AssignmentsEmail.send(ctx.champion)
+    ctx
+  end
+
+  step :send_assignments_email_to_reviewer, ctx do
+    OperatelyEmail.Emails.AssignmentsEmail.send(ctx.reviewer)
+    ctx
+  end
+
+  step :assert_champion_email_contains_urgent_work, ctx do
+    alias Operately.Support.Features.UI.Emails
+
+    email = Emails.last_sent_email(to: ctx.champion.account.email)
+
+    assert email.subject == "#{ctx.company.name}: Your assignments for today"
+    refute email.html =~ "Needs your attention"
+    refute email.html =~ "Upcoming work"
+    assert email.html =~ "Project Atlas"
+    assert email.html =~ "Submit weekly check-in"
+    assert email.html =~ "Prepare weekly update"
+    refute email.html =~ "Draft planning outline"
+    assert email.html =~ "Improve Activation"
+    assert email.html =~ "Overdue by"
+    assert email.html =~ "Due today"
+    refute email.html =~ "Needs your review"
+    assert email.html =~ OperatelyWeb.Endpoint.url()
+
+    refute email.text =~ "Needs your attention"
+    refute email.text =~ "Upcoming work"
+    assert email.text =~ "Project Atlas"
+    assert email.text =~ "Improve Activation"
+    assert email.text =~ "Overdue by"
+    assert email.text =~ "Due today"
+    refute email.text =~ "Needs your review"
+
+    ctx
+  end
+
+  step :assert_reviewer_email_contains_review_assignments, ctx do
+    alias Operately.Support.Features.UI.Emails
+
+    email = Emails.last_sent_email(to: ctx.reviewer.account.email)
+
+    assert email.subject == "#{ctx.company.name}: Your assignments for today"
+    refute email.html =~ "Needs your attention"
+    assert email.html =~ "Project Beacon"
+    assert email.html =~ "Review weekly check-in"
+    assert email.html =~ "Feedback Program"
+    assert email.html =~ "Due today"
+    refute email.html =~ "Needs your review"
+    refute email.html =~ "Draft planning outline"
+
+    assert email.text =~ "Project Beacon"
+    assert email.text =~ "Feedback Program"
+    assert email.text =~ "Due today"
+    refute email.text =~ "Needs your review"
+
+    ctx
+  end
+end

--- a/specs/0005-assignments-email-v2.md
+++ b/specs/0005-assignments-email-v2.md
@@ -1,0 +1,74 @@
+## Overview
+
+Update the assignments email so it mirrors the Review Page v2 experience when the experimental feature flag `review_v2` is enabled for a company. The work spans feature flag plumbing, loader selection, email templates, and feature coverage tests.
+
+## Goals
+
+- Honor the `review_v2` experimental feature flag in `Operately.Companies`.
+- Reuse `Operately.Assignments.LoaderV2` for the assignments email when the flag is enabled.
+- Introduce dedicated HTML + text templates that render grouped assignments exactly like Review Page v2.
+- Extend feature tests to cover both V1 and V2 email behaviors with realistic data factories.
+
+## Non-Goals
+
+- No changes to the Review Page UI.
+- No runtime feature flag management UI changes.
+- No refactors outside the assignments email pipeline.
+
+## Implementation Plan
+
+### 1. Feature Flag Plumbing
+
+1. Extend `app/lib/operately/companies.ex` with `has_experimental_feature?(company, feature_name)`:
+   - Accept `%Operately.Companies.Company{}` or company ID.
+   - Safely handle `nil` or missing experimental features list.
+   - Use guard clauses to keep pattern matching tight.
+2. Ensure the implementation matches existing feature flag storage (`features` JSONB column).
+3. Add unit coverage if a convenient test location exists (otherwise rely on existing tests via integration).
+
+### 2. Email Loader Selection
+
+1. In `app/lib/operately_email/emails/assignments_email.ex`:
+   - Inject the company into the assignments context (ensure already available).
+   - Use `Operately.Companies.has_experimental_feature?(company, "review_v2")` to branch.
+   - When `true`, call `Operately.Assignments.LoaderV2.load(company, opts)` (mirror the arguments used in the Review Page).
+   - Fallback to existing loader for legacy behavior.
+   - Keep assignments payload shape consistent with the template expectations; introduce a helper function if needed.
+2. Ensure formatting changes stay minimal per guidelines.
+
+### 3. New Templates
+
+1. Create `app/lib/operately_email/templates/assignments_v2.html.eex` and `assignments_v2.text.eex`.
+2. Structure the HTML to match `turboui/src/ReviewPageV2/index.tsx`:
+   - Render sections grouped by assignment type (e.g., goals, projects, check-ins, tasks).
+   - Reuse existing email styles/classes when possible for typography and spacing.
+   - Display counts, due dates, and key metadata identical to the web view.
+3. The text template should include headings and bullet lists that parallel the HTML content.
+4. Update the email module to select the appropriate template based on the loader in use.
+
+### 4. Shared Formatting Utilities (Optional)
+
+- If date formatting diverges between V1 and V2 templates, introduce helper functions in the email module to keep templates clean.
+- Ensure timezone handling matches current assignments email behavior.
+
+### 5. Tests
+
+1. Add a new `describe "assignments email v2"` block to `app/test/features/assignments_email_test.exs`.
+2. Use factories to seed:
+   - Companies with and without `review_v2`.
+   - Assignments covering all resource types rendered by LoaderV2.
+3. Use helper utilities (potentially `app/test/support/features/ui/assignments_steps.ex`) to normalize dates and compose payloads.
+4. Assert that:
+   - Loader selection respects the feature flag.
+   - Each group renders with expected text/links in both HTML and text emails.
+   - Legacy behavior remains unaffected when the flag is off.
+
+## Rollout & Monitoring
+
+- Verify `make test.mix.features` passes locally.
+- Consider adding a manual QA checklist comparing Review Page and email outputs.
+
+## Open Questions
+
+- Confirm whether LoaderV2 requires additional context beyond what the email currently passes (e.g., pagination or filters).
+- Validate if any strings need i18n hooks before launch.


### PR DESCRIPTION
I've added the assignments email v2 which mirrors the Review V2 page, showing all the due work grouped by project or goal. It's currently behind the `review_v2` feature flag.

This is what it looks like now:

<img width="871" height="677" alt="Screenshot 2025-10-23 at 16 25 39" src="https://github.com/user-attachments/assets/78cd9f61-f700-4c5f-a369-8ee9c5925f94" />
