### PR TITLE
feat: save local rich text drafts

### DIFF
--- a/app/assets/js/components/Forms/RichTextArea.tsx
+++ b/app/assets/js/components/Forms/RichTextArea.tsx
@@ -68,12 +68,16 @@ function ReadonlyContent(props: RichTextAreaProps) {
 function Editor(props: RichTextAreaProps & { error: boolean }) {
   const form = useFormContext();
   const [value, setValue] = useFieldValue(props.field);
+  const formState = React.useRef(form.state);
+  const clearDraft = React.useRef(() => {});
 
   const handlers = useRichEditorHandlers({ scope: props.mentionSearchScope });
   const editor = useEditor({
+    content: value,
     placeholder: props.placeholder,
     className: contentClassName(props),
     handlers,
+    localDraft: { key: localDraftKey(props.field) },
     onBlur: () => {
       setValue(editor.editor.getJSON());
     },
@@ -90,16 +94,50 @@ function Editor(props: RichTextAreaProps & { error: boolean }) {
   });
 
   React.useEffect(() => {
-    if (editor.editor) {
+    if (editor.editor && !editor.localDraftRestored) {
       editor.editor.commands.setContent(value);
     }
-  }, [editor.editor]);
+  }, [editor.editor, editor.localDraftRestored]);
+
+  React.useEffect(() => {
+    if (!editor.editor || !editor.localDraftRestored) return;
+
+    setValue(editor.editor.getJSON());
+  }, [editor.editor, editor.localDraftRestored]);
+
+  React.useEffect(() => {
+    if (!form.lastSubmitSucceededAt) return;
+
+    clearDraft.current();
+  }, [form.lastSubmitSucceededAt]);
+
+  React.useEffect(() => {
+    formState.current = form.state;
+  }, [form.state]);
+
+  React.useEffect(() => {
+    clearDraft.current = editor.clearLocalDraft;
+  }, [editor.clearLocalDraft]);
+
+  React.useEffect(() => {
+    return () => {
+      if (formState.current === "submitting") {
+        clearDraft.current();
+      }
+    };
+  }, []);
 
   return (
     <div className={wrapperClassName(props)}>
       <RichTextEditor editor={editor} hideToolbar={props.hideToolbar} hideBorder padding="p-0" />
     </div>
   );
+}
+
+function localDraftKey(field: string): string | undefined {
+  if (typeof window === "undefined") return undefined;
+
+  return `form:${window.location.pathname}:${field}`;
 }
 
 function contentClassName(props: RichTextAreaProps) {

--- a/app/assets/js/components/Forms/useForm.tsx
+++ b/app/assets/js/components/Forms/useForm.tsx
@@ -22,6 +22,7 @@ export interface FormState<T extends FieldObject> {
   values: T;
   state: State;
   trigger: string | undefined;
+  lastSubmitSucceededAt: number | undefined;
   errors: ErrorMap;
   hasErrors: boolean;
   hasCancel: boolean;
@@ -45,6 +46,7 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
   const hasCancel = !!props.cancel;
 
   const [errors, setErrors] = React.useState<ErrorMap>({});
+  const [lastSubmitSucceededAt, setLastSubmitSucceededAt] = React.useState<number | undefined>(undefined);
   const clearErrors = () => setErrors({});
   const hasErrors = Object.keys(errors).length > 0;
 
@@ -57,6 +59,7 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
     values,
     state,
     trigger,
+    lastSubmitSucceededAt,
     errors,
     hasErrors,
     hasCancel,
@@ -93,6 +96,7 @@ export function useForm<T extends FieldObject>(props: FormProps<T>): FormState<T
           setState("submitting");
           await props.submit(attrs);
           form.actions.clearErrors();
+          setLastSubmitSucceededAt(Date.now());
 
           setState("idle");
         } catch (e) {

--- a/app/assets/js/features/CommentSection/CommentSection.tsx
+++ b/app/assets/js/features/CommentSection/CommentSection.tsx
@@ -26,6 +26,7 @@ import {
   IconLink,
   useEditor,
   Editor,
+  useDraftActivatedInput,
   showSuccessToast,
   showErrorToast,
   emptyContent,
@@ -95,13 +96,22 @@ function EditComment({ comment, onCancel, form }) {
     className: "min-h-[200px] p-4",
     content: parseCommentContent(comment.content) ?? emptyContent(),
     handlers,
+    localDraft: { key: form.editCommentDraftKey?.(comment.id) },
   });
 
   const handlePost = async () => {
     if (!editor) return;
     if (editor.uploading) return;
 
-    form.editComment(comment.id, editor.editor.getJSON());
+    const success = await form.editComment(comment.id, editor.editor.getJSON());
+    if (success === false) return;
+
+    editor.clearLocalDraft();
+    onCancel();
+  };
+
+  const handleCancel = () => {
+    editor.clearLocalDraft();
     onCancel();
   };
 
@@ -118,7 +128,7 @@ function EditComment({ comment, onCancel, form }) {
                 {editor.uploading ? "Uploading..." : "Save Changes"}
               </PrimaryButton>
 
-              <SecondaryButton onClick={onCancel} size="xs">
+              <SecondaryButton onClick={handleCancel} size="xs">
                 Cancel
               </SecondaryButton>
             </div>
@@ -288,7 +298,7 @@ function AckComment({ person, ackAt }) {
 }
 
 function CommentBox({ form }) {
-  const [active, _, activate, deactivate] = useBoolState(false);
+  const { active, activate, deactivate } = useDraftActivatedInput(form.commentDraftKey);
 
   if (active) {
     return <AddCommentActive onBlur={deactivate} onPost={deactivate} form={form} />;
@@ -321,14 +331,23 @@ function AddCommentActive({ onBlur, onPost, form }) {
     className: "min-h-[200px] px-4 py-3",
     autoFocus: true,
     handlers,
+    localDraft: { key: form.commentDraftKey },
   });
 
   const handlePost = async () => {
     if (!editor) return;
     if (editor.uploading) return;
 
-    form.postComment(editor.editor.getJSON());
+    const success = await form.postComment(editor.editor.getJSON());
+    if (success === false) return;
+
+    editor.clearLocalDraft();
     onPost();
+  };
+
+  const handleCancel = () => {
+    editor.clearLocalDraft();
+    onBlur();
   };
 
   React.useEffect(() => {
@@ -350,7 +369,7 @@ function AddCommentActive({ onBlur, onPost, form }) {
                 {editor.uploading ? "Uploading..." : "Post"}
               </PrimaryButton>
 
-              <SecondaryButton onClick={onBlur} size="xs">
+              <SecondaryButton onClick={handleCancel} size="xs">
                 Cancel
               </SecondaryButton>
             </div>

--- a/app/assets/js/features/CommentSection/form.tsx
+++ b/app/assets/js/features/CommentSection/form.tsx
@@ -3,9 +3,11 @@ import * as People from "@/models/people";
 
 export interface FormState {
   items: CommentItem[];
-  postComment: (content: string) => void;
-  editComment: (commentID: string, content: string) => void;
+  postComment: (content: string) => Promise<boolean | void> | boolean | void;
+  editComment: (commentID: string, content: string) => Promise<boolean | void> | boolean | void;
   deleteComment: (commentID: string) => Promise<void>;
   submitting: boolean;
   mentionSearchScope: People.SearchScope;
+  commentDraftKey?: string;
+  editCommentDraftKey?: (commentID: string) => string;
 }

--- a/app/assets/js/features/CommentSection/useComments.tsx
+++ b/app/assets/js/features/CommentSection/useComments.tsx
@@ -37,6 +37,8 @@ export function useComments(props: Comments.CommentableResource): FormState {
       deleteComment: async (_commentID: string) => {},
       submitting: false,
       mentionSearchScope: { type: "none" },
+      commentDraftKey: undefined,
+      editCommentDraftKey: undefined,
     };
 
   if (error) throw error;
@@ -48,6 +50,8 @@ export function useComments(props: Comments.CommentableResource): FormState {
     deleteComment,
     submitting: creating || editing || deleting,
     mentionSearchScope: findMentionedScope(props),
+    commentDraftKey: `${props.parentType}:${parent.id}:new-comment`,
+    editCommentDraftKey: (commentID: string) => `${props.parentType}:${parent.id}:edit-comment:${commentID}`,
   };
 }
 

--- a/app/assets/js/features/CommentSection/utils/useCreateComment.tsx
+++ b/app/assets/js/features/CommentSection/utils/useCreateComment.tsx
@@ -44,10 +44,12 @@ export function useCreateComment({ setComments, entityId, entityType }: UseCreat
           }
         });
       });
+      return true;
     } catch (error) {
       setComments((comments) => {
         return comments.filter((c) => c.value.id !== tempId);
       });
+      return false;
     }
   };
 

--- a/app/assets/js/features/CommentSection/utils/useEditComment.tsx
+++ b/app/assets/js/features/CommentSection/utils/useEditComment.tsx
@@ -29,6 +29,7 @@ export function useEditComment({ comments, setComments, parentType }: UseEditCom
         content: Comments.stringifyCommentContent(content),
         parentType,
       });
