### PR TITLE
feat: add turboui forms phase 0 parity

### DIFF
--- a/specs/0014-forms-turboui-migration.md
+++ b/specs/0014-forms-turboui-migration.md
@@ -57,13 +57,13 @@ const form = Forms.useForm({ fields: { ... }, submit: async () => { ... } });
 
 **Core gaps vs TurboUI:**
 
-- [ ] `useForm`: `trigger` / `setTrigger`, `addErrors` / `removeErrors`, `onError` (AxiosError)
+- [x] `useForm`: `trigger` / `setTrigger`, `addErrors` / `removeErrors`, `onError` (AxiosError)
 - [x] `FieldGroup`: `horizontal` and `grid` layouts
-- [ ] `Submit`: `layout`, `submitOnEnter`, `buttonSize`, `testId`, `containerClassName`
+- [x] `Submit`: `layout`, `submitOnEnter`, `buttonSize`, `testId`, `containerClassName`
 - [ ] `SubmitButton`: multi-action submit (check-in forms)
 - [x] Validations: `textLength`, `isNumber`
 - [x] Inputs: `PasswordInput`, `NumberInput`, `CheckboxInput`, `RadioButtons`, `TitleInput`
-- [ ] Feedback: `FormError`
+- [x] Feedback: `FormError`
 - [x] Feedback: `ErrorMessage`
 - [x] Primitives: `Elements/Input`, `Elements/Label` (GoalTargetsV2)
 
@@ -82,11 +82,11 @@ const form = Forms.useForm({ fields: { ... }, submit: async () => { ... } });
 
 ## Implementation Status
 
-Phases 0 and 2–8 are not yet implemented. **Phase 1 is complete.** Each remaining phase should land as one or more focused PRs following the checklists below.
+**Phases 0 and 1 are complete.** Phases 2–8 are not yet implemented. Each remaining phase should land as one or more focused PRs following the checklists below.
 
 | Phase | Status |
 | ----- | ------ |
-| 0 — API Parity Foundation | [ ] Not started |
+| 0 — API Parity Foundation | [x] Complete |
 | 1 — Input Primitives and FieldGroup Layouts | [x] Complete |
 | 2 — Auth and Account Forms | [ ] Not started |
 | 3 — Standard CRUD Forms | [ ] Not started |
@@ -142,29 +142,29 @@ flowchart TB
 
 ## Phase 0 — API Parity Foundation
 
-**Phase complete:** [ ]
+**Phase complete:** [x]
 
 **Goal:** Extend TurboUI `useForm` and shared primitives so simple migrations do not regress.
 
 ### TurboUI work
 
-- [ ] `useForm`: `addErrors`, `removeErrors`, `trigger`, `setTrigger`, optional `onError`
+- [x] `useForm`: `addErrors`, `removeErrors`, `trigger`, `setTrigger`, optional `onError`
 - [x] Validations: `validateTextLength`, `validateIsNumber` *(landed in Phase 1)*
-- [ ] `TextInput`: `hidden`, `minLength`, `maxLength`, `onEnter`, `okSign`
-- [ ] `Submit`: `layout`, `submitOnEnter`, `buttonSize`, `testId`, `containerClassName`
-- [ ] `FormError` presentational component
+- [x] `TextInput`: `hidden`, `minLength`, `maxLength`, `onEnter`, `okSign`
+- [x] `Submit`: `layout`, `submitOnEnter`, `buttonSize`, `testId`, `containerClassName`
+- [x] `FormError` presentational component
 - [x] `ErrorMessage` presentational component *(landed in Phase 1)*
 
 ### Storybook
 
-- [ ] `Forms.stories.tsx`: basic form, validation errors, cancel flow, nested paths
+- [x] `Forms.stories.tsx`: basic form, validation errors, cancel flow, nested paths
 
 ### Acceptance
 
-- [ ] SiteMessageModal still works
-- [ ] No app call-site changes
-- [ ] `make turboui.build && make turboui.test`
-- [ ] `make test.tsc.lint`
+- [x] SiteMessageModal still works
+- [x] No app call-site changes
+- [x] `make turboui.build && make turboui.test`
+- [x] `make test.tsc.lint`
 
 ---
 
@@ -415,7 +415,7 @@ import { Forms } from "turboui";
 
 | File | Contents | Status |
 | ---- | -------- | ------ |
