### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,15 @@ Read the testing guide at app/test/AGENTS.md.
 
 - Local env: run `make dev.seed.env` to scaffold `.env` and certs. Never commit secrets.
 - Use `./devenv` wrapper (Docker-based) for consistent tooling and DB.
+
+## Cursor Cloud specific instructions
+
+The entire dev environment runs inside Docker via the `./devenv` wrapper (docker-in-docker). Standard build/run/test commands live in the `Makefile` and `docs/dev-env.md`; the notes below only cover non-obvious caveats for this environment.
+
+- **Docker daemon**: the VM has no systemd, so `dockerd` is launched directly (the startup/update script starts it in the background and `chmod 666 /var/run/docker.sock`). If `docker ps` fails with a socket/permission error, run `sudo chmod 666 /var/run/docker.sock`; if the daemon is not running, start it with `sudo bash -c 'nohup dockerd >/tmp/dockerd.log 2>&1 &'`.
+- **Bring up containers**: only `db` and `pgweb` have `restart: always`, so they auto-start when `dockerd` starts. The `app`, `mailhog`, and `s3mock` containers do NOT auto-restart — run `./devenv up` to (re)create them before doing anything. Compose project name is `workspace` (containers like `workspace-app-1`, `workspace-db-1`).
+- **Refresh deps after pulling**: `make dev.build` is idempotent (deps.get/compile, lockfile-hash-guarded `npm ci`, turboui build, DB create/migrate); rerun it if `mix.lock` / `package-lock.json` / migrations changed. It requires the containers to be up.
+- **Run the app**: `make dev.server` (Phoenix at http://localhost:4000, Vite watcher at :4005). It runs `iex -S mix phx.server`, so run it in a background/tmux session.
+- **First-run onboarding (fastest hello-world)**: visit `http://localhost:4000/setup` to create the first company + admin account in one form (company name, full name, title, email, password ≥12 chars with upper/lower/number). No email code is needed for this path.
+- **Email signup/login code**: `ALLOW_LOGIN_WITH_EMAIL`/`ALLOW_SIGNUP_WITH_EMAIL` are enabled by `dev.seed.env`. In dev, email delivery is always treated as "configured", and the 6-character activation code is stored in the DB rather than shown in the UI. MailHog's UI is NOT published to the host (the `mailhog` service defines no host ports), so fetch codes from Postgres: `docker exec workspace-db-1 psql -U postgres -d operately_dev -c "SELECT email, code FROM email_activation_codes ORDER BY inserted_at DESC LIMIT 5;"`.
+- **Inspect dev data**: `docker exec workspace-db-1 psql -U postgres -d operately_dev -c '<SQL>'` (dev DB is `operately_dev`, test DB is `operately_test`; password `keyboard-cat`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ Read the testing guide at app/test/AGENTS.md.
 - Local env: run `make dev.seed.env` to scaffold `.env` and certs. Never commit secrets.
 - Use `./devenv` wrapper (Docker-based) for consistent tooling and DB.
 
-## Cursor Cloud specific instructions
+## Cursor Cloud-specific instructions
 
 The entire dev environment runs inside Docker via the `./devenv` wrapper (docker-in-docker). Standard build/run/test commands live in the `Makefile` and `docs/dev-env.md`; the notes below only cover non-obvious caveats for this environment.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Operately development environment in the Cursor Cloud VM and documents the non-obvious caveats for future agents. The only code change is an additive `## Cursor Cloud specific instructions` section in `AGENTS.md` (no application code modified).

This Docker-in-Docker, Make-driven environment was brought up end to end:
- Installed Docker engine + compose plugin (fuse-overlayfs storage driver, `containerd-snapshotter` disabled for Docker 29).
- `make dev.build` — pulled the dev image, installed Elixir/Node deps, compiled, built TurboUI, created + migrated the dev and test DBs.
- `make dev.server` — Phoenix dev server live at http://localhost:4000 (Vite watcher at :4005).

## Verification

Lint, tests, and a full end-to-end "hello world" were exercised:
- `make test.tsc.lint` (TypeScript) — pass
- `make test FILE=app/test/operately/companies_test.exs` (Elixir, 8 tests) — pass
- `npx jest src/FormattedTime/LongDate.test.tsx` in `turboui` (Jest) — pass
- Hello-world via UI: created a company + admin account at `/setup`, then created a Goal ("Launch Operately v1"). Verified in Postgres (`companies`, `people`, `goals`).

[operately_create_goal_demo.mp4](https://cursor.com/agents/bc-b8b18fa1-04e1-4cd3-ac7e-f9a9818c69dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperately_create_goal_demo.mp4)

Created goal page:

[Created goal page](https://cursor.com/agents/bc-b8b18fa1-04e1-4cd3-ac7e-f9a9818c69dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foperately_created_goal.webp)

## Notes

- Update script (run on VM startup) only starts the `dockerd` daemon and fixes socket perms — the foundational layer for this Docker-based repo. Container startup (`./devenv up`), builds, and migrations are intentionally left out of the update script and documented in `AGENTS.md` instead.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8b18fa1-04e1-4cd3-ac7e-f9a9818c69dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8b18fa1-04e1-4cd3-ac7e-f9a9818c69dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

