### PR TITLE
fix: Improve task input on mobile

### DIFF
--- a/app/test/support/features/project_milestones_steps.ex
+++ b/app/test/support/features/project_milestones_steps.ex
@@ -281,7 +281,7 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
   step :add_task, ctx, name: name do
     ctx
     |> UI.click(testid: "tasks-section-add-task")
-    |> UI.fill(placeholder: "Add a task...", with: name)
+    |> UI.fill(label: "Add task", with: name)
     |> UI.press_enter()
     |> UI.click_button("Cancel")
   end
@@ -291,7 +291,7 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
 
     Enum.reduce(names, ctx, fn name, ctx ->
       ctx
-      |> UI.fill(placeholder: "Add a task...", with: name)
+      |> UI.fill(label: "Add task", with: name)
       |> UI.press_enter()
     end)
     |> UI.click_button("Cancel")

--- a/app/test/support/features/project_milestones_steps.ex
+++ b/app/test/support/features/project_milestones_steps.ex
@@ -281,7 +281,7 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
   step :add_task, ctx, name: name do
     ctx
     |> UI.click(testid: "tasks-section-add-task")
-    |> UI.fill(label: "Add task", with: name)
+    |> UI.fill(Wallaby.Query.css("[data-test-id^=\"inline-task-creator-milestonepage\"]"), with: name)
     |> UI.press_enter()
     |> UI.click_button("Cancel")
   end
@@ -291,7 +291,7 @@ defmodule Operately.Support.Features.ProjectMilestonesSteps do
 
     Enum.reduce(names, ctx, fn name, ctx ->
       ctx
-      |> UI.fill(label: "Add task", with: name)
+      |> UI.fill(Wallaby.Query.css("[data-test-id^=\"inline-task-creator-milestonepage\"]"), with: name)
       |> UI.press_enter()
     end)
     |> UI.click_button("Cancel")

--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -263,7 +263,7 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
   step :add_task_from_milestone_page, ctx, title do
     ctx
     |> UI.click(testid: "tasks-section-add-task")
-    |> UI.fill(placeholder: "Add a task...", with: title)
+    |> UI.fill(label: "Add task", with: title)
     |> UI.press_enter()
     |> UI.sleep(500)
   end

--- a/app/test/support/features/project_tasks_steps.ex
+++ b/app/test/support/features/project_tasks_steps.ex
@@ -263,7 +263,7 @@ defmodule Operately.Support.Features.ProjectTasksSteps do
   step :add_task_from_milestone_page, ctx, title do
     ctx
     |> UI.click(testid: "tasks-section-add-task")
-    |> UI.fill(label: "Add task", with: title)
+    |> UI.fill(Wallaby.Query.css("[data-test-id^=\"inline-task-creator-milestonepage\"]"), with: title)
     |> UI.press_enter()
     |> UI.sleep(500)
   end

