### PR TITLE
fix: Increase local file limit from default 8mb to 256mb

### DIFF
--- a/app/lib/operately_local_media_storage/plug.ex
+++ b/app/lib/operately_local_media_storage/plug.ex
@@ -6,11 +6,6 @@ defmodule OperatelyLocalMediaStorage.Plug do
   plug :verify_token
   plug :dispatch
 
-  plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
-    json_decoder: Jason
-
   get "*path" do
     conn
     |> put_cache_headers()

--- a/app/lib/operately_web/endpoint.ex
+++ b/app/lib/operately_web/endpoint.ex
@@ -46,7 +46,8 @@ defmodule OperatelyWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    json_decoder: Phoenix.json_library()
+    json_decoder: Phoenix.json_library(),
+    length: 256_000_000 # 256MB limit for file uploads (only affects local storage; S3 uploads bypass the server)
 
   plug Plug.MethodOverride
   plug Plug.Head


### PR DESCRIPTION
This default limit was causing file uploads bigger than 8mb to fail when using `local` storage type.