### PR TITLE
fix: Save rich text content on update instead of only on blur

### DIFF
--- a/app/assets/js/components/Forms/RichTextArea.tsx
+++ b/app/assets/js/components/Forms/RichTextArea.tsx
@@ -77,6 +77,9 @@ function Editor(props: RichTextAreaProps & { error: boolean }) {
     onBlur: () => {
       setValue(editor.editor.getJSON());
     },
+    onUpdate: ({ json }) => {
+      setValue(json);
+    },
     onUploadStatusChange: (status) => {
       if (status) {
         form.actions.setState("uploading");

--- a/turboui/src/RichEditor/Blob/AddBlobsEditorCommand.tsx
+++ b/turboui/src/RichEditor/Blob/AddBlobsEditorCommand.tsx
@@ -1,6 +1,16 @@
 import { UploadFileFn } from "../useEditor";
 
-export function AddBlobsEditorCommand({ files, pos, view, uploadFile }: { files: File[] | FileList; pos: number; view: any; uploadFile: UploadFileFn }) {
+export function AddBlobsEditorCommand({
+  files,
+  pos,
+  view,
+  uploadFile,
+}: {
+  files: File[] | FileList;
+  pos: number;
+  view: any;
+  uploadFile: UploadFileFn;
+}) {
   if (!view.editable) return false;
 
   Array.from(files).forEach(async (file) => {

--- a/turboui/src/RichEditor/useEditor.tsx
+++ b/turboui/src/RichEditor/useEditor.tsx
@@ -42,6 +42,7 @@ interface UseEditorProps {
   content?: any;
   onSave?: (data: OnSaveData) => void;
   onBlur?: (data: OnBlurData) => void;
+  onUpdate?: (data: { json: any; html: string }) => void;
   onUploadStatusChange?: (uploading: boolean) => void;
   className?: string;
   editable?: boolean;
@@ -150,6 +151,13 @@ export function useEditor(props: UseEditorProps): EditorState {
       setSubmittable(!isUploading);
 
       setEmpty(editor.state.doc.childCount === 1 && editor.state.doc.firstChild?.childCount === 0);
+
+      if (props.onUpdate) {
+        props.onUpdate({
+          json: editor.getJSON(),
+          html: editor.getHTML(),
+        });
+      }
     },
   });
 


### PR DESCRIPTION
When using `Forms/RichTextArea.tsx`, files added to rich text were not being saved, unless some other edit occurred in the document after the file was added. That's now fixed.