### PR TITLE
feat: add company feed item for joined members

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -184,6 +184,11 @@ export interface ActivityContentCompanyMemberAdded {
   name: string;
 }
 
+export interface ActivityContentCompanyMemberJoined {
+  company: Company;
+  person: Person;
+}
+
 export interface ActivityContentCompanyMemberConvertedToGuest {
   company: Company;
   person: Person | null;
@@ -2030,6 +2035,7 @@ export type ActivityContent =
   | ActivityContentCompanyAdminAdded
   | ActivityContentCompanyMembersPermissionsEdited
   | ActivityContentCompanyMemberAdded
+  | ActivityContentCompanyMemberJoined
   | ActivityContentCompanyMemberConvertedToGuest
   | ActivityContentGuestInvited
   | ActivityContentCompanyEditing

--- a/app/assets/js/features/activities/CompanyMemberJoined/index.tsx
+++ b/app/assets/js/features/activities/CompanyMemberJoined/index.tsx
@@ -1,0 +1,81 @@
+import type { ActivityContentCompanyMemberJoined } from "@/api";
+import type { Activity } from "@/models/activities";
+import { firstName } from "@/models/people";
+import { usePaths } from "@/routes/paths";
+import * as React from "react";
+import { Link } from "turboui";
+
+import type { ActivityHandler } from "../interfaces";
+import { feedTitle } from "../feedItemLinks";
+
+const CompanyMemberJoined: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, _activity: Activity) {
+    return paths.peoplePath();
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity }: { activity: Activity }) {
+    const { company, person } = content(activity);
+
+    if (!person) {
+      return feedTitle(activity, "joined", company.name);
+    }
+
+    return (
+      <>
+        <PersonFirstNameLink person={person} /> joined {company.name}
+      </>
+    );
+  },
+
+  FeedItemContent(_props: { activity: Activity; page: any }) {
+    return null;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-center";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  NotificationLocation(_props: { activity: Activity }) {
+    return null;
+  },
+};
+
+export default CompanyMemberJoined;
+
+function content(activity: Activity): ActivityContentCompanyMemberJoined {
+  return activity.content as ActivityContentCompanyMemberJoined;
+}
+
+function PersonFirstNameLink({ person }: { person: NonNullable<ActivityContentCompanyMemberJoined["person"]> }) {
+  const paths = usePaths();
+
+  return <Link to={paths.profilePath(person.id)}>{firstName(person)}</Link>;
+}

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -87,6 +87,7 @@ export const DISPLAYED_IN_FEED = [
   "company_owner_removing",
   "company_member_restoring",
   "company_member_added",
+  "company_member_joined",
   "company_member_converted_to_guest",
   "guest_invited",
   "company_adding",
@@ -189,6 +190,7 @@ import CompanyOwnerRemoving from "@/features/activities/CompanyOwnerRemoving";
 import CompanyOwnersAdding from "@/features/activities/CompanyOwnersAdding";
 import CompanyMembersPermissionsEdited from "@/features/activities/CompanyMembersPermissionsEdited";
 import CompanyMemberAdded from "@/features/activities/CompanyMemberAdded";
+import CompanyMemberJoined from "@/features/activities/CompanyMemberJoined";
 import CompanyMemberConvertedToGuest from "@/features/activities/CompanyMemberConvertedToGuest";
 import GuestInvited from "@/features/activities/GuestInvited";
 import DiscussionCommentSubmitted from "@/features/activities/DiscussionCommentSubmitted";
@@ -282,9 +284,9 @@ import GoalTargetDeleting from "./GoalTargetDeleting";
 import GoalTargetUpdating from "./GoalTargetUpdating";
 import ProjectMilestoneCreation from "./ProjectMilestoneCreation";
 import ProjectMilestoneUpdating from "./ProjectMilestoneUpdating";
-import GoalCheckAdding from './GoalCheckAdding';
-import GoalCheckRemoving from './GoalCheckRemoving';
-import GoalCheckToggled from './GoalCheckToggled';
+import GoalCheckAdding from "./GoalCheckAdding";
+import GoalCheckRemoving from "./GoalCheckRemoving";
+import GoalCheckToggled from "./GoalCheckToggled";
 
 function handler(activity: Activity) {
   return match(activity.action)
@@ -299,6 +301,7 @@ function handler(activity: Activity) {
     .with("company_member_restoring", () => CompanyMemberRestoring)
     .with("company_members_permissions_edited", () => CompanyMembersPermissionsEdited)
     .with("company_member_added", () => CompanyMemberAdded)
+    .with("company_member_joined", () => CompanyMemberJoined)
     .with("company_member_converted_to_guest", () => CompanyMemberConvertedToGuest)
     .with("guest_invited", () => GuestInvited)
     .with("discussion_posting", () => DiscussionPosting)

--- a/app/lib/operately/activities/content/company_member_joined.ex
+++ b/app/lib/operately/activities/content/company_member_joined.ex
@@ -1,0 +1,18 @@
+defmodule Operately.Activities.Content.CompanyMemberJoined do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :person, Operately.People.Person
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required([:company_id, :person_id])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/context_auto_assigner.ex
+++ b/app/lib/operately/activities/context_auto_assigner.ex
@@ -28,6 +28,7 @@ defmodule Operately.Activities.ContextAutoAssigner do
     "company_admin_removed",
     "company_member_removed",
     "company_member_restoring",
+    "company_member_joined",
     "company_member_converted_to_guest",
     "company_members_permissions_edited",
     "guest_invited",

--- a/app/lib/operately/activities/notifications/company_member_joined.ex
+++ b/app/lib/operately/activities/notifications/company_member_joined.ex
@@ -1,0 +1,5 @@
+defmodule Operately.Activities.Notifications.CompanyMemberJoined do
+  def dispatch(_activity) do
+    {:ok, []}
+  end
+end

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -53,6 +53,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     "company_invitation_token_created",
     "company_member_added",
     "company_member_converted_to_guest",
+    "company_member_joined",
     "company_member_removed",
     "company_member_restoring",
     "company_members_permissions_edited",

--- a/app/lib/operately/operations/company_joining_via_invite_link.ex
+++ b/app/lib/operately/operations/company_joining_via_invite_link.ex
@@ -1,5 +1,7 @@
 defmodule Operately.Operations.CompanyJoiningViaInviteLink do
   alias Ecto.Multi
+  alias Operately.Activities.Activity
+  alias Operately.Companies.Company
   alias Operately.Repo
   alias Operately.InviteLinks
   alias Operately.People
@@ -82,6 +84,7 @@ defmodule Operately.Operations.CompanyJoiningViaInviteLink do
         account_id: account.id
       })
     end)
