### PR TITLE
fix: GetMe query should rely on the Person serializer

### DIFF
--- a/app/lib/operately_web/api/people/get_me.ex
+++ b/app/lib/operately_web/api/people/get_me.ex
@@ -17,55 +17,15 @@ defmodule OperatelyWeb.Api.People.GetMe do
   end
 
   def call(conn, inputs) do
-    me(conn)
+    conn
+    |> me()
     |> preload_manager(inputs[:include_manager])
-    |> serialize(inputs[:include_manager])
+    |> then(fn me -> %{me: Serializer.serialize(me, level: :full, me: true)} end)
     |> ok_tuple()
   end
 
   defp preload_manager(me, true), do: Repo.preload(me, [:manager])
   defp preload_manager(me, _), do: me
-
-  defp serialize(me, include_manager) do
-    %{
-      me: %{
-        id: OperatelyWeb.Paths.person_id(me),
-        full_name: me.full_name,
-        email: me.email,
-        type: Atom.to_string(me.type),
-        title: me.title,
-        avatar_url: me.avatar_url,
-        timezone: me.timezone,
-        time_format: me |> Operately.People.Person.time_format() |> Atom.to_string(),
-        avatar_blob_id: me.avatar_blob_id,
-        email_preference: me |> Operately.People.Person.email_preference() |> Atom.to_string(),
-        email_window_minutes: Operately.People.Person.email_window_minutes(me),
-        send_daily_summary: Operately.People.Person.send_daily_summary?(me),
-        daily_summary_delivery_time: Operately.People.Person.daily_summary_delivery_time(me),
-        notify_on_mention: Operately.People.Person.notify_on_mention?(me),
-        notify_about_assignments: Operately.People.Person.notify_about_assignments?(me),
-        description: encode_description(me.description),
-        manager: include_manager && serialize_manager(me.manager),
-        show_dev_bar: Application.get_env(:operately, :app_env) == :dev
-      }
-    }
-  end
-
-  defp serialize_manager(nil), do: nil
-
-  defp serialize_manager(manager) do
-    %{
-      id: OperatelyWeb.Paths.person_id(manager),
-      full_name: manager.full_name,
-      email: manager.email,
-      type: Atom.to_string(manager.type),
-      title: manager.title,
-      avatar_url: manager.avatar_url
-    }
-  end
-
-  defp encode_description(nil), do: nil
-  defp encode_description(description), do: Jason.encode!(description)
 
   defp ok_tuple(value) do
     {:ok, value}

--- a/app/lib/operately_web/api/people/get_me.ex
+++ b/app/lib/operately_web/api/people/get_me.ex
@@ -20,7 +20,7 @@ defmodule OperatelyWeb.Api.People.GetMe do
     conn
     |> me()
     |> preload_manager(inputs[:include_manager])
-    |> then(fn me -> %{me: Serializer.serialize(me, level: :full, me: true)} end)
+    |> then(fn me -> %{me: Serializer.serialize(me, level: :full)} end)
     |> ok_tuple()
   end
 

--- a/app/lib/operately_web/api/serializer.ex
+++ b/app/lib/operately_web/api/serializer.ex
@@ -1,12 +1,13 @@
 defmodule OperatelyWeb.Api.Serializer do
   @valid_levels [:essential, :full]
 
-  def serialize(data, opts \\ [level: :essential])
+  def serialize(data) do
+    OperatelyWeb.Api.Serializable.serialize(data, level: :essential)
+  end
 
-  def serialize(data, opts) when is_list(opts) do
-    level = Keyword.fetch!(opts, :level)
+  def serialize(data, level: level) do
     validate_level(level)
-    OperatelyWeb.Api.Serializable.serialize(data, opts)
+    OperatelyWeb.Api.Serializable.serialize(data, level: level)
   end
 
   defp validate_level(level) do

--- a/app/lib/operately_web/api/serializer.ex
+++ b/app/lib/operately_web/api/serializer.ex
@@ -1,13 +1,12 @@
 defmodule OperatelyWeb.Api.Serializer do
   @valid_levels [:essential, :full]
 
-  def serialize(data) do
-    OperatelyWeb.Api.Serializable.serialize(data, level: :essential)
-  end
+  def serialize(data, opts \\ [level: :essential])
 
-  def serialize(data, level: level) do
+  def serialize(data, opts) when is_list(opts) do
+    level = Keyword.fetch!(opts, :level)
     validate_level(level)
-    OperatelyWeb.Api.Serializable.serialize(data, level: level)
+    OperatelyWeb.Api.Serializable.serialize(data, opts)
   end
 
   defp validate_level(level) do

--- a/app/lib/operately_web/api/serializers/person.ex
+++ b/app/lib/operately_web/api/serializers/person.ex
@@ -28,24 +28,9 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     end)
   end
 
