### PR TITLE
chore: Migrate auth/password forms to TurboUI Forms

### DIFF
--- a/app/assets/js/pages/AccountAppearancePage/index.tsx
+++ b/app/assets/js/pages/AccountAppearancePage/index.tsx
@@ -3,9 +3,8 @@ import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
 import * as React from "react";
 
-import { IconSun, IconMoon, IconDeviceLaptop, showErrorToast } from "turboui";
+import { IconSun, IconMoon, IconDeviceLaptop, Forms, showErrorToast } from "turboui";
 
-import Forms from "@/components/Forms";
 import classnames from "classnames";
 
 import { useSetTheme, useTheme } from "@/contexts/ThemeContext";

--- a/app/assets/js/pages/AccountChangePasswordPage/index.tsx
+++ b/app/assets/js/pages/AccountChangePasswordPage/index.tsx
@@ -3,10 +3,9 @@ import * as Paper from "@/components/PaperContainer";
 import * as Accounts from "@/models/accounts";
 import * as React from "react";
 
-import Forms from "@/components/Forms";
 import { PageModule } from "@/routes/types";
 import { useNavigate } from "react-router-dom";
-import { showSuccessToast, showErrorToast } from "turboui";
+import { Forms, showSuccessToast, showErrorToast } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export default { name: "AccountChangePasswordPage", loader: Pages.emptyLoader, Page } as PageModule;

--- a/app/assets/js/pages/CompanyRenamePage/index.tsx
+++ b/app/assets/js/pages/CompanyRenamePage/index.tsx
@@ -3,7 +3,7 @@ import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
 import * as React from "react";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
 import { PageModule } from "@/routes/types";
 import { useNavigate, useRevalidator } from "react-router-dom";
 

--- a/app/assets/js/pages/ForgotPasswordPage/index.tsx
+++ b/app/assets/js/pages/ForgotPasswordPage/index.tsx
@@ -3,10 +3,9 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import Forms from "@/components/Forms";
 import classNames from "classnames";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
-import { ActionLink } from "turboui";
+import { Forms, ActionLink, type FormState } from "turboui";
 
 import { PageModule } from "@/routes/types";
 
@@ -46,7 +45,7 @@ function Page() {
   );
 }
 
-function Form({ form }) {
+function Form({ form }: { form: FormState<{ email: string }> }) {
   return (
     <Forms.Form form={form}>
       <Forms.FieldGroup>

--- a/app/assets/js/pages/JoinPage/index.tsx
+++ b/app/assets/js/pages/JoinPage/index.tsx
@@ -12,7 +12,7 @@ import { SignInWithGoogleButton } from "@/features/auth/Buttons";
 import { logIn } from "@/routes/auth";
 import { redirect } from "react-router-dom";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
 
 export default { name: "JoinPage", loader, Page } as PageModule;
 

--- a/app/assets/js/pages/LoginPage/index.tsx
+++ b/app/assets/js/pages/LoginPage/index.tsx
@@ -4,7 +4,6 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as React from "react";
 
-import Forms from "@/components/Forms";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
 
 import { SignInWithGoogleButton } from "@/features/auth/Buttons";
@@ -12,7 +11,7 @@ import { logIn } from "@/routes/auth";
 import { Paths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 import classNames from "classnames";
-import { DimmedLink, Link } from "turboui";
+import { Forms, DimmedLink, Link, type FormState } from "turboui";
 
 export default { name: "LoginPage", loader: Pages.emptyLoader, Page } as PageModule;
 
@@ -93,7 +92,7 @@ function isSignupEnabled(): boolean {
   return window.appConfig.allowSignupWithEmail || window.appConfig.allowSignupWithGoogle;
 }
 
-function EmailLogin({ form, error }: { form: any; error: string | null }) {
+function EmailLogin({ form, error }: { form: FormState<{ email: string; password: string }>; error: string | null }) {
   return (
     <div>
       <Forms.FieldGroup>

--- a/app/assets/js/pages/NewCompanyPage/index.tsx
+++ b/app/assets/js/pages/NewCompanyPage/index.tsx
@@ -7,9 +7,8 @@ import { OperatelyLogo } from "@/components/OperatelyLogo";
 import { Paths } from "@/routes/paths";
 import { useNavigate } from "react-router-dom";
 
-import Forms from "@/components/Forms";
+import { Forms, Link } from "turboui";
 import { PageModule } from "@/routes/types";
-import { Link } from "turboui";
 import { BillingCatalog, parseBillingIntent } from "./billingIntent";
 
 export default { name: "NewCompanyPage", loader, Page } as PageModule;

--- a/app/assets/js/pages/ResetPasswordPage/index.tsx
+++ b/app/assets/js/pages/ResetPasswordPage/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
 import classNames from "classnames";
 import { OperatelyLogo } from "@/components/OperatelyLogo";
 import { useNavigate } from "react-router-dom";

--- a/specs/0014-forms-turboui-migration.md
+++ b/specs/0014-forms-turboui-migration.md
@@ -210,10 +210,10 @@ flowchart TB
 - [ ] `app/assets/js/pages/ForgotPasswordPage/index.tsx`
 - [ ] `app/assets/js/pages/ResetPasswordPage/index.tsx`
 - [ ] `app/assets/js/pages/AccountChangePasswordPage/index.tsx`
-- [ ] `app/assets/js/pages/CompanyRenamePage/index.tsx`
-- [ ] `app/assets/js/pages/AccountAppearancePage/index.tsx`
-- [ ] `app/assets/js/pages/NewCompanyPage/index.tsx`
-- [ ] `app/assets/js/pages/JoinPage/index.tsx` (text/password fields only)
+- [x] `app/assets/js/pages/CompanyRenamePage/index.tsx`
+- [x] `app/assets/js/pages/AccountAppearancePage/index.tsx`
+- [x] `app/assets/js/pages/NewCompanyPage/index.tsx`
+- [x] `app/assets/js/pages/JoinPage/index.tsx` (text/password fields only)
 
 ### Pattern
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes Phase 2 call-site migration from legacy `@/components/Forms` to TurboUI Forms (`import { Forms } from "turboui"`), per `specs/0014-forms-turboui-migration.md`.

**Phase 2a (auth/password):**
- `LoginPage`, `ForgotPasswordPage`, `ResetPasswordPage`, `AccountChangePasswordPage`

**Phase 2b (account forms):**
- `CompanyRenamePage`
- `AccountAppearancePage`
- `NewCompanyPage`
- `JoinPage`

## Changes

- Replace `import Forms from "@/components/Forms"` with named `Forms` import from `turboui`, merged into existing turboui imports where present.
- Optional typing cleanup in Phase 2a: `FormState` for form props in `LoginPage` and `ForgotPasswordPage`.
- Spec: checked off the four remaining Phase 2 file items (Storybook items left unchecked).

All page-specific behavior preserved (custom submit buttons, okSign, validate, PasswordStrength, `useFieldValue`, RadioButtons, etc.).

## Verification

- [x] `rg '@/components/Forms'` on all 8 Phase 2 pages — no matches
- [x] `npx tsc --noEmit -p tsconfig.lint.json` — passes
- [ ] Feature tests — recommend CI or local `make test.build` + `CI=true` run

## Out of scope

- `Composed.stories.tsx` (Storybook)
- Changes under `app/assets/js/components/Forms/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4742fc3-1162-4e2c-83a8-1e8e56a59e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4742fc3-1162-4e2c-83a8-1e8e56a59e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

