### PR TITLE
fix: Reduce activities shown on Milestone page

### DIFF
--- a/app/assets/js/models/activities/feed.tsx
+++ b/app/assets/js/models/activities/feed.tsx
@@ -24,7 +24,7 @@ import { parseMilestoneForTurboUi } from "../milestones";
 import { parsePersonForTurboUi } from "../people";
 import { parseTaskStatus } from "../tasks";
 
-export const SUPPORTED_ACTIVITY_TYPES = [
+export const TASK_ACTIVITY_TYPES = [
   "task_adding",
   "task_name_updating",
   "task_description_change",
@@ -32,19 +32,30 @@ export const SUPPORTED_ACTIVITY_TYPES = [
   "task_due_date_updating",
   "task_milestone_updating",
   "task_status_updating",
+];
+
+export const MILESTONE_ACTIVITY_TYPES = [
+  "task_adding",
   "project_milestone_creation",
   "milestone_description_updating",
   "milestone_title_updating",
   "milestone_due_date_updating",
 ];
 
-type TurboUiPerson = NonNullable<ReturnType<typeof parsePersonForTurboUi>>;
-
 type PageContext = "task" | "milestone";
 
+const SUPPORTED_ACTIVITY_TYPES_BY_CONTEXT: Record<PageContext, string[]> = {
+  task: TASK_ACTIVITY_TYPES,
+  milestone: MILESTONE_ACTIVITY_TYPES,
+};
+
+type TurboUiPerson = NonNullable<ReturnType<typeof parsePersonForTurboUi>>;
+
 export function parseActivitiesForTurboUi(paths: Paths, activities: Activity[], pageContext: PageContext) {
+  const supportedActivityTypes = SUPPORTED_ACTIVITY_TYPES_BY_CONTEXT[pageContext];
+
   return activities
-    .filter((activity) => SUPPORTED_ACTIVITY_TYPES.includes(activity.action))
+    .filter((activity) => supportedActivityTypes.includes(activity.action))
     .map((activity) => parseActivityForTurboUi(paths, activity, pageContext))
     .filter((activity) => activity !== null);
 }

--- a/app/assets/js/pages/MilestonePage/index.tsx
+++ b/app/assets/js/pages/MilestonePage/index.tsx
@@ -8,7 +8,7 @@ import * as Milestones from "@/models/milestones";
 import * as Tasks from "@/models/tasks";
 import * as Projects from "@/models/projects";
 import * as Activities from "@/models/activities";
-import { parseActivitiesForTurboUi, SUPPORTED_ACTIVITY_TYPES } from "@/models/activities/feed";
+import { parseActivitiesForTurboUi, MILESTONE_ACTIVITY_TYPES } from "@/models/activities/feed";
 
 import { showErrorToast, MilestonePage, Timeline } from "turboui";
 import { Paths, usePaths } from "@/routes/paths";
@@ -58,7 +58,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
         activities: Api.getActivities({
           scopeId: params.id,
           scopeType: "milestone",
-          actions: SUPPORTED_ACTIVITY_TYPES,
+          actions: MILESTONE_ACTIVITY_TYPES,
         }).then((d) => d.activities!),
       }),
   });

--- a/app/assets/js/pages/TaskPage/index.tsx
+++ b/app/assets/js/pages/TaskPage/index.tsx
@@ -9,7 +9,7 @@ import * as Activities from "@/models/activities";
 import * as Comments from "@/models/comments";
 import { parseContextualDate, serializeContextualDate } from "@/models/contextualDates";
 import { parseMilestoneForTurboUi } from "@/models/milestones";
-import { parseActivitiesForTurboUi, SUPPORTED_ACTIVITY_TYPES } from "@/models/activities/feed";
+import { parseActivitiesForTurboUi, TASK_ACTIVITY_TYPES } from "@/models/activities/feed";
 import * as Time from "@/utils/time";
 
 import { Paths, usePaths } from "../../routes/paths";
@@ -56,7 +56,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
         activities: Api.getActivities({
           scopeId: params.id,
           scopeType: "task",
-          actions: SUPPORTED_ACTIVITY_TYPES,
+          actions: TASK_ACTIVITY_TYPES,
         }).then((d) => d.activities!),
         comments: Api.getComments({
           entityId: params.id,


### PR DESCRIPTION
## Summary
- split the activity feed helpers into dedicated task and milestone supported type lists
- update the task and milestone pages to request the context-appropriate activity types when fetching activities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690df4953788832a8ccd74cba6f6c832)