### PR TITLE
fix: improve generated API docs metadata

### DIFF
--- a/app/lib/operately/api_docs/markdown.ex
+++ b/app/lib/operately/api_docs/markdown.ex
@@ -12,7 +12,7 @@ defmodule Operately.ApiDocs.Markdown do
       |> Enum.map(fn endpoint ->
         """
         <tr>
-          <td><a href="./#{endpoint.name}">#{endpoint.name}</a></td>
+          <td><a href="./#{endpoint.name}">#{endpoint_label(endpoint.name)}</a></td>
           <td><code>#{endpoint.method}</code></td>
           <td><code>#{endpoint.type}</code></td>
           <td><code>#{endpoint.path}</code></td>
@@ -69,8 +69,8 @@ defmodule Operately.ApiDocs.Markdown do
 
     """
     ---
-    title: API docs
-    description: Generated reference for Operately API endpoints.
+    title: Operately API
+    description: Browse the Operately API reference by namespace.
     ---
 
     Operately API provides HTTP endpoints for querying and mutating Operately resources.
@@ -95,7 +95,7 @@ defmodule Operately.ApiDocs.Markdown do
       |> Enum.map(fn endpoint ->
         """
         <tr>
-          <td><a href="./#{endpoint.name}">#{endpoint.name}</a></td>
+          <td><a href="./#{endpoint.name}">#{endpoint_label(endpoint.name)}</a></td>
           <td><code>#{endpoint.method}</code></td>
           <td><code>#{endpoint.type}</code></td>
           <td><code>#{endpoint.path}</code></td>
@@ -139,8 +139,8 @@ defmodule Operately.ApiDocs.Markdown do
 
     """
     ---
-    title: API #{namespace_title(namespace)}
-    description: Generated endpoint reference for the #{namespace_title(namespace)} namespace.
+    title: #{namespace_title(namespace)}
+    description: #{namespace_description_text(namespace)}
     ---
 
     #{description_section}
@@ -158,8 +158,8 @@ defmodule Operately.ApiDocs.Markdown do
 
     """
     ---
-    title: "#{endpoint.name}"
-    description: "Generated reference for the #{endpoint.type} endpoint #{endpoint.full_name}."
+    title: "#{endpoint_title(endpoint)}"
+    description: "#{endpoint_description(endpoint)}"
     ---
 
     import CurlExampleBlock from "@components/CurlExampleBlock.jsx"
@@ -290,8 +290,59 @@ defmodule Operately.ApiDocs.Markdown do
     """
   end
 
-  defp namespace_title("root"), do: "Root"
-  defp namespace_title(namespace), do: namespace |> String.replace("_", " ") |> String.capitalize()
+  defp endpoint_title(endpoint) do
+    "#{namespace_title(endpoint_namespace(endpoint))}: #{endpoint_label(endpoint.name)}"
+  end
+
+  defp endpoint_description(endpoint) do
+    "#{endpoint_label(endpoint.name)} with the #{namespace_api_name(endpoint_namespace(endpoint))}."
+  end
+
+  defp namespace_description_text(namespace) do
+    "Browse endpoints in the #{namespace_api_name(namespace)}."
+  end
+
+  defp namespace_title("root"), do: "Operately API"
+
+  defp namespace_title(namespace) do
+    "#{namespace_label(namespace)} API"
+  end
+
+  defp namespace_api_name("root"), do: "Operately API"
+  defp namespace_api_name(namespace), do: "Operately #{namespace_label(namespace)} API"
+
+  defp namespace_label(namespace) do
+    namespace
+    |> humanize_slug()
+    |> String.split()
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join(" ")
+  end
+
+  defp endpoint_label(name) do
+    name
+    |> humanize_slug()
+    |> String.capitalize()
+  end
+
+  defp endpoint_namespace(endpoint) do
+    cond do
+      Map.get(endpoint, :namespace_segment) not in [nil, ""] ->
+        Map.get(endpoint, :namespace_segment)
+
+      Map.get(endpoint, :namespace) not in [nil, ""] ->
+        endpoint.namespace |> to_string()
+
+      true ->
+        "root"
+    end
+  end
+
+  defp humanize_slug(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+  end
 
   defp other_endpoints_section(root_endpoints_section) do
     if root_endpoints_section == "There are currently no additional endpoints." do

--- a/app/test/operately/api_docs/generator_test.exs
+++ b/app/test/operately/api_docs/generator_test.exs
@@ -43,6 +43,8 @@ defmodule Operately.ApiDocs.GeneratorTest do
     page_1 = File.read!(namespaced_endpoint_1)
     page_2 = File.read!(namespaced_endpoint_2)
 
+    assert page_1 =~ ~s(title: "People API: Get account")
+    assert page_1 =~ ~s(description: "Get account with the Operately People API.")
     assert page_1 =~ "| Type | `query` |"
     assert page_1 =~ "| Method | `GET` |"
     assert page_1 =~ "| Path | `/api/external/v1/people/get_account` |"
@@ -55,6 +57,8 @@ defmodule Operately.ApiDocs.GeneratorTest do
     assert page_1 =~ "## Response Example"
     assert page_1 =~ "```json"
 
+    assert page_2 =~ ~s(title: "Goals API: Update name")
+    assert page_2 =~ ~s(description: "Update name with the Operately Goals API.")
     assert page_2 =~ "| Type | `mutation` |"
     assert page_2 =~ "| Method | `POST` |"
     assert page_2 =~ "| Path | `/api/external/v1/goals/update_name` |"

--- a/app/test/operately/api_docs/markdown_test.exs
+++ b/app/test/operately/api_docs/markdown_test.exs
@@ -14,6 +14,7 @@ defmodule Operately.ApiDocs.MarkdownTest do
 
     endpoint = %{
       full_name: "tasks/create",
+      namespace_segment: "tasks",
       name: "create",
       type: :mutation,
       method: "POST",
@@ -31,6 +32,8 @@ defmodule Operately.ApiDocs.MarkdownTest do
 
     page = Markdown.endpoint_page(endpoint, types)
 
+    assert page =~ ~s(title: "Tasks API: Create")
+    assert page =~ ~s(description: "Create with the Operately Tasks API.")
     assert page =~ ~s(<div style={{ overflowX: "auto" }}>)
     assert page =~ ~s(<th style={{ whiteSpace: "nowrap" }}>Field</th>)
     assert page =~ ~s(<th style={{ whiteSpace: "normal" }}>Type</th>)
@@ -77,6 +80,30 @@ defmodule Operately.ApiDocs.MarkdownTest do
     refute page =~ "```json"
   end
 
+  test "humanizes namespace and operation slugs in titles, descriptions, and links" do
+    types = %{primitives: %{}, objects: %{}, unions: %{}, enums: %{}, int_enums: %{}}
+
+    endpoint = %{
+      full_name: "companies/update_members_permissions",
+      namespace_segment: "companies",
+      name: "update_members_permissions",
+      type: :mutation,
+      method: "POST",
+      path: "/api/external/v1/companies/update_members_permissions",
+      handler: "OperatelyWeb.Api.Companies.UpdateMembersPermissions",
+      inputs: [],
+      outputs: []
+    }
+
+    endpoint_page = Markdown.endpoint_page(endpoint, types)
+    namespace_page = Markdown.namespace_index("companies", [endpoint])
+
+    assert endpoint_page =~ ~s(title: "Companies API: Update members permissions")
+    assert endpoint_page =~ ~s(description: "Update members permissions with the Operately Companies API.")
+    assert namespace_page =~ "title: Companies API"
+    assert namespace_page =~ ~s(<a href="./update_members_permissions">Update members permissions</a>)
+  end
+
   test "renders root endpoints in api index without a root namespace section" do
     catalog = %{
       namespaces: ["root", "goals"],
@@ -102,10 +129,12 @@ defmodule Operately.ApiDocs.MarkdownTest do
 
     page = Markdown.api_index(catalog)
 
+    assert page =~ "title: Operately API"
+    assert page =~ "description: Browse the Operately API reference by namespace."
     assert page =~ "## Endpoint Namespaces"
     assert page =~ "## Other Endpoints"
-    assert page =~ "[Goals](./goals)"
-    assert page =~ ~s(<a href="./get_account">get_account</a>)
+    assert page =~ "[Goals API](./goals)"
+    assert page =~ ~s(<a href="./get_account">Get account</a>)
     assert page =~ ~s(<div style={{ overflowX: "auto" }}>)
     assert page =~ ~s(<table style={{ minWidth: "52rem", whiteSpace: "nowrap" }}>)
     refute page =~ "[Root](./root)"
@@ -126,9 +155,11 @@ defmodule Operately.ApiDocs.MarkdownTest do
         }
       ])
 
+    assert page =~ "title: Goals API"
+    assert page =~ "description: Browse endpoints in the Operately Goals API."
     assert page =~ ~s(<div style={{ overflowX: "auto" }}>)
     assert page =~ ~s(<table style={{ minWidth: "52rem", whiteSpace: "nowrap" }}>)
-    assert page =~ ~s(<a href="./update_name">update_name</a>)
+    assert page =~ ~s(<a href="./update_name">Update name</a>)
     assert page =~ ~s(<code>/api/external/v1/goals/update_name</code>)
   end
 end


### PR DESCRIPTION
Updated the generator in `app/lib/operately/api_docs/markdown.ex:8` so human-facing API docs text is derived centrally instead of using raw slugs or generic boilerplate. Tests were updated in `app/test/operately/api_docs/markdown_test.exs:6` and `app/test/operately/api_docs/generator_test.exs:16`.

  Titles and descriptions now come from a small helper set in `markdown.ex`:

  - Namespace title: companies -> Companies API, resource_hubs -> Resource Hubs API
  - Endpoint title: <Namespace> API: <Humanized operation> such as Companies API: Create member
  - Endpoint description: <Humanized operation> with the Operately <Namespace> API.
  - Visible labels in namespace tables and root index are humanized from slugs, while routes and filenames
    stay unchanged
