### PR TITLE
chore: Expand drag-and-drop to support boards

### DIFF
--- a/turboui/src/utils/PragmaticDragAndDrop/BoardExample.stories.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/BoardExample.stories.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+
+import { DragHandle, DropIndicator, useBoardDnD, useSortableItem } from ".";
+import classNames from "../classnames";
+
+interface ExampleTask {
+  id: string;
+  title: string;
+}
+
+type ColumnState = Record<string, string[]>;
+
+const tasks: Record<string, ExampleTask> = {
+  "task-1": { id: "task-1", title: "Draft brief" },
+  "task-2": { id: "task-2", title: "Align stakeholders" },
+  "task-3": { id: "task-3", title: "Create mockups" },
+  "task-4": { id: "task-4", title: "Ship release" },
+  "task-5": { id: "task-5", title: "Retrospective" },
+};
+
+const initialColumns: ColumnState = {
+  "milestone-a:todo": ["task-1", "task-2"],
+  "milestone-a:in_progress": ["task-3"],
+  "milestone-b:todo": ["task-4"],
+  "milestone-b:done": ["task-5"],
+};
+
+const columnsMeta = [
+  { id: "milestone-a:todo", title: "Milestone A • Todo" },
+  { id: "milestone-a:in_progress", title: "Milestone A • In progress" },
+  { id: "milestone-b:todo", title: "Milestone B • Todo" },
+  { id: "milestone-b:done", title: "Milestone B • Done" },
+];
+
+function BoardExample() {
+  const [columns, setColumns] = React.useState<ColumnState>(initialColumns);
+  const { draggedItemId } = useBoardDnD((move) => {
+    action("board-move")(move);
+
+    setColumns((previous) => {
+      const next: ColumnState = { ...previous };
+
+      const sourceList = [...(next[move.source.containerId] || [])];
+      const destinationList =
+        move.source.containerId === move.destination.containerId
+          ? sourceList
+          : [...(next[move.destination.containerId] || [])];
+
+      const currentIndex = sourceList.indexOf(move.itemId);
+      if (currentIndex !== -1) {
+        sourceList.splice(currentIndex, 1);
+      }
+
+      next[move.source.containerId] = sourceList;
+
+      const boundedIndex = Math.max(0, Math.min(move.destination.index, destinationList.length));
+      destinationList.splice(boundedIndex, 0, move.itemId);
+      next[move.destination.containerId] = destinationList;
+
+      return next;
+    });
+  });
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="text-lg font-semibold">Board-style drag and drop</div>
+      <div className="flex gap-4 flex-wrap">
+        {columnsMeta.map((column) => (
+          <BoardColumn
+            key={column.id}
+            title={column.title}
+            containerId={column.id}
+            itemIds={columns[column.id] || []}
+            draggedItemId={draggedItemId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface BoardColumnProps {
+  title: string;
+  containerId: string;
+  itemIds: string[];
+  draggedItemId: string | null;
+}
+
+function BoardColumn({ title, containerId, itemIds, draggedItemId }: BoardColumnProps) {
+  const columnRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const element = columnRef.current;
+    if (!element) return;
+
+    return dropTargetForElements({
+      element,
+      getData: () => ({
+        containerId,
+        index: itemIds.length,
+      }),
+    });
+  }, [containerId, itemIds.length]);
+
+  return (
+    <div
+      ref={columnRef}
+      className="flex-1 min-w-[240px] rounded-lg border border-surface-outline bg-surface-raised p-4 shadow-sm space-y-3"
+    >
+      <div className="text-sm font-semibold">{title}</div>
+      <div className="space-y-3 min-h-[160px]">
+        {itemIds.map((taskId, index) => (
+          <BoardCard
+            key={taskId}
+            task={tasks[taskId]!}
+            containerId={containerId}
+            index={index}
+            isDraggingGlobal={draggedItemId === taskId}
+          />
+        ))}
+
+        {itemIds.length === 0 && (
+          <div className="text-xs text-content-dimmed border border-dashed border-surface-outline rounded-md p-4 text-center bg-surface">
+            Drop tasks here
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface BoardCardProps {
+  task: ExampleTask;
+  containerId: string;
+  index: number;
+  isDraggingGlobal: boolean;
+}
+
+function BoardCard({ task, containerId, index, isDraggingGlobal }: BoardCardProps) {
+  const { ref, dragHandleRef, isDragging, closestEdge } = useSortableItem({
+    itemId: task.id,
+    index,
+    containerId,
+  });
+
+  return (
+    <div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      className={classNames("rounded-md border border-surface-outline bg-surface p-3 shadow-sm relative group", {
+        "opacity-60": isDraggingGlobal,
+      })}
+    >
+      {closestEdge && <DropIndicator edge={closestEdge} />}
+      <div className="flex items-center gap-2">
+        <div ref={dragHandleRef as React.RefObject<HTMLDivElement>}>
+          <DragHandle isDragging={isDragging} />
+        </div>
+        <div className="font-medium text-sm">{task.title}</div>
+      </div>
+    </div>
+  );
+}
+
+const meta = {
+  title: "Utils/PragmaticDragAndDrop/BoardExample",
+  component: BoardExample,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof BoardExample>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicBoard: Story = {
+  render: () => <BoardExample />,
+};

--- a/turboui/src/utils/PragmaticDragAndDrop/index.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/index.tsx
@@ -1,5 +1,6 @@
 export { useSortableList } from "./useSortableList";
 export { useSortableItem } from "./useSortableItem";
+export { useBoardDnD } from "./useBoardDnD";
 export { DropIndicator } from "./DropIndicator";
 export { DragHandle } from "./DragHandle";
-export type { DraggableItem, OnReorderFunction } from "./types";
+export type { DraggableItem, OnReorderFunction, BoardMove, BoardLocation, OnBoardMove } from "./types";

--- a/turboui/src/utils/PragmaticDragAndDrop/types.ts
+++ b/turboui/src/utils/PragmaticDragAndDrop/types.ts
@@ -1,6 +1,20 @@
 export interface DraggableItem {
   id: string;
   index: number;
+  containerId?: string;
 }
 
 export type OnReorderFunction = (itemId: string, newIndex: number) => void | Promise<void>;
+
+export interface BoardLocation {
+  containerId: string;
+  index: number;
+}
+
+export interface BoardMove {
+  itemId: string;
+  source: BoardLocation;
+  destination: BoardLocation;
+}
+
+export type OnBoardMove = (move: BoardMove) => void | Promise<void>;

--- a/turboui/src/utils/PragmaticDragAndDrop/useBoardDnD.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/useBoardDnD.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import type { BoardLocation, BoardMove, OnBoardMove } from "./types";
+
+function isNumber(value: unknown): value is number {
+  return typeof value === "number" && !Number.isNaN(value);
+}
+
+export function useBoardDnD(onBoardMove: OnBoardMove) {
+  const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
+  const sourceLocationRef = useRef<BoardLocation | null>(null);
+
+  useEffect(() => {
+    return monitorForElements({
+      onDragStart: ({ source }) => {
+        const itemId = source.data.itemId as string;
+        const containerId = source.data.containerId as string | undefined;
+        const index = source.data.index;
+
+        setDraggedItemId(itemId);
+
+        if (!containerId || !isNumber(index)) {
+          sourceLocationRef.current = null;
+          return;
+        }
+
+        sourceLocationRef.current = { containerId, index };
+      },
+      onDrop: ({ source, location }) => {
+        setDraggedItemId(null);
+
+        const sourceLocation = sourceLocationRef.current;
+        sourceLocationRef.current = null;
+
+        if (!sourceLocation) return;
+
+        const dropTargets = location.current.dropTargets;
+        const target =
+          dropTargets.find((candidate) => typeof candidate.data.itemId === "string" && typeof candidate.data.containerId === "string") ||
+          dropTargets.find((candidate) => typeof candidate.data.containerId === "string");
+
+        if (!target) return;
+
+        const destinationContainerId = target.data.containerId as string;
+        const targetIndex = isNumber(target.data.index) ? target.data.index : sourceLocation.index;
+        let destinationIndex = targetIndex;
+
+        const closestEdge = extractClosestEdge(target.data);
+        if (closestEdge === "bottom") {
+          destinationIndex += 1;
+        }
+
+        if (destinationContainerId === sourceLocation.containerId && sourceLocation.index < destinationIndex) {
+          destinationIndex -= 1;
+        }
+
+        if (destinationContainerId === sourceLocation.containerId && destinationIndex === sourceLocation.index) {
+          return;
+        }
+
+        const move: BoardMove = {
+          itemId: source.data.itemId as string,
+          source: sourceLocation,
+          destination: {
+            containerId: destinationContainerId,
+            index: destinationIndex,
+          },
+        };
+
+        onBoardMove(move);
+      },
+    });
+  }, [onBoardMove]);
+
+  return {
+    draggedItemId,
+  };
+}

--- a/turboui/src/utils/PragmaticDragAndDrop/useSortableItem.tsx
+++ b/turboui/src/utils/PragmaticDragAndDrop/useSortableItem.tsx
@@ -7,6 +7,7 @@ import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
 interface UseSortableItemProps {
   itemId: string;
   index: number;
+  containerId?: string;
   disabled?: boolean;
 }
 
@@ -41,7 +42,12 @@ interface UseSortableItemReturn {
  *   </div>
  * );
  */
-export function useSortableItem({ itemId, index, disabled = false }: UseSortableItemProps): UseSortableItemReturn {
+export function useSortableItem({
+  itemId,
+  index,
+  containerId,
+  disabled = false,
+}: UseSortableItemProps): UseSortableItemReturn {
   const ref = useRef<HTMLElement>(null);
   const dragHandleRef = useRef<HTMLElement>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -75,7 +81,7 @@ export function useSortableItem({ itemId, index, disabled = false }: UseSortable
       draggable({
         element,
         dragHandle: dragHandle || undefined,
-        getInitialData: () => ({ itemId, index }),
+        getInitialData: () => ({ itemId, index, containerId }),
         onDragStart: () => setIsDragging(true),
         onDrop: () => setIsDragging(false),
       }),
@@ -83,7 +89,7 @@ export function useSortableItem({ itemId, index, disabled = false }: UseSortable
         element,
         getData: ({ input }) => {
           return attachClosestEdge(
-            { itemId, index },
+            { itemId, index, containerId },
             {
               element,
               input,
@@ -116,7 +122,7 @@ export function useSortableItem({ itemId, index, disabled = false }: UseSortable
         },
       }),
     );
-  }, [itemId, index, disabled]);
+  }, [itemId, index, containerId, disabled]);
 
   return {
     ref,


### PR DESCRIPTION
I've expanded the drag-and-drop support so that we can use it for kanban boards.