-  def serialize(%{access_group: %{bindings: bindings}} = data, level: :full, me: true) do
-    serialize_full(data, me: true)
-    |> Map.put(:access_level, find_access_level(bindings))
-  end
-
   def serialize(%{access_group: %{bindings: bindings}} = data, level: :full) do
     serialize_full(data)
     |> Map.put(:access_level, find_access_level(bindings))
-  end
-
-  def serialize(data, level: :full, me: true) do
-    serialize_full(data, me: true)
-    |> then(fn map ->
-      case data.access_level do
-        nil -> map
-        level -> Map.put(map, :access_level, level)
-      end
-    end)
   end
 
   def serialize(data, level: :full) do
@@ -58,7 +43,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     end)
   end
 
-  defp serialize_full(data, opts \\ []) do
+  defp serialize_full(data) do
     %{
       id: OperatelyWeb.Paths.person_id(data),
       full_name: data.full_name,
@@ -83,16 +68,10 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
       daily_summary_delivery_time: Operately.People.Person.daily_summary_delivery_time(data),
       notify_on_mention: Operately.People.Person.notify_on_mention?(data),
       notify_about_assignments: Operately.People.Person.notify_about_assignments?(data),
-      description: encode_description(data.description)
+      description: encode_description(data.description),
+      show_dev_bar: Application.get_env(:operately, :app_env) == :dev
     }
-    |> maybe_put_show_dev_bar(opts)
   end
-
-  defp maybe_put_show_dev_bar(map, me: true) do
-    Map.put(map, :show_dev_bar, Application.get_env(:operately, :app_env) == :dev)
-  end
-
-  defp maybe_put_show_dev_bar(map, _opts), do: map
 
   defp find_access_level([]), do: nil
   defp find_access_level(bindings), do: Enum.max_by(bindings, & &1.access_level).access_level

--- a/app/lib/operately_web/api/serializers/person.ex
+++ b/app/lib/operately_web/api/serializers/person.ex
@@ -28,9 +28,24 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     end)
   end
 
+  def serialize(%{access_group: %{bindings: bindings}} = data, level: :full, me: true) do
+    serialize_full(data, me: true)
+    |> Map.put(:access_level, find_access_level(bindings))
+  end
+
   def serialize(%{access_group: %{bindings: bindings}} = data, level: :full) do
     serialize_full(data)
     |> Map.put(:access_level, find_access_level(bindings))
+  end
+
+  def serialize(data, level: :full, me: true) do
+    serialize_full(data, me: true)
+    |> then(fn map ->
+      case data.access_level do
+        nil -> map
+        level -> Map.put(map, :access_level, level)
+      end
+    end)
   end
 
   def serialize(data, level: :full) do
@@ -43,12 +58,13 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
     end)
   end
 
-  defp serialize_full(data) do
+  defp serialize_full(data, opts \\ []) do
     %{
       id: OperatelyWeb.Paths.person_id(data),
       full_name: data.full_name,
       email: data.email,
       avatar_url: data.avatar_url,
+      avatar_blob_id: data.avatar_blob_id,
       title: data.title,
       type: Atom.to_string(data.type),
       suspended: data.suspended,
@@ -69,7 +85,14 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.People.Person do
       notify_about_assignments: Operately.People.Person.notify_about_assignments?(data),
       description: encode_description(data.description)
     }
+    |> maybe_put_show_dev_bar(opts)
   end
+
+  defp maybe_put_show_dev_bar(map, me: true) do
+    Map.put(map, :show_dev_bar, Application.get_env(:operately, :app_env) == :dev)
+  end
+
+  defp maybe_put_show_dev_bar(map, _opts), do: map
 
   defp find_access_level([]), do: nil
   defp find_access_level(bindings), do: Enum.max_by(bindings, & &1.access_level).access_level

--- a/app/test/operately_web/api/people/get_me_test.exs
+++ b/app/test/operately_web/api/people/get_me_test.exs
@@ -15,86 +15,25 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
     test "it returns the current account's information", ctx do
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{})
 
-      assert data == %{
-        id: Paths.person_id(ctx.person),
-        full_name: ctx.person.full_name,
-        email: ctx.person.email,
-        type: Atom.to_string(ctx.person.type),
-        title: ctx.person.title,
-        avatar_url: ctx.person.avatar_url,
-        avatar_blob_id: ctx.person.avatar_blob_id,
-        timezone: ctx.person.timezone,
-        time_format: "automatic",
-        email_preference: "buffered",
-        email_window_minutes: 5,
-        send_daily_summary: Operately.People.Person.send_daily_summary?(ctx.person),
-        daily_summary_delivery_time: Operately.People.Person.daily_summary_delivery_time(ctx.person),
-        notify_on_mention: Operately.People.Person.notify_on_mention?(ctx.person),
-        notify_about_assignments: Operately.People.Person.notify_about_assignments?(ctx.person),
-        description: nil,
-        manager: nil,
-        show_dev_bar: false,
-      }
+      assert data == Serializer.serialize(ctx.person, level: :full, me: true)
     end
 
     test "includes manager information when requested", ctx do
       manager = person_fixture(company_id: ctx.company.id, full_name: "John Doe")
       {:ok, me} = Operately.People.update_person(ctx.person, %{manager_id: manager.id})
