### PR TITLE
fix: Truncate goal field name

### DIFF
--- a/turboui/src/GoalField/index.tsx
+++ b/turboui/src/GoalField/index.tsx
@@ -130,7 +130,7 @@ function Trigger({ state }: { state: GoalField.State }) {
     const goalContent = (
       <>
         <IconGoal size={state.iconSize} />
-        <div className="text-sm font-medium whitespace-normal break-words flex-1 min-w-0">
+        <div className="text-sm font-medium truncate flex-1 min-w-0" title={state.goal.name}>
           {state.goal.name}
         </div>
       </>


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/3066.

## Summary
- truncate displayed goal names in the GoalField trigger to avoid wrapping in sidebars
- add a tooltip with the full goal name so truncated entries remain accessible

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dfb4f9834832a915c78334694fea8)