### PR TITLE
fix: Invitation is not created for existing account

### DIFF
--- a/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminManagePeoplePage/index.tsx
@@ -28,13 +28,13 @@ interface LoaderResult {
 }
 
 async function loader({ params }): Promise<LoaderResult> {
-  const company = await Companies.getCompany({ id: params.companyId }).then((res) => res.company!);
-  const people = await People.getPeople({ includeManager: true, includeInviteLink: true }).then((res) => res.people!);
+  const company = await Companies.getCompany({ id: params.companyId }).then((res) => res.company);
+  const people = await People.getPeople({ includeManager: true, includeInviteLink: true }).then((res) => res.people);
 
   return {
     company: company,
-    invitedPeople: People.sortByName(people!.filter((person) => person!.hasOpenInvitation)),
-    currentMembers: People.sortByName(people!.filter((person) => !person!.hasOpenInvitation)),
+    invitedPeople: People.sortByName(people?.filter((person) => person.hasOpenInvitation) || []),
+    currentMembers: People.sortByName(people?.filter((person) => !person.hasOpenInvitation) || []),
   };
 }
 

--- a/app/lib/operately/people.ex
+++ b/app/lib/operately/people.ex
@@ -64,12 +64,12 @@ defmodule Operately.People do
     if Operately.People.Account.valid_password?(account, password), do: account
   end
 
-  def is_new_account?(email) when is_binary(email) do
-    not Repo.exists?(
+  def account_exists?(email) when is_binary(email) do
+    Repo.exists?(
       from(a in Account,
-        join: p in assoc(a, :people),
+        left_join: p in assoc(a, :people),
         where: a.email == ^email,
-        where: not p.has_open_invitation
+        where: is_nil(p.id) or p.has_open_invitation == false
       )
     )
   end

--- a/app/lib/operately_web/api/mutations/add_company_member.ex
+++ b/app/lib/operately_web/api/mutations/add_company_member.ex
@@ -51,7 +51,7 @@ defmodule OperatelyWeb.Api.Mutations.AddCompanyMember do
   end
 
   defp create_person(admin, inputs) do
-    skip_invitation = not People.is_new_account?(inputs[:email])
+    skip_invitation = People.account_exists?(inputs[:email])
 
     case Operately.Operations.CompanyMemberAdding.run(admin, inputs, skip_invitation) do
       {:ok, invite_link} ->

--- a/app/test/operately/invite_links_test.exs
+++ b/app/test/operately/invite_links_test.exs
@@ -294,6 +294,8 @@ defmodule Operately.InviteLinksTest do
       member = Repo.preload(member, :account)
       account = member.account
 
+      assert member.has_open_invitation
+
       assert {:ok, person} = InviteLinks.join_company_via_invite_link(account, invite_link.token)
       assert person.id == member.id
 


### PR DESCRIPTION
Invitations were being created for users which already have an existing account instead of adding them to the company directly.