### PR TITLE
fix: Add pagePath to ProjectMilestoneCreation

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -603,7 +603,7 @@ export interface ActivityContentProjectMilestoneCreation {
   company: Company;
   space: Space;
   project: Project;
-  milestone: Milestone;
+  milestone: Milestone | null;
   milestoneName: string;
 }
 

--- a/app/assets/js/features/activities/ProjectMilestoneCreation/index.tsx
+++ b/app/assets/js/features/activities/ProjectMilestoneCreation/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import type { ActivityContentProjectMilestoneCreation } from "@/api";
 import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
@@ -12,9 +10,13 @@ const ProjectMilestoneCreation: ActivityHandler = {
   },
 
   pagePath(paths: Paths, activity: Activity) {
-    const { milestone } = content(activity);
+    const { milestone, project } = content(activity);
 
-    return paths.projectMilestonePath(milestone.id);
+    if (milestone) {
+      return paths.projectMilestonePath(milestone.id);
+    } else {
+      return paths.projectPath(project.id);
+    }
   },
 
   PageTitle(_props: { activity: any }) {
@@ -57,8 +59,9 @@ const ProjectMilestoneCreation: ActivityHandler = {
     throw new Error("Not implemented");
   },
 
-  NotificationTitle(_props: { activity: Activity }) {
-    return <></>;
+  NotificationTitle(props: { activity: Activity }) {
+    const milestoneName = content(props.activity).milestoneName;
+    return `A new milestone "${milestoneName}" was created`;
   },
 
   NotificationLocation(_props: { activity: Activity }) {

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -127,7 +127,7 @@ defmodule OperatelyWeb.Api.Types do
     field :company, :company
     field :space, :space
     field :project, :project
-    field :milestone, :milestone
+    field :milestone, :milestone, null: true
     field :milestone_name, :string
   end
 

--- a/app/test/support/features/feed_steps.ex
+++ b/app/test/support/features/feed_steps.ex
@@ -104,6 +104,14 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "commented on the #{milestone_title} milestone", comment)
   end
 
+  def assert_project_milestone_created(ctx, author: author, milestone_name: milestone_name) do
+    ctx |> assert_feed_item_exists(author, "added the #{milestone_name} milestone", "")
+  end
+
+  def assert_project_milestone_created(ctx, author: author, milestone_name: milestone_name, project_name: project_name) do
+    ctx |> assert_feed_item_exists(author, "added the #{milestone_name} milestone", "to #{project_name}")
+  end
+
   def assert_project_goal_connection(ctx, author: author, goal_name: goal_name) do
     ctx |> assert_feed_item_exists(author, "connected the project to the #{goal_name} goal", "")
   end

--- a/app/test/support/features/project_milestones_steps.ex
+++ b/app/test/support/features/project_milestones_steps.ex
@@ -449,6 +449,36 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
     end)
   end
 
+  step :assert_milestone_creation_visible_in_feed, ctx do
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> UI.find(UI.query(testid: "project-feed"), fn el ->
+      el
+      |> FeedSteps.assert_project_milestone_created(
+        author: ctx.reviewer,
+        milestone_name: ctx.milestone.title
+      )
+    end)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> UI.find(UI.query(testid: "space-feed"), fn el ->
+      el
+      |> FeedSteps.assert_project_milestone_created(
+        author: ctx.reviewer,
+        milestone_name: ctx.milestone.title,
+        project_name: ctx.project.name
+      )
+    end)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.find(UI.query(testid: "company-feed"), fn el ->
+      el
+      |> FeedSteps.assert_project_milestone_created(
+        author: ctx.reviewer,
+        milestone_name: ctx.milestone.title,
+        project_name: ctx.project.name
+      )
+    end)
+  end
+
   #
   # Emails
   #
@@ -503,6 +533,16 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
     })
   end
 
+  step :assert_milestone_creation_email_sent, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.champion,
+      author: ctx.reviewer,
+      action: "created the \"#{ctx.milestone.title}\" milestone"
+    })
+  end
+
   #
   # Notifications
   #
@@ -551,6 +591,15 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
     |> NotificationsSteps.assert_activity_notification(%{
       author: ctx.champion,
       action: "Re: #{ctx.milestone.title}"
+    })
+  end
+
+  step :assert_milestone_creation_notification_sent, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.reviewer,
+      action: "A new milestone \"#{ctx.milestone.title}\" was created"
     })
   end
 


### PR DESCRIPTION
The lack of the `pagePath` implementation was raising an error on the notifications page.