-| `Forms.stories.tsx` | Basic form, validation, cancel, nested paths | [ ] |
+| `Forms.stories.tsx` | Basic form, validation, cancel, nested paths | [x] |
 | `Inputs.stories.tsx` | TextInput, Password, Number, Checkbox, Radio, Title | [x] |
 | `FieldGroup.stories.tsx` | vertical / horizontal / grid | [x] |
 | `RichTextArea.stories.tsx` | editable + readonly | [ ] |

--- a/turboui/src/Forms/FormError.tsx
+++ b/turboui/src/Forms/FormError.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { ErrorMessage } from "./ErrorMessage";
+import { useFormContext } from "./context";
+import type { FormErrorProps } from "./types";
+
+const DEFAULT_MESSAGE = "Please fix the errors above.";
+
+export function FormError({ message = DEFAULT_MESSAGE, when, className }: FormErrorProps) {
+  const form = useFormContext();
+  const shouldShow = when ?? form.hasErrors;
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <div className={className}>
+      <ErrorMessage error={message} />
+    </div>
+  );
+}

--- a/turboui/src/Forms/Forms.stories.tsx
+++ b/turboui/src/Forms/Forms.stories.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Page } from "../Page";
+import { FieldGroup, Form, FormError, Submit, TextInput, useForm } from "./index";
+
+const meta: Meta = {
+  title: "Components/Forms/Forms",
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [
+    (Story) => (
+      <div className="sm:mt-12">
+        <Page size="medium" title="Forms">
+          <div className="p-12">
+            <Story />
+          </div>
+        </Page>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const BasicForm: Story = {
+  render: () => {
+    function Harness() {
+      const form = useForm({
+        fields: { companyName: "", domain: "" },
+        submit: async () => {
+          console.log("Submitted:", form.values);
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <FieldGroup>
+            <TextInput field="companyName" label="Company name" required placeholder="Acme Inc." autoFocus />
+            <TextInput field="domain" label="Domain" placeholder="acme.com" />
+          </FieldGroup>
+          <Submit saveText="Create company" />
+        </Form>
+      );
+    }
+
+    return <Harness />;
+  },
+};
+
+export const ValidationErrors: Story = {
+  render: () => {
+    function Harness() {
+      const form = useForm({
+        fields: { email: "", password: "short" },
+        submit: async () => {
+          console.log("Submitted:", form.values);
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <FieldGroup>
+            <TextInput field="email" label="Email" required placeholder="name@company.com" />
+            <TextInput field="password" label="Password" minLength={12} okSign placeholder="At least 12 characters" />
+          </FieldGroup>
+          <FormError className="mt-4" />
+          <Submit saveText="Save changes" />
+        </Form>
+      );
+    }
+
+    return <Harness />;
+  },
+};
+
+export const CancelFlow: Story = {
+  render: () => {
+    function Harness() {
+      const [status, setStatus] = React.useState("No cancel yet");
+      const form = useForm({
+        fields: { title: "Quarterly planning" },
+        cancel: async () => {
+          setStatus("Cancel callback invoked");
+        },
+        submit: async () => {
+          console.log("Submitted:", form.values);
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="title" label="Title" />
+          <div className="mt-3 text-sm text-content-subtle">{status}</div>
+          <Submit saveText="Save" cancelText="Discard" />
+        </Form>
+      );
+    }
+
+    return <Harness />;
+  },
+};
+
+export const NestedPaths: Story = {
+  render: () => {
+    function Harness() {
+      const form = useForm({
+        fields: {
+          settings: {
+            smtp: [{ host: "smtp.example.com", port: "587" }],
+          },
+        },
+        submit: async () => {
+          console.log("Submitted:", form.values);
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <FieldGroup layout="horizontal" layoutOptions={{ ratio: "1:1", dividers: true }}>
+            <TextInput field="settings.smtp[0].host" label="SMTP host" />
+            <TextInput field="settings.smtp[0].port" label="SMTP port" />
+          </FieldGroup>
+          <Submit saveText="Save settings" submitOnEnter />
+        </Form>
+      );
+    }
+
+    return <Harness />;
+  },
+};

--- a/turboui/src/Forms/Submit.tsx
+++ b/turboui/src/Forms/Submit.tsx
@@ -1,13 +1,39 @@
 import * as React from "react";
 
 import { PrimaryButton, SecondaryButton } from "../Button";
+import classNames from "../utils/classnames";
 import { useFormContext } from "./context";
 import type { SubmitProps } from "./types";
 
-export function Submit({ saveText = "Save", cancelText = "Cancel" }: SubmitProps) {
+const DEFAULT_SUBMIT_PROPS: Required<Pick<SubmitProps, "saveText" | "cancelText" | "layout" | "buttonSize" | "submitOnEnter">> = {
+  saveText: "Save",
+  cancelText: "Cancel",
+  layout: "left",
+  buttonSize: "sm",
+  submitOnEnter: false,
+};
+
+export function Submit(props: SubmitProps) {
   const form = useFormContext();
+  const {
+    buttonSize,
+    cancelText,
+    className,
+    containerClassName,
+    layout,
+    saveText,
+    submitOnEnter,
+    testId,
+  } = { ...DEFAULT_SUBMIT_PROPS, ...props };
   const isLoading = form.state === "submitting" || form.state === "uploading";
   const label = form.state === "uploading" ? "Uploading..." : saveText;
+  const buttonType = submitOnEnter ? "submit" : "button";
+
+  const containerStyles = classNames(
+    "mt-8 flex items-center gap-2",
+    layout === "centered" ? "justify-center" : "justify-start",
+    containerClassName,
+  );
 
   const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -15,13 +41,13 @@ export function Submit({ saveText = "Save", cancelText = "Cancel" }: SubmitProps
   };
 
   return (
-    <div className="mt-8 flex items-center gap-2">
-      <PrimaryButton type="button" size="sm" loading={isLoading} testId="submit" onClick={handleSubmit}>
+    <div className={containerStyles}>
+      <PrimaryButton type={buttonType} size={buttonSize} loading={isLoading} testId={testId ?? "submit"} onClick={handleSubmit} className={className}>
         {label}
       </PrimaryButton>
 
       {form.hasCancel ? (
-        <SecondaryButton type="button" size="sm" testId="cancel" onClick={() => void form.actions.cancel()}>
+        <SecondaryButton type="button" size={buttonSize} testId="cancel" onClick={() => void form.actions.cancel()}>
           {cancelText}
         </SecondaryButton>
       ) : null}

--- a/turboui/src/Forms/TextInput.tsx
+++ b/turboui/src/Forms/TextInput.tsx
@@ -1,32 +1,44 @@
 import * as React from "react";
 
 import { createTestId } from "../TestableElement";
+import { Input } from "./Input";
 import { useFieldError, useFieldValue } from "./context";
 import { InputField } from "./FieldGroup";
-import { useValidation, validatePresence } from "./validation";
+import { useValidation, validatePresence, validateTextLength } from "./validation";
 import type { TextInputProps } from "./types";
 
-export function TextInput({ field, label, testId, autoFocus, required, placeholder }: TextInputProps) {
+const DEFAULT_VALIDATION_PROPS = {
+  required: false,
+  minLength: undefined,
+  maxLength: undefined,
+};
+
+export function TextInput(props: TextInputProps) {
+  const { field, label, hidden, testId, autoFocus, placeholder, onEnter, okSign } = props;
+  const { required, minLength, maxLength } = { ...DEFAULT_VALIDATION_PROPS, ...props };
   const [value, setValue] = useFieldValue<string>(field);
   const error = useFieldError(field);
 
   useValidation(field, validatePresence(required));
+  useValidation(field, validateTextLength(minLength, maxLength));
 
   return (
-    <InputField field={field} label={label} error={error} required={required}>
-      <input
+    <InputField field={field} label={label} error={error} hidden={hidden} required={required}>
+      <Input
         id={field}
-        name={field}
+        field={field}
+        testId={testId ?? createTestId(field)}
+        error={!!error}
         type="text"
         value={value ?? ""}
         autoFocus={autoFocus}
         placeholder={placeholder}
-        data-test-id={testId ?? createTestId(field)}
+        required={required}
+        minLength={minLength}
+        maxLength={maxLength}
+        onEnter={onEnter}
+        okSign={okSign}
         onChange={(event) => setValue(event.target.value)}
-        className={[
-          "w-full rounded-lg border bg-surface-base px-3 py-1.5 text-content-accent placeholder-content-subtle",
-          error ? "border-red-500" : "border-surface-outline",
-        ].join(" ")}
       />
     </InputField>
   );

--- a/turboui/src/Forms/index.test.tsx
+++ b/turboui/src/Forms/index.test.tsx
@@ -6,6 +6,7 @@ import { emptyContent } from "../RichContent/contentOps";
 import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import {
   Form,
+  FormError,
   NumberInput,
   PasswordInput,
   RichTextArea,
@@ -138,6 +139,66 @@ describe("Forms", () => {
     expect(container.querySelector('[data-test-id="items-0-name"]')).toBeInTheDocument();
   });
 
+  test("supports adding and removing submit errors through form actions", async () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" />
+          <FormError when={!!form.errors._submit} message={form.errors._submit} />
+          <button type="button" onClick={() => form.actions.addErrors({ _submit: "Save failed" })}>
+            Add submit error
+          </button>
+          <button type="button" onClick={() => form.actions.removeErrors(["_submit"])}>
+            Remove submit error
+          </button>
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add submit error" }));
+    expect(await screen.findByText("Save failed")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove submit error" }));
+    await waitFor(() => expect(screen.queryByText("Save failed")).not.toBeInTheDocument());
+  });
+
+  test("calls onError when submit fails", async () => {
+    const onError = jest.fn();
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Roadmap" },
+        onError,
+        submit: async () => {
+          throw new Error("submit failed");
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" />
+          <Submit />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+    consoleErrorSpy.mockRestore();
+  });
+
   test("updates select box values", async () => {
     const onSubmit = jest.fn();
 
@@ -174,6 +235,32 @@ describe("Forms", () => {
         status: "false",
       }),
     );
+  });
+
+  test("updates the trigger through form actions", async () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <div data-testid="trigger-value">{form.trigger ?? "none"}</div>
+          <button type="button" onClick={() => form.actions.setTrigger("draft")}>
+            Set draft trigger
+          </button>
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("trigger-value")).toHaveTextContent("none");
+
+    fireEvent.click(screen.getByRole("button", { name: "Set draft trigger" }));
+
+    expect(await screen.findByTestId("trigger-value")).toHaveTextContent("draft");
   });
 
   test("resets field values before invoking cancel", () => {
@@ -237,6 +324,96 @@ describe("Forms", () => {
 
     expect(await screen.findByText("Can't be empty")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("supports text input min and max length validation", async () => {
+    const onSubmit = jest.fn();
+
+    function Harness() {
+      const form = useForm({
+        fields: { name: "hi", code: "toolong" },
+        submit: async () => {
+          onSubmit();
+        },
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" minLength={3} />
+          <TextInput field="code" label="Code" maxLength={4} />
+          <Submit />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Must be at least 3 characters long")).toBeInTheDocument();
+    expect(await screen.findByText("Must be at most 4 characters long")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("supports hidden text inputs", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { secret: "hidden value" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="secret" label="Secret" hidden />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.queryByLabelText("Secret")).not.toBeInTheDocument();
+  });
+
+  test("calls the text input onEnter handler", () => {
+    const onEnter = jest.fn();
+
+    function Harness() {
+      const form = useForm({
+        fields: { name: "" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" onEnter={onEnter} />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.keyDown(screen.getByLabelText("Name"), { key: "Enter" });
+
+    expect(onEnter).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the text input ok sign when the field has no error", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Ready" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" okSign />
+        </Form>
+      );
+    }
+
+    const { container } = render(<Harness />);
+
+    expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
   describe("validateTextLength", () => {
@@ -324,5 +501,85 @@ describe("Forms", () => {
     expect(await screen.findByText("Can't be empty")).toBeInTheDocument();
     expect(await screen.findByText("Must be a valid number")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("shows the default form error when the form has validation errors", async () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" required />
+          <FormError />
+          <Submit />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Please fix the errors above.")).toBeInTheDocument();
+  });
+
+  test("supports submit layout, sizing, and custom ids", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Roadmap" },
+        cancel: async () => undefined,
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" />
+          <Submit
+            saveText="Publish"
+            layout="centered"
+            buttonSize="base"
+            containerClassName="custom-submit-container"
+            testId="publish-button"
+          />
+        </Form>
+      );
+    }
+
+    const { container } = render(<Harness />);
+
+    const saveButton = container.querySelector('[data-test-id="publish-button"]');
+    const cancelButton = container.querySelector('[data-test-id="cancel"]');
+
+    expect(saveButton).toBeInTheDocument();
+    expect(cancelButton).toBeInTheDocument();
+    const submitContainer = saveButton?.parentElement;
+
+    expect(saveButton).toHaveAttribute("type", "button");
+    expect(saveButton).toHaveClass("px-4", "py-2");
+    expect(cancelButton).toHaveClass("px-4", "py-2");
+    expect(submitContainer).toHaveClass("justify-center", "custom-submit-container");
+  });
+
+  test("uses submit button type when submitOnEnter is enabled", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Roadmap" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <TextInput field="name" label="Name" />
+          <Submit submitOnEnter />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute("type", "submit");
   });
 });

--- a/turboui/src/Forms/index.test.tsx
+++ b/turboui/src/Forms/index.test.tsx
@@ -30,6 +30,10 @@ jest.mock("../RichEditor", () => ({
   }),
 }));
 
+jest.mock("../icons", () => ({
+  IconCheck: () => <svg data-testid="icon-check" />,
+}));
+
 jest.mock("react-select", () => {
   return function MockSelect({
     options,
@@ -411,9 +415,9 @@ describe("Forms", () => {
       );
     }
 
-    const { container } = render(<Harness />);
+    render(<Harness />);
 
-    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-check")).toBeInTheDocument();
   });
 
   describe("validateTextLength", () => {

--- a/turboui/src/Forms/index.tsx
+++ b/turboui/src/Forms/index.tsx
@@ -3,6 +3,7 @@ export { FieldGroup, InputField } from "./FieldGroup";
 export { Input } from "./Input";
 export { Label } from "./Label";
 export { ErrorMessage } from "./ErrorMessage";
+export { FormError } from "./FormError";
 export { PasswordInput } from "./PasswordInput";
 export { NumberInput } from "./NumberInput";
 export { CheckboxInput } from "./CheckboxInput";
@@ -24,6 +25,7 @@ export type {
   FieldGroupProps,
   FieldGroupVerticalOptions,
   FieldValidation,
+  FormErrorProps,
   FormErrors,
   FormOption,
   FormProps,

--- a/turboui/src/Forms/types.ts
+++ b/turboui/src/Forms/types.ts
@@ -1,23 +1,28 @@
 import type * as React from "react";
+import type { AxiosError } from "axios";
 
+import type { BaseButtonProps } from "../Button";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
 
 export type FormStatus = "idle" | "uploading" | "validating" | "submitting";
 export type FormValues = Record<string, unknown>;
 export type FormErrors = Record<string, string>;
 export type AddErrorFn = (field: string, message: string) => void;
-export type FormValueUpdater<T> = T | ((currentValue: T) => T);
+export type FormValueUpdater<T> = T | ((currentValue: T | undefined) => T);
 export type FieldValidation = (field: string, value: unknown, addError: AddErrorFn) => void;
 
 export interface FormState<T extends FormValues = FormValues> {
   values: T;
   state: FormStatus;
+  trigger?: string;
   errors: FormErrors;
   hasErrors: boolean;
   hasCancel: boolean;
   lastSubmitSucceededAt?: number;
   actions: {
     clearErrors: () => void;
+    addErrors: (errors: FormErrors) => void;
+    removeErrors: (keys: string[]) => void;
     submit: (attrs?: unknown) => Promise<void>;
     cancel: () => Promise<void>;
     reset: () => void;
@@ -26,6 +31,7 @@ export interface FormState<T extends FormValues = FormValues> {
     getValue: <TValue = unknown>(field: string) => TValue | undefined;
     setValue: <TValue = unknown>(field: string, value: FormValueUpdater<TValue>) => void;
     setState: (state: FormStatus) => void;
+    setTrigger: React.Dispatch<React.SetStateAction<string | undefined>>;
   };
 }
 
@@ -35,6 +41,7 @@ export interface UseFormOptions<T extends FormValues> {
   submit: (attrs?: unknown) => Promise<void> | void;
   cancel?: () => Promise<void> | void;
   onChange?: (args: { newValues: T; field: string | null }) => void;
+  onError?: (error: AxiosError) => void;
 }
 
 export interface FormProps<T extends FormValues = FormValues> {
@@ -83,13 +90,24 @@ export interface TextInputProps {
   label?: string;
   testId?: string;
   autoFocus?: boolean;
+  hidden?: boolean;
   required?: boolean;
+  minLength?: number;
+  maxLength?: number;
   placeholder?: string;
+  onEnter?: (event: React.KeyboardEvent) => void;
+  okSign?: boolean;
 }
 
 export interface SubmitProps {
   saveText?: string;
   cancelText?: string;
+  layout?: "left" | "centered";
+  buttonSize?: BaseButtonProps["size"];
+  submitOnEnter?: boolean;
+  className?: string;
+  containerClassName?: string;
+  testId?: string;
 }
 
 export interface SelectBoxOption {
@@ -169,4 +187,10 @@ export interface TitleInputProps {
   readonly?: boolean;
   errorMessage?: string;
   fontBold?: boolean;
+}
+
+export interface FormErrorProps {
+  message?: string;
+  when?: boolean;
+  className?: string;
 }

--- a/turboui/src/Forms/types.ts
+++ b/turboui/src/Forms/types.ts
@@ -1,5 +1,4 @@
 import type * as React from "react";
-import type { AxiosError } from "axios";
 
 import type { BaseButtonProps } from "../Button";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
@@ -41,7 +40,7 @@ export interface UseFormOptions<T extends FormValues> {
   submit: (attrs?: unknown) => Promise<void> | void;
   cancel?: () => Promise<void> | void;
   onChange?: (args: { newValues: T; field: string | null }) => void;
-  onError?: (error: AxiosError) => void;
+  onError?: (error: any) => void;
 }
 
 export interface FormProps<T extends FormValues = FormValues> {

--- a/turboui/src/Forms/useForm.tsx
+++ b/turboui/src/Forms/useForm.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import type { AxiosError } from "axios";
 
 import { cloneFormValue, getValueAtPath, setValueAtPath } from "./path";
 import type {
@@ -154,7 +153,7 @@ export function useForm<T extends FormValues>(options: UseFormOptions<T>): FormS
         setLastSubmitSucceededAt(Date.now());
       } catch (error) {
         console.error(error);
-        options.onError?.(error as AxiosError);
+        options.onError?.(error);
       } finally {
         setState("idle");
       }

--- a/turboui/src/Forms/useForm.tsx
+++ b/turboui/src/Forms/useForm.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import type { AxiosError } from "axios";
 
 import { cloneFormValue, getValueAtPath, setValueAtPath } from "./path";
 import type {
@@ -24,10 +25,27 @@ export function useForm<T extends FormValues>(options: UseFormOptions<T>): FormS
   });
   const [errors, setErrors] = React.useState<FormErrors>({});
   const [state, setState] = React.useState<FormState<T>["state"]>("idle");
+  const [trigger, setTrigger] = React.useState<string | undefined>(undefined);
   const [lastSubmitSucceededAt, setLastSubmitSucceededAt] = React.useState<number | undefined>(undefined);
 
   const clearErrors = React.useCallback(() => {
     setErrors({});
+  }, []);
+
+  const addErrors = React.useCallback((nextErrors: FormErrors) => {
+    setErrors((currentErrors) => ({ ...nextErrors, ...currentErrors }));
+  }, []);
+
+  const removeErrors = React.useCallback((keys: string[]) => {
+    setErrors((currentErrors) => {
+      const nextErrors = { ...currentErrors };
+
+      keys.forEach((key) => {
+        delete nextErrors[key];
+      });
+
+      return nextErrors;
+    });
   }, []);
 
   const addValidation = React.useCallback((field: string, validation: FieldValidation) => {
@@ -136,6 +154,7 @@ export function useForm<T extends FormValues>(options: UseFormOptions<T>): FormS
         setLastSubmitSucceededAt(Date.now());
       } catch (error) {
         console.error(error);
+        options.onError?.(error as AxiosError);
       } finally {
         setState("idle");
       }
@@ -146,12 +165,15 @@ export function useForm<T extends FormValues>(options: UseFormOptions<T>): FormS
   return {
     values,
     state,
+    trigger,
     errors,
     hasErrors: Object.keys(errors).length > 0,
     hasCancel: Boolean(options.cancel),
     lastSubmitSucceededAt,
     actions: {
       clearErrors,
+      addErrors,
+      removeErrors,
       submit,
       cancel,
       reset,
@@ -160,6 +182,7 @@ export function useForm<T extends FormValues>(options: UseFormOptions<T>): FormS
       getValue,
       setValue,
       setState,
+      setTrigger,
     },
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- extend TurboUI Forms `useForm` to match the legacy parity surface needed for early migrations
- add missing `TextInput`, `Submit`, and `FormError` behaviors plus exports
- add Phase 0 Storybook coverage, focused TurboUI form regression tests, and update the migration spec to mark Phase 0 complete

## Testing
- `npm --prefix turboui run build`
- `npm --prefix turboui run test -- --runInBand`
- `cd app && npx tsc --noEmit -p tsconfig.lint.json`

## Notes
- `make turboui.build`, `make turboui.test`, and `make test.tsc.lint` delegate to `./devenv`, but this VM did not have the `docker` CLI available, so I ran the equivalent direct commands above instead.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6117ca1a-bba1-491e-a8c8-449576cce6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6117ca1a-bba1-491e-a8c8-449576cce6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