+      return true;
     } catch {
       const comment = comments.find((c) => c.value.id === commentID)!;
 
@@ -41,6 +42,7 @@ export function useEditComment({ comments, setComments, parentType }: UseEditCom
           }
         }),
       );
+      return false;
     }
   };
 

--- a/app/assets/js/models/comments/useEditComment.tsx
+++ b/app/assets/js/models/comments/useEditComment.tsx
@@ -27,11 +27,13 @@ export function useEditComment<T extends { id?: string | null; content?: any }>(
         });
 
         invalidateCache();
+        return true;
       } catch (error) {
         if (comment) {
           setComments((prev) => prev.map((c) => (compareIds(c.id, commentId) ? { ...comment } : c)));
         }
         showErrorToast("Error", "Failed to edit comment.");
+        return false;
       }
     },
     [comments, parentType, invalidateCache, setComments],

--- a/app/assets/js/models/comments/useOptimisticComments.tsx
+++ b/app/assets/js/models/comments/useOptimisticComments.tsx
@@ -25,7 +25,7 @@ export function useOptimisticComments(opts: {
     async (content: any) => {
       if (!taskId || !me) {
         showErrorToast("Error", "Failed to add comment.");
-        return;
+        return false;
       }
 
       const tempId = `temp-comment-${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -52,15 +52,17 @@ export function useOptimisticComments(opts: {
         if (!realId) {
           setComments((prev) => prev.filter((c) => c.id !== tempId));
           showErrorToast("Error", "Failed to add comment.");
-          return;
+          return false;
         }
 
         setComments((prev) => prev.map((c) => (c.id === tempId ? { ...c, id: realId, insertedAt: realInsertedAt ?? c.insertedAt } : c)));
 
         onAfterMutation?.();
+        return true;
       } catch {
         setComments((prev) => prev.filter((c) => c.id !== tempId));
         showErrorToast("Error", "Failed to add comment.");
+        return false;
       }
     },
     [parentType, me, onAfterMutation, taskId],
@@ -73,7 +75,7 @@ export function useOptimisticComments(opts: {
 
       if (!taskId || !prevComment) {
         showErrorToast("Error", "Failed to edit comment.");
-        return;
+        return false;
       }
 
       setComments((prev) => prev.map((c) => (c.id === commentId ? { ...c, content: nextContent } : c)));
@@ -86,9 +88,11 @@ export function useOptimisticComments(opts: {
         });
 
         onAfterMutation?.();
+        return true;
       } catch {
         setComments((prev) => prev.map((c) => (c.id === commentId ? prevComment : c)));
         showErrorToast("Error", "Failed to edit comment.");
+        return false;
       }
     },
     [comments, onAfterMutation, parentType, taskId],

--- a/app/assets/js/models/tasks/useTaskSlideInProps.tsx
+++ b/app/assets/js/models/tasks/useTaskSlideInProps.tsx
@@ -328,6 +328,7 @@ export function useTaskSlideInProps(opts: {
 
         assigneePersonSearch: ctx.assigneePersonSearch,
         richTextHandlers: ctx.richTextHandlers,
+        localDraftKeyBase: `task:${taskId}`,
 
         canEdit,
 
@@ -337,12 +338,12 @@ export function useTaskSlideInProps(opts: {
         canComment: canComment,
 
         onAddComment: (content) => {
-          if (activeTaskId !== taskId) return;
-          addComment(content);
+          if (activeTaskId !== taskId) return false;
+          return addComment(content);
         },
         onEditComment: (commentId, content) => {
-          if (activeTaskId !== taskId) return;
-          editComment(commentId, content);
+          if (activeTaskId !== taskId) return false;
+          return editComment(commentId, content);
         },
         onDeleteComment: (commentId) => {
           if (activeTaskId !== taskId) return;

--- a/app/assets/js/pages/GoalPage/index.tsx
+++ b/app/assets/js/pages/GoalPage/index.tsx
@@ -274,6 +274,7 @@ function Page() {
     currentUser: currentUser ? People.parsePersonForTurboUi(paths, currentUser) : null,
 
     richTextHandlers: richEditorHandlers,
+    localDraftKeyBase: `goal:${goal.id}`,
 
     addTarget,
     deleteTarget,

--- a/app/assets/js/pages/GoalReopenPage/useForm.tsx
+++ b/app/assets/js/pages/GoalReopenPage/useForm.tsx
@@ -20,7 +20,8 @@ export function useForm(goal: Goals.Goal, subscriptionsState: SubscriptionsState
   const messageEditor = useEditor({
     placeholder: "Write here...",
     className: "min-h-[200px] py-2 font-medium",
-    handlers
+    handlers,
+    localDraft: { key: `goal:${goal.id}:reopen-message` },
   });
 
   const goalPath = paths.goalPath(goal.id!);
@@ -34,6 +35,7 @@ export function useForm(goal: Goals.Goal, subscriptionsState: SubscriptionsState
       sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
       subscriberIds: subscriptionsState.currentSubscribersList,
     });
+    messageEditor.clearLocalDraft();
     navigate(goalPath);
   };
 

--- a/app/assets/js/pages/MilestonePage/index.tsx
+++ b/app/assets/js/pages/MilestonePage/index.tsx
@@ -194,6 +194,7 @@ function Page() {
     onDeleteComment: handleDeleteComment,
     onAddReaction: handleAddReaction,
     onRemoveReaction: handleRemoveReaction,
+    localDraftKeyBase: `milestone:${milestone.id}`,
 
     // Core milestone data
     title,

--- a/app/assets/js/pages/MilestonePage/useComments.tsx
+++ b/app/assets/js/pages/MilestonePage/useComments.tsx
@@ -72,10 +72,13 @@ export function useComments(paths: Paths, milestone: Milestones.Milestone, inval
             });
           });
           invalidateCache();
+          return true;
         }
+        return false;
       } catch (error) {
         setComments((prev) => prev.filter((c) => c.id !== tempId));
         showErrorToast("Error", "Failed to add comment.");
+        return false;
       }
     },
     [paths, me, milestone.id],

--- a/app/assets/js/pages/ProfileEditPage/index.tsx
+++ b/app/assets/js/pages/ProfileEditPage/index.tsx
@@ -156,6 +156,7 @@ function Page() {
       canChangeAvatar={true}
       managerSearch={managerSearch}
       richTextHandlers={richTextHandlers}
+      localDraftKeyBase={`profile:${person.id}`}
       timezones={Timezones}
       isCurrentUser={isCurrentUser}
       fromLocation={from}

--- a/app/assets/js/pages/ProjectPage/index.tsx
+++ b/app/assets/js/pages/ProjectPage/index.tsx
@@ -328,6 +328,7 @@ function Page() {
     onSaveCustomStatuses: handleSaveStatuses,
 
     richTextHandlers: richEditorHandlers,
+    localDraftKeyBase: `project:${project.id}`,
 
     resources,
     onResourceAdd: createResource,

--- a/app/assets/js/pages/TaskPage/index.tsx
+++ b/app/assets/js/pages/TaskPage/index.tsx
@@ -271,6 +271,7 @@ function Page() {
     subscriptions,
 
     richTextHandlers: richEditorHandlers,
+    localDraftKeyBase: `task:${task.id}`,
   };
 
   return <TaskPage key={task.id} {...props} />;

--- a/turboui/src/CommentSection/CommentInput.tsx
+++ b/turboui/src/CommentSection/CommentInput.tsx
@@ -5,6 +5,7 @@ import { shortName } from "../Avatar/AvatarWithName";
 import { PrimaryButton, SecondaryButton } from "../Button";
 import { CommentInputProps, CommentNotificationInfo, Person } from "./types";
 import { Editor, useEditor } from "../RichEditor";
+import { useDraftActivatedInput } from "./useDraftActivatedInput";
 
 interface CommentInputActiveProps extends CommentInputProps {
   currentUser: Person;
@@ -23,25 +24,22 @@ export function CommentInput({
   richTextHandlers,
   notificationInfo,
 }: CommentInputProps & { currentUser: Person }) {
-  const [active, setActive] = useState(false);
-
-  const handleActivate = () => setActive(true);
-  const handleDeactivate = () => setActive(false);
+  const { active, activate, deactivate } = useDraftActivatedInput(form.commentDraftKey);
 
   if (active) {
     return (
       <CommentInputActive
         form={form}
         currentUser={currentUser}
-        onBlur={handleDeactivate}
-        onPost={handleDeactivate}
+        onBlur={deactivate}
+        onPost={deactivate}
         richTextHandlers={richTextHandlers}
         notificationInfo={notificationInfo}
       />
     );
   }
 
-  return <CommentInputInactive currentUser={currentUser} onClick={handleActivate} />;
+  return <CommentInputInactive currentUser={currentUser} onClick={activate} />;
 }
 
 function CommentInputInactive({ currentUser, onClick }: CommentInputInactiveProps) {
@@ -73,6 +71,7 @@ function CommentInputActive({
     handlers: richTextHandlers,
     autoFocus: true,
     className: "min-h-[200px] px-4 py-3",
+    localDraft: { key: form.commentDraftKey },
   });
 
   const handlePost = async () => {
@@ -81,7 +80,10 @@ function CommentInputActive({
     if (uploading) return;
 
     try {
-      form.postComment(content);
+      const success = await form.postComment(content);
+      if (success === false) return;
+
+      editor.clearLocalDraft();
       editor.setContent("");
       onPost();
     } catch (error) {
@@ -89,10 +91,15 @@ function CommentInputActive({
     }
   };
 
+  const handleCancel = () => {
+    editor.clearLocalDraft();
+    onBlur();
+  };
+
   React.useEffect(() => {
     const handleEscapeKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onBlur();
+        handleCancel();
       }
     };
 
@@ -100,7 +107,7 @@ function CommentInputActive({
     return () => {
       document.removeEventListener("keydown", handleEscapeKey);
     };
-  }, [onBlur]);
+  }, [handleCancel]);
 
   return (
     <div className="py-6 not-first:border-t border-stroke-base flex items-start gap-3" data-test-id="new-comment-form">
@@ -120,7 +127,7 @@ function CommentInputActive({
                 {uploading ? "Uploading..." : "Post"}
               </PrimaryButton>
 
-              <SecondaryButton size="xs" onClick={onBlur}>
+              <SecondaryButton size="xs" onClick={handleCancel}>
                 Cancel
               </SecondaryButton>
             </div>

--- a/turboui/src/CommentSection/CommentItem.tsx
+++ b/turboui/src/CommentSection/CommentItem.tsx
@@ -57,9 +57,11 @@ export function CommentItem({
 
   const canAddReaction = Boolean(canComment && onAddReaction);
 
-  const handleSaveEdit = (content: any) => {
+  const handleSaveEdit = async (content: any) => {
     if (form && form.editComment) {
-      form.editComment(comment.id, content);
+      const success = await form.editComment(comment.id, content);
+      if (success === false) return;
+
       setIsEditing(false);
     }
   };
@@ -128,6 +130,7 @@ export function CommentItem({
             onSave={handleSaveEdit}
             onCancel={() => setIsEditing(false)}
             richTextHandlers={richTextHandlers}
+            localDraftKey={form.editCommentDraftKey?.(comment.id)}
           />
         ) : (
           <CommentViewMode
@@ -240,23 +243,33 @@ function CommentViewMode({
 
 interface CommentEditModeProps {
   content: any;
-  onSave: (content: any) => void;
+  onSave: (content: any) => Promise<boolean | void> | boolean | void;
   onCancel: () => void;
   richTextHandlers: RichEditorHandlers;
+  localDraftKey?: string;
 }
 
-function CommentEditMode({ content, onSave, onCancel, richTextHandlers }: CommentEditModeProps) {
+function CommentEditMode({ content, onSave, onCancel, richTextHandlers, localDraftKey }: CommentEditModeProps) {
   const editor = useEditor({
     content: content,
     editable: true,
     placeholder: "Edit your comment...",
     handlers: richTextHandlers,
+    localDraft: { key: localDraftKey },
   });
 
-  const handleSave = () => {
+  const handleSave = async () => {
     const updatedContent = editor.getJson();
     if (!updatedContent || editor.empty) return;
-    onSave(updatedContent);
+    const success = await onSave(updatedContent);
+    if (success === false) return;
+
+    editor.clearLocalDraft();
+  };
+
+  const handleCancel = () => {
+    editor.clearLocalDraft();
+    onCancel();
   };
 
   return (
@@ -266,7 +279,7 @@ function CommentEditMode({ content, onSave, onCancel, richTextHandlers }: Commen
         <PrimaryButton size="xs" onClick={handleSave} disabled={editor.empty}>
           Save
         </PrimaryButton>
-        <SecondaryButton size="xs" onClick={onCancel}>
+        <SecondaryButton size="xs" onClick={handleCancel}>
           Cancel
         </SecondaryButton>
       </div>

--- a/turboui/src/CommentSection/types.ts
+++ b/turboui/src/CommentSection/types.ts
@@ -38,9 +38,11 @@ export interface CommentFormState {
   items: CommentItem[];
   submitting: boolean;
   mentionSearchScope?: any;
-  postComment: (content: any) => void;
-  editComment: (id: string, content: any) => void;
-  deleteComment?: (id: string) => void;
+  postComment: (content: any) => Promise<boolean | void> | boolean | void;
+  editComment: (id: string, content: any) => Promise<boolean | void> | boolean | void;
+  deleteComment?: (id: string) => Promise<void> | void;
+  commentDraftKey?: string;
+  editCommentDraftKey?: (id: string) => string | undefined;
 }
 
 export interface CommentItemProps {

--- a/turboui/src/CommentSection/useDraftActivatedInput.ts
+++ b/turboui/src/CommentSection/useDraftActivatedInput.ts
@@ -1,0 +1,18 @@
+import React from "react";
+import { hasLocalDraft } from "../RichEditor";
+
+export function useDraftActivatedInput(commentDraftKey?: string) {
+  const [active, setActive] = React.useState(() => hasLocalDraft({ key: commentDraftKey }, undefined));
+
+  const activate = React.useCallback(() => setActive(true), []);
+  const deactivate = React.useCallback(() => setActive(false), []);
+
+  React.useEffect(() => {
+    if (active) return;
+    if (!hasLocalDraft({ key: commentDraftKey }, undefined)) return;
+
+    setActive(true);
+  }, [active, commentDraftKey]);
+
+  return { active, activate, deactivate };
+}

--- a/turboui/src/GoalPage/Overview.tsx
+++ b/turboui/src/GoalPage/Overview.tsx
@@ -30,6 +30,7 @@ function MainContent(props: GoalPage.State) {
         label="Goal description"
         placeholder="Describe the goal..."
         zeroStatePlaceholder="Describe the goal to provide context and clarity."
+        localDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:description` : undefined}
       />
       <Targets {...props} />
       <Checklists {...props} />

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -166,6 +166,7 @@ export namespace GoalPage {
 
     // Rich text support
     richTextHandlers: RichEditorHandlers;
+    localDraftKeyBase?: string;
   }
 
   export type Props = CommonProps & SpaceProps;

--- a/turboui/src/MilestonePage/index.tsx
+++ b/turboui/src/MilestonePage/index.tsx
@@ -116,6 +116,7 @@ export namespace MilestonePage {
 
     // Rich editor support for description and comments
     richTextHandlers: RichEditorHandlers;
+    localDraftKeyBase?: string;
   };
 
   export type State = Props & {
@@ -231,6 +232,7 @@ export function MilestonePage(props: MilestonePage.Props) {
               placeholder="Describe the milestone..."
               zeroStatePlaceholder="Add details about this milestone..."
               emptyTestId="description-section-empty"
+              localDraftKey={state.localDraftKeyBase ? `${state.localDraftKeyBase}:description` : undefined}
             />
 
             <TasksSection {...state} />
@@ -346,6 +348,7 @@ function TimelineSection(props: MilestonePage.State) {
         onAddReaction={props.onAddReaction}
         onRemoveReaction={props.onRemoveReaction}
         richTextHandlers={props.richTextHandlers}
+        commentDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:new-comment` : undefined}
         commentNotificationInfo={{
           entityLabel: "milestone",
           subscribedPeople: props.subscriptions.subscribedPeople ?? [],

--- a/turboui/src/PageDescription/index.tsx
+++ b/turboui/src/PageDescription/index.tsx
@@ -16,6 +16,7 @@ interface Props {
   zeroStatePlaceholder?: string;
   testId?: string;
   emptyTestId?: string;
+  localDraftKey?: string;
 }
 
 export function PageDescription({
@@ -28,6 +29,7 @@ export function PageDescription({
   zeroStatePlaceholder = "Add notes...",
   testId,
   emptyTestId,
+  localDraftKey,
 }: Props) {
   const initialMode = isContentEmpty(description) ? "zero" : "view";
   const [mode, setMode] = useState<"view" | "edit" | "zero">(initialMode);
@@ -54,6 +56,7 @@ export function PageDescription({
           onDescriptionChange={onDescriptionChange}
           setMode={setMode}
           placeholder={placeholder}
+          localDraftKey={localDraftKey}
         />
       )}
     </div>
@@ -106,15 +109,17 @@ interface EditModeProps {
   onDescriptionChange: (newDescription: any) => Promise<boolean>;
   setMode: React.Dispatch<React.SetStateAction<"view" | "edit" | "zero">>;
   placeholder: string;
+  localDraftKey?: string;
 }
 
-function EditMode({ description, richTextHandlers, onDescriptionChange, setMode, placeholder }: EditModeProps) {
+function EditMode({ description, richTextHandlers, onDescriptionChange, setMode, placeholder, localDraftKey }: EditModeProps) {
   const editor = useEditor({
     content: description,
     editable: true,
     placeholder,
     handlers: richTextHandlers,
     autoFocus: true,
+    localDraft: { key: localDraftKey },
   });
 
   const save = useCallback(async () => {
@@ -122,6 +127,8 @@ function EditMode({ description, richTextHandlers, onDescriptionChange, setMode,
     const success = await onDescriptionChange(content);
 
     if (success) {
+      editor.clearLocalDraft();
+
       if (isContentEmpty(content)) {
         setMode("zero");
       } else {
@@ -131,8 +138,9 @@ function EditMode({ description, richTextHandlers, onDescriptionChange, setMode,
   }, [editor, setMode, onDescriptionChange]);
 
   const cancel = useCallback(() => {
+    editor.clearLocalDraft();
     setMode(isContentEmpty(description) ? "zero" : "view");
-  }, [setMode]);
+  }, [editor, setMode, description]);
 
   return (
     <div className="mt-2">

--- a/turboui/src/ProfileEditPage/index.tsx
+++ b/turboui/src/ProfileEditPage/index.tsx
@@ -59,6 +59,7 @@ export namespace ProfileEditPage {
 
     // Rich text handlers
     richTextHandlers: RichEditorHandlers;
+    localDraftKeyBase?: string;
 
     // Options
     timezones: Timezone[];
@@ -125,6 +126,7 @@ export function ProfileEditPage(props: ProfileEditPage.Props) {
                   value={props.aboutMe}
                   onChange={props.onAboutMeChange}
                   handlers={props.richTextHandlers}
+                  localDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:about-me` : undefined}
                 />
               </div>
             )}
@@ -198,22 +200,32 @@ function AboutMeEditor({
   value,
   onChange,
   handlers,
+  localDraftKey,
 }: {
   value: any;
   onChange: (value: any) => void;
   handlers: RichEditorHandlers;
+  localDraftKey?: string;
 }) {
   const editor = useEditor({
     handlers,
     placeholder: "Share a short bio, what you work on, or anything you'd like others to know.",
     onUpdate: ({ json }) => onChange(json),
+    content: value,
+    localDraft: { key: localDraftKey },
   });
 
   React.useEffect(() => {
-    if (editor.editor) {
+    if (editor.editor && !editor.localDraftRestored) {
       editor.editor.commands.setContent(value);
     }
-  }, [editor.editor]);
+  }, [editor.editor, editor.localDraftRestored]);
+
+  React.useEffect(() => {
+    if (!editor.editor || !editor.localDraftRestored) return;
+
+    onChange(editor.editor.getJSON());
+  }, [editor.editor, editor.localDraftRestored]);
 
   return <Editor editor={editor} />;
 }

--- a/turboui/src/ProjectPage/Overview.tsx
+++ b/turboui/src/ProjectPage/Overview.tsx
@@ -52,6 +52,7 @@ function OverviewSection(props: ProjectPage.State) {
         label="Description"
         placeholder="Add a project description..."
         zeroStatePlaceholder="Add a project description..."
+        localDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:description` : undefined}
       />
     </div>
   );

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -173,6 +173,7 @@ export namespace ProjectPage {
     currentUser?: Person | null;
 
     richTextHandlers: RichEditorHandlers;
+    localDraftKeyBase?: string;
 
     onTaskDescriptionChange: (taskId: string, description: any) => Promise<boolean>;
     getTaskPageProps: KanbanBoardProps["getTaskPageProps"];

--- a/turboui/src/RichEditor/index.stories.tsx
+++ b/turboui/src/RichEditor/index.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { Editor, useEditor } from "./index";
 import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
+import { PrimaryButton } from "../Button";
 
 const meta: Meta<typeof Editor> = {
   title: "Components/RichEditor",
@@ -51,5 +52,39 @@ export const WithContent: Story = {
     });
 
     return <Editor editor={editor} />;
+  },
+};
+
+export const WithLocalDraft: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Direct useEditor consumers should pass a stable localDraft key and clear it only after confirmed save success.",
+      },
+    },
+  },
+  render: () => {
+    const [savedContent, setSavedContent] = React.useState<any>(null);
+    const editor = useEditor({
+      placeholder: "Type something, refresh Storybook, and reopen this story...",
+      handlers: createMockRichEditorHandlers(),
+      localDraft: { key: "storybook:rich-editor:local-draft" },
+    });
+
+    const save = async () => {
+      setSavedContent(editor.getJson());
+      editor.clearLocalDraft();
+    };
+
+    return (
+      <div className="space-y-3">
+        <Editor editor={editor} />
+        <PrimaryButton size="sm" onClick={save}>
+          Save
+        </PrimaryButton>
+        {savedContent && <div className="text-xs text-content-dimmed">Saved in story state</div>}
+      </div>
+    );
   },
 };

--- a/turboui/src/RichEditor/index.tsx
+++ b/turboui/src/RichEditor/index.tsx
@@ -8,6 +8,7 @@ import classNames from "../utils/classnames";
 
 export { useEditor } from "./useEditor";
 export type { MentionedPersonLookupFn } from "./useEditor";
+export { hasLocalDraft } from "./localDrafts";
 
 interface EditorProps {
   editor: EditorState;

--- a/turboui/src/RichEditor/localDrafts.test.ts
+++ b/turboui/src/RichEditor/localDrafts.test.ts
@@ -1,0 +1,69 @@
+import { clearLocalDraft, hasLocalDraft, isRichTextEmpty, readLocalDraft, writeLocalDraft } from "./localDrafts";
+
+const emptyDoc = { type: "doc", content: [{ type: "paragraph" }] };
+const baseDoc = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Original" }] }] };
+const draftDoc = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Draft" }] }] };
+
+describe("local rich text drafts", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    jest.spyOn(Date, "now").mockReturnValue(1_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("restores a draft when it was based on the current content", () => {
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+
+    expect(readLocalDraft({ key: "task:1:description" }, baseDoc)).toEqual(draftDoc);
+  });
+
+  it("restores a draft for editors that started without content", () => {
+    writeLocalDraft({ key: "discussion:1:new-comment" }, draftDoc, undefined);
+
+    expect(readLocalDraft({ key: "discussion:1:new-comment" }, undefined)).toEqual(draftDoc);
+    expect(hasLocalDraft({ key: "discussion:1:new-comment" }, undefined)).toBe(true);
+  });
+
+  it("does not restore a draft when the base content changed", () => {
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+
+    const changedBase = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "Changed" }] }] };
+
+    expect(readLocalDraft({ key: "task:1:description" }, changedBase)).toBeNull();
+  });
+
+  it("removes drafts that match the base content or are empty", () => {
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+    writeLocalDraft({ key: "task:1:description" }, baseDoc, baseDoc);
+
+    expect(readLocalDraft({ key: "task:1:description" }, baseDoc)).toBeNull();
+
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+    writeLocalDraft({ key: "task:1:description" }, emptyDoc, baseDoc);
+
+    expect(readLocalDraft({ key: "task:1:description" }, baseDoc)).toBeNull();
+  });
+
+  it("expires old drafts", () => {
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+
+    jest.spyOn(Date, "now").mockReturnValue(3_000);
+
+    expect(readLocalDraft({ key: "task:1:description", ttlMs: 1_000 }, baseDoc)).toBeNull();
+  });
+
+  it("clears a draft explicitly", () => {
+    writeLocalDraft({ key: "task:1:description" }, draftDoc, baseDoc);
+    clearLocalDraft({ key: "task:1:description" });
+
+    expect(readLocalDraft({ key: "task:1:description" }, baseDoc)).toBeNull();
+  });
+
+  it("treats blank rich text documents as empty", () => {
+    expect(isRichTextEmpty(emptyDoc)).toBe(true);
+    expect(isRichTextEmpty(draftDoc)).toBe(false);
+  });
+});

--- a/turboui/src/RichEditor/localDrafts.ts
+++ b/turboui/src/RichEditor/localDrafts.ts
@@ -1,0 +1,174 @@
+const STORAGE_PREFIX = "operately:rich-text-draft:";
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+interface DraftPayload {
+  content: any;
+  baseContent: any;
+  updatedAt: number;
+}
+
+export interface LocalDraftOptions {
+  key?: string;
+  enabled?: boolean;
+  ttlMs?: number;
+}
+
+export function readLocalDraft(options: LocalDraftOptions | undefined, baseContent: any): any | null {
+  const key = storageKey(options);
+  if (!key) return null;
+
+  const storage = getLocalStorage();
+  if (!storage) return null;
+
+  const raw = safeRead(storage, key);
+  if (!raw) return null;
+
+  const payload = parsePayload(raw);
+  if (!payload) {
+    safeRemove(storage, key);
+    return null;
+  }
+
+  const ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+
+  if (Date.now() - payload.updatedAt > ttlMs) {
+    safeRemove(storage, key);
+    return null;
+  }
+
+  if (!contentEquals(payload.baseContent, baseContent)) {
+    return null;
+  }
+
+  return payload.content;
+}
+
+export function writeLocalDraft(options: LocalDraftOptions | undefined, content: any, baseContent: any): void {
+  const key = storageKey(options);
+  if (!key) return;
+
+  const storage = getLocalStorage();
+  if (!storage) return;
+
+  if (isRichTextEmpty(content) || contentEquals(content, baseContent)) {
+    safeRemove(storage, key);
+    return;
+  }
+
+  safeWrite(
+    storage,
+    key,
+    JSON.stringify({
+      content,
+      baseContent: normalizeEmptyContent(baseContent),
+      updatedAt: Date.now(),
+    } satisfies DraftPayload),
+  );
+}
+
+export function hasLocalDraft(options: LocalDraftOptions | undefined, baseContent: any): boolean {
+  return readLocalDraft(options, baseContent) !== null;
+}
+
+export function clearLocalDraft(options: LocalDraftOptions | undefined): void {
+  const key = storageKey(options);
+  if (!key) return;
+
+  const storage = getLocalStorage();
+  if (!storage) return;
+
+  safeRemove(storage, key);
+}
+
+export function isRichTextEmpty(content: any): boolean {
+  if (!content) return true;
+  if (content === "") return true;
+
+  if (typeof content === "string") {
+    try {
+      return isRichTextEmpty(JSON.parse(content));
+    } catch {
+      return content.trim() === "";
+    }
+  }
+
+  if (content.type === "doc" && Array.isArray(content.content)) {
+    return content.content.every(isRichTextEmpty);
+  }
+
+  if (content.type === "paragraph" && !content.content) {
+    return true;
+  }
+
+  if (Array.isArray(content.content)) {
+    return content.content.every(isRichTextEmpty);
+  }
+
+  if (typeof content.text === "string") {
+    return content.text.trim() === "";
+  }
+
+  return false;
+}
+
+function storageKey(options: LocalDraftOptions | undefined): string | null {
+  if (!options?.key || options.enabled === false) return null;
+
+  return STORAGE_PREFIX + options.key;
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function parsePayload(raw: string): DraftPayload | null {
+  try {
+    const payload = JSON.parse(raw);
+
+    if (typeof payload?.updatedAt !== "number") return null;
+    if (!("content" in payload)) return null;
+    if (!("baseContent" in payload)) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+function contentEquals(left: any, right: any): boolean {
+  return JSON.stringify(normalizeEmptyContent(left)) === JSON.stringify(normalizeEmptyContent(right));
+}
+
+function normalizeEmptyContent(content: any): any {
+  return isRichTextEmpty(content) ? null : content;
+}
+
+function safeRead(storage: Storage, key: string): string | null {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeWrite(storage: Storage, key: string, value: string): void {
+  try {
+    storage.setItem(key, value);
+  } catch {
+    // Local drafts are best-effort only.
+  }
+}
+
+function safeRemove(storage: Storage, key: string): void {
+  try {
+    storage.removeItem(key);
+  } catch {
+    // Local drafts are best-effort only.
+  }
+}

--- a/turboui/src/RichEditor/useEditor.tsx
+++ b/turboui/src/RichEditor/useEditor.tsx
@@ -8,6 +8,13 @@ import StarterKit from "@tiptap/starter-kit";
 import Blob, { isUploadInProgress } from "./Blob";
 import FakeTextSelection from "./extensions/FakeTextSelection";
 import Highlight from "./extensions/Highlight";
+import {
+  clearLocalDraft,
+  isRichTextEmpty,
+  LocalDraftOptions,
+  readLocalDraft,
+  writeLocalDraft,
+} from "./localDrafts";
 import MentionPeople, { SearchFn } from "./extensions/MentionPeople";
 
 export interface Person {
@@ -48,6 +55,7 @@ interface UseEditorProps {
   editable?: boolean;
   autoFocus?: boolean;
   tabindex?: string;
+  localDraft?: LocalDraftOptions;
 
   handlers: RichEditorHandlers;
 }
@@ -65,6 +73,8 @@ export interface EditorState {
   setContent: (content: any) => void;
   setFocused: (focused: boolean) => void;
   getJson: () => any;
+  localDraftRestored: boolean;
+  clearLocalDraft: () => void;
 }
 
 const DEFAULT_EDITOR_PROPS: Partial<UseEditorProps> = {
@@ -85,8 +95,11 @@ export function useEditor(props: UseEditorProps): EditorState {
   const [linkEditActive, setLinkEditActive] = React.useState(false);
   const [submittable, setSubmittable] = React.useState(true);
   const [focused, setFocused] = React.useState(false);
-  const [empty, setEmpty] = React.useState(props.content === undefined || props.content === "");
   const [uploading, setUploading] = React.useState(false);
+  const baseContent = React.useRef(props.content);
+  const [restoredDraft] = React.useState(() => readLocalDraft(props.localDraft, baseContent.current));
+  const initialContent = restoredDraft ?? props.content;
+  const [empty, setEmpty] = React.useState(isRichTextEmpty(initialContent));
 
   const mentionPeople = React.useMemo(() => {
     return MentionPeople.configure(props.handlers.peopleSearch);
@@ -94,7 +107,7 @@ export function useEditor(props: UseEditorProps): EditorState {
 
   const editor = TipTap.useEditor({
     editable: props.editable,
-    content: props.content,
+    content: initialContent,
     autofocus: props.autoFocus,
     injectCSS: false,
     editorProps: {
@@ -150,11 +163,17 @@ export function useEditor(props: UseEditorProps): EditorState {
       setUploading(isUploading);
       setSubmittable(!isUploading);
 
+      const json = editor.getJSON();
+
       setEmpty(editor.state.doc.childCount === 1 && editor.state.doc.firstChild?.childCount === 0);
+
+      if (props.editable && !isUploading) {
+        writeLocalDraft(props.localDraft, json, baseContent.current);
+      }
 
       if (props.onUpdate) {
         props.onUpdate({
-          json: editor.getJSON(),
+          json,
           html: editor.getHTML(),
         });
       }
@@ -173,6 +192,10 @@ export function useEditor(props: UseEditorProps): EditorState {
     if (!editor) return null;
     return editor.getJSON();
   }, [editor]);
+
+  const clearDraft = React.useCallback(() => {
+    clearLocalDraft(props.localDraft);
+  }, [props.localDraft?.key, props.localDraft?.enabled, props.localDraft?.ttlMs]);
 
   React.useEffect(() => {
     if (!editor) return;
@@ -195,5 +218,7 @@ export function useEditor(props: UseEditorProps): EditorState {
     setContent,
     setFocused,
     getJson,
+    localDraftRestored: Boolean(restoredDraft),
+    clearLocalDraft: clearDraft,
   };
 }

--- a/turboui/src/TaskPage/Overview.tsx
+++ b/turboui/src/TaskPage/Overview.tsx
@@ -11,6 +11,7 @@ export function Overview(props: TaskPage.ContentState) {
         label="Notes"
         placeholder="Describe the task..."
         zeroStatePlaceholder="Add notes about this task..."
+        localDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:description` : undefined}
       />
       <ActivitySection {...props} />
     </div>
@@ -34,6 +35,7 @@ function ActivitySection(props: TaskPage.ContentState) {
           onAddReaction={props.onAddReaction}
           onRemoveReaction={props.onRemoveReaction}
           richTextHandlers={props.richTextHandlers}
+          commentDraftKey={props.localDraftKeyBase ? `${props.localDraftKeyBase}:new-comment` : undefined}
           filters={props.timelineFilters}
           commentNotificationInfo={{
             entityLabel: "task",

--- a/turboui/src/TaskPage/index.tsx
+++ b/turboui/src/TaskPage/index.tsx
@@ -111,6 +111,7 @@ export namespace TaskPage {
     // Assignee selection
     assigneePersonSearch: PersonField.SearchData;
     richTextHandlers: RichEditorHandlers;
+    localDraftKeyBase?: string;
 
     // Permissions
     permissions: ProjectPermissions;
@@ -159,6 +160,7 @@ export namespace TaskPage {
     | "projectSearch"
     | "assigneePersonSearch"
     | "richTextHandlers"
+    | "localDraftKeyBase"
     | "canEdit"
     | "timelineItems"
     | "timelineIsLoading"
@@ -234,6 +236,7 @@ function useTaskPageState(props: TaskPage.Props): TaskPage.ContentState {
     spaceSearch: props.spaceSearch,
     assigneePersonSearch: props.assigneePersonSearch,
     richTextHandlers: props.richTextHandlers,
+    localDraftKeyBase: props.localDraftKeyBase,
     canEdit: props.canEdit,
     timelineItems: props.timelineItems,
     timelineIsLoading: props.timelineIsLoading,

--- a/turboui/src/Timeline/Timeline.tsx
+++ b/turboui/src/Timeline/Timeline.tsx
@@ -26,6 +26,7 @@ export function Timeline({
   richTextHandlers,
   filters,
   commentNotificationInfo,
+  commentDraftKey,
 }: Timeline.Props) {
   if (isLoading) {
     return <TimelineSkeleton />;
@@ -72,8 +73,11 @@ export function Timeline({
       editComment: onEditComment || (() => {}),
       addReaction: onAddReaction,
       removeReaction: onRemoveReaction,
+      commentDraftKey,
+      editCommentDraftKey: (commentId: string) =>
+        commentDraftKey ? `${commentDraftKey}:edit-comment:${commentId}` : undefined,
     }),
-    [onAddComment, onEditComment, onAddReaction, onRemoveReaction],
+    [onAddComment, onEditComment, onAddReaction, onRemoveReaction, commentDraftKey],
   );
 
   return (
@@ -91,6 +95,7 @@ export function Timeline({
             onEditComment={onEditComment}
             onDeleteComment={onDeleteComment}
             richTextHandlers={richTextHandlers}
+            commentDraftKey={commentDraftKey}
             onAddReaction={onAddReaction}
             onRemoveReaction={onRemoveReaction}
           />

--- a/turboui/src/Timeline/TimelineItem.tsx
+++ b/turboui/src/Timeline/TimelineItem.tsx
@@ -19,6 +19,7 @@ export function TimelineItem({
   onEditComment,
   onDeleteComment,
   richTextHandlers,
+  commentDraftKey,
   onAddReaction,
   onRemoveReaction,
 }: TimelineItemProps) {
@@ -33,6 +34,8 @@ export function TimelineItem({
             postComment: () => {},
             editComment: onEditComment,
             deleteComment: onDeleteComment,
+            editCommentDraftKey: (commentId: string) =>
+              commentDraftKey ? `${commentDraftKey}:edit-comment:${commentId}` : undefined,
           }}
           commentParentType={commentParentType}
           canComment={canComment}

--- a/turboui/src/Timeline/types.ts
+++ b/turboui/src/Timeline/types.ts
@@ -163,14 +163,15 @@ export interface TimelineProps {
   currentUser: Person;
   canComment: boolean;
   commentParentType: string;
-  onAddComment: (content: any) => void;
-  onEditComment: (id: string, content: any) => void;
-  onDeleteComment: (id: string) => void;
+  onAddComment: (content: any) => Promise<boolean | void> | boolean | void;
+  onEditComment: (id: string, content: any) => Promise<boolean | void> | boolean | void;
+  onDeleteComment: (id: string) => Promise<void> | void;
   onAddReaction?: (commentId: string, emoji: string) => void | Promise<void>;
   onRemoveReaction?: (commentId: string, reactionId: string) => void | Promise<void>;
   filters?: TimelineFilters;
   richTextHandlers: RichEditorHandlers;
   commentNotificationInfo?: CommentNotificationInfo;
+  commentDraftKey?: string;
 }
 
 export interface TimelineFilters {
@@ -188,9 +189,10 @@ export interface TimelineItemProps {
   currentUser: Person;
   canComment: boolean;
   commentParentType: string;
-  onEditComment: (id: string, content: any) => void;
-  onDeleteComment: (id: string) => void;
+  onEditComment: (id: string, content: any) => Promise<boolean | void> | boolean | void;
+  onDeleteComment: (id: string) => Promise<void> | void;
   richTextHandlers: RichEditorHandlers;
+  commentDraftKey?: string;
   onAddReaction?: (commentId: string, emoji: string) => void | Promise<void>;
   onRemoveReaction?: (commentId: string, reactionId: string) => void | Promise<void>;
 }

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -4,6 +4,7 @@ export * from "./Avatar";
 export * from "./Button";
 export * from "./Chronometer";
 export * from "./CommentSection";
+export { useDraftActivatedInput } from "./CommentSection/useDraftActivatedInput";
 export * from "./CopyToClipboard";
 export * from "./ConfirmDialog";
 export * from "./FormattedTime";
@@ -73,7 +74,7 @@ export { SubscribersSelector, CurrentSubscriptions } from "./Subscriptions";
 export { SpaceKanbanPage } from "./SpaceKanbanPage";
 
 export { Summary } from "./RichContent";
-export { Editor, useEditor } from "./RichEditor";
+export { Editor, hasLocalDraft, useEditor } from "./RichEditor";
 export type { RichEditorHandlers } from "./RichEditor/useEditor";
 export { RichContent };
 


### PR DESCRIPTION
Resolves #4486.

Adds ephemeral local draft recovery for rich text editors so user-typed content survives page refreshes,
  navigation interruptions, and accidental reloads without persisting drafts server-side.

  The core implementation lives in TurboUI’s rich editor layer:

  - `turboui/src/RichEditor/localDrafts.ts`
  - `turboui/src/RichEditor/useEditor.tsx`

  Drafts are stored in localStorage with:

  - per-editor draft keys
  - 24h expiry
  - base-content matching, so stale drafts are not restored over newer server content
  - best-effort storage safety
  - cleanup on successful save/submit or explicit cancel

  Coverage was wired through existing shared rich text surfaces:

  - Forms.RichTextArea
  - app comment sections
  - TurboUI comment/timeline inputs
  - task, milestone, project, and goal descriptions
  - task slide-ins
  - profile “About me”
  - goal reopen message

  ### Important For Future Rich Text Screens

  If you use Forms.RichTextArea, draft recovery is automatic. The draft key is derived from:

```
  form:${window.location.pathname}:${field}
```

  If you use TurboUI useEditor directly, pass a stable localDraft key:

```
  const editor = useEditor({
    content,
    handlers,
    localDraft: { key: `resource-type:${resourceId}:field-name` },
  });
```

  Then clear the draft only after confirmed success:

```
  const success = await save(editor.getJson());
  if (success === false) return;

  editor.clearLocalDraft();
```

  For comment-style collapsed editors, use:

```
  useDraftActivatedInput(commentDraftKey)
```

  That auto-opens the composer when a saved draft exists.

  ### Design Notes

  The logic is intentionally centralized in RichEditor/localDrafts.ts and useEditor, but draft identity still has
  to be supplied by the screen or component that knows the resource ID. That’s why several files changed: most
  edits are just passing stable draft keys down to shared editor components.

  The one thing to avoid: clearing drafts optimistically before a mutation has truly succeeded. Handlers that
  swallow failures should return false, and editors preserve drafts when they see false.