### PR TITLE
fix: use first token for mentions

### DIFF
--- a/app/lib/operately/rich_content.ex
+++ b/app/lib/operately/rich_content.ex
@@ -95,7 +95,7 @@ defmodule Operately.RichContent do
   end
 
   def rich_content_to_string(%{"type" => "mention", "attrs" => %{"label" => label}}) when is_binary(label) do
-    label
+    first_name(label)
   end
 
   def rich_content_to_string(%{"content" => content}) when is_list(content) do
@@ -103,6 +103,13 @@ defmodule Operately.RichContent do
   end
 
   def rich_content_to_string(_), do: ""
+
+  defp first_name(full_name) when is_binary(full_name) do
+    full_name
+    |> String.split()
+    |> List.first()
+    |> Kernel.||("")
+  end
 
   defmodule Blob do
     def find_ids(nil), do: []

--- a/app/test/operately/rich_content_test.exs
+++ b/app/test/operately/rich_content_test.exs
@@ -231,6 +231,26 @@ defmodule Operately.RichContentTest do
     assert Operately.RichContent.find_blob_ids(document) == [blob.id]
   end
 
+  describe ".rich_content_to_string/1" do
+    test "uses the full single-part mention label" do
+      mention = %{"type" => "mention", "attrs" => %{"label" => "Madonna"}}
+
+      assert Operately.RichContent.rich_content_to_string(mention) == "Madonna"
+    end
+
+    test "uses the first token from a two-part mention label" do
+      mention = %{"type" => "mention", "attrs" => %{"label" => "John Smith"}}
+
+      assert Operately.RichContent.rich_content_to_string(mention) == "John"
+    end
+
+    test "uses the first token from a multi-part mention label" do
+      mention = %{"type" => "mention", "attrs" => %{"label" => "John Michael Smith"}}
+
+      assert Operately.RichContent.rich_content_to_string(mention) == "John"
+    end
+  end
+
   describe ".tiptap_document?/1" do
     test "returns true for an empty TipTap document" do
       assert Operately.RichContent.tiptap_document?(%{"type" => "doc", "content" => []})

--- a/turboui/src/Avatar/AvatarWithName.tsx
+++ b/turboui/src/Avatar/AvatarWithName.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { BlackLink } from "../Link";
+import { firstName } from "../utils/people";
 import { Avatar } from ".";
 import { AvatarProps, AvatarSizeString, NameFormat } from "./types";
 import classNames from "../utils/classnames";
