### PR TITLE
feat: add locale-aware time formatting preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - Agents should not format Elixir code beyond the scope of the requested change or bug fix; only format the lines directly related to the current work.
 - TypeScript/JS: Prettier (`printWidth: 120`, `trailingComma: all`). Check: `npm --prefix app run prettier:check`; fix: `make js.fmt.fix`.
 - When TypeScript warns that a value may be `null` or `undefined` (common in activity handlers under `app/assets/js/features/activities`), do not silence the warning with the non-null assertion operator (`!`) or with helpers like `assertPresent`. Add the guards or type refinements needed so the compiler is satisfied without risking runtime errors.
+- Locale-aware formatting: do not hard-code `"en-US"` or manually format user-facing dates, times, or numbers. Use shared formatting helpers and keep timezone, locale, and explicit display preferences as separate concerns. Timezone controls which local time is shown; locale/preferences control how dates, times, and numbers are displayed.
 - Components and pages: PascalCase for React components; filenames `ComponentName.tsx`. Tests: `*.spec.ts(x)`.
 - TurboUI component architecture and patterns: `turboui/AGENTS.md`.
 

--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1504,6 +1504,7 @@ export interface Person {
   type: string;
   description?: string | null;
   timezone?: string | null;
+  timeFormat?: TimeFormat;
   emailPreference?: EmailPreferenceValues;
   emailWindowMinutes?: EmailWindowMinutes;
   sendDailySummary?: boolean;
@@ -2327,6 +2328,8 @@ export type SubscriptionParentType =
 export type SuccessStatus = "achieved" | "missed";
 
 export type TaskType = "space" | "project";
+
+export type TimeFormat = "automatic" | "hour_12" | "hour_24";
 
 export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secret";
 
@@ -4303,6 +4306,7 @@ export interface PeopleUpdateInput {
   fullName?: string;
   title?: string;
   timezone?: string;
+  timeFormat?: TimeFormat;
   managerId?: Id | null;
   theme?: string;
   notifyAboutAssignments?: boolean;

--- a/app/assets/js/components/FormattedTime/LongDate.tsx
+++ b/app/assets/js/components/FormattedTime/LongDate.tsx
@@ -1,26 +1,32 @@
 import React from "react";
 import * as Time from "@/utils/time";
-import { useTranslation } from "react-i18next";
 import { findOrdinalNumberSuffix } from "@/utils/numbers";
+import { formatDate } from "@/utils/formatting";
 
-export default function LongDate({ time }: { time: Date }): JSX.Element {
-  const { t } = useTranslation();
+export default function LongDate({ time, locale }: { time: Date; locale: string }): JSX.Element {
+  if (!locale.startsWith("en")) {
+    const options: Intl.DateTimeFormatOptions = {
+      day: "numeric",
+      month: "long",
+    };
 
-  let options = {
-    val: time,
-    formatParams: {
-      val: {
-        day: "numeric",
-        month: "long",
-      },
-    },
-  };
+    if (!Time.isCurrentYear(time)) {
+      options.year = "numeric";
+    }
+
+    return <>{formatDate(time, locale, options)}</>;
+  }
+
+  const formattedDate = formatDate(time, locale, {
+    day: "numeric",
+    month: "long",
+  });
   const day = time.getDate();
   const suffix = findOrdinalNumberSuffix(day);
 
   return (
     <>
-      {t("intlDateTime", options)}
+      {formattedDate}
       {suffix}
       {Time.isCurrentYear(time) ? "" : ", " + time.getFullYear()}
     </>

--- a/app/assets/js/components/FormattedTime/RelativeTimeOrDate.tsx
+++ b/app/assets/js/components/FormattedTime/RelativeTimeOrDate.tsx
@@ -5,7 +5,7 @@ import RelativeTime from "./RelativeTime";
 import { hoursBetween } from "@/utils/time";
 import { useRenderInterval } from "./useRenderInterval";
 
-export default function RelativeTimeOrDate({ time }) {
+export default function RelativeTimeOrDate({ time, locale }: { time: Date; locale: string }) {
   const lastRender = useRenderInterval(time);
 
   const now = new Date();
@@ -13,7 +13,7 @@ export default function RelativeTimeOrDate({ time }) {
 
   return (
     <Fragment key={lastRender}>
-      {delta < 24 ? <RelativeTime time={time} /> : <RelativeWeekdayOrDate time={time} />}
+      {delta < 24 ? <RelativeTime time={time} /> : <RelativeWeekdayOrDate time={time} locale={locale} />}
     </Fragment>
   );
 }

--- a/app/assets/js/components/FormattedTime/RelativeWeekdayOrDate.tsx
+++ b/app/assets/js/components/FormattedTime/RelativeWeekdayOrDate.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import * as Time from "@/utils/time";
 import ShortDateWithWeekday from "./ShortDateWithWeekday";
+import { formatDate } from "@/utils/formatting";
 
-export default function ({ time }: { time: Date }): JSX.Element {
+export default function ({ time, locale }: { time: Date; locale: string }): JSX.Element {
   const { t } = useTranslation();
 
   if (Time.isToday(time)) {
@@ -19,17 +20,12 @@ export default function ({ time }: { time: Date }): JSX.Element {
   }
 
   if (Time.isFuture(time) && Time.isThisWeek(time)) {
-    const params = {
-      val: time,
-      formatParams: {
-        val: {
-          weekday: "long",
-        },
-      },
+    const params: Intl.DateTimeFormatOptions = {
+      weekday: "long",
     };
 
-    return <>this {t("intlDateTime", params)}</>;
+    return <>this {formatDate(time, locale, params)}</>;
   }
 
-  return <ShortDateWithWeekday time={time} />;
+  return <ShortDateWithWeekday time={time} locale={locale} />;
 }

--- a/app/assets/js/components/FormattedTime/ShortDate.tsx
+++ b/app/assets/js/components/FormattedTime/ShortDate.tsx
@@ -1,23 +1,24 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { formatDate } from "@/utils/formatting";
 
 import * as Time from "@/utils/time";
 
-export default function ShortDate({ time, weekday }: { time: Date; weekday: boolean }): JSX.Element {
-  const { t } = useTranslation();
-
-  let params = {
-    val: time,
-    formatParams: {
-      val: {},
-    },
+export default function ShortDate({
+  time,
+  weekday,
+  locale,
+}: {
+  time: Date;
+  weekday: boolean;
+  locale: string;
+}): JSX.Element {
+  let options: Intl.DateTimeFormatOptions = {
+    day: "numeric",
+    month: "short",
   };
 
-  params["formatParams"]["val"]["day"] = "numeric";
-  params["formatParams"]["val"]["month"] = "short";
-
   if (!Time.isCurrentYear(time)) {
-    params["formatParams"]["val"]["year"] = "numeric";
+    options.year = "numeric";
   }
 
   let prefix = "";
@@ -28,11 +29,11 @@ export default function ShortDate({ time, weekday }: { time: Date; weekday: bool
     } else if (isYesterday(time)) {
       prefix = "Yesterday, ";
     } else {
-      params["formatParams"]["val"]["weekday"] = "long";
+      options.weekday = "long";
     }
   }
 
-  return <>{prefix + t("intlDateTime", params)}</>;
+  return <>{prefix + formatDate(time, locale, options)}</>;
 }
 
 function isSameDay(date: Date, other: Date) {

--- a/app/assets/js/components/FormattedTime/ShortDateWithWeekday.tsx
+++ b/app/assets/js/components/FormattedTime/ShortDateWithWeekday.tsx
@@ -1,27 +1,20 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { formatDate } from "@/utils/formatting";
 
 function isCurrentYear(date: Date) {
   return date.getFullYear() === new Date().getFullYear();
 }
 
-export default function ShortDateWithWeekday({ time }: { time: Date }): JSX.Element {
-  const { t } = useTranslation();
-
-  let params = {
-    val: time,
-    formatParams: {
-      val: {
-        month: "short",
-        day: "numeric",
-        weekday: "short",
-      },
-    },
+export default function ShortDateWithWeekday({ time, locale }: { time: Date; locale: string }): JSX.Element {
+  let options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "numeric",
+    weekday: "short",
   };
 
   if (!isCurrentYear(time)) {
-    params["formatParams"]["val"]["year"] = "numeric";
+    options.year = "numeric";
   }
 
-  return <>{t("intlDateTime", params)}</>;
+  return <>{formatDate(time, locale, options)}</>;
 }

--- a/app/assets/js/components/FormattedTime/TimeOnly.tsx
+++ b/app/assets/js/components/FormattedTime/TimeOnly.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
+import { formatTime } from "@/utils/formatting";
+import type { TimeFormat } from "@/utils/formatting";
 
 interface TimeOnlyProps {
   time: Date;
+  locale: string;
+  timeFormat: TimeFormat;
 }
 
-export default function TimeOnly({ time }: TimeOnlyProps): JSX.Element {
-  return (
-    <>
-      {time.toLocaleTimeString("en-US", { timeStyle: "short", hour12: true }).replace(" AM", "am").replace(" PM", "pm")}
-    </>
-  );
+export default function TimeOnly({ time, locale, timeFormat }: TimeOnlyProps): JSX.Element {
+  return <>{formatTime(time, locale, timeFormat)}</>;
 }

--- a/app/assets/js/components/FormattedTime/index.tsx
+++ b/app/assets/js/components/FormattedTime/index.tsx
@@ -8,7 +8,7 @@ import RelativeTime from "./RelativeTime";
 import ShortDateWithWeekday from "./ShortDateWithWeekday";
 import RelativeWeekdayOrDate from "./RelativeWeekdayOrDate";
 import RelativeTimeOrDate from "./RelativeTimeOrDate";
-import { useTimezone } from "@/contexts/TimezoneContext";
+import { useLocale, useTimeFormat, useTimezone } from "@/contexts/TimezoneContext";
 import { match } from "ts-pattern";
 
 type Format =
@@ -39,6 +39,8 @@ interface FormattedTimeProps {
 
 export default function FormattedTime(props: FormattedTimeProps): JSX.Element {
   const timezone = useTimezone();
+  const locale = useLocale();
+  const timeFormat = useTimeFormat();
 
   const parsedTime = match(props.format)
     .with("relative", () => Time.parse(props.time))
@@ -54,17 +56,17 @@ export default function FormattedTime(props: FormattedTimeProps): JSX.Element {
     case "relative":
       return <RelativeTime time={time} />;
     case "relative-weekday-or-date":
-      return <RelativeWeekdayOrDate time={time} />;
+      return <RelativeWeekdayOrDate time={time} locale={locale} />;
     case "relative-time-or-date":
-      return <RelativeTimeOrDate time={time} />;
+      return <RelativeTimeOrDate time={time} locale={locale} />;
     case "short-date":
-      return <ShortDate time={time} weekday={false} />;
+      return <ShortDate time={time} weekday={false} locale={locale} />;
     case "short-date-with-weekday":
-      return <ShortDateWithWeekday time={time} />;
+      return <ShortDateWithWeekday time={time} locale={locale} />;
     case "time-only":
-      return <TimeOnly time={time} />;
+      return <TimeOnly time={time} locale={locale} timeFormat={timeFormat} />;
     case "long-date":
-      return <LongDate time={time} />;
+      return <LongDate time={time} locale={locale} />;
     default:
       throw "Unknown format " + props.format;
   }

--- a/app/assets/js/contexts/TimezoneContext.tsx
+++ b/app/assets/js/contexts/TimezoneContext.tsx
@@ -1,14 +1,20 @@
 import * as React from "react";
 import * as People from "@/models/people";
+import { browserLocale } from "@/utils/formatting";
+import type { TimeFormat } from "@/utils/formatting";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 
 interface TimezoneContextProps {
   timezone: string;
+  locale: string;
+  timeFormat: TimeFormat;
 }
 
 const TimezoneContext = React.createContext<TimezoneContextProps>({
   timezone: "Etc/UTC",
+  locale: "en-US",
+  timeFormat: "automatic",
 });
 
 export function TimezoneProvider({ children }) {
@@ -22,10 +28,20 @@ export function useTimezone(): string {
   return React.useContext(TimezoneContext).timezone;
 }
 
+export function useLocale(): string {
+  return React.useContext(TimezoneContext).locale;
+}
+
+export function useTimeFormat(): TimeFormat {
+  return React.useContext(TimezoneContext).timeFormat;
+}
+
 function initializeTimezone(me: People.Person | null): TimezoneContextProps {
+  const locale = browserLocale();
+
   if (!me || !me.timezone) {
-    return { timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
+    return { timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, locale, timeFormat: "automatic" };
   } else {
-    return { timezone: me.timezone };
+    return { timezone: me.timezone, locale, timeFormat: me.timeFormat || "automatic" };
   }
 }

--- a/app/assets/js/features/activities/GoalDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/GoalDueDateUpdating/index.tsx
@@ -2,7 +2,7 @@ import type { ActivityContentGoalDueDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
 import React from "react";
-import { FormattedTime } from "turboui";
+import FormattedTime from "@/components/FormattedTime";
 import { feedTitle, goalLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
 

--- a/app/assets/js/features/activities/GoalStartDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/GoalStartDateUpdating/index.tsx
@@ -2,7 +2,7 @@ import type { ActivityContentGoalStartDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
 import React from "react";
-import { FormattedTime } from "turboui";
+import FormattedTime from "@/components/FormattedTime";
 import { feedTitle, goalLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
 

--- a/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectDueDateUpdating/index.tsx
@@ -1,7 +1,7 @@
 import type { ActivityContentProjectDueDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
 import React from "react";
-import { FormattedTime } from "turboui";
+import FormattedTime from "@/components/FormattedTime";
 import { feedTitle, projectLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
 

--- a/app/assets/js/features/activities/ProjectStartDateUpdating/index.tsx
+++ b/app/assets/js/features/activities/ProjectStartDateUpdating/index.tsx
@@ -2,7 +2,7 @@ import type { ActivityContentProjectStartDateUpdating } from "@/api";
 import type { Activity } from "@/models/activities";
 import { Paths } from "@/routes/paths";
 import React from "react";
-import { FormattedTime } from "turboui";
+import FormattedTime from "@/components/FormattedTime";
 import { feedTitle, projectLink } from "../feedItemLinks";
 import type { ActivityHandler } from "../interfaces";
 

--- a/app/assets/js/features/goals/GoalTargetsV2/components/TargetValue.tsx
+++ b/app/assets/js/features/goals/GoalTargetsV2/components/TargetValue.tsx
@@ -6,6 +6,8 @@ import { createTestId } from "@/utils/testid";
 import { isPresent } from "@/utils/isPresent";
 import { isCheckInTarget, Target } from "../types";
 import { TargetNumericField } from "./TargetNumericField";
+import { useLocale } from "@/contexts/TimezoneContext";
+import { formatNumber } from "@/utils/formatting";
 
 interface Props {
   readonly: boolean;
@@ -28,10 +30,12 @@ export function TargetValue(props: Props) {
 }
 
 function ValueDisplay({ target }: { target: Target }) {
+  const locale = useLocale();
+
   return (
     <div className="flex items-center">
       <div className="py-1 text-right text-sm">
-        <span className="font-extrabold">{target.value}</span>
+        <span className="font-extrabold">{isPresent(target.value) ? formatNumber(target.value, locale) : ""}</span>
         {target.unit === "%" ? "%" : ` ${target.unit}`}
       </div>
       <ValueDifference target={target} />
@@ -40,6 +44,8 @@ function ValueDisplay({ target }: { target: Target }) {
 }
 
 function ValueDifference({ target }: { target: Target }) {
+  const locale = useLocale();
+
   if (!isPresent(target.value) || !isCheckInTarget(target) || !isPresent(target.previousValue)) {
     return null;
   }
@@ -48,7 +54,7 @@ function ValueDifference({ target }: { target: Target }) {
   if (diff === 0) return null;
 
   const sentiment = GoalCheckIns.targetChangeSentiment(target);
-  const diffText = formatNumber(Math.abs(diff));
+  const diffText = formatNumber(Math.abs(diff), locale, { maximumFractionDigits: 2 });
   const diffSign = diff > 0 ? "+" : "-";
   const color = sentiment === "positive" ? "text-green-600" : "text-content-error";
 
@@ -58,20 +64,4 @@ function ValueDifference({ target }: { target: Target }) {
       {diffText}
     </div>
   );
-}
-
-//
-// If the value is an integer, return it as is.
-// If it has decimal places, return it with up to 2 decimal places. Always return trailing zeros.
-//
-function formatNumber(num: number) {
-  if (Number.isInteger(num)) {
-    return num.toString();
-  } else {
-    // Convert to number with up to 2 decimal places
-    const fixed = num.toFixed(2);
-
-    // Parse it back to a number (removes trailing zeros) and convert to string
-    return parseFloat(fixed).toString();
-  }
 }

--- a/app/assets/js/pages/ProfileEditPage/index.tsx
+++ b/app/assets/js/pages/ProfileEditPage/index.tsx
@@ -64,6 +64,7 @@ function Page() {
     return parseContent(person.description);
   });
   const [timezone, setTimezone] = React.useState(person.timezone || "");
+  const [timeFormat, setTimeFormat] = React.useState<ProfileEditPage.TimeFormat>(person.timeFormat || "automatic");
   const [manager, setManager] = React.useState<ProfileEditPage.Person | null>(
     person.manager ? People.parsePersonForTurboUi(paths, person.manager) : null,
   );
@@ -104,6 +105,7 @@ function Page() {
 
       if (isCurrentUser) {
         updateParams.description = JSON.stringify(aboutMe);
+        updateParams.timeFormat = timeFormat;
       }
 
       await People.updateProfile(updateParams);
@@ -118,7 +120,7 @@ function Page() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [fullName, title, aboutMe, timezone, manager, person.id, isCurrentUser, navigate, paths]);
+  }, [fullName, title, aboutMe, timezone, timeFormat, manager, person.id, isCurrentUser, navigate, paths]);
 
   const displayPerson: ProfileEditPage.Person = {
     id: person.id,
@@ -135,11 +137,13 @@ function Page() {
       title={title}
       aboutMe={aboutMe}
       timezone={timezone}
+      timeFormat={timeFormat}
       manager={manager}
       onFullNameChange={setFullName}
       onTitleChange={setTitle}
       onAboutMeChange={setAboutMe}
       onTimezoneChange={setTimezone}
+      onTimeFormatChange={setTimeFormat}
       onManagerChange={setManager}
       onSubmit={handleSubmit}
       onAvatarUpload={avatar.handleAvatarUpload}

--- a/app/assets/js/utils/formatting.test.ts
+++ b/app/assets/js/utils/formatting.test.ts
@@ -1,0 +1,48 @@
+import { browserLocale, formatNumber, formatTime } from "@/utils/formatting";
+
+describe("browserLocale", () => {
+  test("falls back to en-US when navigator is unavailable", () => {
+    const originalNavigator = global.navigator;
+
+    Object.defineProperty(global, "navigator", {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(browserLocale()).toEqual("en-US");
+
+    Object.defineProperty(global, "navigator", {
+      configurable: true,
+      value: originalNavigator,
+    });
+  });
+});
+
+describe("formatNumber", () => {
+  test("uses locale-specific separators", () => {
+    expect(formatNumber(1000.5, "de-DE", { minimumFractionDigits: 2 })).toEqual("1.000,50");
+    expect(formatNumber(1000.5, "en-US", { minimumFractionDigits: 2 })).toEqual("1,000.50");
+  });
+});
+
+describe("formatTime", () => {
+  const time = new Date("2026-05-23T14:30:00");
+
+  test("supports explicit 24-hour format", () => {
+    expect(formatTime(time, "en-US", "hour_24")).toEqual("14:30");
+  });
+
+  test("supports explicit 12-hour format", () => {
+    expect(formatTime(time, "en-US", "hour_12")).toEqual("2:30pm");
+  });
+
+  test("only applies English AM/PM casing to English locales", () => {
+    expect(formatTime(time, "en-US", "hour_12")).toEqual(expect.not.stringContaining(" PM"));
+    expect(formatTime(time, "ar-EG", "hour_12")).toEqual(
+      new Intl.DateTimeFormat("ar-EG", {
+        timeStyle: "short",
+        hour12: true,
+      }).format(time),
+    );
+  });
+});

--- a/app/assets/js/utils/formatting.ts
+++ b/app/assets/js/utils/formatting.ts
@@ -1,0 +1,53 @@
+export type TimeFormat = "automatic" | "hour_12" | "hour_24";
+
+export function browserLocale(): string {
+  if (typeof navigator === "undefined") {
+    return "en-US";
+  }
+
+  return navigator.languages?.[0] || navigator.language || "en-US";
+}
+
+export function formatNumber(
+  value: number,
+  locale: string = browserLocale(),
+  options?: Intl.NumberFormatOptions,
+): string {
+  return new Intl.NumberFormat(locale, options).format(value);
+}
+
+export function formatTime(
+  value: Date,
+  locale: string = browserLocale(),
+  timeFormat: TimeFormat = "automatic",
+  options: Intl.DateTimeFormatOptions = { timeStyle: "short" },
+): string {
+  const hour12 = hour12Option(timeFormat);
+  const formatOptions = hour12 === undefined ? options : { ...options, hour12 };
+  const formatted = new Intl.DateTimeFormat(locale, formatOptions).format(value);
+
+  if (!locale.toLowerCase().startsWith("en")) {
+    return formatted;
+  }
+
+  return formatted.replace(" AM", "am").replace(" PM", "pm");
+}
+
+export function formatDate(
+  value: Date,
+  locale: string = browserLocale(),
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  return new Intl.DateTimeFormat(locale, options).format(value);
+}
+
+function hour12Option(timeFormat: TimeFormat): boolean | undefined {
+  switch (timeFormat) {
+    case "hour_12":
+      return true;
+    case "hour_24":
+      return false;
+    case "automatic":
+      return undefined;
+  }
+}

--- a/app/lib/operately/people/person.ex
+++ b/app/lib/operately/people/person.ex
@@ -82,6 +82,9 @@ defmodule Operately.People.Person do
   def send_daily_summary?(person), do: notification_preferences(person).send_daily_summary
   def daily_summary_delivery_time(person), do: notification_preferences(person).daily_summary_delivery_time || NotificationPreferences.default_daily_summary_delivery_time()
 
+  def time_format(%__MODULE__{preferences: %Preferences{time_format: time_format}}) when not is_nil(time_format), do: time_format
+  def time_format(_), do: Preferences.default_time_format()
+
   def short_name(person) do
     parts = String.split(person.full_name, " ")
 

--- a/app/lib/operately/people/preferences.ex
+++ b/app/lib/operately/people/preferences.ex
@@ -2,6 +2,7 @@ defmodule Operately.People.Preferences do
   use Operately.Schema
 
   @primary_key false
+  @time_format_values [:automatic, :hour_12, :hour_24]
 
   defmodule Notifications do
     use Operately.Schema
@@ -60,12 +61,17 @@ defmodule Operately.People.Preferences do
   end
 
   embedded_schema do
+    field :time_format, Ecto.Enum, values: @time_format_values, default: :automatic
     embeds_one :notifications, Notifications, on_replace: :update, defaults_to_struct: true
   end
 
   def changeset(preferences, attrs) do
     preferences
-    |> cast(attrs, [])
+    |> cast(attrs, [:time_format])
+    |> validate_inclusion(:time_format, @time_format_values)
     |> cast_embed(:notifications, with: &Notifications.changeset/2)
   end
+
+  def time_format_values, do: @time_format_values
+  def default_time_format, do: :automatic
 end

--- a/app/lib/operately_web/api/people/get_me.ex
+++ b/app/lib/operately_web/api/people/get_me.ex
@@ -36,6 +36,7 @@ defmodule OperatelyWeb.Api.People.GetMe do
         title: me.title,
         avatar_url: me.avatar_url,
         timezone: me.timezone,
+        time_format: me |> Operately.People.Person.time_format() |> Atom.to_string(),
         avatar_blob_id: me.avatar_blob_id,
         email_preference: me |> Operately.People.Person.email_preference() |> Atom.to_string(),
         email_window_minutes: Operately.People.Person.email_window_minutes(me),

--- a/app/lib/operately_web/api/people/update.ex
+++ b/app/lib/operately_web/api/people/update.ex
@@ -7,12 +7,14 @@ defmodule OperatelyWeb.Api.People.Update do
   use OperatelyWeb.Api.Helpers
 
   @notification_preference_fields [:notify_about_assignments, :notify_on_mention, :send_daily_summary, :email_window_minutes, :daily_summary_delivery_time]
+  @display_preference_fields [:time_format]
   @updatable_fields_for_oneself [
     :full_name,
     :title,
     :timezone,
     :manager_id,
     :theme,
+    :time_format,
     :notify_about_assignments,
     :notify_on_mention,
     :send_daily_summary,
@@ -27,6 +29,7 @@ defmodule OperatelyWeb.Api.People.Update do
     field? :full_name, :string, null: false
     field? :title, :string, null: false
     field? :timezone, :string, null: false
+    field? :time_format, :time_format, null: false
     field? :manager_id, :id, null: true
     field? :theme, :string, null: false
     field? :notify_about_assignments, :boolean, null: false
@@ -64,12 +67,14 @@ defmodule OperatelyWeb.Api.People.Update do
   end
 
   defp update_profile(person, inputs, requester_id) do
-    inputs = if person.id == requester_id do
-      Map.take(inputs, @updatable_fields_for_oneself)
-      |> normalize_notification_preferences()
-    else
-      Map.take(inputs, @updatable_fields_for_others)
-    end
+    inputs =
+      if person.id == requester_id do
+        Map.take(inputs, @updatable_fields_for_oneself)
+        |> normalize_display_preferences()
+        |> normalize_notification_preferences()
+      else
+        Map.take(inputs, @updatable_fields_for_others)
+      end
 
     with {:ok, person} <- Operately.People.update_person(person, inputs) do
       OperatelyWeb.ApiSocket.broadcast!("api:profile_updated:#{person.id}")
@@ -85,7 +90,27 @@ defmodule OperatelyWeb.Api.People.Update do
     else
       inputs
       |> Map.drop(@notification_preference_fields)
-      |> Map.put(:preferences, %{notifications: notifications})
+      |> put_preference(:notifications, notifications)
     end
+  end
+
+  defp normalize_display_preferences(inputs) do
+    display_preferences = Map.take(inputs, @display_preference_fields)
+
+    if map_size(display_preferences) == 0 do
+      inputs
+    else
+      inputs
+      |> Map.drop(@display_preference_fields)
+      |> put_preferences(display_preferences)
+    end
+  end
+
+  defp put_preferences(inputs, preferences) do
+    Map.update(inputs, :preferences, preferences, &Map.merge(&1, preferences))
+  end
+
+  defp put_preference(inputs, key, value) do
+    put_preferences(inputs, %{key => value})
   end
 end

--- a/app/lib/operately_web/api/serializers/person.ex
+++ b/app/lib/operately_web/api/serializers/person.ex
@@ -53,6 +53,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
       type: Atom.to_string(data.type),
       suspended: data.suspended,
       timezone: data.timezone,
+      time_format: data |> Operately.People.Person.time_format() |> Atom.to_string(),
       manager: OperatelyWeb.Api.Serializer.serialize(data.manager),
       reports: OperatelyWeb.Api.Serializer.serialize(data.reports),
       peers: OperatelyWeb.Api.Serializer.serialize(data.peers),

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1632,6 +1632,8 @@ defmodule OperatelyWeb.Api.Types do
 
   int_enum(:email_window_minutes, values: Operately.People.Preferences.Notifications.email_window_minutes())
 
+  enum(:time_format, values: Operately.People.Preferences.time_format_values())
+
   object :person do
     field :id, :string
     field :full_name, :string
@@ -1643,6 +1645,7 @@ defmodule OperatelyWeb.Api.Types do
     field? :description, :string, null: true
 
     field? :timezone, :string, null: true
+    field? :time_format, :time_format, null: false
     field? :email_preference, :email_preference_values, null: false
     field? :email_window_minutes, :email_window_minutes, null: false
     field? :send_daily_summary, :boolean, null: false

--- a/app/test/features/account_settings_test.exs
+++ b/app/test/features/account_settings_test.exs
@@ -40,6 +40,13 @@ defmodule Operately.Features.AccountSettingsTest do
     |> Steps.assert_person_timezone_changed(props)
   end
 
+  feature "changing the time format in account settings", ctx do
+    ctx
+    |> Steps.open_account_settings()
+    |> Steps.change_time_format("24-hour clock")
+    |> Steps.assert_person_time_format_changed(:hour_24)
+  end
+
   feature "setting my manager in account settings", ctx do
     ctx
     |> Steps.open_account_settings()

--- a/app/test/operately/people/preferences_test.exs
+++ b/app/test/operately/people/preferences_test.exs
@@ -17,6 +17,32 @@ defmodule Operately.People.PreferencesTest do
       assert person.preferences.notifications.notify_on_mention
       refute person.preferences.notifications.send_daily_summary
       assert person.preferences.notifications.daily_summary_delivery_time == "18:00"
+      assert person.preferences.time_format == :automatic
+    end
+
+    test "updates time format preference" do
+      changeset =
+        Person.changeset(%Person{}, %{
+          preferences: %{
+            time_format: "hour_24"
+          }
+        })
+
+      person = Ecto.Changeset.apply_changes(changeset)
+
+      assert person.preferences.time_format == :hour_24
+    end
+
+    test "rejects invalid time format preference" do
+      changeset =
+        Person.changeset(%Person{}, %{
+          preferences: %{
+            time_format: "military"
+          }
+        })
+
+      refute changeset.valid?
+      assert Enum.any?(changeset.changes.preferences.errors, fn {field, _} -> field == :time_format end)
     end
 
     test "merges provided notification preferences into defaults for new people" do
@@ -127,6 +153,7 @@ defmodule Operately.People.PreferencesTest do
       assert Person.notify_on_mention?(%Person{})
       refute Person.send_daily_summary?(%Person{})
       assert Person.daily_summary_delivery_time(%Person{}) == "18:00"
+      assert Person.time_format(%Person{}) == :automatic
     end
 
     test "use embedded notification settings when present" do
@@ -149,6 +176,16 @@ defmodule Operately.People.PreferencesTest do
       refute Person.notify_on_mention?(person)
       refute Person.send_daily_summary?(person)
       assert Person.daily_summary_delivery_time(person) == "21:00"
+    end
+
+    test "uses embedded time format when present" do
+      person = %Person{
+        preferences: %Preferences{
+          time_format: :hour_24
+        }
+      }
+
+      assert Person.time_format(person) == :hour_24
     end
 
     test "falls back to default daily summary delivery time when value is nil" do

--- a/app/test/operately_web/api/people/get_me_test.exs
+++ b/app/test/operately_web/api/people/get_me_test.exs
@@ -24,6 +24,7 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
         avatar_url: ctx.person.avatar_url,
         avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: ctx.person.timezone,
+        time_format: "automatic",
         email_preference: "buffered",
         email_window_minutes: 5,
         send_daily_summary: Operately.People.Person.send_daily_summary?(ctx.person),
@@ -51,6 +52,7 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
         avatar_url: ctx.person.avatar_url,
         avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: me.timezone,
+        time_format: "automatic",
         email_preference: "buffered",
         email_window_minutes: 5,
         send_daily_summary: Operately.People.Person.send_daily_summary?(me),
@@ -82,6 +84,7 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
         avatar_url: ctx.person.avatar_url,
         avatar_blob_id: ctx.person.avatar_blob_id,
         timezone: ctx.person.timezone,
+        time_format: "automatic",
         email_preference: "buffered",
         email_window_minutes: 5,
         send_daily_summary: Operately.People.Person.send_daily_summary?(ctx.person),
@@ -115,6 +118,20 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
       refute data.send_daily_summary
       assert data.daily_summary_delivery_time == "09:00"
       assert Operately.People.Person.email_preference(person) == :buffered
+    end
+
+    test "it returns custom display preference settings", ctx do
+      {:ok, person} =
+        Operately.People.update_person(ctx.person, %{
+          preferences: %{
+            time_format: "hour_24"
+          }
+        })
+
+      assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{})
+
+      assert data.time_format == "hour_24"
+      assert Operately.People.Person.time_format(person) == :hour_24
     end
   end
 end

--- a/app/test/operately_web/api/people/update_test.exs
+++ b/app/test/operately_web/api/people/update_test.exs
@@ -146,6 +146,26 @@ defmodule OperatelyWeb.Api.People.UpdateTest do
       assert Operately.People.Person.daily_summary_delivery_time(person) == "09:00"
     end
 
+    test "it updates display preferences", ctx do
+      assert {200, %{person: %{}}} =
+               mutation(ctx.conn, [:people, :update], %{
+                 id: Paths.person_id(ctx.person),
+                 time_format: "hour_24"
+               })
+
+      person = Operately.People.get_person!(ctx.person.id)
+
+      assert Operately.People.Person.time_format(person) == :hour_24
+    end
+
+    test "it rejects invalid display preferences", ctx do
+      assert {400, %{}} =
+               mutation(ctx.conn, [:people, :update], %{
+                 id: Paths.person_id(ctx.person),
+                 time_format: "military"
+               })
+    end
+
     test "it rejects invalid notification preferences", ctx do
       assert {400, %{}} =
                mutation(ctx.conn, [:people, :update], %{

--- a/app/test/support/features/account_settings_steps.ex
+++ b/app/test/support/features/account_settings_steps.ex
@@ -81,6 +81,19 @@ defmodule Operately.Support.Features.AccountSettingsSteps do
     |> UI.assert_text(props[:label])
   end
 
+  step :change_time_format, ctx, option do
+    ctx
+    |> UI.select(testid: "time-format", option: option)
+    |> UI.click(testid: "submit")
+    |> UI.assert_has(testid: "my-account-page")
+  end
+
+  step :assert_person_time_format_changed, ctx, time_format do
+    assert Operately.People.Person.time_format(Operately.People.get_person!(ctx.person.id)) == time_format
+
+    ctx
+  end
+
   step :given_a_person_exists_in_company, ctx, manager_name do
     {:ok, _} =
       ctx.person

--- a/turboui/src/ProfileEditPage/index.stories.tsx
+++ b/turboui/src/ProfileEditPage/index.stories.tsx
@@ -37,8 +37,11 @@ const DefaultStory = (args: Partial<ProfileEditPage.Props>) => {
   const currentPerson = args.person || genPerson();
   const [fullName, setFullName] = useState(currentPerson.fullName);
   const [title, setTitle] = useState(currentPerson.title || "");
-  const [aboutMe, setAboutMe] = useState(asRichText("I like setting teams up for success and pairing on tricky problems."));
+  const [aboutMe, setAboutMe] = useState(
+    asRichText("I like setting teams up for success and pairing on tricky problems."),
+  );
   const [timezone, setTimezone] = useState("America/New_York");
+  const [timeFormat, setTimeFormat] = useState<ProfileEditPage.TimeFormat>("automatic");
 
   const [manager, setManager] = useState<ProfileEditPage.Person | null>(() => {
     if ("manager" in args) {
@@ -59,7 +62,7 @@ const DefaultStory = (args: Partial<ProfileEditPage.Props>) => {
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
-    console.log("Submitting profile:", { fullName, title, timezone, manager });
+    console.log("Submitting profile:", { fullName, title, timezone, timeFormat, manager });
     await new Promise((resolve) => setTimeout(resolve, 1000));
     setIsSubmitting(false);
     alert("Profile updated successfully!");
@@ -103,11 +106,13 @@ const DefaultStory = (args: Partial<ProfileEditPage.Props>) => {
       title={title}
       aboutMe={aboutMe}
       timezone={timezone}
+      timeFormat={timeFormat}
       manager={manager}
       onFullNameChange={setFullName}
       onTitleChange={setTitle}
       onAboutMeChange={setAboutMe}
       onTimezoneChange={setTimezone}
+      onTimeFormatChange={setTimeFormat}
       onManagerChange={setManager}
       onSubmit={handleSubmit}
       onAvatarUpload={args.canChangeAvatar !== false ? handleAvatarUpload : undefined}

--- a/turboui/src/ProfileEditPage/index.tsx
+++ b/turboui/src/ProfileEditPage/index.tsx
@@ -23,6 +23,8 @@ export namespace ProfileEditPage {
     label: string;
   }
 
+  export type TimeFormat = "automatic" | "hour_12" | "hour_24";
+
   export interface Props {
     // Person data
     person: Person;
@@ -32,6 +34,7 @@ export namespace ProfileEditPage {
     title: string;
     aboutMe: any;
     timezone: string;
+    timeFormat: TimeFormat;
     manager: Person | null;
 
     // Form handlers
@@ -39,6 +42,7 @@ export namespace ProfileEditPage {
     onTitleChange: (value: string) => void;
     onAboutMeChange: (value: any) => void;
     onTimezoneChange: (value: string) => void;
+    onTimeFormatChange: (value: TimeFormat) => void;
     onManagerChange: (person: Person | null) => void;
     onSubmit: () => Promise<void>;
     onCancel?: () => void;
@@ -143,6 +147,22 @@ export function ProfileEditPage(props: ProfileEditPage.Props) {
                 ))}
               </select>
             </div>
+
+            {props.isCurrentUser && (
+              <div>
+                <label className="font-bold text-sm mb-1 block">Time format</label>
+                <select
+                  value={props.timeFormat}
+                  onChange={(e) => props.onTimeFormatChange(e.target.value as ProfileEditPage.TimeFormat)}
+                  className="w-full border border-stroke-base rounded-lg px-3 py-1.5 bg-surface-base text-content-base focus:outline-none focus:ring-2 focus:ring-primary-base"
+                  data-test-id="time-format"
+                >
+                  <option value="automatic">Automatic</option>
+                  <option value="hour_12">12-hour clock</option>
+                  <option value="hour_24">24-hour clock</option>
+                </select>
+              </div>
+            )}
 
             {/* Manager Section */}
             <div>


### PR DESCRIPTION
## Summary

Adds locale-aware formatting support for user-facing dates, times, and numbers, while keeping timezone and formatting preferences separate.

This implements the scoped direction from the localization issue:

- keep the existing user timezone setting
- use browser/OS locale as the default locale source
- add an explicit user preference for time format only:
  - Automatic
  - 12-hour clock
  - 24-hour clock
- avoid adding a generic locale dropdown
- avoid adding a separate date format setting for now

## Changes

- Added `time_format` to user preferences.
- Exposed `time_format` through the People API and generated TypeScript client.
- Added a “Time format” select to the profile edit page.
- Added shared formatting helpers for dates, times, and numbers.
- Updated shared `FormattedTime` rendering to use browser locale.
- Updated goal target number display to use locale-aware number formatting.
- Added backend and frontend tests for the new preference and formatting behavior.

## Notes

Date formatting is locale-aware through the browser/OS locale. There is intentionally no explicit date-format dropdown in this PR.

For example, German browser locale can render German-style dates and number separators, while users can still override only the 12/24-hour clock preference.

Resolves #4284.