### PR TITLE
fix: use milestone ordering state for next step when due dates tie

### DIFF
--- a/app/lib/operately/projects/ordering_state.ex
+++ b/app/lib/operately/projects/ordering_state.ex
@@ -3,12 +3,50 @@ defmodule Operately.Projects.OrderingState do
   Manages the ordering of milestones within a project using a list of short milestone IDs.
   """
 
+  alias OperatelyWeb.Api.Helpers
+  alias OperatelyWeb.Paths
+
   def load(nil), do: initialize()
   def load(list) when is_list(list), do: list
   def load(_), do: initialize()
 
   def initialize do
     []
+  end
+
+  def ids_match?(id1, id2) do
+    Helpers.id_without_comments(id1) == Helpers.id_without_comments(id2)
+  end
+
+  def normalize(ordering_state, milestones) when is_list(milestones) do
+    milestone_ids = Enum.map(milestones, &Paths.milestone_id/1)
+    normalize_ordering_state(load(ordering_state), milestone_ids)
+  end
+
+  @doc """
+  Returns where each milestone sits in the project's ordering.
+
+  The result is a map of `milestone.id => position`, where position is 0 for first, 1 for second, and so on.
+  Milestones not in the ordering state are left out. Used to break ties between pending milestones.
+  """
+  def positions(ordering_state, milestones) when is_list(milestones) do
+    milestones_by_normalized_id =
+      Enum.reduce(milestones, %{}, fn milestone, acc ->
+        normalized_id = Helpers.id_without_comments(Paths.milestone_id(milestone))
+        Map.put(acc, normalized_id, milestone)
+      end)
+
+    ordering_state
+    |> normalize(milestones)
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {ordered_id, index}, acc ->
+      normalized_id = Helpers.id_without_comments(ordered_id)
+
+      case Map.get(milestones_by_normalized_id, normalized_id) do
+        nil -> acc
+        milestone -> Map.put(acc, milestone.id, index)
+      end
+    end)
   end
 
   def add_milestone(ordering_state, milestone, index \\ nil) do
@@ -27,5 +65,32 @@ defmodule Operately.Projects.OrderingState do
   def remove_milestone(ordering_state, milestone) do
     milestone_short_id = OperatelyWeb.Paths.milestone_id(milestone)
     List.delete(ordering_state, milestone_short_id)
+  end
+
+  # Reconcile the saved ordering with the current milestones: keep the saved order,
+  # drop removed milestones, dedupe, then append any new milestones at the end.
+  defp normalize_ordering_state(_ordering_state, []), do: []
+
+  defp normalize_ordering_state(ordering_state, milestone_ids) do
+    # Keep saved order for milestones that still exist.
+    from_ordering =
+      Enum.reduce(ordering_state, [], fn ordering_id, normalized ->
+        matching_id = Enum.find(milestone_ids, &ids_match?(&1, ordering_id))
+
+        cond do
+          is_nil(matching_id) -> normalized
+          id_in_list?(normalized, matching_id) -> normalized
+          true -> normalized ++ [matching_id]
+        end
+      end)
+
+    # Append milestones not yet in the ordering state.
+    Enum.reduce(milestone_ids, from_ordering, fn milestone_id, normalized ->
+      if id_in_list?(normalized, milestone_id), do: normalized, else: normalized ++ [milestone_id]
+    end)
+  end
+
+  defp id_in_list?(list, id) do
+    Enum.any?(list, &ids_match?(&1, id))
   end
 end

--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -6,7 +6,7 @@ defmodule Operately.Projects.Project do
   alias Operately.Access.AccessLevels
   alias Operately.WorkMaps.WorkMapItem
   alias Operately.ContextualDates.Timeframe
-  alias Operately.Projects.{Contributor, Permissions, CheckIn}
+  alias Operately.Projects.{Contributor, OrderingState, Permissions, CheckIn}
 
   @behaviour WorkMapItem
 
@@ -303,24 +303,50 @@ defmodule Operately.Projects.Project do
         project
 
       milestones ->
+        ordering_positions = OrderingState.positions(project.milestones_ordering_state, milestones)
+
         next =
           milestones
           |> Enum.filter(fn milestone -> milestone.status == :pending end)
           |> Enum.sort(fn milestone1, milestone2 ->
-            date1 = Timeframe.end_date(milestone1.timeframe)
-            date2 = Timeframe.end_date(milestone2.timeframe)
-
-            case {date1, date2} do
-              {nil, nil} -> false
-              {nil, _} -> false
-              {_, nil} -> true
-              {d1, d2} -> Date.compare(d1, d2) != :gt
-            end
+            compare_pending_milestones(milestone1, milestone2, ordering_positions)
           end)
           |> List.first()
 
         Map.put(project, :next_milestone, next)
     end
+  end
+
+  # Sort comparator for picking the next pending milestone: earliest due date wins,
+  # undated milestones sort last, and ties fall back to the project's milestone ordering.
+  defp compare_pending_milestones(milestone1, milestone2, ordering_positions) do
+    date1 = Timeframe.end_date(milestone1.timeframe)
+    date2 = Timeframe.end_date(milestone2.timeframe)
+
+    case {date1, date2} do
+      {nil, nil} ->
+        compare_by_ordering_position(milestone1, milestone2, ordering_positions)
+
+      {nil, _} ->
+        false
+
+      {_, nil} ->
+        true
+
+      {d1, d2} ->
+        case Date.compare(d1, d2) do
+          :eq -> compare_by_ordering_position(milestone1, milestone2, ordering_positions)
+          :gt -> false
+          :lt -> true
+        end
+    end
+  end
+
+  defp compare_by_ordering_position(milestone1, milestone2, ordering_positions) do
+    pos1 = Map.get(ordering_positions, milestone1.id, :infinity)
+    pos2 = Map.get(ordering_positions, milestone2.id, :infinity)
+
+    pos1 < pos2
   end
 
   def load_contributor_access_levels(project) do

--- a/app/lib/operately/projects/project.ex
+++ b/app/lib/operately/projects/project.ex
@@ -343,10 +343,15 @@ defmodule Operately.Projects.Project do
   end
 
   defp compare_by_ordering_position(milestone1, milestone2, ordering_positions) do
-    pos1 = Map.get(ordering_positions, milestone1.id, :infinity)
-    pos2 = Map.get(ordering_positions, milestone2.id, :infinity)
+    pos1 = Map.get(ordering_positions, milestone1.id)
+    pos2 = Map.get(ordering_positions, milestone2.id)
 
-    pos1 < pos2
+    case {pos1, pos2} do
+      {nil, nil} -> false
+      {nil, _} -> false
+      {_, nil} -> true
+      {p1, p2} -> p1 < p2
+    end
   end
 
   def load_contributor_access_levels(project) do

--- a/app/test/operately/projects_test.exs
+++ b/app/test/operately/projects_test.exs
@@ -340,4 +340,107 @@ defmodule Operately.ProjectsTest do
       assert %Ecto.Changeset{} = Projects.change_key_resource(ctx.key_resource)
     end
   end
+
+  describe "Project.set_next_milestone/1 and next_step/1" do
+    alias Operately.Projects.{Milestone, Project}
+    alias OperatelyWeb.Paths
+
+    defp milestone_without_due_date(project, title) do
+      milestone_fixture(%{
+        project_id: project.id,
+        creator_id: project.creator_id,
+        title: title,
+        timeframe: %{}
+      })
+    end
+
+    defp milestone_with_due_date(project, title, due_date) do
+      milestone_fixture(%{
+        project_id: project.id,
+        creator_id: project.creator_id,
+        title: title,
+        timeframe: %{
+          contextual_end_date: ContextualDate.create_day_date(due_date)
+        }
+      })
+    end
+
+    defp load_project_with_milestones(project, ordering_state) do
+      {:ok, project} = Projects.update_project(project, %{milestones_ordering_state: ordering_state})
+
+      project
+      |> Operately.Repo.preload(:milestones)
+      |> Project.after_load_hooks()
+    end
+
+    test "picks first pending milestone by ordering state when milestones have no due dates", ctx do
+      first = milestone_without_due_date(ctx.project, "First")
+      second = milestone_without_due_date(ctx.project, "Second")
+      third = milestone_without_due_date(ctx.project, "Third")
+
+      ordering = [Paths.milestone_id(third), Paths.milestone_id(first), Paths.milestone_id(second)]
+
+      project =
+        load_project_with_milestones(ctx.project, ordering)
+
+      assert Project.next_step(project) == "Third"
+      assert project.next_milestone.id == third.id
+    end
+
+    test "picks first pending milestone when earlier milestones are done", ctx do
+      first = milestone_without_due_date(ctx.project, "First")
+      second = milestone_without_due_date(ctx.project, "Second")
+      {:ok, _} = Milestone.set_status(second, :done)
+
+      ordering = [Paths.milestone_id(second), Paths.milestone_id(first)]
+
+      project =
+        load_project_with_milestones(ctx.project, ordering)
+
+      assert Project.next_step(project) == "First"
+      assert project.next_milestone.id == first.id
+    end
+
+    test "dated milestones sort by due date and undated milestones use ordering state", ctx do
+      undated_first = milestone_without_due_date(ctx.project, "Undated First")
+      dated_later = milestone_with_due_date(ctx.project, "Dated Later", ~D[2025-06-01])
+      undated_second = milestone_without_due_date(ctx.project, "Undated Second")
+
+      ordering = [
+        Paths.milestone_id(undated_first),
+        Paths.milestone_id(dated_later),
+        Paths.milestone_id(undated_second)
+      ]
+
+      project =
+        load_project_with_milestones(ctx.project, ordering)
+
+      assert Project.next_step(project) == "Dated Later"
+      assert project.next_milestone.id == dated_later.id
+    end
+
+    test "breaks ties on equal due dates using ordering state", ctx do
+      later_in_order = milestone_with_due_date(ctx.project, "Later in order", ~D[2025-06-01])
+      earlier_in_order = milestone_with_due_date(ctx.project, "Earlier in order", ~D[2025-06-01])
+
+      ordering = [Paths.milestone_id(earlier_in_order), Paths.milestone_id(later_in_order)]
+
+      project =
+        load_project_with_milestones(ctx.project, ordering)
+
+      assert Project.next_step(project) == "Earlier in order"
+      assert project.next_milestone.id == earlier_in_order.id
+    end
+
+    test "returns empty string when all milestones are done", ctx do
+      first = milestone_without_due_date(ctx.project, "First")
+      {:ok, _} = Milestone.set_status(first, :done)
+
+      project =
+        load_project_with_milestones(ctx.project, [Paths.milestone_id(first)])
+
+      assert Project.next_step(project) == ""
+      assert is_nil(project.next_milestone)
+    end
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4266 — the work map (and other consumers of `Project.next_step/1`) showed the wrong "Next step" when pending milestones had no due dates.

## Root cause

`Project.set_next_milestone/1` sorted pending milestones by `Timeframe.end_date/1`. When both dates were `nil`, the comparator always returned `false`, so sort order was undefined.

## Fix

- Added `OrderingState.normalize/2`, `OrderingState.positions/2`, and `OrderingState.ids_match?/2` to mirror the frontend `parseMilestonesForTurboUi` ordering source of truth.
- Updated `set_next_milestone/1` to keep date-based sorting (earliest due date first; dated milestones before undated), and break ties using `milestones_ordering_state`.

## Tests

Added unit tests in `app/test/operately/projects_test.exs` covering:
- Multiple pending milestones with no due dates and explicit ordering state
- Skipping done milestones to pick the first pending in order
- Dated milestones still sorting by due date ahead of undated ones
- Tie-breaking equal due dates via ordering state
- Empty next step when all milestones are done

## Verification

```bash
make test FILE=app/test/operately/projects_test.exs
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a875da0e-7b12-4a82-9e62-8bdec4269e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a875da0e-7b12-4a82-9e62-8bdec4269e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

