### PR TITLE
fix: register app i18n for prod relative time

### DIFF
--- a/app/assets/js/i18n.js
+++ b/app/assets/js/i18n.js
@@ -1,5 +1,5 @@
 import i18n from "i18next";
-import { initReactI18next } from "react-i18next";
+import { initReactI18next, setI18n } from "react-i18next";
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -405,3 +405,7 @@ i18n.use(initReactI18next).init({
   lng: "en",
   fallbackLng: "en",
 });
+
+setI18n(i18n);
+
+export default i18n;

--- a/app/assets/js/i18n.js
+++ b/app/assets/js/i18n.js
@@ -407,5 +407,3 @@ i18n.use(initReactI18next).init({
 });
 
 setI18n(i18n);
-
-export default i18n;

--- a/app/vite.config.mjs
+++ b/app/vite.config.mjs
@@ -48,7 +48,7 @@ export default defineConfig({
   },
 
   resolve: {
-    dedupe: ["react", "react-dom", "react-router", "react-router-dom"],
+    dedupe: ["react", "react-dom", "react-router", "react-router-dom", "i18next", "react-i18next"],
 
     alias: [
       { find: /^@\/ee\/(.*)$/, replacement: path.resolve(__dirname, "ee/assets/js/$1") },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- explicitly register the app i18n singleton with `react-i18next` after initialization
- dedupe `i18next` and `react-i18next` in Vite so app and TurboUI share the same runtime instance
- remove the unused `default` export from `app/assets/js/i18n.js` so the Semaphore dead-code check passes
- target the production-only SaaS admin relative time regression where date cells render `intlRelativeDateTime`

## Testing
- `cd app && npm run knip -- --no-progress`
- `cd app && NODE_ENV=production npx vite build`
- `cd app && NODE_ENV=production npx vite build --minify false`
- inspected the non-minified prod bundle and confirmed the built app chunk contains both `instance.use(initReactI18next).init(...)` and `setI18n(instance);`

## CI failure addressed
- Semaphore `App Tests -> Lint` failed in `make test.js.dead.code`
- root cause: Knip reported an unused export at `assets/js/i18n.js:411:8`
- fix: removed `export default i18n;` because the file is imported for side effects only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-402cdd7d-296e-4d9a-afb0-50b2b20e3cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-402cdd7d-296e-4d9a-afb0-50b2b20e3cd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

