### PR TITLE
fix: tolerate agent-shaped CLI flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Read the testing guide at app/test/AGENTS.md.
 
 ## Commit & Pull Request Guidelines
 
-- DCO required: sign off every commit. Example: `git commit -s -m "feat: add goal editor"` (see `docs/commit_sign-off.md`).
+- DCO required: all commits must be signed off. Agents should always use `git commit -s` or `git commit --signoff` when committing. Example: `git commit -s -m "feat: add goal editor"` (see `docs/commit_sign-off.md`).
 - PR title format enforced: `feat: ...`, `fix: ...`, `chore: ...`, or `docs: ...` (checked by `scripts/pr-name-check`).
 - PRs should include: clear description, screenshots for UI changes, migration notes if DB changes, and linked issues.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -203,6 +203,12 @@ Arrays:
 operately notifications mark_many_as_read --ids n1 --ids n2
 ```
 
+Repeated flags are the canonical form. For compatibility with scripts and agents, list flags also accept a JSON array string:
+
+```bash
+operately notifications mark_many_as_read --ids '["n1","n2"]'
+```
+
 Nested objects and lists use dot-index notation:
 
 ```bash
@@ -275,6 +281,9 @@ For API endpoint commands:
 ```bash
 # Pretty JSON (default)
 operately people get_me
+
+# Pretty JSON (explicit alias)
+operately people get_me --json
 
 # Compact JSON
 operately people get_me --compact

--- a/cli/src/commands/help.ts
+++ b/cli/src/commands/help.ts
@@ -71,6 +71,7 @@ Global flags:
   --base-url <url>
   --profile <name>
   --compact
+  --json
   --output <file>
   --verbose
   --version
@@ -345,6 +346,19 @@ function formatTypeHint(typeRef: CatalogTypeRef): string {
   return typeRef.name;
 }
 
+function formatFlagTypeHint(typeRef: CatalogTypeRef): string {
+  return typeRef.kind === "list" ? formatTypeHint(typeRef.item) : formatTypeHint(typeRef);
+}
+
+function formatFlagQualifiers(field: CatalogEndpoint["inputs"][number]): string {
+  const qualifiers = [field.optional ? "optional" : "required"];
+
+  if (field.nullable) qualifiers.push("nullable");
+  if (field.type.kind === "list") qualifiers.push("repeatable");
+
+  return qualifiers.join(", ");
+}
+
 export function printEndpointHelp(endpoint: CatalogEndpoint, command: string, types?: CatalogTypes): void {
   const header = [`Command: ${command}`];
 
@@ -372,10 +386,8 @@ export function printEndpointHelp(endpoint: CatalogEndpoint, command: string, ty
       ? ["  (none)"]
       : endpoint.inputs.flatMap((field) => {
           const flag = `--${field.name.replace(/_/g, "-")}`;
-          const required = field.optional ? "optional" : "required";
-          const nullable = field.nullable ? ", nullable" : "";
-          const typeHint = formatTypeHint(field.type);
-          const rows = [`  ${flag} <${typeHint}> (${required}${nullable})`];
+          const typeHint = formatFlagTypeHint(field.type);
+          const rows = [`  ${flag} <${typeHint}> (${formatFlagQualifiers(field)})`];
 
           if (field.type.kind === "named" && field.type.name === "contextual_date") {
             hasContextualDate = true;

--- a/cli/src/core/flags.ts
+++ b/cli/src/core/flags.ts
@@ -1,7 +1,7 @@
 import { UsageError } from "./parser-types";
 import type { GlobalFlags } from "./parser-types";
 
-const GLOBAL_FLAG_KEYS = new Set(["token", "base-url", "profile", "compact", "output", "verbose"]);
+const GLOBAL_FLAG_KEYS = new Set(["token", "base-url", "profile", "compact", "json", "output", "verbose"]);
 
 export function parseFlags(tokens: string[]): Map<string, unknown[]> {
   const flags = new Map<string, unknown[]>();
@@ -44,6 +44,7 @@ export function parseFlags(tokens: string[]): Map<string, unknown[]> {
 export function parseGlobalFlags(flags: Map<string, unknown[]>): GlobalFlags {
   const globalFlags: GlobalFlags = {
     compact: false,
+    json: false,
     verbose: false,
   };
 
@@ -57,6 +58,7 @@ export function parseGlobalFlags(flags: Map<string, unknown[]>): GlobalFlags {
     if (key === "profile") globalFlags.profile = ensureStringFlag("profile", last);
     if (key === "output") globalFlags.output = ensureStringFlag("output", last);
     if (key === "compact") globalFlags.compact = ensureBooleanFlag("compact", last);
+    if (key === "json") globalFlags.json = ensureBooleanFlag("json", last);
     if (key === "verbose") globalFlags.verbose = ensureBooleanFlag("verbose", last);
   }
 

--- a/cli/src/core/input-coercion.ts
+++ b/cli/src/core/input-coercion.ts
@@ -221,7 +221,7 @@ function coerceFieldValue(
 
   // Handle list/array types
   if (typeRef.kind === "list") {
-    const list = Array.isArray(value) ? value : [value];
+    const list = normalizeListValue(value);
     return list.map((item, i) =>
       coerceFieldValue(typeRef.item, item, { ...field, nullable: false }, types, `${path}[${i}]`),
     );
@@ -281,6 +281,31 @@ function coerceFieldValue(
   }
 
   throw new UsageError(`Unknown type '${typeName}' for field '${path}'.`);
+}
+
+function normalizeListValue(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(normalizeListValue);
+  }
+
+  if (typeof value === "string") {
+    const parsed = parseJsonArray(value);
+    if (parsed) return parsed.flatMap(normalizeListValue);
+  }
+
+  return [value];
+}
+
+function parseJsonArray(value: string): unknown[] | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function coerceBuiltinType(typeName: string, value: unknown, path: string): unknown {

--- a/cli/src/core/parser-types.ts
+++ b/cli/src/core/parser-types.ts
@@ -11,6 +11,7 @@ export interface GlobalFlags {
   baseUrl?: string;
   profile?: string;
   compact: boolean;
+  json: boolean;
   output?: string;
   verbose: boolean;
 }

--- a/cli/src/test/integration.test.ts
+++ b/cli/src/test/integration.test.ts
@@ -173,7 +173,7 @@ describe("CLI Integration Tests", () => {
       const result = await runCLI(["tasks", "update_assignee", "--help"]);
       assert.strictEqual(result.exitCode, 0);
       assert.ok(result.stdout.includes("--assignee-id <id> (optional, nullable)"));
-      assert.ok(result.stdout.includes("--assignee-ids <[id]> (optional, nullable)"));
+      assert.ok(result.stdout.includes("--assignee-ids <id> (optional, nullable, repeatable)"));
     });
 
     it("shows command help with trailing help", async () => {
@@ -487,7 +487,7 @@ describe("CLI Integration Tests", () => {
     it("shows object type field definitions in help", async () => {
       const result = await runCLI(["help", "spaces", "add_members"]);
       assert.strictEqual(result.exitCode, 0);
-      assert.ok(result.stdout.includes("--members <[add_member_input]>"));
+      assert.ok(result.stdout.includes("--members <add_member_input> (required, repeatable)"));
       assert.ok(result.stdout.includes("Fields for object 'add_member_input':"));
       assert.ok(result.stdout.includes("id: <id>"));
       assert.ok(result.stdout.includes("access_level: <access_options_int>"));
@@ -546,7 +546,7 @@ describe("CLI Integration Tests", () => {
     it("shows object type help only for list item types", async () => {
       const result = await runCLI(["help", "spaces", "add_members"]);
       assert.strictEqual(result.exitCode, 0);
-      assert.ok(result.stdout.includes("--members <[add_member_input]>"));
+      assert.ok(result.stdout.includes("--members <add_member_input> (required, repeatable)"));
       assert.ok(result.stdout.includes("Fields for object 'add_member_input':"));
     });
 

--- a/cli/src/test/unit/custom-endpoints.test.ts
+++ b/cli/src/test/unit/custom-endpoints.test.ts
@@ -34,6 +34,7 @@ function buildInput(
     },
     globalFlags: {
       compact: false,
+      json: false,
       verbose: false,
     },
   };

--- a/cli/src/test/unit/parser.test.ts
+++ b/cli/src/test/unit/parser.test.ts
@@ -147,6 +147,33 @@ test("parses scalar arrays from repeated flags", () => {
   }
 });
 
+test("parses scalar arrays from JSON array strings", () => {
+  const registry = createRegistry(fixtureCatalog);
+  const parsed = parseCommand(
+    [
+      "goals",
+      "update_target_value",
+      "--goal-id",
+      "g1",
+      "--target-value",
+      "10.5",
+      "--subscriber-ids",
+      '["u1","u2"]',
+    ],
+    registry,
+    fixtureCatalog.types,
+  );
+
+  assert.equal(parsed.kind, "endpoint");
+  if (parsed.kind === "endpoint") {
+    assert.deepEqual(parsed.endpointInputs, {
+      goal_id: "g1",
+      target_value: 10.5,
+      subscriber_ids: ["u1", "u2"],
+    });
+  }
+});
+
 test("parses repeated task assignee ids", () => {
   const registry = createRegistry(fixtureCatalog);
   const parsed = parseCommand(
@@ -172,6 +199,28 @@ test("parses repeated task assignee ids", () => {
       task_id: "t1",
       type: "project",
       assignee_ids: ["p1", "p2"],
+    });
+  }
+});
+
+test("accepts json as a global output flag", () => {
+  const registry = createRegistry(fixtureCatalog);
+  const parsed = parseCommand(
+    ["goals", "update_due_date", "--goal-id", "g1", "--due-date", "2026-03-20", "--json"],
+    registry,
+    fixtureCatalog.types,
+  );
+
+  assert.equal(parsed.kind, "endpoint");
+  if (parsed.kind === "endpoint") {
+    assert.equal(parsed.globalFlags.json, true);
+    assert.deepEqual(parsed.endpointInputs, {
+      goal_id: "g1",
+      due_date: {
+        date_type: "day",
+        value: "Mar 20, 2026",
+        date: "2026-03-20",
+      },
     });
   }
 });


### PR DESCRIPTION
## Summary

- Accept `--json` as a global no-op alias for the CLI’s default JSON output.
- Accept JSON array strings for list flags, while keeping repeated flags as the canonical documented form.
- Update command help to show list flags as repeatable, e.g. `--ids <id> (required, repeatable)`.
- Document the tolerated list-array and `--json` forms in the CLI README.
- Clarify in `AGENTS.md` that every commit must be signed off for DCO.

## Context

A customer's OpenClaw cron runs failed after an agent used two common but non-canonical CLI shapes:

- `operately people list_assignments --json`
- `operately notifications mark_many_as_read --ids '["id1","id2"]'`

The CLI already emits JSON by default, and repeated flags remain the preferred list syntax. This change applies Postel’s law to tolerate these agent-shaped inputs while making help text less ambiguous.