+      me = Operately.Repo.preload(me, [:manager])
 
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{include_manager: true})
 
-      assert data == %{
-        id: Paths.person_id(ctx.person),
-        full_name: me.full_name,
-        email: me.email,
-        type: Atom.to_string(me.type),
-        title: ctx.person.title,
-        avatar_url: ctx.person.avatar_url,
-        avatar_blob_id: ctx.person.avatar_blob_id,
-        timezone: me.timezone,
-        time_format: "automatic",
-        email_preference: "buffered",
-        email_window_minutes: 5,
-        send_daily_summary: Operately.People.Person.send_daily_summary?(me),
-        daily_summary_delivery_time: Operately.People.Person.daily_summary_delivery_time(me),
-        notify_on_mention: Operately.People.Person.notify_on_mention?(me),
-        notify_about_assignments: Operately.People.Person.notify_about_assignments?(me),
-        description: nil,
-        show_dev_bar: false,
-        manager: %{
-          id: Paths.person_id(manager),
-          full_name: manager.full_name,
-          email: manager.email,
-          type: Atom.to_string(manager.type),
-          title: manager.title,
-          avatar_url: nil,
-        },
-      }
+      assert data == Serializer.serialize(me, level: :full, me: true)
+      assert data.manager == Serializer.serialize(manager, level: :essential)
     end
 
     test "when the account has no manager, it returns null even when requested", ctx do
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{include_manager: true})
 
-      assert data == %{
-        id: Paths.person_id(ctx.person),
-        full_name: ctx.person.full_name,
-        email: ctx.person.email,
-        type: Atom.to_string(ctx.person.type),
-        title: ctx.person.title,
-        avatar_url: ctx.person.avatar_url,
-        avatar_blob_id: ctx.person.avatar_blob_id,
-        timezone: ctx.person.timezone,
-        time_format: "automatic",
-        email_preference: "buffered",
-        email_window_minutes: 5,
-        send_daily_summary: Operately.People.Person.send_daily_summary?(ctx.person),
-        daily_summary_delivery_time: Operately.People.Person.daily_summary_delivery_time(ctx.person),
-        notify_on_mention: Operately.People.Person.notify_on_mention?(ctx.person),
-        notify_about_assignments: Operately.People.Person.notify_about_assignments?(ctx.person),
-        description: nil,
-        show_dev_bar: false,
-        manager: nil
-      }
+      assert data == Serializer.serialize(ctx.person, level: :full, me: true)
+      assert data.manager == nil
     end
 
     test "it returns custom notification preference settings", ctx do

--- a/app/test/operately_web/api/people/get_me_test.exs
+++ b/app/test/operately_web/api/people/get_me_test.exs
@@ -15,7 +15,7 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
     test "it returns the current account's information", ctx do
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{})
 
-      assert data == Serializer.serialize(ctx.person, level: :full, me: true)
+      assert data == Serializer.serialize(ctx.person, level: :full)
     end
 
     test "includes manager information when requested", ctx do
@@ -25,14 +25,14 @@ defmodule OperatelyWeb.Api.People.GetMeTest do
 
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{include_manager: true})
 
-      assert data == Serializer.serialize(me, level: :full, me: true)
+      assert data == Serializer.serialize(me, level: :full)
       assert data.manager == Serializer.serialize(manager, level: :essential)
     end
 
     test "when the account has no manager, it returns null even when requested", ctx do
       assert {200, %{me: data}} = query(ctx.conn, [:people, :get_me], %{include_manager: true})
 
-      assert data == Serializer.serialize(ctx.person, level: :full, me: true)
+      assert data == Serializer.serialize(ctx.person, level: :full)
       assert data.manager == nil
     end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4159 by removing hand-rolled person field mapping from `GetMe` and delegating to the shared Person serializer, matching the pattern already used by `People.Get`.

- `GetMe` now returns `%{me: Serializer.serialize(me, level: :full)}` after optional manager preload
- Person serializer `:full` level now includes `avatar_blob_id` and `show_dev_bar` (previously only in GetMe's local serializer)
- No new serializer handlers or options — missing fields were added directly to the existing `:full` variant
- GetMe tests assert against `Serializer.serialize(..., level: :full)` instead of duplicating field lists

## Test plan

- [ ] `make test FILE=app/test/operately_web/api/people/get_me_test.exs`
- [ ] `make test FILE=app/test/operately_web/api/people/get_test.exs`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cce5352b-4bb2-4f11-b920-5d90fa722bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cce5352b-4bb2-4f11-b920-5d90fa722bdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

