### PR TITLE
fix: allow marking comments as solutions

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1049,6 +1049,9 @@ export interface Comment {
   author?: Person | null;
   reactions?: Reaction[] | null;
   notification?: Notification | null;
+  isSolution?: boolean | null;
+  canMarkAsSolution?: boolean | null;
+  canUnmarkSolution?: boolean | null;
 }
 
 export interface CommentThread {

--- a/app/assets/js/features/CommentSection/form.tsx
+++ b/app/assets/js/features/CommentSection/form.tsx
@@ -8,4 +8,6 @@ export interface FormState {
   deleteComment: (commentID: string) => Promise<void>;
   submitting: boolean;
   mentionSearchScope: People.SearchScope;
+  markCommentAsSolution?: (commentID: string) => Promise<void> | void;
+  unmarkCommentAsSolution?: (commentID: string) => Promise<void> | void;
 }

--- a/app/assets/js/models/comments/index.tsx
+++ b/app/assets/js/models/comments/index.tsx
@@ -59,5 +59,8 @@ function parseCommentForTurboUi(paths: Paths, comment: Comment) {
     insertedAt: comment.insertedAt,
     reactions,
     notification: comment.notification,
+    isSolution: Boolean(comment.isSolution),
+    canMarkAsSolution: Boolean(comment.canMarkAsSolution),
+    canUnmarkSolution: Boolean(comment.canUnmarkSolution),
   };
 }

--- a/turboui/src/CommentSection/types.ts
+++ b/turboui/src/CommentSection/types.ts
@@ -16,6 +16,9 @@ export interface Comment {
   insertedAt: string;
   reactions: Reactions.Reaction[];
   notification?: any; // For notification intersection handling
+  isSolution?: boolean;
+  canMarkAsSolution?: boolean;
+  canUnmarkSolution?: boolean;
 }
 
 export type CommentItem =
@@ -40,6 +43,8 @@ export interface CommentFormState {
   postComment: (content: any) => void;
   editComment: (id: string, content: any) => void;
   deleteComment?: (id: string) => void;
+  markCommentAsSolution?: (id: string) => void | Promise<void>;
+  unmarkCommentAsSolution?: (id: string) => void | Promise<void>;
 }
 
 export interface CommentItemProps {
@@ -52,6 +57,8 @@ export interface CommentItemProps {
   currentUserId?: string;
   onAddReaction?: (commentId: string, emoji: string) => void | Promise<void>;
   onRemoveReaction?: (commentId: string, reactionId: string) => void | Promise<void>;
+  onMarkSolution?: (commentId: string) => void | Promise<void>;
+  onUnmarkSolution?: (commentId: string) => void | Promise<void>;
 }
 
 export interface CommentInputProps {


### PR DESCRIPTION
## Summary
- add optional solution metadata to comment API models and parsing helpers
- expose solution actions and badge in the app comment section menu
- update TurboUI comment items to surface solution controls and styling

## Testing
- npm --prefix turboui run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e35b15d70832abbcfafb0c17e9e8a)