### PR TITLE
fix: Clicking once on milestone on mobile redirects to milestone

### DIFF
--- a/app/priv/static/.vite/manifest.json
+++ b/app/priv/static/.vite/manifest.json
@@ -4,7 +4,7 @@
     "name": "vendor"
   },
   "assets/js/app.tsx": {
-    "file": "assets/app-CzRHq6S2.js",
+    "file": "assets/app-C8DSyt3k.js",
     "name": "app",
     "src": "assets/js/app.tsx",
     "isEntry": true,

--- a/turboui/src/ProjectPage/MilestoneItem.tsx
+++ b/turboui/src/ProjectPage/MilestoneItem.tsx
@@ -124,8 +124,8 @@ export function MilestoneItem({
       data-test-id={milestoneTestId}
     >
       {isDraggable && (
-        // Drag handle - shown on hover when draggable (hover only on devices with hover capability)
-        <div className="flex items-center mt-1 opacity-0 [@media(hover:hover)]:group-hover:opacity-100 transition-opacity">
+        // Drag handle - shown on hover when draggable (hover disabled on small screens to prevent double-tap on mobile)
+        <div className="flex items-center mt-1 opacity-0 md:group-hover:opacity-100 transition-opacity">
           <IconGripVertical size={16} className="text-content-subtle" />
         </div>
       )}
@@ -166,8 +166,8 @@ export function MilestoneItem({
             />
 
             {canEdit && (
-              // Edit button - shown on hover only for devices with hover capability (prevents double-tap on mobile)
-              <div className="opacity-0 [@media(hover:hover)]:group-hover:opacity-100 transition-opacity">
+              // Edit button - shown on hover on medium+ screens (hover disabled on small screens to prevent double-tap on mobile)
+              <div className="opacity-0 md:group-hover:opacity-100 transition-opacity">
                 <SecondaryButton testId={editBtnTestId} size="xxs" onClick={() => setIsEditing(true)}>
                   Edit
                 </SecondaryButton>

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -100,8 +100,8 @@ export function MilestoneCard({
             <div className="flex items-center gap-2 flex-1 min-w-0">
               <BlackLink
                 to={milestone.link || ""}
-                // Hover color change only on devices with hover capability (prevents double-tap on mobile)
-                className="truncate text-sm font-semibold text-content-base [@media(hover:hover)]:hover:text-link-hover transition-colors min-w-0"
+                // Hover color change on medium+ screens (hover disabled on small screens to prevent double-tap on mobile) 
+                className="truncate text-sm font-semibold text-content-base md:hover:text-link-hover transition-colors min-w-0"
                 underline="hover"
                 title={milestone.name}
               >
@@ -137,8 +137,8 @@ export function MilestoneCard({
                     size="small"
                   />
                 ) : (
-                  // Show date picker on hover only for devices with hover capability (prevents double-tap on mobile)
-                  <div className="opacity-0 transition-opacity [@media(hover:hover)]:group-hover/milestone-due-date:opacity-100 [@media(hover:hover)]:group-hover/milestone-header:opacity-100">
+                  // Show date picker on hover on medium+ screens (hover disabled on small screens to prevent double-tap on mobile)
+                  <div className="opacity-0 transition-opacity md:group-hover/milestone-due-date:opacity-100 md:group-hover/milestone-header:opacity-100">
                     <DateField
                       date={null}
                       onDateSelect={handleMilestoneDueDateChange}


### PR DESCRIPTION
Previously, the user had to click twice on the milestone in order to be redirected to the milestone page on mobile.