### PR TITLE
feat: Project timeline in work maps

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -2023,11 +2023,19 @@ export interface WorkMapItem {
   isNew: boolean;
   completedOn: string | null;
   timeframe: Timeframe | null;
+  milestones: WorkMapItemMilestone[];
   children: WorkMapItem[];
   type: WorkMapItemType;
   itemPath: string;
   privacy: WorkMapItemPrivacy;
   assignees?: Person[] | null;
+}
+
+export interface WorkMapItemMilestone {
+  id: string;
+  title: string;
+  status: MilestoneStatus;
+  timeframe: Timeframe | null;
 }
 
 export type ActivityContent =

--- a/app/assets/js/models/workMap/index.tsx
+++ b/app/assets/js/models/workMap/index.tsx
@@ -27,6 +27,13 @@ function convertToWorkMapItem(paths: Paths, item: WorkMapItem): WorkMap.Item {
     spacePath: item.spacePath,
     taskStatus: parseTaskStatusForTurboUi(item.taskStatus),
     timeframe: convertTimeframe(item.timeframe),
+    milestones: (item.milestones || []).map((milestone) => ({
+      id: milestone.id,
+      name: milestone.title,
+      status: milestone.status,
+      dueDate: parseContextualDate(milestone.timeframe?.contextualEndDate),
+      link: paths.projectMilestonePath(milestone.id),
+    })),
     children: item.children.map((c) => convertToWorkMapItem(paths, c)),
   };
 }
