### PR TITLE
chore: Add option to hide feed events

### DIFF
--- a/app/assets/js/features/Feed/index.tsx
+++ b/app/assets/js/features/Feed/index.tsx
@@ -8,7 +8,7 @@ import { DivLink } from "turboui";
 
 import Api from "@/api";
 import FormattedTime from "@/components/FormattedTime";
-import ActivityHandler, { DISPLAYED_IN_FEED } from "@/features/activities";
+import ActivityHandler, { DISPLAYED_IN_FEED, filterVisibleActivities } from "@/features/activities";
 import classNames from "classnames";
 import { Avatar } from "turboui";
 
@@ -42,10 +42,12 @@ const FEED_PROP_DEFAULTS = {
 export function Feed(props: FeedProps) {
   props = { ...FEED_PROP_DEFAULTS, ...props };
 
+  const visibleItems = filterVisibleActivities(props.items);
+
   return (
     <ErrorBoundary fallback={<div>Ooops, something went wrong while loading the feed</div>}>
       <div className="w-full" data-test-id={props.testId}>
-        {Activities.groupByDate(props.items).map((group, index) => (
+        {Activities.groupByDate(visibleItems).map((group, index) => (
           <ActivityGroup
             key={index}
             group={group}

--- a/app/assets/js/features/activities/DiscussionCommentSubmitted/index.tsx
+++ b/app/assets/js/features/activities/DiscussionCommentSubmitted/index.tsx
@@ -82,6 +82,10 @@ const DiscussionCommentSubmitted: ActivityHandler = {
   NotificationLocation({ activity }: { activity: Activity }) {
     return content(activity).space.name;
   },
+
+  hidden(activity: Activity) {
+    return !content(activity).comment;
+  }
 };
 
 function content(activity: Activity): ActivityContentDiscussionCommentSubmitted {

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -59,9 +59,27 @@ const ActivityHandler: interfaces.ActivityHandler = {
   NotificationLocation({ activity }: { activity: Activity }) {
     return React.createElement(handler(activity).NotificationLocation, { activity });
   },
+
+  hidden(activity: Activity) {
+    const h = handler(activity);
+    return h.hidden ? h.hidden(activity) : false;
+  },
 };
 
 export default ActivityHandler;
+
+/**
+ * Filters out activities that should be hidden based on their handler's hidden? method.
+ * Uses memoization to avoid re-filtering on every render.
+ */
+export function filterVisibleActivities(activities: Activity[]): Activity[] {
+  return React.useMemo(() => {
+    return activities.filter((activity) => {
+      const h = handler(activity);
+      return !h.hidden || !h.hidden(activity);
+    });
+  }, [activities]);
+}
 
 export const DISPLAYED_IN_FEED = [
   "goal_check_toggled",

--- a/app/assets/js/features/activities/interfaces.tsx
+++ b/app/assets/js/features/activities/interfaces.tsx
@@ -21,4 +21,7 @@ export interface ActivityHandler {
   // Comments
   commentCount(activity: Activity): number;
   hasComments(activity: Activity): boolean;
+
+  // Visibility
+  hidden?(activity: Activity): boolean;
 }


### PR DESCRIPTION
Some feed events don’t make much sense after their associated resource has been deleted. This wasn’t an issue earlier because we didn’t support deletion for most resources, but now we do. Cascade-deleting these events is tricky, since their relationships are stored in embedded fields and not at the DB level.

In this PR, I added an optional `hidden` method to ActivityHandler. This allows us to define a condition to hide an activity. For example, for the DiscussionCommentSubmitted event, if the associated comment is null, it means the comment no longer exists, so the event is hidden.

This solution works well for the feed, but I’d like to find a solution that  also worked for notifications. The current solution doesn’t work for notifications because, although we can use the same `hidden` method to filter them, the notification count logic happens independently in the backend.