### PR TITLE
fix: initialize formatted time translations

### DIFF
--- a/turboui/src/FormattedTime/index.test.tsx
+++ b/turboui/src/FormattedTime/index.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { FormattedTime } from "./index";
+import { defaultFormattedTimePreferences } from "./types";
+import * as BreakpointHooks from "../utils/useWindowSizeBreakpoint";
+
+jest.mock("./useRenderInterval", () => ({
+  useRenderInterval: () => 0,
+}));
+
+jest.mock("../utils/useWindowSizeBreakpoint", () => ({
+  __esModule: true,
+  ...jest.requireActual("../utils/useWindowSizeBreakpoint"),
+  useWindowSizeBiggerOrEqualTo: jest.fn(),
+}));
+
+const mockUseWindowSizeBiggerOrEqualTo = BreakpointHooks.useWindowSizeBiggerOrEqualTo as jest.Mock;
+
+describe("FormattedTime", () => {
+  const NOW = new Date("2024-01-01T12:00:00Z").getTime();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  beforeEach(() => {
+    mockUseWindowSizeBiggerOrEqualTo.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders relative time labels without external i18n setup", () => {
+    render(
+      <FormattedTime
+        {...defaultFormattedTimePreferences}
+        time={new Date(NOW - 5 * 60 * 1000)}
+        format="relative"
+      />,
+    );
+
+    expect(screen.getByText("5 minutes ago")).toBeInTheDocument();
+  });
+});

--- a/turboui/src/FormattedTime/index.tsx
+++ b/turboui/src/FormattedTime/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { match } from "ts-pattern";
 
+import "../i18n";
 import * as Time from "../utils/time";
 import LongDate from "./LongDate";
 import RelativeTime from "./RelativeTime";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- initialize TurboUI formatted-time translations at the shared `FormattedTime` entrypoint
- add a regression test that renders relative time labels without relying on a separate page-level i18n import
- fix SaaS admin relative date columns so Last Activity and Created At render human-readable text again

## Testing
- `cd turboui && npm ci && npm test -- --runInBand src/FormattedTime/index.test.tsx src/FormattedTime/RelativeTime.test.tsx && npm run build`
- `cd app && npm ci && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-402cdd7d-296e-4d9a-afb0-50b2b20e3cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-402cdd7d-296e-4d9a-afb0-50b2b20e3cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