+    |> insert_activity()
     |> Multi.run(:invite_link_update, fn _repo, %{invite_link: invite_link} ->
       InviteLinks.increment_use_count(invite_link)
     end)
@@ -110,9 +113,24 @@ defmodule Operately.Operations.CompanyJoiningViaInviteLink do
     |> Multi.run(:account_first_login, fn _, _ ->
       People.mark_account_first_login(account)
     end)
+    |> insert_activity()
     |> Multi.run(:invite_link_update, fn _repo, %{invite_link: invite_link} ->
       InviteLinks.revoke_invite_link(invite_link)
     end)
     |> Repo.transaction()
+  end
+
+  defp insert_activity(multi) do
+    Multi.insert(multi, :joined_activity, fn %{person: person} ->
+      company = Repo.get!(Company, person.company_id) |> Repo.preload(:access_context)
+      {:ok, content} = Operately.Activities.build_content("company_member_joined", %{company_id: company.id, person_id: person.id})
+
+      Activity.changeset(%{
+        author_id: person.id,
+        action: "company_member_joined",
+        content: content,
+        access_context_id: company.access_context.id,
+      })
+    end)
   end
 end

--- a/app/lib/operately/operations/password_first_time_changing.ex
+++ b/app/lib/operately/operations/password_first_time_changing.ex
@@ -1,6 +1,8 @@
 defmodule Operately.Operations.PasswordFirstTimeChanging do
   alias Ecto.Multi
   alias Operately.Repo
+  alias Operately.Activities.Activity
+  alias Operately.Companies.Company
   alias Operately.People.Account
 
   def run(attrs, invite_link) do
@@ -12,6 +14,7 @@ defmodule Operately.Operations.PasswordFirstTimeChanging do
     |> change_password(attrs, member.account)
     |> deactivate_invite_link(invite_link)
     |> insert_activity(invite_link, admin, member)
+    |> insert_joined_activity(member)
     |> Repo.transaction()
   end
 
@@ -34,6 +37,20 @@ defmodule Operately.Operations.PasswordFirstTimeChanging do
         member_name: member.full_name,
         member_email: member.email,
       }
+    end)
+  end
+
+  defp insert_joined_activity(multi, member) do
+    Multi.insert(multi, :joined_activity, fn _changes ->
+      company = Repo.get!(Company, member.company_id) |> Repo.preload(:access_context)
+      {:ok, content} = Operately.Activities.build_content("company_member_joined", %{company_id: company.id, person_id: member.id})
+
+      Activity.changeset(%{
+        author_id: member.id,
+        action: "company_member_joined",
+        content: content,
+        access_context_id: company.access_context.id,
+      })
     end)
   end
 

