### PR TITLE
chore: Delete MilestoneUpdating activities where milestone didn't change

### DIFF
--- a/app/assets/js/features/activities/TaskMilestoneUpdating/index.tsx
+++ b/app/assets/js/features/activities/TaskMilestoneUpdating/index.tsx
@@ -3,7 +3,6 @@ import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
 import { feedTitle, milestoneLink, projectLink, taskLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
-import { compareIds } from "turboui/utils/ids";
 
 const TaskMilestoneUpdating: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
@@ -37,11 +36,7 @@ const TaskMilestoneUpdating: ActivityHandler = {
     } else if (oldMilestone && !newMilestone) {
       message = ["removed", taskName, "from milestone", milestoneLink(oldMilestone)];
     } else if (oldMilestone && newMilestone) {
-      if (compareIds(oldMilestone.id, newMilestone.id)) {
-        message = ["reordered", taskName, "in the", milestoneLink(oldMilestone), "milestone"];
-      } else {
-        message = ["moved", taskName, "from milestone", milestoneLink(oldMilestone), "to", milestoneLink(newMilestone)];
-      }
+      message = ["moved", taskName, "from milestone", milestoneLink(oldMilestone), "to", milestoneLink(newMilestone)];
     } else {
       message = ["updated", taskName, "milestone"];
     }

--- a/app/lib/operately/data/change_086_delete_duplicate_task_milestone_updating_activities.ex
+++ b/app/lib/operately/data/change_086_delete_duplicate_task_milestone_updating_activities.ex
@@ -1,0 +1,66 @@
+defmodule Operately.Data.Change086DeleteDuplicateTaskMilestoneUpdatingActivities do
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias __MODULE__.Activity
+
+  def run do
+    Repo.transaction(fn ->
+      fetch_activities()
+      |> collect_duplicate_ids()
+      |> delete_activities()
+    end)
+  end
+
+  defp fetch_activities do
+    from(a in Activity, where: a.action == "task_milestone_updating")
+    |> Repo.all()
+  end
+
+  defp collect_duplicate_ids(activities) do
+    activities
+    |> Enum.filter(&milestone_ids_same?/1)
+    |> Enum.map(& &1.id)
+  end
+
+  defp milestone_ids_same?(activity) do
+    {old_id, old_present?} = fetch_old_milestone_id(activity.content)
+    {new_id, new_present?} = fetch_new_milestone_id(activity.content)
+
+    old_present? and new_present? and old_id == new_id
+  end
+
+  defp fetch_old_milestone_id(content) do
+    fetch_milestone_id(content, "old_milestone_id", :old_milestone_id)
+  end
+
+  defp fetch_new_milestone_id(content) do
+    fetch_milestone_id(content, "new_milestone_id", :new_milestone_id)
+  end
+
+  defp fetch_milestone_id(content, string_key, atom_key) do
+    cond do
+      Map.has_key?(content, string_key) -> {Map.get(content, string_key), true}
+      Map.has_key?(content, atom_key) -> {Map.get(content, atom_key), true}
+      true -> {nil, false}
+    end
+  end
+
+  defp delete_activities([]), do: :ok
+
+  defp delete_activities(ids) do
+    from(a in Activity, where: a.id in ^ids)
+    |> Repo.delete_all()
+
+    :ok
+  end
+
+  defmodule Activity do
+    use Operately.Schema
+
+    schema "activities" do
+      field :action, :string
+      field :content, :map
+    end
+  end
+end

--- a/app/priv/repo/migrations/20251029125230_delete_milestone_updating_activities_where_milestone_didnt_change.exs
+++ b/app/priv/repo/migrations/20251029125230_delete_milestone_updating_activities_where_milestone_didnt_change.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.DeleteMilestoneUpdatingActivitiesWhereMilestoneDidntChange do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change086DeleteDuplicateTaskMilestoneUpdatingActivities.run()
+  end
+
+  def down do
+
+  end
+end

--- a/app/test/operately/data/change_086_delete_duplicate_task_milestone_updating_activities_test.exs
+++ b/app/test/operately/data/change_086_delete_duplicate_task_milestone_updating_activities_test.exs
@@ -1,0 +1,74 @@
+defmodule Operately.Data.Change086DeleteDuplicateTaskMilestoneUpdatingActivitiesTest do
+  use Operately.DataCase
+
+  alias Operately.Activities.Activity
+  alias Operately.Data.Change086DeleteDuplicateTaskMilestoneUpdatingActivities
+
+  setup ctx do
+    Factory.setup(ctx)
+  end
+
+  test "deletes activities where milestone ids are the same", ctx do
+    duplicate_id = Ecto.UUID.generate()
+
+    duplicate_with_string_keys = create_activity(ctx.creator.id, %{
+      "old_milestone_id" => duplicate_id,
+      "new_milestone_id" => duplicate_id
+    })
+
+    duplicate_with_atom_keys = create_activity(ctx.creator.id, %{
+      old_milestone_id: duplicate_id,
+      new_milestone_id: duplicate_id
+    })
+
+    kept_activity = create_activity(ctx.creator.id, %{
+      "old_milestone_id" => duplicate_id,
+      "new_milestone_id" => Ecto.UUID.generate()
+    })
+
+    Change086DeleteDuplicateTaskMilestoneUpdatingActivities.run()
+
+    refute Repo.get(Activity, duplicate_with_string_keys.id)
+    refute Repo.get(Activity, duplicate_with_atom_keys.id)
+    assert Repo.get(Activity, kept_activity.id)
+  end
+
+  test "keeps activities without complete milestone data", ctx do
+    different_ids = create_activity(ctx.creator.id, %{
+      "old_milestone_id" => Ecto.UUID.generate(),
+      "new_milestone_id" => Ecto.UUID.generate()
+    })
+
+    missing_new = create_activity(ctx.creator.id, %{
+      "old_milestone_id" => Ecto.UUID.generate()
+    })
+
+    missing_old = create_activity(ctx.creator.id, %{
+      "new_milestone_id" => Ecto.UUID.generate()
+    })
+
+    both_nil = create_activity(ctx.creator.id, %{})
+
+    Change086DeleteDuplicateTaskMilestoneUpdatingActivities.run()
+
+    assert Repo.get(Activity, different_ids.id)
+    assert Repo.get(Activity, missing_new.id)
+    assert Repo.get(Activity, missing_old.id)
+    assert Repo.get(Activity, both_nil.id)
+  end
+
+  defp create_activity(author_id, content_overrides) do
+    base_content = %{
+      "company_id" => Ecto.UUID.generate(),
+      "space_id" => Ecto.UUID.generate(),
+      "project_id" => Ecto.UUID.generate(),
+      "task_id" => Ecto.UUID.generate()
+    }
+
+    Repo.insert!(%Activity{
+      action: "task_milestone_updating",
+      author_id: author_id,
+      content: Map.merge(base_content, content_overrides)
+    })
+  end
+end


### PR DESCRIPTION
Previously, when reordering a Task within the same Milestone created MilestoneUpdating activities, but the milestone wasn't updated. I'm adding a migration to delete these activities. 

Changes were already made to the code so that such activities are no longer created. 