### PR TITLE
chore: Reorder Goal targets with pragmatic drag-and-drop

### DIFF
--- a/turboui/src/Checklist/index.tsx
+++ b/turboui/src/Checklist/index.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 import { PrimaryButton, SecondaryButton } from "../Button";
-import { IconGripVertical } from "../icons";
-import { useSortableList, useSortableItem, DropIndicator } from "../utils/PragmaticDragAndDrop";
+import { useSortableList, useSortableItem, DropIndicator, DragHandle } from "../utils/PragmaticDragAndDrop";
 
 import { useForm } from "react-hook-form";
 import classNames from "../utils/classnames";
@@ -346,16 +345,6 @@ function ChecklistItemView({ state, item }: { state: State; item: ChecklistItemS
     }
   };
 
-  const dragGripClass = classNames(
-    "absolute -left-5 mt-0.5 text-content-subtle opacity-0 group-hover:opacity-100 transition-all",
-    {
-      "cursor-grab": !isDragging && state.togglable,
-      "cursor-grabbing": isDragging && state.togglable,
-      "opacity-100": isDragging && state.togglable,
-      hidden: !state.togglable,
-    },
-  );
-
   const groupClass = classNames("group relative flex items-start gap-2", {
     "hover:bg-surface-highlight transition-colors": state.togglable,
     "opacity-40": isDragging,
@@ -369,7 +358,7 @@ function ChecklistItemView({ state, item }: { state: State; item: ChecklistItemS
     >
       {closestEdge && <DropIndicator edge={closestEdge} />}
       <div ref={dragHandleRef as React.RefObject<HTMLDivElement>}>
-        <IconGripVertical size={16} className={dragGripClass} />
+        <DragHandle isDragging={isDragging} disabled={!state.togglable} className="absolute -left-5 mt-0.5" />
       </div>
       <Checkbox
         checked={item.completed}

--- a/turboui/src/GoalTargetList/useGoalTargetListState.tsx
+++ b/turboui/src/GoalTargetList/useGoalTargetListState.tsx
@@ -29,7 +29,7 @@ export interface State {
   deleteTarget: (id: string) => void;
   cancelDelete: (id: string) => void;
 
-  reorder: (item: any, targetId: string, indexInDropZone: number) => boolean;
+  reorder: (itemId: string, newIndex: number) => void;
 }
 
 export function useGoalTargetListState(props: GoalTargetList.Props): State {
@@ -120,15 +120,13 @@ export function useGoalTargetListState(props: GoalTargetList.Props): State {
       updateTargetState(id, (target) => ({ ...target, mode: "view" as const }));
     },
 
-    reorder: (_: any, targetId: string, indexInDropZone: number) => {
-      const current = targetsRef.current.find((target) => target.id === targetId);
-      if (!current || current.index === indexInDropZone) {
-        return false;
+    reorder: (itemId: string, newIndex: number) => {
+      const current = targetsRef.current.find((target) => target.id === itemId);
+      if (!current || current.index === newIndex) {
+        return;
       }
 
-      props.updateTargetIndex(targetId, indexInDropZone);
-
-      return true;
+      props.updateTargetIndex(itemId, newIndex);
     },
   };
 

--- a/turboui/src/utils/PragmaticDragAndDrop/DragHandle.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/DragHandle.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import classNames from "../classnames";
+import { IconGripVertical } from "../../icons";
+
+interface DragHandleProps {
+  isDragging: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Reusable drag handle component with consistent styling.
+ * 
+ * Shows a grip icon that appears on hover and provides visual feedback during dragging.
+ * Use this with the dragHandleRef from useSortableItem.
+ * 
+ * @param isDragging - Whether the item is currently being dragged
+ * @param disabled - Whether dragging is disabled
+ * @param className - Additional CSS classes to apply
+ * 
+ * @example
+ * const { dragHandleRef, isDragging } = useSortableItem({ itemId, index });
+ * 
+ * return (
+ *   <div ref={dragHandleRef}>
+ *     <DragHandle isDragging={isDragging} />
+ *   </div>
+ * );
+ */
+export function DragHandle({ isDragging, disabled = false, className }: DragHandleProps) {
+  const dragGripClass = classNames(
+    "text-content-subtle opacity-0 group-hover:opacity-100 transition-all",
+    {
+      "cursor-grab": !isDragging && !disabled,
+      "cursor-grabbing": isDragging && !disabled,
+      "opacity-100": isDragging && !disabled,
+      hidden: disabled,
+    },
+    className,
+  );
+
+  return <IconGripVertical size={16} className={dragGripClass} />;
+}

--- a/turboui/src/utils/PragmaticDragAndDrop/index.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/index.tsx
@@ -1,4 +1,5 @@
 export { useSortableList } from "./useSortableList";
 export { useSortableItem } from "./useSortableItem";
 export { DropIndicator } from "./DropIndicator";
+export { DragHandle } from "./DragHandle";
 export type { DraggableItem, OnReorderFunction } from "./types";


### PR DESCRIPTION
Goal targets reordering is now also handled using the the pragmatic drag-and-drop library, similarly to the Goal checklist.