### PR TITLE
fix: send immediate emails for encoded task mentions

### DIFF
--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -1,6 +1,7 @@
 defmodule Operately.Notifications.DirectMentionClassifier do
   import Ecto.Query, warn: false
 
+  alias Operately.Activities.Notifications.MentionedPeople
   alias Operately.Notifications.Notification
   alias Operately.Repo
   alias Operately.Comments.CommentThread
@@ -350,7 +351,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
   defp has_mention?(_content, nil), do: false
 
   defp has_mention?(content, person_id) do
-    mentioned_ids = Operately.RichContent.find_mentioned_ids(content, :decode_ids)
+    mentioned_ids = MentionedPeople.ids(content)
     Enum.member?(mentioned_ids, person_id)
   rescue
     _ -> false

--- a/app/lib/operately_email/emails/task_adding_email.ex
+++ b/app/lib/operately_email/emails/task_adding_email.ex
@@ -10,27 +10,56 @@ defmodule OperatelyEmail.Emails.TaskAddingEmail do
 
     {:ok, task} =
       Task.get(:system,
-        id: activity.content["task_id"],
+        id: content_value(activity.content, :task_id),
         opts: [preload: [:project, :space]]
       )
+
+    action = get_action(person, activity, task)
 
     company
     |> new()
     |> from(author)
     |> to(person)
-    |> subject(where: find_where_name(task), who: author, action: "added the task \"#{task.name}\"")
+    |> subject(where: find_where_name(task), who: author, action: action)
     |> assign(:author, author)
+    |> assign(:action, action)
+    |> assign(:mentioned, mentioned?(person, activity))
     |> assign(:task_name, task.name)
     |> assign(:cta_url, Paths.task_path(company, task) |> Paths.to_url())
     |> render("task_adding")
   end
 
+  defp get_action(person, activity, task) do
+    if mentioned?(person, activity) do
+      "mentioned you in the description for \"#{task.name}\""
+    else
+      "added the task \"#{task.name}\""
+    end
+  end
+
+  defp mentioned?(person, activity) do
+    mentioned_ids =
+      activity.content
+      |> content_value(:description)
+      |> Operately.RichContent.find_mentioned_ids(:decode_ids)
+
+    person.id in mentioned_ids
+  rescue
+    _ -> false
+  end
+
+  defp content_value(content, key) when is_map(content) do
+    Map.get(content, Atom.to_string(key)) || Map.get(content, key)
+  end
+
+  defp content_value(_content, _key), do: nil
+
   defp find_where_name(task) do
     case task do
-        %{project: %{name: name}} -> name
-        %{space: %{name: name}} -> name
-        _ -> "Unknown"
-      end
+      %{project: %{name: name}} -> name
+      %{space: %{name: name}} -> name
+      _ -> "Unknown"
+    end
   end
 
   def buffered_item(_person, activity) do

--- a/app/lib/operately_email/templates/task_adding.html.eex
+++ b/app/lib/operately_email/templates/task_adding.html.eex
@@ -1,9 +1,13 @@
-<%= title("#{short_name(@author)} added the task \"#{@task_name}\"") %>
+<%= title("#{short_name(@author)} #{@action}") %>
 
 <%= spacer() %>
 
 <%= row do %>
-  A new task named <%= @task_name %> was created in this project.
+  <%= if @mentioned do %>
+    You were mentioned in the description for <%= @task_name %>.
+  <% else %>
+    A new task named <%= @task_name %> was created in this project.
+  <% end %>
 <% end %>
 
 <%= spacer() %>

--- a/app/lib/operately_email/templates/task_adding.text.eex
+++ b/app/lib/operately_email/templates/task_adding.text.eex
@@ -1,3 +1,3 @@
-<%= short_name(@author) %> added the task "<%= @task_name %>".
+<%= short_name(@author) %> <%= @action %>.
 
 Link: <%= @cta_url %>

--- a/app/test/operately/notifications/bulk_create_test.exs
+++ b/app/test/operately/notifications/bulk_create_test.exs
@@ -139,6 +139,28 @@ defmodule Operately.Notifications.BulkCreateTest do
     assert Repo.all(EmailBatch) == []
   end
 
+  test "notify_on_mention sends encoded rich text task mentions immediately", ctx do
+    {:ok, _person} =
+      Operately.People.update_person(ctx.person, %{
+        preferences: %{notifications: %{notify_on_mention: true}}
+      })
+
+    description = RichText.rich_text(mentioned_people: [ctx.person])
+    activity = activity_fixture(author_id: ctx.person.id, action: "task_adding", content: %{"description" => description})
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, notifications} =
+               Notifications.bulk_create([
+                 %{person_id: ctx.person.id, activity_id: activity.id, should_send_email: true}
+               ])
+
+      assert_enqueued worker: EmailWorker, args: %{notification_id: hd(notifications).id}
+      refute_enqueued worker: BufferedEmailWorker
+    end)
+
+    assert Repo.all(EmailBatch) == []
+  end
+
   test "notify_on_mention keeps non-mentions buffered for mention-capable actions", ctx do
     {:ok, _person} =
       Operately.People.update_person(ctx.person, %{

--- a/app/test/operately_web/api/tasks_test.exs
+++ b/app/test/operately_web/api/tasks_test.exs
@@ -2,10 +2,13 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
   alias Operately.Support.RichText
   alias Operately.Projects.Contributor
   alias Operately.Access.Binding
+  alias Operately.Notifications.{BufferedEmailWorker, EmailWorker}
 
   import Ecto.Query, only: [from: 2]
+  import Swoosh.TestAssertions
   use OperatelyWeb.TurboCase
   use Operately.Support.Notifications
+  use Oban.Testing, repo: Operately.Repo
 
   setup ctx do
     ctx
@@ -210,11 +213,27 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
 
       assert 0 == notifications_count(action: action)
 
-      perform_job(activity.id)
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        perform_job(activity.id)
+      end)
+
       notifications = fetch_notifications(activity.id, action: action)
 
       assert 1 == notifications_count(action: action)
       assert hd(notifications).person_id == ctx.mentioned_person.id
+      assert hd(notifications).should_send_email
+      assert_enqueued worker: EmailWorker, args: %{notification_id: hd(notifications).id}
+      refute_enqueued worker: BufferedEmailWorker
+
+      flush_emails()
+      assert :ok = Oban.Testing.perform_job(EmailWorker, %{notification_id: hd(notifications).id}, [])
+
+      assert_email_sent(fn email ->
+        {_name, email_address} = hd(email.to)
+
+        email_address == ctx.mentioned_person.email &&
+          email.subject =~ "mentioned you in the description for \"Task with mention\""
+      end)
     end
 
     test "it subscribes the creator to the task", ctx do
@@ -2700,5 +2719,14 @@ defmodule OperatelyWeb.Api.ProjectTasksTest do
       order_by: [desc: a.inserted_at],
       limit: 1
     )
+  end
+
+  defp flush_emails do
+    receive do
+      {:email, _email} -> flush_emails()
+      {:emails, _emails} -> flush_emails()
+    after
+      0 -> :ok
+    end
   end
 end


### PR DESCRIPTION
related to #1219 