### PR TITLE
chore: move image placeholder to turboui

### DIFF
--- a/app/assets/js/components/Image/index.tsx
+++ b/app/assets/js/components/Image/index.tsx
@@ -1,1 +1,0 @@
-export { ImageWithPlaceholder } from "./ImageWithPlaceholder";

--- a/app/assets/js/pages/ResourceHubFilePage/Content.tsx
+++ b/app/assets/js/pages/ResourceHubFilePage/Content.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ImageWithPlaceholder } from "turboui";
+import { calculateImageRatio, ImageWithPlaceholder } from "turboui";
 
 import { assertPresent } from "@/utils/assertions";
 import { useLoadedData } from "./loader";
@@ -18,14 +18,11 @@ export function Content() {
 function Image() {
   const { file } = useLoadedData();
   assertPresent(file.blob, "blob must be present in file");
-  assertPresent(file.blob.height, "image height must be present");
-  assertPresent(file.blob.width, "image width must be present");
   assertPresent(file.blob.url, "image url must be present");
-  assertPresent(file.name, "file name must be present");
 
-  const imgRatio = file.blob.height / file.blob.width;
+  const imgRatio = calculateImageRatio(file.blob.width, file.blob.height);
 
-  return <ImageWithPlaceholder src={file.blob.url} alt={file.name} ratio={imgRatio} />;
+  return <ImageWithPlaceholder src={file.blob.url} alt={file.name || undefined} ratio={imgRatio} />;
 }
 
 function Video() {

--- a/app/assets/js/pages/ResourceHubFilePage/Content.tsx
+++ b/app/assets/js/pages/ResourceHubFilePage/Content.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { ImageWithPlaceholder } from "turboui";
 
 import { assertPresent } from "@/utils/assertions";
-import { ImageWithPlaceholder } from "@/components/Image";
 import { useLoadedData } from "./loader";
 
 export function Content() {
@@ -18,10 +18,14 @@ export function Content() {
 function Image() {
   const { file } = useLoadedData();
   assertPresent(file.blob, "blob must be present in file");
+  assertPresent(file.blob.height, "image height must be present");
+  assertPresent(file.blob.width, "image width must be present");
+  assertPresent(file.blob.url, "image url must be present");
+  assertPresent(file.name, "file name must be present");
 
-  const imgRatio = file.blob.height! / file.blob.width!;
+  const imgRatio = file.blob.height / file.blob.width;
 
-  return <ImageWithPlaceholder src={file.blob.url!} alt={file.name!} ratio={imgRatio} />;
+  return <ImageWithPlaceholder src={file.blob.url} alt={file.name} ratio={imgRatio} />;
 }
 
 function Video() {

--- a/turboui/src/ImageWithPlaceholder/index.stories.tsx
+++ b/turboui/src/ImageWithPlaceholder/index.stories.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ImageWithPlaceholder } from "./index";
+
+const meta: Meta<typeof ImageWithPlaceholder> = {
+  title: "Components/ImageWithPlaceholder",
+  component: ImageWithPlaceholder,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[480px] max-w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    src: "https://placehold.co/1200x800/png?text=Resource+Hub+Preview",
+    alt: "Sample resource hub preview",
+    ratio: 2 / 3,
+  },
+};

--- a/turboui/src/ImageWithPlaceholder/index.tsx
+++ b/turboui/src/ImageWithPlaceholder/index.tsx
@@ -1,13 +1,25 @@
-import React, { useState } from "react";
+import * as React from "react";
 
-interface Props {
+export interface ImageWithPlaceholderProps {
   src: string;
   alt?: string;
   ratio: number;
 }
 
-export function ImageWithPlaceholder({ src, alt, ratio }: Props) {
-  const [loaded, setLoaded] = useState(false);
+const LOADING_ANIMATION_NAME = "turboui-image-with-placeholder-loading";
+const LOADING_KEYFRAMES = `
+  @keyframes ${LOADING_ANIMATION_NAME} {
+    0% {
+      background-position: -200% 0;
+    }
+    100% {
+      background-position: 200% 0;
+    }
+  }
+`;
+
+export function ImageWithPlaceholder({ src, alt, ratio }: ImageWithPlaceholderProps) {
+  const [loaded, setLoaded] = React.useState(false);
 
   return (
     <div
@@ -25,10 +37,11 @@ export function ImageWithPlaceholder({ src, alt, ratio }: Props) {
             inset: 0,
             background: "linear-gradient(90deg, #f5f5f5 25%, #e0e0e0 50%, #f5f5f5 75%)",
             backgroundSize: "200% 100%",
-            animation: "loading 3.5s infinite",
+            animation: `${LOADING_ANIMATION_NAME} 3.5s infinite`,
           }}
         />
       )}
+
       <img
         src={src}
         alt={alt}
@@ -44,18 +57,8 @@ export function ImageWithPlaceholder({ src, alt, ratio }: Props) {
         }}
         onLoad={() => setLoaded(true)}
       />
-      <style>
-        {`
-          @keyframes loading {
-            0% {
-              background-position: -200% 0;
-            }
-            100% {
-              background-position: 200% 0;
-            }
-          }
-        `}
-      </style>
+
+      <style>{LOADING_KEYFRAMES}</style>
     </div>
   );
 }

--- a/turboui/src/ImageWithPlaceholder/index.tsx
+++ b/turboui/src/ImageWithPlaceholder/index.tsx
@@ -6,6 +6,7 @@ export interface ImageWithPlaceholderProps {
   ratio: number;
 }
 
+const DEFAULT_RATIO = 1;
 const LOADING_ANIMATION_NAME = "turboui-image-with-placeholder-loading";
 const LOADING_KEYFRAMES = `
   @keyframes ${LOADING_ANIMATION_NAME} {
@@ -18,15 +19,24 @@ const LOADING_KEYFRAMES = `
   }
 `;
 
+export function calculateImageRatio(width?: number | null, height?: number | null) {
+  if (!isPositiveNumber(width) || !isPositiveNumber(height)) {
+    return DEFAULT_RATIO;
+  }
+
+  return normalizeImageRatio(height / width);
+}
+
 export function ImageWithPlaceholder({ src, alt, ratio }: ImageWithPlaceholderProps) {
   const [loaded, setLoaded] = React.useState(false);
+  const safeRatio = normalizeImageRatio(ratio);
 
   return (
     <div
       style={{
         position: "relative",
         width: "100%",
-        paddingBottom: `${ratio * 100}%`,
+        paddingBottom: `${safeRatio * 100}%`,
         overflow: "hidden",
       }}
     >
@@ -61,4 +71,12 @@ export function ImageWithPlaceholder({ src, alt, ratio }: ImageWithPlaceholderPr
       <style>{LOADING_KEYFRAMES}</style>
     </div>
   );
+}
+
+function normalizeImageRatio(ratio: number) {
+  return Number.isFinite(ratio) && ratio > 0 ? ratio : DEFAULT_RATIO;
+}
+
+function isPositiveNumber(value?: number | null): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
 }

--- a/turboui/src/ResourceHub/NodeIcon.tsx
+++ b/turboui/src/ResourceHub/NodeIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
+import { calculateImageRatio, ImageWithPlaceholder } from "../ImageWithPlaceholder";
 import classNames from "../utils/classnames";
-import { ImageWithPlaceholder } from "../ImageWithPlaceholder";
 import { IconAlignJustified, IconChartColumn, IconFolderFilled, IconLink, IconLogs, IconVideo } from "../icons";
 import { getNodeLinkType, getNodeThumbnail, getNodeType, hasNodeContentType, isNodeMovFile, isNodeVideoFile } from "./selectors";
 import type { ResourceHubNode } from "./types";
@@ -82,7 +82,7 @@ function FileIconBadge({ size, filetype, color }: FileIconProps) {
 
 function Thumbnail({ url, alt, width, height, size }: { url: string; alt: string; width: number; height: number; size: number }) {
   const padding = 1;
-  const imgRatio = height / width;
+  const imgRatio = calculateImageRatio(width, height);
   const thumbnailWidth = size - padding * 2;
   const thumbnailHeight = thumbnailWidth * imgRatio;
 

--- a/turboui/src/ResourceHub/NodeIcon.tsx
+++ b/turboui/src/ResourceHub/NodeIcon.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import classNames from "../utils/classnames";
+import { ImageWithPlaceholder } from "../ImageWithPlaceholder";
 import { IconAlignJustified, IconChartColumn, IconFolderFilled, IconLink, IconLogs, IconVideo } from "../icons";
 import { getNodeLinkType, getNodeThumbnail, getNodeType, hasNodeContentType, isNodeMovFile, isNodeVideoFile } from "./selectors";
 import type { ResourceHubNode } from "./types";
@@ -90,42 +91,6 @@ function Thumbnail({ url, alt, width, height, size }: { url: string; alt: string
       <div style={{ width: thumbnailWidth, height: thumbnailHeight }}>
         <ImageWithPlaceholder src={url} alt={alt} ratio={imgRatio} />
       </div>
-    </div>
-  );
-}
-
-function ImageWithPlaceholder({ src, alt, ratio }: { src: string; alt: string; ratio: number }) {
-  const [loaded, setLoaded] = React.useState(false);
-
-  return (
-    <div style={{ position: "relative", width: "100%", paddingBottom: `${ratio * 100}%`, overflow: "hidden" }}>
-      {!loaded && (
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            background: "linear-gradient(90deg, #f5f5f5 25%, #e0e0e0 50%, #f5f5f5 75%)",
-            backgroundSize: "200% 100%",
-            animation: "loading 3.5s infinite",
-          }}
-        />
-      )}
-      <img
-        src={src}
-        alt={alt}
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: "100%",
-          height: "100%",
-          objectFit: "cover",
-          opacity: loaded ? 1 : 0,
-          transition: "opacity 500ms ease-in-out",
-        }}
-        onLoad={() => setLoaded(true)}
-      />
-      <style>{`@keyframes loading { 0% { background-position: -200% 0; } 100% { background-position: 200% 0; } }`}</style>
     </div>
   );
 }

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -14,6 +14,7 @@ export * from "./FormattedTime";
 export * as Forms from "./Forms";
 export * from "./BrandIcons";
 export { BulletDot } from "./BulletDot";
+export * from "./ImageWithPlaceholder";
 export * from "./icons";
 export * from "./Link";
 export * from "./Menu";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- move `ImageWithPlaceholder` from the app layer into `turboui/src/ImageWithPlaceholder`
- add a Storybook story and export the component from the TurboUI entrypoint
- update Resource Hub image rendering to import the shared TurboUI component and remove the legacy app copy
- reuse the new shared component in `turboui/src/ResourceHub/NodeIcon.tsx` to avoid keeping duplicate shimmer logic
- guard image aspect-ratio calculations so missing, zero, or invalid dimensions fall back to a safe default instead of producing `Infinity`/`NaN`

## Testing
- `npm --prefix turboui run build`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.lint.json` (from `app/`)

## Migration Notes
- no backend or database changes
- no visual behavior changes intended
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1e4307f-02f5-4eb8-bfd1-ccdda8bc65ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1e4307f-02f5-4eb8-bfd1-ccdda8bc65ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

