### PR TITLE
fix: Do not redirect to setup/ when instance has an account

### DIFF
--- a/app/lib/operately/people.ex
+++ b/app/lib/operately/people.ex
@@ -20,6 +20,10 @@ defmodule Operately.People do
     Repo.all(from p in Person, where: p.company_id == ^company_id and p.type == :ai and not p.suspended)
   end
 
+  def count_accounts do
+    Repo.aggregate(Account, :count, :id)
+  end
+
   def get_account!(id), do: Repo.get!(Account, id)
   def get_person(id), do: Repo.get(Person, id)
   def get_person!(id), do: Repo.get!(Person, id)

--- a/app/lib/operately_web/controllers/page_controller.ex
+++ b/app/lib/operately_web/controllers/page_controller.ex
@@ -20,7 +20,7 @@ defmodule OperatelyWeb.PageController do
       baseUrl: OperatelyWeb.Endpoint.url(),
       demoBuilder: Application.get_env(:operately, :demo_builder_allowed),
       showDevBar: Application.get_env(:operately, :app_env) == :dev,
-      configured: Operately.Companies.count_companies() > 0,
+      configured: configured?(),
       allowLoginWithGoogle: Application.get_env(:operately, :allow_login_with_google),
       allowSignupWithGoogle: Application.get_env(:operately, :allow_signup_with_google),
       allowLoginWithEmail: Application.get_env(:operately, :allow_login_with_email),
@@ -64,6 +64,10 @@ defmodule OperatelyWeb.PageController do
 
   defp ai_configured? do
     Application.get_env(:operately, :ai_configured, false)
+  end
+
+  defp configured? do
+    Operately.Companies.count_companies() > 0 or Operately.People.count_accounts() > 0
   end
 
   defp vite_url do

--- a/app/test/operately_web/controllers/page_controller_test.exs
+++ b/app/test/operately_web/controllers/page_controller_test.exs
@@ -1,10 +1,31 @@
 defmodule OperatelyWeb.PageControllerTest do
   use OperatelyWeb.ConnCase
 
-  setup :register_and_log_in_account
+  import Operately.PeopleFixtures
+  import Operately.CompaniesFixtures
 
-  test "GET /", %{conn: conn} do
+  test "GET / renders configured false when there are no companies and no accounts", %{conn: conn} do
     conn = get(conn, "/")
+
     assert html_response(conn, 200)
+    assert conn.resp_body =~ ~s("configured":false)
+  end
+
+  test "GET / renders configured true when there are accounts but no companies", %{conn: conn} do
+    account_fixture()
+
+    conn = get(conn, "/")
+
+    assert html_response(conn, 200)
+    assert conn.resp_body =~ ~s("configured":true)
+  end
+
+  test "GET / renders configured true when there is at least one company", %{conn: conn} do
+    company_fixture()
+
+    conn = get(conn, "/")
+
+    assert html_response(conn, 200)
+    assert conn.resp_body =~ ~s("configured":true)
   end
 end


### PR DESCRIPTION
Previously, if an instance had no companies, we forced the user to go through the setup. However, now that we support deleting companies, this behavior became problematic, because a user who has already setup and then delete their company should not have to go through setup again. This PR fixes that.