@@ -85,6 +92,7 @@ export function useWorkMapItems(initialItems: WorkMapItem[] = []): [WorkMapItem[
       reviewerPath: null,
       nextStep: "",
       timeframe: null,
+      milestones: [],
       children: [],
       isNew: true,
       completedOn: null,
@@ -129,6 +137,7 @@ export function useWorkMapItems(initialItems: WorkMapItem[] = []): [WorkMapItem[
       reviewerPath: null,
       nextStep: "",
       timeframe: null,
+      milestones: [],
       children: [],
       isNew: true,
       completedOn: null,

--- a/app/lib/operately_web/api/serializers/work_map_item.ex
+++ b/app/lib/operately_web/api/serializers/work_map_item.ex
@@ -24,11 +24,25 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
       is_new: item.is_new,
       completed_on: OperatelyWeb.Api.Serializer.serialize(item.completed_on),
       timeframe: OperatelyWeb.Api.Serializer.serialize(item.timeframe),
+      milestones: serialize_milestones(item),
       children: OperatelyWeb.Api.Serializer.serialize(item.children),
       privacy: OperatelyWeb.Api.Serializer.serialize(item.privacy),
       assignees: OperatelyWeb.Api.Serializer.serialize(item.assignees)
     }
   end
+
+  defp serialize_milestones(%{type: :project, resource: %{milestones: milestones}}) when is_list(milestones) do
+    Enum.map(milestones, fn milestone ->
+      %{
+        id: Paths.milestone_id(milestone),
+        title: milestone.title,
+        status: OperatelyWeb.Api.Serializer.serialize(milestone.status),
+        timeframe: OperatelyWeb.Api.Serializer.serialize(milestone.timeframe)
+      }
+    end)
+  end
+
+  defp serialize_milestones(_item), do: []
 
   defp item_id(item) do
     case item.type do

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -2179,12 +2179,20 @@ defmodule OperatelyWeb.Api.Types do
     field :is_new, :boolean, null: false
     field :completed_on, :date, null: true
     field :timeframe, :timeframe, null: true
+    field :milestones, list_of(:work_map_item_milestone), null: false
     field :children, list_of(:work_map_item), null: false
     field :type, :work_map_item_type, null: false
     field :item_path, :string, null: false
     field :privacy, :work_map_item_privacy, null: false
 
     field? :assignees, list_of(:person), null: true
+  end
+
+  object :work_map_item_milestone do
+    field :id, :string, null: false
+    field :title, :string, null: false
+    field :status, :milestone_status, null: false
+    field :timeframe, :timeframe, null: true
   end
 
   enum(:success_status, values: [:achieved, :missed])

--- a/turboui/src/Tabs/index.tsx
+++ b/turboui/src/Tabs/index.tsx
@@ -56,9 +56,13 @@ function useTabPath(tabId: string, urlPath?: string) {
   return `${pathname}?${searchParams.toString()}`;
 }
 
-export function Tabs({ tabs }: { tabs: TabsState }) {
+export function Tabs({ tabs, showBorder = true }: { tabs: TabsState; showBorder?: boolean }) {
   return (
-    <div className="border-stroke-base border-b shadow-b-xs pl-1 mt-2 overflow-x-auto sm:pl-4">
+    <div
+      className={classNames("pl-1 mt-2 overflow-x-auto sm:pl-4", {
+        "border-stroke-base border-b shadow-b-xs": showBorder,
+      })}
+    >
       <nav className="flex gap-2 px-1 whitespace-nowrap sm:gap-4 sm:px-0">
         {tabs.tabs.map((tab) => (
           <TabItem key={tab.id} tab={tab} activeTab={tabs.active} urlPath={tabs.urlPath} />

--- a/turboui/src/ViewToggle/index.stories.tsx
+++ b/turboui/src/ViewToggle/index.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+
+import { IconTable, IconTimeline } from "../icons";
+import { ViewToggle } from ".";
+
+const meta: Meta<typeof ViewToggle> = {
+  title: "Components/ViewToggle",
+  component: ViewToggle,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ViewToggle>;
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState<"table" | "timeline">("timeline");
+
+    return (
+      <ViewToggle
+        value={value}
+        ariaLabel="View"
+        options={[
+          { value: "table", label: "Table", icon: <IconTable size={14} />, onSelect: (next) => setValue(next) },
+          {
+            value: "timeline",
+            label: "Timeline",
+            icon: <IconTimeline size={14} />,
+            onSelect: (next) => setValue(next),
+          },
+        ]}
+      />
+    );
+  },
+};

--- a/turboui/src/ViewToggle/index.tsx
+++ b/turboui/src/ViewToggle/index.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import { DivLink } from "../Link";
+import classNames from "../utils/classnames";
+
+interface BaseOption<Value extends string> {
+  value: Value;
+  label: string;
+  icon?: React.ReactNode;
+  testId?: string;
+}
+
+interface LinkOption<Value extends string> extends BaseOption<Value> {
+  to: string;
+}
+
+interface ButtonOption<Value extends string> extends BaseOption<Value> {
+  onSelect: (value: Value) => void;
+}
+
+export type ViewToggleOption<Value extends string> = LinkOption<Value> | ButtonOption<Value>;
+
+export interface ViewToggleProps<Value extends string> {
+  value: Value;
+  options: ViewToggleOption<Value>[];
+  ariaLabel: string;
+  className?: string;
+}
+
+export function ViewToggle<Value extends string>({ value, options, ariaLabel, className }: ViewToggleProps<Value>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={classNames(
+        "inline-flex items-center gap-0.5 rounded-lg border border-surface-outline bg-surface-dimmed p-0.5 shadow-inner shadow-black/[0.03]",
+        "dark:border-gray-700 dark:bg-gray-900/70 dark:shadow-none",
+        className,
+      )}
+    >
+      {options.map((option) => (
+        <ViewToggleItem key={option.value} option={option} active={option.value === value} />
+      ))}
+    </div>
+  );
+}
+
+function ViewToggleItem<Value extends string>({ option, active }: { option: ViewToggleOption<Value>; active: boolean }) {
+  const className = classNames(
+    "inline-flex h-7 items-center gap-1.5 rounded-md px-2.5 text-xs font-semibold leading-none transition",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-base focus-visible:ring-offset-1",
+    active
+      ? "bg-surface-base text-content-accent shadow-sm ring-1 ring-black/5 dark:bg-gray-800 dark:text-gray-50 dark:ring-white/10"
+      : "text-content-dimmed hover:bg-surface-base/70 hover:text-content-base dark:hover:bg-gray-800/80 dark:hover:text-gray-100",
+  );
+
+  const content = (
+    <>
+      {option.icon && <span className="flex size-3.5 items-center justify-center">{option.icon}</span>}
+      <span>{option.label}</span>
+    </>
+  );
+
+  if ("to" in option) {
+    return (
+      <DivLink
+        to={option.to}
+        className={className}
+        testId={option.testId}
+        aria-current={active ? "page" : undefined}
+      >
+        {content}
+      </DivLink>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={className}
+      data-test-id={option.testId}
+      aria-pressed={active}
+      onClick={() => option.onSelect(option.value)}
+    >
+      {content}
+    </button>
+  );
+}

--- a/turboui/src/WorkMap/components/WorkMapNavigation.tsx
+++ b/turboui/src/WorkMap/components/WorkMapNavigation.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { useLocation } from "react-router-dom";
-import { IconChartColumn, IconTable } from "../../icons";
-import { DivLink } from "../../Link";
+import { IconTable, IconTimeline } from "../../icons";
 import { Tabs, TabsState } from "../../Tabs";
-import classNames from "../../utils/classnames";
+import { ViewToggle } from "../../ViewToggle";
 import { WorkMap } from ".";
 
 export interface Props {
@@ -18,21 +17,21 @@ export function WorkMapNavigation({ tabsState, timelineAvailable = false, view =
   const timelinePath = buildViewPath(location.pathname, location.search, "timeline");
 
   return (
-    <div className="flex items-end justify-between gap-4 px-4">
+    <div className="flex items-center justify-between gap-4 px-4">
       <div className="min-w-0 flex-1 overflow-x-auto">
         <Tabs tabs={tabsState} />
       </div>
 
       {timelineAvailable && (
-        <div className="mb-2 flex shrink-0 items-center gap-1 rounded-lg border border-surface-outline bg-surface-dimmed p-1">
-          <ViewToggleButton label="Table" icon={<IconTable size={15} />} to={tablePath} active={view === "table"} />
-          <ViewToggleButton
-            label="Timeline"
-            icon={<IconChartColumn size={15} />}
-            to={timelinePath}
-            active={view === "timeline"}
-          />
-        </div>
+        <ViewToggle
+          className="my-2 shrink-0"
+          value={view}
+          ariaLabel="Work map view"
+          options={[
+            { value: "table", label: "Table", icon: <IconTable size={14} />, to: tablePath },
+            { value: "timeline", label: "Timeline", icon: <IconTimeline size={14} />, to: timelinePath },
+          ]}
+        />
       )}
     </div>
   );
@@ -51,29 +50,4 @@ function buildViewPath(pathname: string, search: string, view: WorkMap.View) {
 
   const nextSearch = searchParams.toString();
   return nextSearch ? `${pathname}?${nextSearch}` : pathname;
-}
-
-function ViewToggleButton({
-  label,
-  icon,
-  to,
-  active,
-}: {
-  label: string;
-  icon: React.ReactNode;
-  to: string;
-  active: boolean;
-}) {
-  return (
-    <DivLink
-      to={to}
-      className={classNames(
-        "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors",
-        active ? "bg-surface-base text-content-accent shadow-sm" : "text-content-dimmed hover:text-content-base",
-      )}
-    >
-      {icon}
-      <span>{label}</span>
-    </DivLink>
-  );
 }

--- a/turboui/src/WorkMap/components/WorkMapNavigation.tsx
+++ b/turboui/src/WorkMap/components/WorkMapNavigation.tsx
@@ -17,9 +17,9 @@ export function WorkMapNavigation({ tabsState, timelineAvailable = false, view =
   const timelinePath = buildViewPath(location.pathname, location.search, "timeline");
 
   return (
-    <div className="flex items-center justify-between gap-4 px-4">
+    <div className="flex items-center justify-between gap-4 border-b border-stroke-base px-4 shadow-b-xs">
       <div className="min-w-0 flex-1 overflow-x-auto">
-        <Tabs tabs={tabsState} />
+        <Tabs tabs={tabsState} showBorder={false} />
       </div>
 
       {timelineAvailable && (

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -16,31 +16,11 @@ import {
   getMarkerPosition,
   type TimelineColumn as Column,
 } from "../utils/timeline";
+import { flattenTimelineItems, normalizeTimelineDate, toTimelineItem, type TimelineItem, type TimelineMilestone } from "../utils/timelineItem";
 
 interface Props {
   items: WorkMap.Item[];
   tab: WorkMap.Filter;
-}
-
-interface TimelineItem {
-  id: string;
-  name: string;
-  type: WorkMap.Item["type"];
-  status: WorkMap.Item["status"];
-  owner: WorkMap.Item["owner"];
-  space: WorkMap.Item["space"];
-  itemPath: string;
-  startDate: Date | null;
-  endDate: Date | null;
-  milestones: TimelineMilestone[];
-}
-
-interface TimelineMilestone {
-  id: string;
-  name: string;
-  status: WorkMap.Milestone["status"];
-  link: string;
-  dueDate: Date;
 }
 
 interface MonthGroup {
@@ -50,8 +30,17 @@ interface MonthGroup {
   span: number;
 }
 
+const TIMELINE_LAYOUT = {
+  rowHeight: 58,
+  bottomPadding: 24,
+  barTop: 8,
+  barHeight: 40,
+  milestoneTop: 31,
+  milestoneIconSize: 16,
+};
+
 export function WorkMapTimeline({ items, tab }: Props) {
-  const flattenedItems = React.useMemo(() => flattenItems(items), [items]);
+  const flattenedItems = React.useMemo(() => flattenTimelineItems(items), [items]);
   const timelineItems = React.useMemo(() => flattenedItems.map(toTimelineItem), [flattenedItems]);
   const hiddenUndatedCount = timelineItems.filter((item) => !item.startDate && !item.endDate).length;
 
@@ -77,9 +66,11 @@ export function WorkMapTimeline({ items, tab }: Props) {
   const rangeEnd = range.end.getTime();
   const rangeMs = Math.max(rangeEnd - rangeStart, 1);
   const timelineMinWidth = Math.max(columns.length * 96, 820);
-  const todayLeft = getMarkerPosition(new Date(), rangeStart, rangeEnd);
-  const todayLabel = todayLeft === null ? null : formatMarkerDate(new Date());
+  const today = new Date();
+  const todayLeft = getMarkerPosition(today, rangeStart, rangeEnd);
+  const todayLabel = todayLeft === null ? null : formatMarkerDate(today);
   const monthGroups = buildMonthGroups(columns);
+  const highlightedColumnKey = columns.find((column) => columnContainsDate(column, today))?.key ?? null;
 
   return (
     <div className="bg-surface-base rounded-b-lg">
@@ -91,13 +82,13 @@ export function WorkMapTimeline({ items, tab }: Props) {
 
       <div className="overflow-x-auto">
         <div
-          className="relative min-w-full px-4 pb-6"
-          style={{ minWidth: `${timelineMinWidth}px` }}
+          className="relative min-w-full px-4"
+          style={{ minWidth: `${timelineMinWidth}px`, paddingBottom: TIMELINE_LAYOUT.bottomPadding }}
         >
           <TodayBadge left={todayLeft} label={todayLabel} />
           <TimelineMarker left={todayLeft} className="bg-brand-1/90 dark:bg-blue-300/90" />
 
-          <TimelineHeader columns={columns} monthGroups={monthGroups} />
+          <TimelineHeader columns={columns} monthGroups={monthGroups} highlightedColumnKey={highlightedColumnKey} />
 
           {visibleItems.map((item) => (
             <TimelineRow
@@ -106,6 +97,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
               columns={columns}
               rangeStart={rangeStart}
               rangeMs={rangeMs}
+              highlightedColumnKey={highlightedColumnKey}
             />
           ))}
         </div>
@@ -119,11 +111,13 @@ function TimelineRow({
   columns,
   rangeStart,
   rangeMs,
+  highlightedColumnKey,
 }: {
   item: TimelineItem;
   columns: Column[];
   rangeStart: number;
   rangeMs: number;
+  highlightedColumnKey: string | null;
 }) {
   const barStartDate = getBarStartDate(item);
   const left = barStartDate ? clampPercent(((barStartDate.getTime() - rangeStart) / rangeMs) * 100) : null;
@@ -134,20 +128,20 @@ function TimelineRow({
 
   return (
     <div className="border-b border-surface-outline/70 dark:border-gray-700/70">
-      <div className="relative h-[58px] bg-surface-base">
-        <TimelineGrid columns={columns} />
+      <div className="relative bg-surface-base" style={{ height: TIMELINE_LAYOUT.rowHeight }}>
+        <TimelineGrid columns={columns} highlightedColumnKey={highlightedColumnKey} />
 
         <div className="absolute inset-y-0 left-0 right-0">
           {barWidth !== null && left !== null && (
             <BarLabel
-                to={item.itemPath}
-                name={item.name}
-                rangeLabel={rangeLabel}
-                status={item.status}
-                openEnded={false}
-                style={{ left: `${left}%`, width: `${barWidth}%` }}
-              />
-            )}
+              to={item.itemPath}
+              name={item.name}
+              rangeLabel={rangeLabel}
+              status={item.status}
+              openEnded={false}
+              style={{ left: `${left}%`, width: `${barWidth}%` }}
+            />
+          )}
 
           {hasInfiniteBar && left !== null && (
             <BarLabel
@@ -177,9 +171,11 @@ function TimelineRow({
 function TimelineHeader({
   columns,
   monthGroups,
+  highlightedColumnKey,
 }: {
   columns: Column[];
   monthGroups: MonthGroup[];
+  highlightedColumnKey: string | null;
 }) {
   return (
     <div className="sticky left-0 z-10 border-b border-surface-outline bg-surface-base dark:border-gray-700">
@@ -207,7 +203,7 @@ function TimelineHeader({
             key={column.key}
             className={classNames("border-l border-surface-outline/70 px-3 py-2 dark:border-gray-700", {
               "border-l-0": index === 0,
-              "bg-surface-dimmed/70 dark:bg-gray-800/60": columnContainsDate(column, new Date()),
+              "bg-surface-dimmed/70 dark:bg-gray-800/60": column.key === highlightedColumnKey,
             })}
           >
             {formatWeekCellLabel(column.start)}
@@ -218,7 +214,7 @@ function TimelineHeader({
   );
 }
 
-function TimelineGrid({ columns }: { columns: Column[] }) {
+function TimelineGrid({ columns, highlightedColumnKey }: { columns: Column[]; highlightedColumnKey: string | null }) {
   return (
     <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}>
       {columns.map((column, index) => (
@@ -226,7 +222,7 @@ function TimelineGrid({ columns }: { columns: Column[] }) {
           key={column.key}
           className={classNames("border-l border-surface-outline/70 dark:border-gray-700/70", {
             "border-l-0": index === 0,
-            "bg-surface-dimmed/40 dark:bg-gray-800/40": columnContainsDate(column, new Date()),
+            "bg-surface-dimmed/40 dark:bg-gray-800/40": column.key === highlightedColumnKey,
           })}
         />
       ))}
@@ -237,7 +233,12 @@ function TimelineGrid({ columns }: { columns: Column[] }) {
 function TimelineMarker({ left, className }: { left: number | null; className: string }) {
   if (left === null) return null;
 
-  return <div className={classNames("pointer-events-none absolute bottom-6 top-0 z-20 w-px", className)} style={{ left: `${left}%` }} />;
+  return (
+    <div
+      className={classNames("pointer-events-none absolute top-0 z-20 w-px", className)}
+      style={{ left: `${left}%`, bottom: TIMELINE_LAYOUT.bottomPadding }}
+    />
+  );
 }
 
 function TodayBadge({ left, label }: { left: number | null; label: string | null }) {
@@ -272,11 +273,11 @@ function BarLabel({
   return (
     <div
       className={classNames(
-        "absolute top-2 flex h-10 min-w-0 items-start rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle dark:bg-gray-800/90 dark:text-gray-100 dark:shadow-none dark:hover:border-gray-500",
+        "absolute flex min-w-0 items-start rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle dark:bg-gray-800/90 dark:text-gray-100 dark:shadow-none dark:hover:border-gray-500",
         tone.border,
         { "rounded-r-none border-r-0": openEnded },
       )}
-      style={style}
+      style={{ ...style, top: TIMELINE_LAYOUT.barTop, height: TIMELINE_LAYOUT.barHeight }}
       title={rangeLabel ? `${name} · ${rangeLabel}` : name}
     >
       <span className={classNames("h-full w-1 shrink-0 rounded-l-lg", tone.accent)} />
@@ -307,8 +308,8 @@ function MilestoneMarker({
   return (
     <BlackLink
       to={milestone.link}
-      className="group absolute top-[31px] z-30 -translate-x-1/2"
-      style={{ left: `${left}%` }}
+      className="group absolute z-30 -translate-x-1/2"
+      style={{ left: `${left}%`, top: TIMELINE_LAYOUT.milestoneTop }}
       title={title}
       underline="never"
     >
@@ -328,52 +329,14 @@ function MilestoneMarker({
           />
         )}
       </span>
-      <span className="pointer-events-none absolute left-1/2 top-4 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-surface-outline bg-surface-base px-2 py-1 text-[11px] font-medium text-content-accent shadow-lg group-hover:block dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50">
+      <span
+        className="pointer-events-none absolute left-1/2 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-surface-outline bg-surface-base px-2 py-1 text-[11px] font-medium text-content-accent shadow-lg group-hover:block dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50"
+        style={{ top: TIMELINE_LAYOUT.milestoneIconSize }}
+      >
         {title}
       </span>
     </BlackLink>
   );
-}
-
-function flattenItems(items: WorkMap.Item[]): WorkMap.Item[] {
-  return items.flatMap((item) => [item, ...flattenItems(item.children)]);
-}
-
-function toTimelineItem(item: WorkMap.Item): TimelineItem {
-  return {
-    id: item.id,
-    name: item.name,
-    type: item.type,
-    status: item.status,
-    owner: item.owner,
-    space: item.space,
-    itemPath: item.itemPath,
-    startDate: normalizeDate(item.timeframe?.startDate?.date),
-    endDate: normalizeDate(item.timeframe?.endDate?.date),
-    milestones: item.milestones
-      .map((milestone) => {
-        const dueDate = normalizeDate(milestone.dueDate?.date);
-        if (!dueDate) return null;
-
-        return {
-          id: milestone.id,
-          name: milestone.name,
-          status: milestone.status,
-          link: milestone.link,
-          dueDate,
-        };
-      })
-      .filter((milestone): milestone is TimelineMilestone => Boolean(milestone))
-      .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime()),
-  };
-}
-
-function normalizeDate(date: Date | null | undefined) {
-  if (!date) return null;
-
-  const value = new Date(date);
-  value.setHours(0, 0, 0, 0);
-  return value;
 }
 
 function buildMonthGroups(columns: Column[]): MonthGroup[] {
@@ -400,9 +363,10 @@ function buildMonthGroups(columns: Column[]): MonthGroup[] {
 }
 
 function columnContainsDate(column: Column, date: Date) {
-  const value = normalizeDate(date)?.getTime();
-  if (!value) return false;
+  const normalized = normalizeTimelineDate(date);
+  if (!normalized) return false;
 
+  const value = normalized.getTime();
   return value >= column.start.getTime() && value <= column.end.getTime();
 }
 

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { WorkMap } from ".";
 import { BlackLink } from "../../Link";
+import { IconFlag, IconFlagFilled } from "../../icons";
 import classNames from "../../utils/classnames";
 import {
   buildColumns,
@@ -81,9 +82,9 @@ export function WorkMapTimeline({ items, tab }: Props) {
   const monthGroups = buildMonthGroups(columns);
 
   return (
-    <div className="bg-surface-base rounded-b-lg border-t border-surface-outline">
+    <div className="bg-surface-base rounded-b-lg border-t border-surface-outline dark:border-gray-700">
       {hiddenUndatedCount > 0 && (
-        <div className="px-4 py-3 border-b border-surface-outline text-xs text-content-dimmed">
+        <div className="px-4 py-3 border-b border-surface-outline dark:border-gray-700 text-xs text-content-dimmed">
           {hiddenUndatedCount} hidden without dates
         </div>
       )}
@@ -94,7 +95,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
           style={{ minWidth: `${timelineMinWidth}px` }}
         >
           <TodayBadge left={todayLeft} label={todayLabel} />
-          <TimelineMarker left={todayLeft} className="bg-red-500/90" />
+          <TimelineMarker left={todayLeft} className="bg-brand-1/90 dark:bg-blue-300/90" />
 
           <TimelineHeader columns={columns} monthGroups={monthGroups} />
 
@@ -132,7 +133,7 @@ function TimelineRow({
   const rangeLabel = formatRangeLabel(item);
 
   return (
-    <div className="border-b border-surface-outline/70">
+    <div className="border-b border-surface-outline/70 dark:border-gray-700/70">
       <div className="relative h-[58px] bg-surface-base">
         <TimelineGrid columns={columns} />
 
@@ -181,15 +182,15 @@ function TimelineHeader({
   monthGroups: MonthGroup[];
 }) {
   return (
-    <div className="sticky left-0 z-10 border-b border-surface-outline bg-surface-base">
+    <div className="sticky left-0 z-10 border-b border-surface-outline bg-surface-base dark:border-gray-700">
       <div
-        className="grid border-t border-surface-outline/70 text-xs font-semibold text-content-accent"
+        className="grid border-t border-surface-outline/70 text-xs font-semibold text-content-accent dark:border-gray-700"
         style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}
       >
         {monthGroups.map((group) => (
           <div
             key={group.key}
-            className="border-l border-surface-outline/70 px-3 py-2 first:border-l-0"
+            className="border-l border-surface-outline/70 px-3 py-2 first:border-l-0 dark:border-gray-700"
             style={{ gridColumn: `${group.startColumn + 1} / span ${group.span}` }}
           >
             {group.label}
@@ -204,9 +205,9 @@ function TimelineHeader({
         {columns.map((column, index) => (
           <div
             key={column.key}
-            className={classNames("border-l border-surface-outline/70 px-3 py-2", {
+            className={classNames("border-l border-surface-outline/70 px-3 py-2 dark:border-gray-700", {
               "border-l-0": index === 0,
-              "bg-surface-dimmed/70": columnContainsDate(column, new Date()),
+              "bg-surface-dimmed/70 dark:bg-gray-800/60": columnContainsDate(column, new Date()),
             })}
           >
             {formatWeekCellLabel(column.start)}
@@ -223,9 +224,9 @@ function TimelineGrid({ columns }: { columns: Column[] }) {
       {columns.map((column, index) => (
         <div
           key={column.key}
-          className={classNames("border-l border-surface-outline/70", {
+          className={classNames("border-l border-surface-outline/70 dark:border-gray-700/70", {
             "border-l-0": index === 0,
-            "bg-surface-dimmed/40": columnContainsDate(column, new Date()),
+            "bg-surface-dimmed/40 dark:bg-gray-800/40": columnContainsDate(column, new Date()),
           })}
         />
       ))}
@@ -244,7 +245,7 @@ function TodayBadge({ left, label }: { left: number | null; label: string | null
 
   return (
     <div className="pointer-events-none absolute top-1 z-30 -translate-x-1/2" style={{ left: `${left}%` }}>
-      <div className="rounded-full border border-red-200 bg-red-50 px-2 py-1 text-[10px] font-semibold leading-none text-red-700 shadow-sm">
+      <div className="rounded-full border border-blue-200 bg-blue-50 px-2 py-1 text-[10px] font-semibold leading-none text-blue-700 shadow-sm dark:border-blue-700 dark:bg-blue-900 dark:text-blue-100 dark:shadow-none">
         Today · {label}
       </div>
     </div>
@@ -271,7 +272,7 @@ function BarLabel({
   return (
     <div
       className={classNames(
-        "absolute top-3 flex h-8 min-w-0 items-center rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle",
+        "absolute top-2 flex h-10 min-w-0 items-start rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle dark:bg-gray-800/90 dark:text-gray-100 dark:shadow-none dark:hover:border-gray-500",
         tone.border,
         { "rounded-r-none border-r-0": openEnded },
       )}
@@ -279,11 +280,11 @@ function BarLabel({
       title={rangeLabel ? `${name} · ${rangeLabel}` : name}
     >
       <span className={classNames("h-full w-1 shrink-0 rounded-l-lg", tone.accent)} />
-      <BlackLink to={to} className="min-w-0 truncate px-3 text-sm font-medium leading-none" underline="hover">
+      <BlackLink to={to} className="min-w-0 truncate px-3 pt-2 text-sm font-medium leading-none" underline="hover">
         {name}
       </BlackLink>
       {openEnded && (
-        <span className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-r from-transparent to-surface-base" />
+        <span className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-r from-transparent to-surface-base dark:to-[#1f1e24]" />
       )}
     </div>
   );
@@ -306,19 +307,28 @@ function MilestoneMarker({
   return (
     <BlackLink
       to={milestone.link}
-      className="group absolute top-[35px] z-30 -translate-x-1/2"
+      className="group absolute top-[31px] z-30 -translate-x-1/2"
       style={{ left: `${left}%` }}
       title={title}
       underline="never"
     >
       <span
         className={classNames(
-          "block h-2 w-2 rounded-full border border-surface-base shadow-sm transition-transform group-hover:scale-125",
-          done ? "bg-surface-outline" : "bg-blue-500",
-          { "ring-2 ring-amber-300/70": outsideBar },
+          "flex h-4 w-4 items-center justify-center rounded-sm opacity-85 transition group-hover:scale-110 group-hover:opacity-100",
+          { "bg-amber-50 ring-1 ring-amber-300/80 dark:bg-amber-950 dark:ring-amber-500/80": outsideBar },
         )}
-      />
-      <span className="pointer-events-none absolute left-1/2 top-4 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-surface-outline bg-surface-base px-2 py-1 text-[11px] text-content-base shadow-lg group-hover:block">
+      >
+        {done ? (
+          <IconFlagFilled size={12} className="text-emerald-600 dark:text-emerald-400" />
+        ) : (
+          <IconFlag
+            size={12}
+            className="text-content-dimmed drop-shadow-[0_1px_0_rgba(255,255,255,0.9)] dark:text-gray-300 dark:drop-shadow-none"
+            stroke={2.5}
+          />
+        )}
+      </span>
+      <span className="pointer-events-none absolute left-1/2 top-4 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-surface-outline bg-surface-base px-2 py-1 text-[11px] font-medium text-content-accent shadow-lg group-hover:block dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50">
         {title}
       </span>
     </BlackLink>
@@ -405,13 +415,13 @@ function isOutsideBar(date: Date, startDate: Date | null, endDate: Date | null) 
 function barTone(status: WorkMap.Item["status"]) {
   switch (status) {
     case "off_track":
-      return { border: "border-red-200", accent: "bg-red-400" };
+      return { border: "border-red-200 dark:border-red-700/70", accent: "bg-red-400 dark:bg-red-400" };
     case "caution":
-      return { border: "border-amber-200", accent: "bg-amber-400" };
+      return { border: "border-amber-200 dark:border-amber-600/80", accent: "bg-amber-400 dark:bg-amber-400" };
     case "on_track":
-      return { border: "border-emerald-200", accent: "bg-emerald-400" };
+      return { border: "border-emerald-200 dark:border-emerald-700/80", accent: "bg-emerald-400 dark:bg-emerald-400" };
     default:
-      return { border: "border-surface-outline", accent: "bg-surface-outline" };
+      return { border: "border-surface-outline dark:border-gray-600", accent: "bg-surface-outline dark:bg-gray-500" };
   }
 }
 

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 import { WorkMap } from ".";
 import { BlackLink } from "../../Link";
-import { IconInfinity } from "../../icons";
 import classNames from "../../utils/classnames";
 import {
   buildColumns,
   calculateRange,
   clampPercent,
   compareTimelineItems,
+  formatMarkerDate,
   formatMonthLabel,
   formatRangeLabel,
-  formatTimelineYearRange,
   formatWeekCellLabel,
   getBarStartDate,
   getMarkerPosition,
@@ -78,8 +77,8 @@ export function WorkMapTimeline({ items, tab }: Props) {
   const rangeMs = Math.max(rangeEnd - rangeStart, 1);
   const timelineMinWidth = Math.max(columns.length * 96, 820);
   const todayLeft = getMarkerPosition(new Date(), rangeStart, rangeEnd);
+  const todayLabel = todayLeft === null ? null : formatMarkerDate(new Date());
   const monthGroups = buildMonthGroups(columns);
-  const yearLabel = formatTimelineYearRange(range.start, range.end);
 
   return (
     <div className="bg-surface-base rounded-b-lg border-t border-surface-outline">
@@ -94,9 +93,10 @@ export function WorkMapTimeline({ items, tab }: Props) {
           className="relative min-w-full px-4 pb-6"
           style={{ minWidth: `${timelineMinWidth}px` }}
         >
+          <TodayBadge left={todayLeft} label={todayLabel} />
           <TimelineMarker left={todayLeft} className="bg-red-500/90" />
 
-          <TimelineHeader columns={columns} monthGroups={monthGroups} yearLabel={yearLabel} />
+          <TimelineHeader columns={columns} monthGroups={monthGroups} />
 
           {visibleItems.map((item) => (
             <TimelineRow
@@ -139,28 +139,24 @@ function TimelineRow({
         <div className="absolute inset-y-0 left-0 right-0">
           {barWidth !== null && left !== null && (
             <BarLabel
-              to={item.itemPath}
-              name={item.name}
-              rangeLabel={rangeLabel}
-              status={item.status}
-              style={{ left: `${left}%`, width: `${barWidth}%` }}
-            />
-          )}
-
-          {hasInfiniteBar && left !== null && (
-            <>
-              <BarLabel
                 to={item.itemPath}
                 name={item.name}
                 rangeLabel={rangeLabel}
                 status={item.status}
-                style={{ left: `${left}%`, width: `${Math.max(100 - left, 12)}%` }}
+                openEnded={false}
+                style={{ left: `${left}%`, width: `${barWidth}%` }}
               />
-              <div className="absolute right-2 top-2 flex items-center gap-1 rounded-full border border-surface-outline bg-surface-base/90 px-2 py-1 text-[11px] text-content-dimmed">
-                <IconInfinity size={12} />
-                <span>No end</span>
-              </div>
-            </>
+            )}
+
+          {hasInfiniteBar && left !== null && (
+            <BarLabel
+              to={item.itemPath}
+              name={item.name}
+              rangeLabel={rangeLabel}
+              status={item.status}
+              openEnded
+              style={{ left: `${left}%`, width: `${Math.max(100 - left, 12)}%` }}
+            />
           )}
 
           {item.milestones.map((milestone) => (
@@ -180,18 +176,12 @@ function TimelineRow({
 function TimelineHeader({
   columns,
   monthGroups,
-  yearLabel,
 }: {
   columns: Column[];
   monthGroups: MonthGroup[];
-  yearLabel: string;
 }) {
   return (
     <div className="sticky left-0 z-10 border-b border-surface-outline bg-surface-base">
-      <div className="px-1 pb-2 pt-3 text-[11px] font-medium uppercase tracking-wide text-content-subtle">
-        Timeline · {yearLabel}
-      </div>
-
       <div
         className="grid border-t border-surface-outline/70 text-xs font-semibold text-content-accent"
         style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}
@@ -249,17 +239,31 @@ function TimelineMarker({ left, className }: { left: number | null; className: s
   return <div className={classNames("pointer-events-none absolute bottom-6 top-0 z-20 w-px", className)} style={{ left: `${left}%` }} />;
 }
 
+function TodayBadge({ left, label }: { left: number | null; label: string | null }) {
+  if (left === null || !label) return null;
+
+  return (
+    <div className="pointer-events-none absolute top-1 z-30 -translate-x-1/2" style={{ left: `${left}%` }}>
+      <div className="rounded-full border border-red-200 bg-red-50 px-2 py-1 text-[10px] font-semibold leading-none text-red-700 shadow-sm">
+        Today · {label}
+      </div>
+    </div>
+  );
+}
+
 function BarLabel({
   to,
   name,
   rangeLabel,
   status,
+  openEnded,
   style,
 }: {
   to: string;
   name: string;
   rangeLabel: string | null;
   status: WorkMap.Item["status"];
+  openEnded: boolean;
   style: React.CSSProperties;
 }) {
   const tone = barTone(status);
@@ -269,6 +273,7 @@ function BarLabel({
       className={classNames(
         "absolute top-3 flex h-8 min-w-0 items-center rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle",
         tone.border,
+        { "rounded-r-none border-r-0": openEnded },
       )}
       style={style}
       title={rangeLabel ? `${name} · ${rangeLabel}` : name}
@@ -277,6 +282,9 @@ function BarLabel({
       <BlackLink to={to} className="min-w-0 truncate px-3 text-sm font-medium leading-none" underline="hover">
         {name}
       </BlackLink>
+      {openEnded && (
+        <span className="pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-r from-transparent to-surface-base" />
+      )}
     </div>
   );
 }

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -7,12 +7,12 @@ import {
   buildColumns,
   calculateRange,
   clampPercent,
-  chooseScale,
   compareTimelineItems,
-  formatMarkerDate,
+  formatMonthLabel,
   formatRangeLabel,
+  formatTimelineYearRange,
+  formatWeekCellLabel,
   getBarStartDate,
-  getDateAtPosition,
   getMarkerPosition,
   type TimelineColumn as Column,
 } from "../utils/timeline";
@@ -32,10 +32,25 @@ interface TimelineItem {
   itemPath: string;
   startDate: Date | null;
   endDate: Date | null;
+  milestones: TimelineMilestone[];
+}
+
+interface TimelineMilestone {
+  id: string;
+  name: string;
+  status: WorkMap.Milestone["status"];
+  link: string;
+  dueDate: Date;
+}
+
+interface MonthGroup {
+  key: string;
+  label: string;
+  startColumn: number;
+  span: number;
 }
 
 export function WorkMapTimeline({ items, tab }: Props) {
-  const [hoverLeft, setHoverLeft] = React.useState<number | null>(null);
   const flattenedItems = React.useMemo(() => flattenItems(items), [items]);
   const timelineItems = React.useMemo(() => flattenedItems.map(toTimelineItem), [flattenedItems]);
   const hiddenUndatedCount = timelineItems.filter((item) => !item.startDate && !item.endDate).length;
@@ -57,25 +72,17 @@ export function WorkMapTimeline({ items, tab }: Props) {
   }
 
   const range = calculateRange(visibleItems);
-  const scale = chooseScale(range.start, range.end);
-  const columns = buildColumns(range.start, range.end, scale);
+  const columns = buildColumns(range.start, range.end, "week");
   const rangeStart = range.start.getTime();
   const rangeEnd = range.end.getTime();
   const rangeMs = Math.max(rangeEnd - rangeStart, 1);
-  const timelineMinWidth = Math.max(columns.length * 72, 720);
+  const timelineMinWidth = Math.max(columns.length * 96, 820);
   const todayLeft = getMarkerPosition(new Date(), rangeStart, rangeEnd);
-  const hoverDate = hoverLeft === null ? null : getDateAtPosition(hoverLeft, rangeStart, rangeEnd);
-  const todayDate = getDateAtPosition(todayLeft, rangeStart, rangeEnd);
-
-  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    const relativeX = event.clientX - rect.left;
-    const nextLeft = clampPercent((relativeX / rect.width) * 100);
-    setHoverLeft(nextLeft);
-  };
+  const monthGroups = buildMonthGroups(columns);
+  const yearLabel = formatTimelineYearRange(range.start, range.end);
 
   return (
-    <div className="bg-surface-base rounded-b-lg">
+    <div className="bg-surface-base rounded-b-lg border-t border-surface-outline">
       {hiddenUndatedCount > 0 && (
         <div className="px-4 py-3 border-b border-surface-outline text-xs text-content-dimmed">
           {hiddenUndatedCount} hidden without dates
@@ -84,38 +91,12 @@ export function WorkMapTimeline({ items, tab }: Props) {
 
       <div className="overflow-x-auto">
         <div
-          className="relative min-w-full px-4 pb-4"
+          className="relative min-w-full px-4 pb-6"
           style={{ minWidth: `${timelineMinWidth}px` }}
-          onMouseMove={handleMouseMove}
-          onMouseLeave={() => setHoverLeft(null)}
         >
-          <MarkerBadge
-            left={todayLeft}
-            label={todayDate ? formatMarkerDate(todayDate) : null}
-            className="border border-red-200 bg-red-50 text-red-700"
-          />
-          <MarkerBadge
-            left={hoverLeft}
-            label={hoverDate ? formatMarkerDate(hoverDate) : null}
-            className="border border-sky-200 bg-sky-50 text-sky-800"
-          />
           <TimelineMarker left={todayLeft} className="bg-red-500/90" />
-          <TimelineMarker left={hoverLeft} className="bg-red-400/60" />
 
-          <div
-            className="grid border-b border-surface-outline bg-surface-base text-xs font-semibold text-content-dimmed"
-            style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(72px, 1fr))` }}
-          >
-            {columns.map((column, index) => (
-              <div
-                key={column.key}
-                className={classNames("px-3 py-3 border-l border-surface-outline/70", { "border-l-0": index === 0 })}
-              >
-                <div>{column.label}</div>
-                <div className="mt-1 text-[11px] text-content-subtle">{column.shortLabel}</div>
-              </div>
-            ))}
-          </div>
+          <TimelineHeader columns={columns} monthGroups={monthGroups} yearLabel={yearLabel} />
 
           {visibleItems.map((item) => (
             <TimelineRow
@@ -148,10 +129,11 @@ function TimelineRow({
   const finiteEnd = item.endDate ? clampPercent(((item.endDate.getTime() - rangeStart) / rangeMs) * 100) : null;
   const hasInfiniteBar = item.startDate && !item.endDate;
   const barWidth = left !== null && finiteEnd !== null ? Math.max(finiteEnd - left, 8) : null;
+  const rangeLabel = formatRangeLabel(item);
 
   return (
-    <div className="border-b border-surface-outline/70 py-2">
-      <div className="relative h-[64px] bg-surface-base">
+    <div className="border-b border-surface-outline/70">
+      <div className="relative h-[58px] bg-surface-base">
         <TimelineGrid columns={columns} />
 
         <div className="absolute inset-y-0 left-0 right-0">
@@ -159,7 +141,8 @@ function TimelineRow({
             <BarLabel
               to={item.itemPath}
               name={item.name}
-              className="border-[#d9e2f1] bg-[#f7f9fc] text-content-accent"
+              rangeLabel={rangeLabel}
+              status={item.status}
               style={{ left: `${left}%`, width: `${barWidth}%` }}
             />
           )}
@@ -169,7 +152,8 @@ function TimelineRow({
               <BarLabel
                 to={item.itemPath}
                 name={item.name}
-                className="border-[#d9e2f1] bg-gradient-to-r from-[#f7f9fc] to-[#eef5ff]/80 text-content-accent"
+                rangeLabel={rangeLabel}
+                status={item.status}
                 style={{ left: `${left}%`, width: `${Math.max(100 - left, 12)}%` }}
               />
               <div className="absolute right-2 top-2 flex items-center gap-1 rounded-full border border-surface-outline bg-surface-base/90 px-2 py-1 text-[11px] text-content-dimmed">
@@ -179,8 +163,65 @@ function TimelineRow({
             </>
           )}
 
-          <TimelineRangeLabel item={item} />
+          {item.milestones.map((milestone) => (
+            <MilestoneMarker
+              key={milestone.id}
+              milestone={milestone}
+              left={getMarkerPosition(milestone.dueDate, rangeStart, rangeStart + rangeMs)}
+              outsideBar={isOutsideBar(milestone.dueDate, barStartDate, item.endDate)}
+            />
+          ))}
         </div>
+      </div>
+    </div>
+  );
+}
+
+function TimelineHeader({
+  columns,
+  monthGroups,
+  yearLabel,
+}: {
+  columns: Column[];
+  monthGroups: MonthGroup[];
+  yearLabel: string;
+}) {
+  return (
+    <div className="sticky left-0 z-10 border-b border-surface-outline bg-surface-base">
+      <div className="px-1 pb-2 pt-3 text-[11px] font-medium uppercase tracking-wide text-content-subtle">
+        Timeline · {yearLabel}
+      </div>
+
+      <div
+        className="grid border-t border-surface-outline/70 text-xs font-semibold text-content-accent"
+        style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}
+      >
+        {monthGroups.map((group) => (
+          <div
+            key={group.key}
+            className="border-l border-surface-outline/70 px-3 py-2 first:border-l-0"
+            style={{ gridColumn: `${group.startColumn + 1} / span ${group.span}` }}
+          >
+            {group.label}
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="grid text-[11px] font-medium text-content-dimmed"
+        style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}
+      >
+        {columns.map((column, index) => (
+          <div
+            key={column.key}
+            className={classNames("border-l border-surface-outline/70 px-3 py-2", {
+              "border-l-0": index === 0,
+              "bg-surface-dimmed/70": columnContainsDate(column, new Date()),
+            })}
+          >
+            {formatWeekCellLabel(column.start)}
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -188,22 +229,16 @@ function TimelineRow({
 
 function TimelineGrid({ columns }: { columns: Column[] }) {
   return (
-    <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(72px, 1fr))` }}>
+    <div className="absolute inset-0 grid" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(96px, 1fr))` }}>
       {columns.map((column, index) => (
-        <div key={column.key} className={classNames("border-l border-surface-outline/70", { "border-l-0": index === 0 })} />
+        <div
+          key={column.key}
+          className={classNames("border-l border-surface-outline/70", {
+            "border-l-0": index === 0,
+            "bg-surface-dimmed/40": columnContainsDate(column, new Date()),
+          })}
+        />
       ))}
-    </div>
-  );
-}
-
-function TimelineRangeLabel({ item }: { item: TimelineItem }) {
-  const label = formatRangeLabel(item);
-
-  if (!label) return null;
-
-  return (
-    <div className="absolute right-2 bottom-1 text-[11px] text-content-dimmed">
-      {label}
     </div>
   );
 }
@@ -211,55 +246,74 @@ function TimelineRangeLabel({ item }: { item: TimelineItem }) {
 function TimelineMarker({ left, className }: { left: number | null; className: string }) {
   if (left === null) return null;
 
-  return <div className={classNames("pointer-events-none absolute bottom-4 top-0 z-20 w-px", className)} style={{ left: `${left}%` }} />;
-}
-
-function MarkerBadge({
-  left,
-  label,
-  className,
-}: {
-  left: number | null;
-  label: string | null;
-  className: string;
-}) {
-  if (left === null || !label) return null;
-
-  return (
-    <div
-      className="pointer-events-none absolute top-2 z-30 -translate-x-1/2"
-      style={{ left: `${clampPercent(left)}%` }}
-    >
-      <div className={classNames("rounded-full px-2 py-1 text-[10px] font-semibold tracking-wide shadow-sm", className)}>
-        {label}
-      </div>
-    </div>
-  );
+  return <div className={classNames("pointer-events-none absolute bottom-6 top-0 z-20 w-px", className)} style={{ left: `${left}%` }} />;
 }
 
 function BarLabel({
   to,
   name,
+  rangeLabel,
+  status,
   style,
-  className,
 }: {
   to: string;
   name: string;
+  rangeLabel: string | null;
+  status: WorkMap.Item["status"];
   style: React.CSSProperties;
-  className: string;
 }) {
+  const tone = barTone(status);
+
   return (
     <div
       className={classNames(
-        "absolute top-2 flex h-9 min-w-0 items-center rounded-xl border px-3 shadow-sm",
-        className,
+        "absolute top-3 flex h-8 min-w-0 items-center rounded-lg border bg-surface-dimmed text-content-accent shadow-sm transition-colors hover:border-content-subtle",
+        tone.border,
       )}
       style={style}
+      title={rangeLabel ? `${name} · ${rangeLabel}` : name}
     >
-      <BlackLink to={to} className="truncate text-sm font-medium leading-none" underline="hover">
+      <span className={classNames("h-full w-1 shrink-0 rounded-l-lg", tone.accent)} />
+      <BlackLink to={to} className="min-w-0 truncate px-3 text-sm font-medium leading-none" underline="hover">
         {name}
       </BlackLink>
     </div>
+  );
+}
+
+function MilestoneMarker({
+  milestone,
+  left,
+  outsideBar,
+}: {
+  milestone: TimelineMilestone;
+  left: number | null;
+  outsideBar: boolean;
+}) {
+  if (left === null) return null;
+
+  const done = milestone.status === "done";
+  const title = `${milestone.name} · ${formatMilestoneDate(milestone.dueDate)}${done ? " · Done" : ""}`;
+
+  return (
+    <BlackLink
+      to={milestone.link}
+      className="group absolute top-[35px] z-30 -translate-x-1/2"
+      style={{ left: `${left}%` }}
+      title={title}
+      underline="never"
+    >
+      <span
+        className={classNames(
+          "block h-2 w-2 rounded-full border border-surface-base shadow-sm transition-transform group-hover:scale-125",
+          done ? "bg-surface-outline" : "bg-blue-500",
+          { "ring-2 ring-amber-300/70": outsideBar },
+        )}
+      />
+      <span className="pointer-events-none absolute left-1/2 top-4 hidden -translate-x-1/2 whitespace-nowrap rounded-md border border-surface-outline bg-surface-base px-2 py-1 text-[11px] text-content-base shadow-lg group-hover:block">
+        {title}
+      </span>
+    </BlackLink>
   );
 }
 
@@ -278,6 +332,21 @@ function toTimelineItem(item: WorkMap.Item): TimelineItem {
     itemPath: item.itemPath,
     startDate: normalizeDate(item.timeframe?.startDate?.date),
     endDate: normalizeDate(item.timeframe?.endDate?.date),
+    milestones: item.milestones
+      .map((milestone) => {
+        const dueDate = normalizeDate(milestone.dueDate?.date);
+        if (!dueDate) return null;
+
+        return {
+          id: milestone.id,
+          name: milestone.name,
+          status: milestone.status,
+          link: milestone.link,
+          dueDate,
+        };
+      })
+      .filter((milestone): milestone is TimelineMilestone => Boolean(milestone))
+      .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime()),
   };
 }
 
@@ -287,6 +356,59 @@ function normalizeDate(date: Date | null | undefined) {
   const value = new Date(date);
   value.setHours(0, 0, 0, 0);
   return value;
+}
+
+function buildMonthGroups(columns: Column[]): MonthGroup[] {
+  const groups: MonthGroup[] = [];
+
+  columns.forEach((column, index) => {
+    const key = `${column.start.getFullYear()}-${column.start.getMonth()}`;
+    const previous = groups[groups.length - 1];
+
+    if (previous && previous.key === key) {
+      previous.span += 1;
+      return;
+    }
+
+    groups.push({
+      key,
+      label: formatMonthLabel(column.start),
+      startColumn: index,
+      span: 1,
+    });
+  });
+
+  return groups;
+}
+
+function columnContainsDate(column: Column, date: Date) {
+  const value = normalizeDate(date)?.getTime();
+  if (!value) return false;
+
+  return value >= column.start.getTime() && value <= column.end.getTime();
+}
+
+function isOutsideBar(date: Date, startDate: Date | null, endDate: Date | null) {
+  if (startDate && date < startDate) return true;
+  if (endDate && date > endDate) return true;
+  return false;
+}
+
+function barTone(status: WorkMap.Item["status"]) {
+  switch (status) {
+    case "off_track":
+      return { border: "border-red-200", accent: "bg-red-400" };
+    case "caution":
+      return { border: "border-amber-200", accent: "bg-amber-400" };
+    case "on_track":
+      return { border: "border-emerald-200", accent: "bg-emerald-400" };
+    default:
+      return { border: "border-surface-outline", accent: "bg-surface-outline" };
+  }
+}
+
+function formatMilestoneDate(date: Date) {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
 }
 
 function TimelineEmptyState({ message, hiddenUndatedCount }: { message: string; hiddenUndatedCount?: number }) {

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -82,7 +82,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
   const monthGroups = buildMonthGroups(columns);
 
   return (
-    <div className="bg-surface-base rounded-b-lg border-t border-surface-outline dark:border-gray-700">
+    <div className="bg-surface-base rounded-b-lg">
       {hiddenUndatedCount > 0 && (
         <div className="px-4 py-3 border-b border-surface-outline dark:border-gray-700 text-xs text-content-dimmed">
           {hiddenUndatedCount} hidden without dates

--- a/turboui/src/WorkMap/components/index.tsx
+++ b/turboui/src/WorkMap/components/index.tsx
@@ -45,7 +45,7 @@ export function WorkMap({
   const location = useLocation();
   const { filteredItems, tabsState, tab } = useWorkMapTab({ rawItems: items, type, opts: { tabOptions } });
   const searchParams = new URLSearchParams(location.search);
-  const timelineAvailable = type === "company" && tab === "projects";
+  const timelineAvailable = type !== "personal" && tab === "projects";
   const view = timelineAvailable && searchParams.get("view") === "timeline" ? "timeline" : "table";
 
   return (
@@ -137,6 +137,14 @@ export namespace WorkMap {
     endDate: DateField.ContextualDate | null;
   }
 
+  export interface Milestone {
+    id: string;
+    name: string;
+    status: "pending" | "done" | string;
+    dueDate: DateField.ContextualDate | null;
+    link: string;
+  }
+
   export interface Item {
     id: string;
     parentId: string | null;
@@ -157,6 +165,7 @@ export namespace WorkMap {
     children: Item[];
     completedOn: string | null;
     timeframe: Timeframe | null;
+    milestones: Milestone[];
     type: ItemType;
     itemPath: string;
     privacy: PrivacyIndicator.PrivacyLevels;

--- a/turboui/src/WorkMap/tests/mockData.ts
+++ b/turboui/src/WorkMap/tests/mockData.ts
@@ -51,6 +51,7 @@ function withDefaults(item: any): WorkMap.Item {
     completedOn: null,
     nextStep: "",
     taskStatus: null,
+    milestones: [],
     privacy: "internal" as PrivacyIndicator.PrivacyLevels,
     ...item,
     children: (item.children || []).map(withDefaults),

--- a/turboui/src/WorkMap/utils/timeline.ts
+++ b/turboui/src/WorkMap/utils/timeline.ts
@@ -109,6 +109,22 @@ export function formatMarkerDate(date: Date) {
   return markerDateLabel.format(date).toUpperCase();
 }
 
+export function formatWeekCellLabel(date: Date) {
+  const end = addDays(date, 6);
+  return `${dayLabel.format(date)}-${dayLabel.format(end)}`;
+}
+
+export function formatMonthLabel(date: Date) {
+  return monthLabel.format(date);
+}
+
+export function formatTimelineYearRange(start: Date, end: Date) {
+  const startYear = yearLabel.format(start);
+  const endYear = yearLabel.format(end);
+
+  return startYear === endYear ? startYear : `${startYear}-${endYear}`;
+}
+
 export function getBarStartDate(item: TimelineDatedItem) {
   if (item.startDate) return item.startDate;
   if (!item.endDate) return null;
@@ -196,4 +212,5 @@ const monthDayLabel = new Intl.DateTimeFormat(undefined, { month: "short", day: 
 const compactDateLabel = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
 const markerDateLabel = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
 const monthLabel = new Intl.DateTimeFormat(undefined, { month: "short" });
+const dayLabel = new Intl.DateTimeFormat(undefined, { day: "numeric" });
 const yearLabel = new Intl.DateTimeFormat(undefined, { year: "numeric" });

--- a/turboui/src/WorkMap/utils/timeline.ts
+++ b/turboui/src/WorkMap/utils/timeline.ts
@@ -95,7 +95,7 @@ export function formatRangeLabel(item: TimelineDatedItem) {
   }
 
   if (item.startDate && !item.endDate) {
-    return `${compactDateLabel.format(item.startDate)} - forever`;
+    return `${compactDateLabel.format(item.startDate)} - no deadline`;
   }
 
   if (!item.startDate && item.endDate) {

--- a/turboui/src/WorkMap/utils/timelineItem.test.ts
+++ b/turboui/src/WorkMap/utils/timelineItem.test.ts
@@ -1,0 +1,102 @@
+import { WorkMap } from "../components";
+import { toTimelineItem } from "./timelineItem";
+
+describe("toTimelineItem", () => {
+  it("filters milestones without a valid due date", () => {
+    const item = makeItem({
+      milestones: [
+        makeMilestone({ id: "valid", dueDate: contextualDate(new Date(2026, 4, 10, 12)) }),
+        makeMilestone({ id: "missing", dueDate: null }),
+        makeMilestone({ id: "invalid", dueDate: contextualDate(new Date("invalid")) }),
+      ],
+    });
+
+    expect(toTimelineItem(item).milestones.map((milestone) => milestone.id)).toEqual(["valid"]);
+  });
+
+  it("maps milestone fields and sorts them by due date", () => {
+    const item = makeItem({
+      milestones: [
+        makeMilestone({
+          id: "late",
+          name: "Late milestone",
+          status: "pending",
+          link: "/late",
+          dueDate: contextualDate(new Date(2026, 5, 20, 12)),
+        }),
+        makeMilestone({
+          id: "early",
+          name: "Early milestone",
+          status: "done",
+          link: "/early",
+          dueDate: contextualDate(new Date(2026, 4, 5, 12)),
+        }),
+      ],
+    });
+
+    expect(toTimelineItem(item).milestones).toEqual([
+      {
+        id: "early",
+        name: "Early milestone",
+        status: "done",
+        link: "/early",
+        dueDate: new Date(2026, 4, 5),
+      },
+      {
+        id: "late",
+        name: "Late milestone",
+        status: "pending",
+        link: "/late",
+        dueDate: new Date(2026, 5, 20),
+      },
+    ]);
+  });
+});
+
+function makeItem(overrides: Partial<WorkMap.Item> = {}): WorkMap.Item {
+  return {
+    id: "item-1",
+    parentId: null,
+    name: "Project",
+    status: "on_track",
+    taskStatus: null,
+    progress: 0,
+    project: null,
+    projectPath: null,
+    space: null,
+    spacePath: null,
+    owner: null,
+    ownerPath: null,
+    reviewer: null,
+    reviewerPath: null,
+    nextStep: "",
+    isNew: false,
+    children: [],
+    completedOn: null,
+    timeframe: null,
+    milestones: [],
+    type: "project",
+    itemPath: "/project",
+    privacy: "internal",
+    ...overrides,
+  };
+}
+
+function makeMilestone(overrides: Partial<WorkMap.Milestone> = {}): WorkMap.Milestone {
+  return {
+    id: "milestone-1",
+    name: "Milestone",
+    status: "pending",
+    dueDate: contextualDate(new Date(2026, 4, 10, 12)),
+    link: "/milestone",
+    ...overrides,
+  };
+}
+
+function contextualDate(date: Date): WorkMap.Milestone["dueDate"] {
+  return {
+    date,
+    dateType: "day",
+    value: Number.isNaN(date.getTime()) ? "Invalid date" : date.toISOString(),
+  };
+}

--- a/turboui/src/WorkMap/utils/timelineItem.ts
+++ b/turboui/src/WorkMap/utils/timelineItem.ts
@@ -1,0 +1,65 @@
+import { WorkMap } from "../components";
+
+export interface TimelineItem {
+  id: string;
+  name: string;
+  type: WorkMap.Item["type"];
+  status: WorkMap.Item["status"];
+  owner: WorkMap.Item["owner"];
+  space: WorkMap.Item["space"];
+  itemPath: string;
+  startDate: Date | null;
+  endDate: Date | null;
+  milestones: TimelineMilestone[];
+}
+
+export interface TimelineMilestone {
+  id: string;
+  name: string;
+  status: WorkMap.Milestone["status"];
+  link: string;
+  dueDate: Date;
+}
+
+export function flattenTimelineItems(items: WorkMap.Item[]): WorkMap.Item[] {
+  return items.flatMap((item) => [item, ...flattenTimelineItems(item.children)]);
+}
+
+export function toTimelineItem(item: WorkMap.Item): TimelineItem {
+  return {
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    status: item.status,
+    owner: item.owner,
+    space: item.space,
+    itemPath: item.itemPath,
+    startDate: normalizeTimelineDate(item.timeframe?.startDate?.date),
+    endDate: normalizeTimelineDate(item.timeframe?.endDate?.date),
+    milestones: item.milestones
+      .map((milestone) => {
+        const dueDate = normalizeTimelineDate(milestone.dueDate?.date);
+        if (!dueDate) return null;
+
+        return {
+          id: milestone.id,
+          name: milestone.name,
+          status: milestone.status,
+          link: milestone.link,
+          dueDate,
+        };
+      })
+      .filter((milestone): milestone is TimelineMilestone => Boolean(milestone))
+      .sort((a, b) => a.dueDate.getTime() - b.dueDate.getTime()),
+  };
+}
+
+export function normalizeTimelineDate(date: Date | null | undefined) {
+  if (!date) return null;
+
+  const value = new Date(date);
+  if (Number.isNaN(value.getTime())) return null;
+
+  value.setHours(0, 0, 0, 0);
+  return value;
+}

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -144,6 +144,7 @@ import IconTable from "@tabler/icons-react/dist/esm/icons/IconTable.mjs";
 import IconTarget from "@tabler/icons-react/dist/esm/icons/IconTarget.mjs";
 import IconTargetArrow from "@tabler/icons-react/dist/esm/icons/IconTargetArrow.mjs";
 import IconTent from "@tabler/icons-react/dist/esm/icons/IconTent.mjs";
+import IconTimeline from "@tabler/icons-react/dist/esm/icons/IconTimeline.mjs";
 import IconTrash from "@tabler/icons-react/dist/esm/icons/IconTrash.mjs";
 import IconTrophy from "@tabler/icons-react/dist/esm/icons/IconTrophy.mjs";
 import IconUpload from "@tabler/icons-react/dist/esm/icons/IconUpload.mjs";
@@ -305,6 +306,7 @@ export {
   IconTarget,
   IconTargetArrow,
   IconTent,
+  IconTimeline,
   IconTrash,
   IconTrophy,
   IconUpload,

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -19,6 +19,7 @@ export * from "./RichContent";
 export * from "./StatusBadge";
 export * from "./TimeframeSelector";
 export * from "./Timeline";
+export * from "./ViewToggle";
 export * from "./WorkMap";
 
 import RichContent from "./RichContent";


### PR DESCRIPTION
- Redesigns the Work Map project timeline for a cleaner executive/program planning view.
- Adds week-based timeline headers, an explicit Today marker, and milestone flags inside project bars.
- Exposes project milestones through the Work Map API and maps them into TurboUI.
- Enables timeline view for space Work Maps.
- Adds a reusable TurboUI `ViewToggle` and polishes Work Map navigation spacing/dividers.

<img width="2106" height="1424" alt="CleanShot 2026-05-20 at 11 36 31@2x" src="https://github.com/user-attachments/assets/c681d197-7214-4452-b634-101b23b1915f" />