@@ -41,10 +42,6 @@ export function AvatarWithName({
       </div>
     </div>
   );
-}
-
-function firstName(fullName: string): string {
-  return fullName.split(" ")[0]!;
 }
 
 export function shortName(fullName: string): string {

--- a/turboui/src/RichContent/contentOps.test.tsx
+++ b/turboui/src/RichContent/contentOps.test.tsx
@@ -1,4 +1,4 @@
-import { areRichTextObjectsEqual, countCharacters, shortenContent } from "./contentOps";
+import { areRichTextObjectsEqual, countCharacters, richContentToString, shortenContent } from "./contentOps";
 
 describe("shortenContent", () => {
   it("few words in a single line", () => {
@@ -73,6 +73,35 @@ describe("countCharacters", () => {
     const input = `{"content":[{"content":[{"text":"Some very long text ","type":"text"},{"attrs":{"id":"fred-williams-H8bQVAffZB6ddLrgofhWL","label":"Fred Williams"},"type":"mention"},{"text":" more text.","type":"text"}],"type":"paragraph"},{"content":[{"text":"Contrary to popular belief, Lorem Ipsum is not simply random text.","type":"text"}],"type":"paragraph"}],"type":"doc"}`;
 
     expect(countCharacters(input)).toEqual(110);
+  });
+});
+
+describe("richContentToString", () => {
+  it("uses the full single-part mention label", () => {
+    const input = {
+      type: "mention",
+      attrs: { id: "madonna", label: "Madonna" },
+    };
+
+    expect(richContentToString(input)).toBe("Madonna");
+  });
+
+  it("uses the first token from a two-part mention label", () => {
+    const input = {
+      type: "mention",
+      attrs: { id: "john-smith", label: "John Smith" },
+    };
+
+    expect(richContentToString(input)).toBe("John");
+  });
+
+  it("uses the first token from a multi-part mention label", () => {
+    const input = {
+      type: "mention",
+      attrs: { id: "john-michael-smith", label: "John Michael Smith" },
+    };
+
+    expect(richContentToString(input)).toBe("John");
   });
 });
 

--- a/turboui/src/RichContent/contentOps.tsx
+++ b/turboui/src/RichContent/contentOps.tsx
@@ -1,3 +1,5 @@
+import { firstName } from "../utils/people";
+
 // ShortenContent truncates the text content of a rich text object to a given character limit.
 // It does not remove non-text content.
 //
@@ -121,7 +123,7 @@ export function richContentToString(node: any): string {
   if (node.type === "text") {
     result.push(node.text);
   } else if (node.type === "mention") {
-    result.push(node.attrs.label);
+    result.push(firstName(node.attrs.label || ""));
   } else if (node.content) {
     node.content.forEach((child: any) => {
       result.push(richContentToString(child));

--- a/turboui/src/RichEditor/extensions/MentionPeople/NodeView.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/NodeView.tsx
@@ -5,12 +5,6 @@ import { Avatar } from "../../../Avatar";
 import { firstName } from "../../../utils/people";
 import { usePerson } from "../../EditorContext";
 
-interface Person {
-  id: string;
-  fullName: string;
-  avatarUrl: string | null;
-}
-
 //
 // The node view is responsible for rendering the node as a DOM element.
 // It behaves like a React component, but it needs to be wrapped in a

--- a/turboui/src/RichEditor/extensions/MentionPeople/NodeView.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/NodeView.tsx
@@ -2,6 +2,7 @@ import * as TipTap from "@tiptap/react";
 import React from "react";
 
 import { Avatar } from "../../../Avatar";
+import { firstName } from "../../../utils/people";
 import { usePerson } from "../../EditorContext";
 
 interface Person {
@@ -48,21 +49,10 @@ export const NodeView: React.FC<TipTap.NodeViewProps> = (props) => {
         <Avatar person={person} size={avatarsize} />
       </span>
 
-      {firstName(person)}
+      {firstName(person.fullName)}
     </TipTap.NodeViewWrapper>
   );
 };
-
-function firstName(person: Person): string {
-  if (!person) return "";
-  const name = person.fullName || "";
-  const parts = name.split(" ");
-  if (parts.length > 1) {
-    return parts.slice(0, -1).join(" ");
-  } else {
-    return name;
-  }
-}
 
 function getFontSize(element: HTMLElement): number {
   const style = window.getComputedStyle(element, null);

--- a/turboui/src/utils/people.test.ts
+++ b/turboui/src/utils/people.test.ts
@@ -1,0 +1,15 @@
+import { firstName } from "./people";
+
+describe("firstName", () => {
+  it("returns a single-part name unchanged", () => {
+    expect(firstName("Madonna")).toBe("Madonna");
+  });
+
+  it("returns the first token from a two-part name", () => {
+    expect(firstName("John Smith")).toBe("John");
+  });
+
+  it("returns the first token from a multi-part name", () => {
+    expect(firstName("John Michael Smith")).toBe("John");
+  });
+});

--- a/turboui/src/utils/people.tsx
+++ b/turboui/src/utils/people.tsx
@@ -1,3 +1,3 @@
-export function firstName(fullName: string) {
-  return fullName.split(" ")[0];
+export function firstName(fullName: string): string {
+  return fullName.trim().split(/\s+/)[0] || "";
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the local mention chip first-name helper with the shared TurboUI helper
- make the shared helper return the first whitespace-separated token and reuse it in AvatarWithName
- align rich-content plain-text mention rendering in TurboUI and Elixir with the same first-token behavior
- add targeted JS and Elixir regression tests for single-, two-, and multi-part names
- remove the now-unused local mention node type so the TurboUI TypeScript build passes in CI

## Testing
- make turboui.test
- make test FILE=app/test/operately/rich_content_test.exs

## Migration Notes
- none

Fixes https://github.com/operately/operately/issues/4586
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-262480a6-5dda-4462-8b5f-15edd5ededf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-262480a6-5dda-4462-8b5f-15edd5ededf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

Fixes https://github.com/operately/operately/issues/4586
