### PR TITLE
feat: add task keyboard navigation

### DIFF
--- a/turboui/src/MilestonePage/components/TasksSection.tsx
+++ b/turboui/src/MilestonePage/components/TasksSection.tsx
@@ -15,6 +15,7 @@ import { FilterBadges } from "../../TaskBoard/components/TaskFilter";
 import TaskList from "../../TaskBoard/components/TaskList";
 import { InlineTaskCreator } from "../../TaskBoard/components/InlineTaskCreator";
 import { useInlineTaskCreator } from "../../TaskBoard/hooks/useInlineTaskCreator";
+import { useTaskKeyboardNavigation } from "../../TaskBoard/hooks/useTaskKeyboardNavigation";
 import { sortTasks } from "../../TaskBoard/utils/sortTasks";
 
 export function TasksSection({
@@ -32,6 +33,12 @@ export function TasksSection({
   statusOptions,
 }: MilestonePage.State) {
   const {
+    containerRef: keyboardNavigationRef,
+    selectedTaskId,
+    clearSelection: clearTaskSelection,
+    scopeBind: keyboardNavigationScopeBind,
+  } = useTaskKeyboardNavigation<HTMLDivElement>();
+  const {
     open: creatorOpen,
     openCreator,
     closeCreator,
@@ -39,6 +46,7 @@ export function TasksSection({
     hoverBind,
   } = useInlineTaskCreator({
     requireHover: false,
+    onOpen: clearTaskSelection,
   });
   const stats = calculateMilestoneStats(tasks);
   const completionPercentage = calculateCompletionPercentage(stats);
@@ -91,7 +99,7 @@ export function TasksSection({
 
   const { draggedItemId, destination, draggedItemDimensions } = useBoardDnD(handleTaskMove);
 
-  // Hotkey handled by useInlineTaskCreator
+  // Inline creation hotkey handled by useInlineTaskCreator
 
   return (
     <div className="space-y-4 pt-6" data-test-id="tasks-section" {...hoverBind}>
@@ -142,7 +150,11 @@ export function TasksSection({
         )}
 
         {/* Task list content */}
-        <div className="bg-surface-base rounded-b-lg overflow-hidden">
+        <div
+          ref={keyboardNavigationRef}
+          {...keyboardNavigationScopeBind}
+          className="bg-surface-base rounded-b-lg overflow-hidden"
+        >
           {baseFilteredTasks.length === 0 ? (
             /* Empty state with inline creation */
             <div className="px-4 py-6">
@@ -184,6 +196,7 @@ export function TasksSection({
               draggedItemId={draggedItemId}
               targetLocation={destination}
               placeholderHeight={draggedItemDimensions?.height ?? null}
+              selectedTaskId={selectedTaskId}
               inlineCreateRow={
                 creatorOpen ? (
                   <InlineTaskCreator

--- a/turboui/src/TaskBoard/components/MilestoneCard.tsx
+++ b/turboui/src/TaskBoard/components/MilestoneCard.tsx
@@ -34,6 +34,8 @@ export interface MilestoneCardProps {
   draggedItemId?: string | null;
   targetLocation?: BoardLocation | null;
   placeholderHeight?: number | null;
+  selectedTaskId?: string | null;
+  onInlineCreateOpen?: () => void;
 
   /**
    * Milestone statistics - if not provided, will be calculated from tasks
@@ -62,7 +64,10 @@ export function MilestoneCard({
   draggedItemId = null,
   targetLocation = null,
   placeholderHeight = null,
+  selectedTaskId = null,
+  onInlineCreateOpen,
 }: MilestoneCardProps) {
+  const cardRef = React.useRef<HTMLLIElement>(null);
   const sortedTasks = React.useMemo(() => sortTasks(tasks, milestone), [tasks, milestone.tasksOrderingState]);
 
   // Generate default stats if not provided
@@ -70,7 +75,13 @@ export function MilestoneCard({
   const completionPercentage = calculateCompletionPercentage(milestoneStats);
   const completionLabel = `${Math.round(completionPercentage)}% complete`;
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
-  const { open: creatorOpen, openCreator, closeCreator, creatorRef, hoverBind } = useInlineTaskCreator();
+  const { open: creatorOpen, openCreator, closeCreator, creatorRef, hoverBind } = useInlineTaskCreator({
+    onOpen: onInlineCreateOpen,
+    isActive: () => {
+      const activeElement = document.activeElement;
+      return activeElement instanceof HTMLElement && Boolean(cardRef.current?.contains(activeElement));
+    },
+  });
 
   const handleCreateTask = (newTask: Types.NewTaskPayload) => {
     if (onTaskCreate) {
@@ -90,7 +101,7 @@ export function MilestoneCard({
 
   return (
     <>
-      <li {...hoverBind}>
+      <li ref={cardRef} {...hoverBind}>
         {/* Milestone header */}
         <div
           className={classNames(
@@ -211,6 +222,7 @@ export function MilestoneCard({
             draggedItemId={draggedItemId}
             targetLocation={targetLocation}
             placeholderHeight={placeholderHeight}
+            selectedTaskId={selectedTaskId}
             inlineCreateRow={
               creatorOpen ? (
                 <InlineTaskCreator

--- a/turboui/src/TaskBoard/components/TaskItem.tsx
+++ b/turboui/src/TaskBoard/components/TaskItem.tsx
@@ -20,6 +20,7 @@ interface TaskItemProps {
   assigneePersonSearch?: PersonField.SearchData;
   statusOptions: StatusSelector.StatusOption[];
   draggingDisabled?: boolean;
+  selected?: boolean;
 }
 
 export function TaskItem({
@@ -31,6 +32,7 @@ export function TaskItem({
   assigneePersonSearch,
   statusOptions,
   draggingDisabled = false,
+  selected = false,
 }: TaskItemProps) {
   const [currentAssignee, setCurrentAssignee] = useState<Person | null>(task.assignees?.[0] || null);
   const [currentDueDate, setCurrentDueDate] = useState<DateField.ContextualDate | null>(task.dueDate || null);
@@ -90,9 +92,18 @@ export function TaskItem({
   };
 
   return (
-    <li ref={ref as React.RefObject<HTMLLIElement>} className={classNames("group/task-row", itemClasses)}>
+    <li
+      ref={ref as React.RefObject<HTMLLIElement>}
+      className={classNames("group/task-row focus:outline-none", itemClasses)}
+      data-task-row-id={task.id}
+      tabIndex={-1}
+      aria-selected={selected}
+    >
       <div
-        className="flex items-center px-4 py-2.5 bg-surface-base hover:bg-surface-highlight"
+        className={classNames(
+          "flex items-center px-4 py-2.5 bg-surface-base hover:bg-surface-highlight",
+          selected ? "bg-surface-highlight ring-2 ring-inset ring-brand-1" : undefined,
+        )}
         data-test-id={createTestId("task", task.id)}
       >
         {/* Left side: Status and task info */}

--- a/turboui/src/TaskBoard/components/TaskList.tsx
+++ b/turboui/src/TaskBoard/components/TaskList.tsx
@@ -27,6 +27,7 @@ export interface TaskListProps {
   draggedItemId?: string | null;
   targetLocation?: BoardLocation | null;
   placeholderHeight?: number | null;
+  selectedTaskId?: string | null;
 }
 
 /**
@@ -47,6 +48,7 @@ export function TaskList({
   draggedItemId = null,
   targetLocation = null,
   placeholderHeight = null,
+  selectedTaskId = null,
 }: TaskListProps) {
   const [hiddenTasksExpanded, setHiddenTasksExpanded] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -139,6 +141,7 @@ export function TaskList({
                 assigneePersonSearch={assigneePersonSearch}
                 statusOptions={statusOptions}
                 draggingDisabled={false}
+                selected={task.id === selectedTaskId}
               />
             </React.Fragment>
           ))}
@@ -215,6 +218,7 @@ export function TaskList({
               assigneePersonSearch={assigneePersonSearch}
               statusOptions={statusOptions}
               draggingDisabled={true}
+              selected={task.id === selectedTaskId}
             />
           </ul>
         ))}

--- a/turboui/src/TaskBoard/components/index.tsx
+++ b/turboui/src/TaskBoard/components/index.tsx
@@ -13,6 +13,7 @@ import { TaskFilter, FilterBadges } from "./TaskFilter";
 import { useFilteredTasks } from "../hooks";
 import { InlineTaskCreator } from "./InlineTaskCreator";
 import { useInlineTaskCreator } from "../hooks/useInlineTaskCreator";
+import { useTaskKeyboardNavigation } from "../hooks/useTaskKeyboardNavigation";
 import { TasksMenu } from "./TasksMenu";
 import { TaskDisplayMenu } from "./TaskDisplayMenu";
 import { StatusSelector } from "../../StatusSelector";
@@ -55,18 +56,31 @@ export function TaskBoard({
   displayMode = "list",
   onDisplayModeChange,
 }: Types.TaskBoardProps) {
+  const {
+    containerRef: keyboardNavigationRef,
+    selectedTaskId,
+    clearSelection: clearTaskSelection,
+    scopeBind: keyboardNavigationScopeBind,
+  } = useTaskKeyboardNavigation<HTMLDivElement>();
   const [internalTasks, setInternalTasks] = useState<Types.Task[]>(externalTasks);
   const [internalMilestones, setInternalMilestones] = useState<Types.Milestone[]>(externalMilestones);
   const [activeTaskMilestoneId, setActiveTaskMilestoneId] = useState<string | undefined>();
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [isMilestoneModalOpen, setIsMilestoneModalOpen] = useState(false);
+  const noMilestoneRef = React.useRef<HTMLLIElement>(null);
   const {
     open: noMilestoneCreatorOpen,
     openCreator: openNoMilestoneCreator,
     closeCreator: closeNoMilestoneCreator,
     creatorRef: noMilestoneCreatorRef,
     hoverBind: noMilestoneHoverBind,
-  } = useInlineTaskCreator();
+  } = useInlineTaskCreator({
+    onOpen: clearTaskSelection,
+    isActive: () => {
+      const activeElement = document.activeElement;
+      return activeElement instanceof HTMLElement && Boolean(noMilestoneRef.current?.contains(activeElement));
+    },
+  });
 
   // Keep internal tasks in sync with external tasks
   useLayoutEffect(() => {
@@ -186,6 +200,8 @@ export function TaskBoard({
       />
 
       <div
+        ref={keyboardNavigationRef}
+        {...keyboardNavigationScopeBind}
         className="flex flex-col flex-1 bg-surface-base border border-surface-outline rounded-md overflow-hidden"
         data-test-id="tasks-board"
       >
@@ -219,12 +235,14 @@ export function TaskBoard({
                   draggedItemId={draggedItemId}
                   targetLocation={destination}
                   placeholderHeight={draggedItemDimensions?.height ?? null}
+                  selectedTaskId={selectedTaskId}
+                  onInlineCreateOpen={clearTaskSelection}
                 />
               ))}
 
               {/* Tasks with no milestone */}
               {hasTasksWithoutMilestone && (
-                <li {...noMilestoneHoverBind}>
+                <li ref={noMilestoneRef} {...noMilestoneHoverBind}>
                   {/* No milestone header */}
                   <div className="flex items-center justify-between px-4 py-3 bg-surface-dimmed border-b border-surface-outline">
                     <div className="flex items-center gap-2">
@@ -256,6 +274,7 @@ export function TaskBoard({
                     draggedItemId={draggedItemId}
                     targetLocation={destination}
                     placeholderHeight={draggedItemDimensions?.height ?? null}
+                    selectedTaskId={selectedTaskId}
                     inlineCreateRow={
                       noMilestoneCreatorOpen ? (
                         <InlineTaskCreator

--- a/turboui/src/TaskBoard/hooks/useInlineTaskCreator.ts
+++ b/turboui/src/TaskBoard/hooks/useInlineTaskCreator.ts
@@ -5,10 +5,12 @@ import { InlineTaskCreatorHandle } from "../components/InlineTaskCreator";
 export interface UseInlineTaskCreatorOptions {
   hotkey?: string; // default: 'c'
   requireHover?: boolean; // default: true
+  onOpen?: () => void;
+  isActive?: () => boolean;
 }
 
 export function useInlineTaskCreator(options: UseInlineTaskCreatorOptions = {}) {
-  const { hotkey = "c", requireHover = true } = options;
+  const { hotkey = "c", requireHover = true, onOpen, isActive } = options;
 
   const [open, setOpen] = React.useState(false);
   const creatorRef = React.useRef<InlineTaskCreatorHandle | null>(null);
@@ -29,9 +31,10 @@ export function useInlineTaskCreator(options: UseInlineTaskCreatorOptions = {}) 
   }, []);
 
   const openCreator = React.useCallback(() => {
+    onOpen?.();
     setOpen(true);
     setTimeout(() => focusCreator(), 0);
-  }, [focusCreator]);
+  }, [focusCreator, onOpen]);
 
   const closeCreator = React.useCallback(() => setOpen(false), []);
 
@@ -53,7 +56,7 @@ export function useInlineTaskCreator(options: UseInlineTaskCreatorOptions = {}) 
       const tag = target?.tagName;
       const isEditable = !!target && (target.isContentEditable || tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT");
       if (isEditable) return;
-      if (requireHoverRef.current && !isHoveredRef.current) return;
+      if (requireHoverRef.current && !isHoveredRef.current && !isActive?.()) return;
 
       evt.preventDefault();
       // Stop other handlers from also reacting to this key
@@ -69,7 +72,7 @@ export function useInlineTaskCreator(options: UseInlineTaskCreatorOptions = {}) 
 
     hotkeys(hotkey, handler);
     return () => hotkeys.unbind(hotkey, handler);
-  }, [hotkey, openCreator, requireHover]);
+  }, [hotkey, isActive, openCreator, requireHover]);
 
   return { open, openCreator, closeCreator, focusCreator, creatorRef, hoverBind } as const;
 }

--- a/turboui/src/TaskBoard/hooks/useTaskKeyboardNavigation.test.tsx
+++ b/turboui/src/TaskBoard/hooks/useTaskKeyboardNavigation.test.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { useTaskKeyboardNavigation } from "./useTaskKeyboardNavigation";
+
+describe("useTaskKeyboardNavigation", () => {
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  it("selects the first task with j and moves down/up with j/k", () => {
+    const { getByTestId } = render(<KeyboardNavigationHarness />);
+
+    fireTaskKey("j", 74);
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "true");
+
+    fireTaskKey("j", 74);
+    expect(getByTestId("task-two")).toHaveAttribute("data-selected", "true");
+
+    fireTaskKey("k", 75);
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "true");
+  });
+
+  it("ignores shortcuts from unrelated interactive controls", () => {
+    const { getByTestId } = render(<KeyboardNavigationHarness />);
+
+    fireEvent.keyDown(getByTestId("outside-button"), { key: "j", keyCode: 74, which: 74 });
+
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "false");
+    expect(getByTestId("task-two")).toHaveAttribute("data-selected", "false");
+  });
+
+  it("ignores shortcuts from editable fields", () => {
+    const { getByTestId } = render(<KeyboardNavigationHarness />);
+
+    fireEvent.keyDown(getByTestId("task-input"), { key: "j", keyCode: 74, which: 74 });
+
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "false");
+    expect(getByTestId("task-two")).toHaveAttribute("data-selected", "false");
+  });
+
+  it("clears the selected task with escape", () => {
+    const { getByTestId } = render(<KeyboardNavigationHarness />);
+
+    fireTaskKey("j", 74);
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "true");
+
+    fireTaskKey("Escape", 27);
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "false");
+    expect(getByTestId("task-two")).toHaveAttribute("data-selected", "false");
+  });
+
+  it("exposes clearSelection for transitions like opening the inline creator", () => {
+    const { getByTestId } = render(<KeyboardNavigationHarness />);
+
+    fireTaskKey("j", 74);
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "true");
+
+    fireEvent.click(getByTestId("clear-selection"));
+    expect(getByTestId("task-one")).toHaveAttribute("data-selected", "false");
+  });
+
+  it("handles neutral shortcuts in only one mounted task navigation scope", () => {
+    const { getByTestId } = render(
+      <>
+        <KeyboardNavigationHarness idPrefix="first-" />
+        <KeyboardNavigationHarness idPrefix="second-" />
+      </>,
+    );
+
+    fireTaskKey("j", 74);
+
+    expect(getByTestId("first-task-one")).toHaveAttribute("data-selected", "false");
+    expect(getByTestId("second-task-one")).toHaveAttribute("data-selected", "true");
+  });
+
+  it("uses the focused task navigation scope even when another scope is mounted", () => {
+    const { getByTestId } = render(
+      <>
+        <KeyboardNavigationHarness idPrefix="first-" />
+        <KeyboardNavigationHarness idPrefix="second-" />
+      </>,
+    );
+
+    getByTestId("first-task-one").focus();
+    fireTaskKey("j", 74);
+
+    expect(getByTestId("first-task-one")).toHaveAttribute("data-selected", "true");
+    expect(getByTestId("second-task-one")).toHaveAttribute("data-selected", "false");
+  });
+});
+
+function KeyboardNavigationHarness({ idPrefix = "" }: { idPrefix?: string }) {
+  const { containerRef, selectedTaskId, clearSelection, scopeBind } = useTaskKeyboardNavigation<HTMLDivElement>();
+
+  return (
+    <>
+      <button data-testid={`${idPrefix}outside-button`}>Outside control</button>
+      <div ref={containerRef} data-testid={`${idPrefix}task-container`} {...scopeBind}>
+        <input data-testid={`${idPrefix}task-input`} />
+        <button data-testid={`${idPrefix}clear-selection`} onClick={clearSelection}>
+          Clear
+        </button>
+        {["one", "two"].map((id) => (
+          <div
+            key={id}
+            data-task-row-id={id}
+            data-testid={`${idPrefix}task-${id}`}
+            data-selected={selectedTaskId === id ? "true" : "false"}
+            tabIndex={-1}
+          >
+            {id}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function fireTaskKey(key: "j" | "k" | "Escape", keyCode: number) {
+  fireEvent.keyDown(document, { key, keyCode, which: keyCode });
+  fireEvent.keyUp(document, { key, keyCode, which: keyCode });
+}

--- a/turboui/src/TaskBoard/hooks/useTaskKeyboardNavigation.ts
+++ b/turboui/src/TaskBoard/hooks/useTaskKeyboardNavigation.ts
@@ -1,0 +1,180 @@
+import React from "react";
+import hotkeys from "hotkeys-js";
+
+export const TASK_ROW_SELECTOR = "[data-task-row-id]";
+
+type Direction = "down" | "up";
+
+let nextNavigationScopeId = 0;
+let activeNavigationScopeId: number | null = null;
+
+export function useTaskKeyboardNavigation<TElement extends HTMLElement>() {
+  const containerRef = React.useRef<TElement | null>(null);
+  const scopeIdRef = React.useRef<number | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = React.useState<string | null>(null);
+  const selectedTaskIdRef = React.useRef<string | null>(null);
+
+  if (scopeIdRef.current === null) {
+    scopeIdRef.current = ++nextNavigationScopeId;
+  }
+
+  React.useEffect(() => {
+    selectedTaskIdRef.current = selectedTaskId;
+  }, [selectedTaskId]);
+
+  React.useEffect(() => {
+    activeNavigationScopeId = scopeIdRef.current;
+
+    return () => {
+      if (activeNavigationScopeId === scopeIdRef.current) {
+        activeNavigationScopeId = null;
+      }
+    };
+  }, []);
+
+  const activateScope = React.useCallback(() => {
+    activeNavigationScopeId = scopeIdRef.current;
+  }, []);
+
+  const clearSelection = React.useCallback(() => {
+    setSelectedTaskId(null);
+
+    if (
+      document.activeElement instanceof HTMLElement &&
+      document.activeElement.closest(TASK_ROW_SELECTOR)
+    ) {
+      document.activeElement.blur();
+    }
+  }, []);
+
+  const scopeBind = React.useMemo(
+    () => ({
+      onFocusCapture: activateScope,
+      onMouseEnter: activateScope,
+    }),
+    [activateScope],
+  );
+
+  const selectTask = React.useCallback((direction: Direction) => {
+    const rows = getTaskRows(containerRef.current);
+    if (rows.length === 0) return false;
+
+    const currentIndex = rows.findIndex((row) => row.dataset.taskRowId === selectedTaskIdRef.current);
+    const nextIndex = getNextIndex(currentIndex, rows.length, direction);
+    const nextRow = rows[nextIndex];
+    const nextTaskId = nextRow?.dataset.taskRowId;
+
+    if (!nextRow || !nextTaskId) return false;
+
+    setSelectedTaskId(nextTaskId);
+
+    requestAnimationFrame(() => {
+      nextRow.focus({ preventScroll: true });
+      nextRow.scrollIntoView({ block: "nearest" });
+    });
+
+    return true;
+  }, []);
+
+  React.useEffect(() => {
+    const handleKey = (event: KeyboardEvent, direction: Direction) => {
+      if (event.defaultPrevented || shouldIgnoreKeyboardEvent(event)) return;
+      if (!isInNavigationScope(event, containerRef.current, scopeIdRef.current)) return;
+
+      activateScope();
+
+      const handled = selectTask(direction);
+
+      if (!handled) return;
+
+      event.preventDefault();
+      try {
+        (event as Event).stopImmediatePropagation();
+      } catch {
+        event.stopPropagation();
+      }
+    };
+    const clearSelectionWithEscape = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || shouldIgnoreKeyboardEvent(event)) return;
+      if (!selectedTaskIdRef.current) return;
+      if (!isInNavigationScope(event, containerRef.current, scopeIdRef.current)) return;
+
+      activateScope();
+
+      clearSelection();
+
+      event.preventDefault();
+      try {
+        (event as Event).stopImmediatePropagation();
+      } catch {
+        event.stopPropagation();
+      }
+    };
+    const selectNextTask = (event: KeyboardEvent) => handleKey(event, "down");
+    const selectPreviousTask = (event: KeyboardEvent) => handleKey(event, "up");
+
+    hotkeys("j", selectNextTask);
+    hotkeys("k", selectPreviousTask);
+    hotkeys("esc", clearSelectionWithEscape);
+    return () => {
+      hotkeys.unbind("j", selectNextTask);
+      hotkeys.unbind("k", selectPreviousTask);
+      hotkeys.unbind("esc", clearSelectionWithEscape);
+    };
+  }, [activateScope, clearSelection, selectTask]);
+
+  return { containerRef, selectedTaskId, clearSelection, scopeBind } as const;
+}
+
+function getTaskRows(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+
+  return Array.from(container.querySelectorAll<HTMLElement>(TASK_ROW_SELECTOR));
+}
+
+function getNextIndex(currentIndex: number, rowsCount: number, direction: Direction): number {
+  if (currentIndex === -1) return 0;
+
+  if (direction === "down") {
+    return Math.min(currentIndex + 1, rowsCount - 1);
+  } else {
+    return Math.max(currentIndex - 1, 0);
+  }
+}
+
+function shouldIgnoreKeyboardEvent(event: KeyboardEvent): boolean {
+  if (event.altKey || event.ctrlKey || event.metaKey) return true;
+
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return false;
+
+  const tag = target.tagName;
+  if (target.isContentEditable || tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+
+  return Boolean(target.closest("button, a, [role='button'], [role='menuitem'], [aria-haspopup='menu']"));
+}
+
+function isInNavigationScope(event: KeyboardEvent, container: HTMLElement | null, scopeId: number | null): boolean {
+  if (!container) return false;
+
+  const target = event.target;
+  if (target instanceof Node && container.contains(target)) return true;
+
+  const activeElement = document.activeElement;
+  if (activeElement instanceof HTMLElement && container.contains(activeElement)) return true;
+
+  return (
+    scopeId !== null &&
+    activeNavigationScopeId === scopeId &&
+    isNeutralDocumentTarget(target) &&
+    isNeutralActiveElement(activeElement)
+  );
+}
+
+function isNeutralDocumentTarget(target: EventTarget | null): boolean {
+  return target === document || target === document.body || target === document.documentElement;
+}
+
+function isNeutralActiveElement(activeElement: Element | null): boolean {
+  return !activeElement || activeElement === document.body || activeElement === document.documentElement;
+}


### PR DESCRIPTION
adds support for `j/k` and `esc` key navigation to pages with task lists (project>tasks, milestone).

also now pressing 'c' anywhere on page opens up the inline task creation form.

related to #4474.