### PR TITLE
fix: Add ALLOW_SIGNUP_WITH_EMAIL variable to installation script

### DIFF
--- a/app/rel/single-host/templates/install.sh.eex
+++ b/app/rel/single-host/templates/install.sh.eex
@@ -132,6 +132,7 @@ POSTGRES_PASSWORD=$(openssl rand -hex 32)
 DATABASE_URL="ecto://${DB_USERNAME}:${POSTGRES_PASSWORD}@db/operately"
 NOTIFICATION_EMAIL="notifications@${DOMAIN}"
 ALLOW_LOGIN_WITH_EMAIL="yes"
+ALLOW_SIGNUP_WITH_EMAIL="yes"
 OPERATELY_BEACON_ENABLED="true"
 
 echo "OPERATELY_HOST=\"${DOMAIN}\"" >> operately.env
@@ -149,6 +150,7 @@ echo "POSTGRES_PASSWORD=\"${POSTGRES_PASSWORD}\"" >> operately.env
 echo "DATABASE_URL=\"${DATABASE_URL}\"" >> operately.env
 echo "NOTIFICATION_EMAIL=\"${NOTIFICATION_EMAIL}\"" >> operately.env
 echo "ALLOW_LOGIN_WITH_EMAIL=\"${ALLOW_LOGIN_WITH_EMAIL}\"" >> operately.env
+echo "ALLOW_SIGNUP_WITH_EMAIL=\"${ALLOW_SIGNUP_WITH_EMAIL}\"" >> operately.env
 echo "OPERATELY_BEACON_ENABLED=\"${OPERATELY_BEACON_ENABLED}\"" >> operately.env
 
 # Write email configuration based on user choice


### PR DESCRIPTION
Previously, users could log in with email and password, but couldn't sign up.