--- a/turboui/src/MilestonePage/components/TasksSection.tsx
+++ b/turboui/src/MilestonePage/components/TasksSection.tsx
@@ -159,7 +159,7 @@ export function TasksSection({
                     autoFocus
                     testId="inline-task-creator-milestonepage-empty"
                   />
-                  <div className="px-0 pt-2 text-center text-content-subtle text-xs">
+                  <div className="hidden px-0 pt-2 text-center text-content-subtle text-xs sm:block">
                     Press Enter to add. You can also drag tasks here.
                   </div>
                 </>

--- a/turboui/src/MilestonePage/components/TasksSection.tsx
+++ b/turboui/src/MilestonePage/components/TasksSection.tsx
@@ -164,8 +164,9 @@ export function TasksSection({
                   </div>
                 </>
               ) : (
-                <div className="text-center text-content-subtle text-sm">
-                  Click + or press c to add a task, or drag a task here.
+                <div className="text-left text-content-subtle text-sm sm:text-center">
+                  <span className="sm:hidden">Tap + to add a task.</span>
+                  <span className="hidden sm:inline">Click + or press c to add a task, or drag a task here.</span>
                 </div>
               )}
             </div>

--- a/turboui/src/PieChart/index.tsx
+++ b/turboui/src/PieChart/index.tsx
@@ -8,10 +8,12 @@ interface Slice {
 interface PieChartProps {
   size?: number;
   bgcolor?: string;
+  ariaLabel?: string;
+  title?: string;
   slices: Slice[];
 }
 
-export function PieChart({ size = 20, bgcolor = "var(--color-surface-subtle)", slices }: PieChartProps) {
+export function PieChart({ size = 20, bgcolor = "var(--color-surface-subtle)", ariaLabel, title, slices }: PieChartProps) {
   const colors = React.useMemo(() => {
     let start = 0;
     let total = 0;
@@ -36,6 +38,9 @@ export function PieChart({ size = 20, bgcolor = "var(--color-surface-subtle)", s
   return (
     <div
       className="rounded-full"
+      role={ariaLabel ? "img" : undefined}
+      aria-label={ariaLabel}
+      title={title}
       style={{
         background: colors,
         width: `${size}px`,

--- a/turboui/src/Tabs/index.tsx
+++ b/turboui/src/Tabs/index.tsx
@@ -58,8 +58,8 @@ function useTabPath(tabId: string, urlPath?: string) {
 
 export function Tabs({ tabs }: { tabs: TabsState }) {
   return (
-    <div className="border-stroke-base border-b shadow-b-xs pl-4 mt-2 overflow-x-auto">
-      <nav className="flex gap-4 px-2 sm:px-0 whitespace-nowrap">
+    <div className="border-stroke-base border-b shadow-b-xs pl-1 mt-2 overflow-x-auto sm:pl-4">
+      <nav className="flex gap-2 px-1 whitespace-nowrap sm:gap-4 sm:px-0">
         {tabs.tabs.map((tab) => (
           <TabItem key={tab.id} tab={tab} activeTab={tabs.active} urlPath={tabs.urlPath} />
         ))}
@@ -72,7 +72,7 @@ function TabItem({ tab, activeTab, urlPath }: { tab: Tab; activeTab: string; url
   const tabPath = useTabPath(tab.id, urlPath);
   const testId = `tab-${tab.label.toLowerCase()}`;
 
-  const labelClass = classNames("flex items-center gap-1 px-1.5 py-1.5 text-sm relative -mb-px font-medium -mx-1.5", {
+  const labelClass = classNames("flex items-center gap-1 px-1 py-1.5 text-sm relative -mb-px font-medium sm:px-1.5 sm:-mx-1.5", {
     "text-white rounded-t": activeTab === tab.id,
     "text-content-dimmed hover:text-content-base": activeTab !== tab.id,
     "hover:bg-surface-dimmed rounded-lg": activeTab !== tab.id,
@@ -81,8 +81,8 @@ function TabItem({ tab, activeTab, urlPath }: { tab: Tab; activeTab: string; url
   return (
     <div className="relative pb-1.5">
       <DivLink className={labelClass} to={tabPath} testId={testId}>
-        <span className="flex-shrink-0">{tab.icon}</span>
-        <span className="leading-none whitespace-nowrap ml-1">{tab.label}</span>
+        <span className="hidden flex-shrink-0 sm:inline-flex">{tab.icon}</span>
+        <span className="leading-none whitespace-nowrap sm:ml-1">{tab.label}</span>
         <TabCountBadge count={tab.count} />
       </DivLink>
 

--- a/turboui/src/TaskBoard/components/EmptyMilestoneDropZone.tsx
+++ b/turboui/src/TaskBoard/components/EmptyMilestoneDropZone.tsx
@@ -54,8 +54,9 @@ export function EmptyMilestoneDropZone({
       {children ? (
         children
       ) : (
-        <div className="text-center text-content-subtle text-sm">
-          Click + or press c to add a task, or drag a task here.
+        <div className="text-left text-content-subtle text-sm sm:text-center">
+          <span className="sm:hidden">Tap + to add a task.</span>
+          <span className="hidden sm:inline">Click + or press c to add a task, or drag a task here.</span>
         </div>
       )}
     </div>

--- a/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
+++ b/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import * as Types from "../types";
-import { PrimaryButton, SecondaryButton } from "../../Button";
+import { PrimaryButton } from "../../Button";
 
 export interface InlineTaskCreatorProps {
   milestone: Types.Milestone | null;
@@ -81,16 +81,16 @@ export const InlineTaskCreator = forwardRef<InlineTaskCreatorHandle, InlineTaskC
             <PrimaryButton size="xs" disabled={!title.trim()} onClick={submit} className="w-full sm:w-auto">
               Add
             </PrimaryButton>
-            <SecondaryButton
-              size="xs"
-              className="w-full sm:w-auto"
+            <button
+              type="button"
+              className="w-full rounded-md px-2.5 py-1 text-sm font-semibold text-content-dimmed transition hover:bg-surface-dimmed hover:text-content-base sm:w-auto"
               onClick={() => {
                 setTitle("");
                 onCancel?.();
               }}
             >
               Cancel
-            </SecondaryButton>
+            </button>
           </div>
         </div>
       </div>

--- a/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
+++ b/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
@@ -65,7 +65,7 @@ export const InlineTaskCreator = forwardRef<InlineTaskCreatorHandle, InlineTaskC
 
     return (
       <div className="px-4 py-2.5 bg-surface-base">
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
           <input
             ref={inputRef}
             value={title}
@@ -74,21 +74,24 @@ export const InlineTaskCreator = forwardRef<InlineTaskCreatorHandle, InlineTaskC
             placeholder={placeholder}
             aria-label="Add task"
             data-test-id={testId || "inline-task-title"}
-            className="flex-1 rounded-md border border-surface-outline bg-transparent px-2 py-1 text-base sm:text-sm outline-none focus:border-indigo-500"
+            className="w-full rounded-md border border-surface-outline bg-transparent px-2 py-2 text-base outline-none focus:border-indigo-500 sm:flex-1 sm:py-1 sm:text-sm"
           />
 
-          <PrimaryButton size="xs" disabled={!title.trim()} onClick={submit}>
-            Add
-          </PrimaryButton>
-          <SecondaryButton
-            size="xs"
-            onClick={() => {
-              setTitle("");
-              onCancel?.();
-            }}
-          >
-            Cancel
-          </SecondaryButton>
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
+            <PrimaryButton size="xs" disabled={!title.trim()} onClick={submit} className="w-full sm:w-auto">
+              Add
+            </PrimaryButton>
+            <SecondaryButton
+              size="xs"
+              className="w-full sm:w-auto"
+              onClick={() => {
+                setTitle("");
+                onCancel?.();
+              }}
+            >
+              Cancel
+            </SecondaryButton>
+          </div>
         </div>
       </div>
     );

--- a/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
+++ b/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
@@ -17,7 +17,7 @@ export interface InlineTaskCreatorHandle {
 }
 
 export const InlineTaskCreator = forwardRef<InlineTaskCreatorHandle, InlineTaskCreatorProps>(
-  ({ milestone, onCreate, onRequestAdvanced, onCancel, placeholder = "Add a task...", testId, autoFocus }, ref) => {
+  ({ milestone, onCreate, onRequestAdvanced, onCancel, placeholder = "Task name", testId, autoFocus }, ref) => {
     const [title, setTitle] = useState("");
     const inputRef = useRef<HTMLInputElement | null>(null);
 

--- a/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
+++ b/turboui/src/TaskBoard/components/InlineTaskCreator.tsx
@@ -28,7 +28,14 @@ export const InlineTaskCreator = forwardRef<InlineTaskCreatorHandle, InlineTaskC
     }));
 
     useEffect(() => {
-      if (autoFocus) inputRef.current?.focus();
+      if (!autoFocus) return;
+
+      const input = inputRef.current;
+      input?.focus();
+
+      if (typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches) {
+        input?.scrollIntoView({ block: "center", inline: "nearest" });
+      }
     }, [autoFocus]);
 
     const submit = () => {

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -178,7 +178,13 @@ export function MilestoneCard({
               </Tooltip>
             )}
 
-            <SecondaryButton size="xs" icon={IconPlus} onClick={openCreator} testId="milestone-add-task">
+            <SecondaryButton
+              size="xs"
+              icon={IconPlus}
+              className="min-h-11 min-w-11 sm:min-h-0 sm:min-w-0"
+              onClick={openCreator}
+              testId="milestone-add-task"
+            >
               {/* icon-only for reduced repetition; keep accessible label */}
               <span className="sr-only">Add task</span>
             </SecondaryButton>

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -244,8 +244,9 @@ export function MilestoneCard({
                 </div>
               </>
             ) : (
-              <div className="text-center text-content-subtle text-sm">
-                Click + or press 'c' to add a task, or drag a task here.
+              <div className="text-left text-content-subtle text-sm sm:text-center">
+                <span className="sm:hidden">Tap + to add a task.</span>
+                <span className="hidden sm:inline">Click + or press 'c' to add a task, or drag a task here.</span>
               </div>
             )}
           </EmptyMilestoneDropZone>

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -67,6 +67,8 @@ export function MilestoneCard({
 
   // Generate default stats if not provided
   const milestoneStats = stats || calculateMilestoneStats(sortedTasks);
+  const completionPercentage = calculateCompletionPercentage(milestoneStats);
+  const completionLabel = `${Math.round(completionPercentage)}% complete`;
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const { open: creatorOpen, openCreator, closeCreator, creatorRef, hoverBind } = useInlineTaskCreator();
 
@@ -101,9 +103,11 @@ export function MilestoneCard({
             {/* Progress pie chart */}
             <PieChart
               size={16}
+              ariaLabel={`Milestone progress: ${completionLabel}`}
+              title={`Milestone progress: ${completionLabel}`}
               slices={[
                 {
-                  percentage: calculateCompletionPercentage(milestoneStats),
+                  percentage: completionPercentage,
                   color: "var(--color-callout-success-content)",
                 },
               ]}

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -239,7 +239,7 @@ export function MilestoneCard({
                   autoFocus
                   testId="inline-task-creator-empty"
                 />
-                <div className="px-4 pb-3 text-center text-content-subtle text-xs">
+                <div className="hidden px-4 pb-3 text-center text-content-subtle text-xs sm:block">
                   Press Enter to add. You can also drag tasks here.
                 </div>
               </>

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -112,11 +112,13 @@ export function MilestoneCard({
               <BlackLink
                 to={milestone.link || ""}
                 // Hover color change on medium+ screens (hover disabled on small screens to prevent double-tap on mobile) 
-                className="truncate text-sm font-semibold text-content-base md:hover:text-link-hover transition-colors min-w-0"
+                className="min-w-0 text-sm font-semibold text-content-base transition-colors md:hover:text-link-hover"
                 underline="hover"
                 title={milestone.name}
               >
-                <span className="truncate">{milestone.name}</span>
+                <span className="overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] sm:block sm:truncate">
+                  {milestone.name}
+                </span>
               </BlackLink>
 
               {/* Milestone indicators */}

--- a/turboui/src/TaskBoard/components/TaskDisplayMenu.tsx
+++ b/turboui/src/TaskBoard/components/TaskDisplayMenu.tsx
@@ -15,13 +15,13 @@ export function TaskDisplayMenu({ mode, onChange }: Props) {
     <Menu
       customTrigger={
         <button
-          className="inline-flex items-center gap-1 py-1.5 px-2 rounded-md text-sm font-medium text-content-dimmed hover:text-content-base hover:bg-surface-dimmed transition"
+          className="inline-flex min-h-11 min-w-11 items-center justify-center gap-0 rounded-md px-2 py-1.5 text-sm font-medium text-content-dimmed transition hover:bg-surface-dimmed hover:text-content-base sm:min-h-0 sm:min-w-0 sm:gap-1"
           aria-label="Display options"
           data-test-id="display-menu-trigger"
           type="button"
         >
           <IconAdjustmentsHorizontal size={18} />
-          <span>Display</span>
+          <span className="hidden sm:inline">Display</span>
         </button>
       }
       size="tiny"

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -158,8 +158,9 @@ export function TaskList({
 
         {/* Empty state message when no visible tasks but there are hidden tasks */}
         {visibleTasks.length === 0 && totalHiddenCount > 0 && showHiddenTasksToggle && (
-          <div className="py-3 px-4 text-center text-content-subtle text-sm bg-surface-base">
-            Click + or press c to add a task, or drag a task here.
+          <div className="py-3 px-4 text-left text-content-subtle text-sm bg-surface-base sm:text-center">
+            <span className="sm:hidden">Tap + to add a task.</span>
+            <span className="hidden sm:inline">Click + or press c to add a task, or drag a task here.</span>
           </div>
         )}
       </div>

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -175,11 +175,23 @@ export function TaskList({
             <div className="transition-transform duration-200">
               {hiddenTasksExpanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
             </div>
-            <span>
-              {hiddenTasksExpanded
-                ? `${totalHiddenCount} completed task${totalHiddenCount !== 1 ? "s" : ""} (click to collapse)`
-                : `Show ${totalHiddenCount} completed task${totalHiddenCount !== 1 ? "s" : ""}`}
-            </span>
+            {hiddenTasksExpanded ? (
+              <>
+                <span className="sm:hidden">Hide completed</span>
+                <span className="hidden sm:inline">
+                  {totalHiddenCount} completed task{totalHiddenCount !== 1 ? "s" : ""} (click to collapse)
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="sm:hidden">
+                  {totalHiddenCount} completed task{totalHiddenCount !== 1 ? "s" : ""}
+                </span>
+                <span className="hidden sm:inline">
+                  Show {totalHiddenCount} completed task{totalHiddenCount !== 1 ? "s" : ""}
+                </span>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/turboui/src/TaskBoard/components/TasksMenu.tsx
+++ b/turboui/src/TaskBoard/components/TasksMenu.tsx
@@ -39,7 +39,7 @@ export function TasksMenu({ canManageStatuses, statuses, onSaveCustomStatuses }:
         <Menu
           customTrigger={
             <button
-              className="p-1.5 text-content-dimmed hover:text-content-base hover:bg-surface-dimmed rounded-full transition"
+              className="flex min-h-11 min-w-11 items-center justify-center rounded-full text-content-dimmed transition hover:bg-surface-dimmed hover:text-content-base sm:min-h-0 sm:min-w-0 sm:p-1.5"
               aria-label="Settings"
             >
               <IconSettings size={20} />

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -235,6 +235,7 @@ export function TaskBoard({
                     <SecondaryButton
                       size="xs"
                       icon={IconPlus}
+                      className="min-h-11 min-w-11 sm:min-h-0 sm:min-w-0"
                       onClick={openNoMilestoneCreator}
                       testId="no-milestone-add-task"
                     >

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -315,8 +315,8 @@ function StickyActionBar({
   onDisplayModeChange,
 }: ActionBarProps) {
   return (
-    <header className="sticky top-0 z-10 flex flex-col sm:flex-row sm:items-center sm:justify-between py-6 bg-surface-base px-4 lg:px-0">
-      <div className="flex flex-row items-center gap-4">
+    <header className="sticky top-0 z-10 flex items-start justify-between gap-3 py-4 bg-surface-base px-4 sm:items-center sm:py-6 lg:px-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-4">
         {canCreateTask && (
           <PrimaryButton
             size="xs"
@@ -342,7 +342,7 @@ function StickyActionBar({
         {onFiltersChange && <FilterBadges filters={filters} onFiltersChange={onFiltersChange} />}
       </div>
 
-      <div className="flex items-center -mb-2">
+      <div className="flex flex-shrink-0 items-center gap-1 sm:-mb-2">
         <TasksMenu
           canManageStatuses={canManageStatuses}
           statuses={statuses}


### PR DESCRIPTION
Key areas changed:

  - Mobile inline task entry now stacks input/actions and scrolls into view.
  - Placeholder changed to Task name.
  - Cancel is now lower-emphasis.
  - Mobile add + targets are larger.
  - Milestone titles can wrap to two lines on mobile.
  - Desktop-only keyboard/drag hints are hidden or replaced with mobile copy.
  - Completed-task toggle is shorter on mobile.
  - TaskBoard action bar and project tabs are more compact on mobile.
  - Milestone progress indicators now have explicit labels.