### PR TITLE
fix: refine Work Map timeline edge cases

### DIFF
--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -39,7 +39,11 @@ const TIMELINE_LAYOUT = {
   milestoneIconSize: 16,
 };
 
+type MilestonePlacement = "start" | "middle" | "end";
+
 export function WorkMapTimeline({ items, tab }: Props) {
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const centeredRangeRef = React.useRef<string | null>(null);
   const flattenedItems = React.useMemo(() => flattenTimelineItems(items), [items]);
   const timelineItems = React.useMemo(() => flattenedItems.map(toTimelineItem), [flattenedItems]);
   const hiddenUndatedCount = timelineItems.filter((item) => !item.startDate && !item.endDate).length;
@@ -52,6 +56,37 @@ export function WorkMapTimeline({ items, tab }: Props) {
     [timelineItems],
   );
 
+  const range = visibleItems.length > 0 ? calculateRange(visibleItems) : null;
+  const columns = range ? buildColumns(range.start, range.end, "week") : [];
+  const rangeStart = range?.start.getTime() ?? 0;
+  const rangeEnd = range?.end.getTime() ?? 0;
+  const rangeMs = Math.max(rangeEnd - rangeStart, 1);
+  const timelineMinWidth = Math.max(columns.length * 96, 820);
+  const today = new Date();
+  const todayLeft = range ? getMarkerPosition(today, rangeStart, rangeEnd) : null;
+  const todayLabel = todayLeft === null ? null : formatMarkerDate(today);
+  const monthGroups = buildMonthGroups(columns);
+  const highlightedColumnKey = columns.find((column) => columnContainsDate(column, today))?.key ?? null;
+  const centeredRangeKey = todayLeft === null ? null : `${rangeStart}:${rangeEnd}:${timelineMinWidth}`;
+
+  React.useEffect(() => {
+    if (!centeredRangeKey || todayLeft === null || centeredRangeRef.current === centeredRangeKey) return;
+
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      const markerLeft = scrollContainer.scrollWidth * (todayLeft / 100);
+      const targetLeft = markerLeft - scrollContainer.clientWidth / 2;
+      const maxLeft = scrollContainer.scrollWidth - scrollContainer.clientWidth;
+
+      scrollContainer.scrollLeft = Math.max(0, Math.min(targetLeft, maxLeft));
+      centeredRangeRef.current = centeredRangeKey;
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [centeredRangeKey, todayLeft]);
+
   if (items.length === 0) {
     return <TimelineEmptyState message={emptyStateMessage(tab)} />;
   }
@@ -59,18 +94,6 @@ export function WorkMapTimeline({ items, tab }: Props) {
   if (visibleItems.length === 0) {
     return <TimelineEmptyState message="Nothing in this view has dates yet." hiddenUndatedCount={hiddenUndatedCount} />;
   }
-
-  const range = calculateRange(visibleItems);
-  const columns = buildColumns(range.start, range.end, "week");
-  const rangeStart = range.start.getTime();
-  const rangeEnd = range.end.getTime();
-  const rangeMs = Math.max(rangeEnd - rangeStart, 1);
-  const timelineMinWidth = Math.max(columns.length * 96, 820);
-  const today = new Date();
-  const todayLeft = getMarkerPosition(today, rangeStart, rangeEnd);
-  const todayLabel = todayLeft === null ? null : formatMarkerDate(today);
-  const monthGroups = buildMonthGroups(columns);
-  const highlightedColumnKey = columns.find((column) => columnContainsDate(column, today))?.key ?? null;
 
   return (
     <div className="bg-surface-base rounded-b-lg">
@@ -80,7 +103,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
         </div>
       )}
 
-      <div className="overflow-x-auto">
+      <div ref={scrollContainerRef} className="overflow-x-auto">
         <div
           className="relative min-w-full px-4"
           style={{ minWidth: `${timelineMinWidth}px`, paddingBottom: TIMELINE_LAYOUT.bottomPadding }}
@@ -160,6 +183,7 @@ function TimelineRow({
               milestone={milestone}
               left={getMarkerPosition(milestone.dueDate, rangeStart, rangeStart + rangeMs)}
               outsideBar={isOutsideBar(milestone.dueDate, barStartDate, item.endDate)}
+              placement={milestonePlacement(milestone.dueDate, barStartDate, item.endDate)}
             />
           ))}
         </div>
@@ -295,10 +319,12 @@ function MilestoneMarker({
   milestone,
   left,
   outsideBar,
+  placement,
 }: {
   milestone: TimelineMilestone;
   left: number | null;
   outsideBar: boolean;
+  placement: MilestonePlacement;
 }) {
   if (left === null) return null;
 
@@ -308,15 +334,17 @@ function MilestoneMarker({
   return (
     <BlackLink
       to={milestone.link}
-      className="group absolute z-30 -translate-x-1/2"
+      className={classNames("group absolute z-30", milestoneTranslateClass(placement))}
       style={{ left: `${left}%`, top: TIMELINE_LAYOUT.milestoneTop }}
       title={title}
       underline="never"
     >
       <span
         className={classNames(
-          "flex h-4 w-4 items-center justify-center rounded-sm opacity-85 transition group-hover:scale-110 group-hover:opacity-100",
-          { "bg-amber-50 ring-1 ring-amber-300/80 dark:bg-amber-950 dark:ring-amber-500/80": outsideBar },
+          "flex h-4 w-4 items-center justify-center rounded-sm transition group-hover:scale-110",
+          outsideBar
+            ? "bg-amber-50 text-amber-700 opacity-95 ring-1 ring-amber-300/90 dark:bg-amber-900/40 dark:text-amber-300 dark:ring-amber-400/70"
+            : "opacity-85 group-hover:opacity-100",
         )}
       >
         {done ? (
@@ -324,7 +352,11 @@ function MilestoneMarker({
         ) : (
           <IconFlag
             size={12}
-            className="text-content-dimmed drop-shadow-[0_1px_0_rgba(255,255,255,0.9)] dark:text-gray-300 dark:drop-shadow-none"
+            className={classNames({
+              "text-amber-700 dark:text-amber-300": outsideBar,
+              "text-content-dimmed drop-shadow-[0_1px_0_rgba(255,255,255,0.9)] dark:text-gray-300 dark:drop-shadow-none":
+                !outsideBar,
+            })}
             stroke={2.5}
           />
         )}
@@ -374,6 +406,27 @@ function isOutsideBar(date: Date, startDate: Date | null, endDate: Date | null) 
   if (startDate && date < startDate) return true;
   if (endDate && date > endDate) return true;
   return false;
+}
+
+function milestonePlacement(date: Date, startDate: Date | null, endDate: Date | null): MilestonePlacement {
+  if (startDate && sameDay(date, startDate)) return "start";
+  if (endDate && sameDay(date, endDate)) return "end";
+  return "middle";
+}
+
+function milestoneTranslateClass(placement: MilestonePlacement) {
+  switch (placement) {
+    case "start":
+      return "translate-x-0";
+    case "end":
+      return "-translate-x-full";
+    default:
+      return "-translate-x-1/2";
+  }
+}
+
+function sameDay(a: Date, b: Date) {
+  return normalizeTimelineDate(a)?.getTime() === normalizeTimelineDate(b)?.getTime();
 }
 
 function barTone(status: WorkMap.Item["status"]) {

--- a/turboui/src/WorkMap/components/WorkMapTimeline.tsx
+++ b/turboui/src/WorkMap/components/WorkMapTimeline.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { WorkMap } from ".";
 import { BlackLink } from "../../Link";
-import { IconFlag, IconFlagFilled } from "../../icons";
+import { IconArrowLeft, IconArrowRight, IconFlag, IconFlagFilled } from "../../icons";
 import classNames from "../../utils/classnames";
 import {
   buildColumns,
@@ -37,13 +37,20 @@ const TIMELINE_LAYOUT = {
   barHeight: 40,
   milestoneTop: 31,
   milestoneIconSize: 16,
+  continuationInset: 14,
 };
 
 type MilestonePlacement = "start" | "middle" | "end";
 
+interface TimelineViewport {
+  left: number;
+  right: number;
+}
+
 export function WorkMapTimeline({ items, tab }: Props) {
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
   const centeredRangeRef = React.useRef<string | null>(null);
+  const [viewport, setViewport] = React.useState<TimelineViewport | null>(null);
   const flattenedItems = React.useMemo(() => flattenTimelineItems(items), [items]);
   const timelineItems = React.useMemo(() => flattenedItems.map(toTimelineItem), [flattenedItems]);
   const hiddenUndatedCount = timelineItems.filter((item) => !item.startDate && !item.endDate).length;
@@ -69,6 +76,13 @@ export function WorkMapTimeline({ items, tab }: Props) {
   const highlightedColumnKey = columns.find((column) => columnContainsDate(column, today))?.key ?? null;
   const centeredRangeKey = todayLeft === null ? null : `${rangeStart}:${rangeEnd}:${timelineMinWidth}`;
 
+  const updateViewport = React.useCallback(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+
+    setViewport(calculateTimelineViewport(scrollContainer));
+  }, []);
+
   React.useEffect(() => {
     if (!centeredRangeKey || todayLeft === null || centeredRangeRef.current === centeredRangeKey) return;
 
@@ -82,10 +96,15 @@ export function WorkMapTimeline({ items, tab }: Props) {
 
       scrollContainer.scrollLeft = Math.max(0, Math.min(targetLeft, maxLeft));
       centeredRangeRef.current = centeredRangeKey;
+      setViewport(calculateTimelineViewport(scrollContainer));
     });
 
     return () => window.cancelAnimationFrame(frame);
   }, [centeredRangeKey, todayLeft]);
+
+  React.useEffect(() => {
+    updateViewport();
+  }, [timelineMinWidth, updateViewport]);
 
   if (items.length === 0) {
     return <TimelineEmptyState message={emptyStateMessage(tab)} />;
@@ -103,7 +122,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
         </div>
       )}
 
-      <div ref={scrollContainerRef} className="overflow-x-auto">
+      <div ref={scrollContainerRef} className="overflow-x-auto" onScroll={updateViewport}>
         <div
           className="relative min-w-full px-4"
           style={{ minWidth: `${timelineMinWidth}px`, paddingBottom: TIMELINE_LAYOUT.bottomPadding }}
@@ -121,6 +140,7 @@ export function WorkMapTimeline({ items, tab }: Props) {
               rangeStart={rangeStart}
               rangeMs={rangeMs}
               highlightedColumnKey={highlightedColumnKey}
+              viewport={viewport}
             />
           ))}
         </div>
@@ -135,18 +155,21 @@ function TimelineRow({
   rangeStart,
   rangeMs,
   highlightedColumnKey,
+  viewport,
 }: {
   item: TimelineItem;
   columns: Column[];
   rangeStart: number;
   rangeMs: number;
   highlightedColumnKey: string | null;
+  viewport: TimelineViewport | null;
 }) {
   const barStartDate = getBarStartDate(item);
   const left = barStartDate ? clampPercent(((barStartDate.getTime() - rangeStart) / rangeMs) * 100) : null;
   const finiteEnd = item.endDate ? clampPercent(((item.endDate.getTime() - rangeStart) / rangeMs) * 100) : null;
   const hasInfiniteBar = item.startDate && !item.endDate;
   const barWidth = left !== null && finiteEnd !== null ? Math.max(finiteEnd - left, 8) : null;
+  const visualBarEnd = left === null ? null : hasInfiniteBar ? Math.max(100, left + 12) : barWidth === null ? null : left + barWidth;
   const rangeLabel = formatRangeLabel(item);
 
   return (
@@ -177,6 +200,10 @@ function TimelineRow({
             />
           )}
 
+          {left !== null && visualBarEnd !== null && (
+            <BarContinuationIndicators barStart={left} barEnd={visualBarEnd} viewport={viewport} />
+          )}
+
           {item.milestones.map((milestone) => (
             <MilestoneMarker
               key={milestone.id}
@@ -188,6 +215,52 @@ function TimelineRow({
           ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+function BarContinuationIndicators({
+  barStart,
+  barEnd,
+  viewport,
+}: {
+  barStart: number;
+  barEnd: number;
+  viewport: TimelineViewport | null;
+}) {
+  if (!viewport) return null;
+
+  const showLeft = viewport.left > 0 && barStart < viewport.left && barEnd > viewport.left;
+  const showRight = viewport.right < 100 && barStart < viewport.right && barEnd > viewport.right;
+
+  if (!showLeft && !showRight) return null;
+
+  return (
+    <>
+      {showLeft && <BarContinuationIndicator direction="left" left={viewport.left} />}
+      {showRight && <BarContinuationIndicator direction="right" left={viewport.right} />}
+    </>
+  );
+}
+
+function BarContinuationIndicator({ direction, left }: { direction: "left" | "right"; left: number }) {
+  const Icon = direction === "left" ? IconArrowLeft : IconArrowRight;
+
+  return (
+    <div
+      className={classNames(
+        "pointer-events-none absolute z-40 flex size-5 items-center justify-center rounded-md border border-surface-outline bg-surface-base/90 text-content-dimmed shadow-sm backdrop-blur-sm dark:border-gray-600 dark:bg-gray-800/90 dark:text-gray-200",
+        { "-translate-x-full": direction === "right" },
+      )}
+      style={{
+        left:
+          direction === "left"
+            ? `calc(${left}% + ${TIMELINE_LAYOUT.continuationInset}px)`
+            : `calc(${left}% - ${TIMELINE_LAYOUT.continuationInset}px)`,
+        top: TIMELINE_LAYOUT.barTop + 10,
+      }}
+    >
+      <Icon size={14} stroke={2.5} />
     </div>
   );
 }
@@ -427,6 +500,15 @@ function milestoneTranslateClass(placement: MilestonePlacement) {
 
 function sameDay(a: Date, b: Date) {
   return normalizeTimelineDate(a)?.getTime() === normalizeTimelineDate(b)?.getTime();
+}
+
+function calculateTimelineViewport(scrollContainer: HTMLDivElement): TimelineViewport {
+  const scrollWidth = Math.max(scrollContainer.scrollWidth, 1);
+
+  return {
+    left: clampPercent((scrollContainer.scrollLeft / scrollWidth) * 100),
+    right: clampPercent(((scrollContainer.scrollLeft + scrollContainer.clientWidth) / scrollWidth) * 100),
+  };
 }
 
 function barTone(status: WorkMap.Item["status"]) {


### PR DESCRIPTION
- Auto-centers the project timeline on Today when the view opens.
- Keeps milestone flags inside the project bar when they fall on the project deadline.
- Improves the dark-mode treatment for milestones outside the project date range.
- Adds subtle continuation arrows when project bars extend beyond the visible viewport.