--- a/app/lib/operately_web/api/serializers/activity_content/company_member_joined.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/company_member_joined.ex
@@ -1,0 +1,10 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.CompanyMemberJoined do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      company: Serializer.serialize(content["company"], level: :essential),
+      person: Serializer.serialize(content["person"], level: :essential),
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -230,6 +230,11 @@ defmodule OperatelyWeb.Api.Types do
     field :name, :string, null: false
   end
 
+  object :activity_content_company_member_joined do
+    field :company, :company, null: false
+    field :person, :person, null: false
+  end
+
   object :activity_content_company_member_converted_to_guest do
     field :company, :company, null: false
     field :person, :person, null: true
@@ -701,6 +706,7 @@ defmodule OperatelyWeb.Api.Types do
       :activity_content_company_admin_added,
       :activity_content_company_members_permissions_edited,
       :activity_content_company_member_added,
+      :activity_content_company_member_joined,
       :activity_content_company_member_converted_to_guest,
       :activity_content_guest_invited,
       :activity_content_company_editing,

--- a/app/test/operately/access/activity_context_assigner_test.exs
+++ b/app/test/operately/access/activity_context_assigner_test.exs
@@ -80,6 +80,18 @@ defmodule Operately.AccessActivityContextAssignerTest do
       |> assert_context_assigned(ctx.company.access_context.id)
     end
 
+    test "company_member_joined action", ctx do
+      member = person_fixture_with_account(%{company_id: ctx.company.id})
+      attrs = %{
+        action: "company_member_joined",
+        author_id: member.id,
+        content: %{company_id: ctx.company.id, person_id: member.id}
+      }
+
+      create_activity(attrs)
+      |> assert_context_assigned(ctx.company.access_context.id)
+    end
+
     test "company_member_converted_to_guest action", ctx do
       member = person_fixture_with_account(%{company_id: ctx.company.id})
       attrs = %{

--- a/app/test/operately/operations/account_signing_up_test.exs
+++ b/app/test/operately/operations/account_signing_up_test.exs
@@ -2,6 +2,7 @@ defmodule Operately.Operations.AccountSigningUpTest do
   use Operately.DataCase, async: true
 
   alias Operately.Operations.AccountSigningUp
+  alias Operately.Activities.Activity
   alias Operately.People
   alias Operately.People.EmailActivationCode
   alias Operately.Support.Factory
@@ -70,6 +71,11 @@ defmodule Operately.Operations.AccountSigningUpTest do
       assert invite_context.company.id == ctx.company.id
       assert invite_context.person.email == @email
       assert invite_context.error == nil
+
+      activity = from(a in Activity, where: a.action == "company_member_joined" and a.author_id == ^invite_context.person.id) |> Repo.one()
+
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["person_id"] == invite_context.person.id
     end
 
     test "succeeds but sets invite error when invite token is invalid" do

--- a/app/test/operately/operations/password_first_time_changing_test.exs
+++ b/app/test/operately/operations/password_first_time_changing_test.exs
@@ -50,4 +50,13 @@ defmodule Operately.Operations.PasswordFirstTimeChangingTest do
     assert activity.content["company_id"] == ctx.company.id
     assert activity.content["invite_link_id"] == ctx.invite_link.id
   end
+
+  test "PasswordFirstTimeChanging operation creates joined activity", ctx do
+    {:ok, _} = Operately.Operations.PasswordFirstTimeChanging.run(ctx.attrs, ctx.invite_link)
+
+    activity = from(a in Activity, where: a.action == "company_member_joined" and a.author_id == ^ctx.member.id) |> Repo.one()
+
+    assert activity.content["company_id"] == ctx.company.id
+    assert activity.content["person_id"] == ctx.member.id
+  end
 end

--- a/app/test/operately_web/api/cli_auth_test.exs
+++ b/app/test/operately_web/api/cli_auth_test.exs
@@ -1,6 +1,7 @@
 defmodule OperatelyWeb.Api.CliAuthTest do
   use OperatelyWeb.TurboCase
 
+  alias Operately.Activities.Activity
   alias Operately.People.{CliAuthSession, EmailActivationCode}
   alias Operately.Support.Factory
 
@@ -806,6 +807,11 @@ defmodule OperatelyWeb.Api.CliAuthTest do
 
       assert res.company.id == Paths.company_id(ctx.company)
       assert Repo.reload!(invite_link).is_active == false
+
+      activity = Repo.get_by(Activity, action: "company_member_joined", author_id: member.id)
+
+      assert activity.content["company_id"] == ctx.company.id
+      assert activity.content["person_id"] == member.id
     end
 
     test "returns bad_request for invalid invite token", ctx do


### PR DESCRIPTION
Create a company_member_joined activity when invited users join an org, and render it in the company feed with a profile link.

Purely vibe coded with codex, needs review.

Fixes #4455.