### PR TITLE
fix: allow selecting multiple files in resource hub upload dialog

### DIFF
--- a/turboui/src/ResourceHub/useAddFile.test.ts
+++ b/turboui/src/ResourceHub/useAddFile.test.ts
@@ -1,0 +1,66 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useAddFile } from "./useAddFile";
+
+function mockFileInput() {
+  const createdInputs: HTMLInputElement[] = [];
+  const createElement = Document.prototype.createElement;
+
+  jest.spyOn(document, "createElement").mockImplementation(function (this: Document, tagName: string) {
+    const element = createElement.call(this, tagName);
+
+    if (tagName === "input") {
+      createdInputs.push(element as HTMLInputElement);
+      jest.spyOn(element, "click").mockImplementation(() => undefined);
+    }
+
+    return element;
+  });
+
+  return createdInputs;
+}
+
+describe("useAddFile", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("selectFiles creates a file input that allows multiple selection", () => {
+    const createdInputs = mockFileInput();
+    const { result } = renderHook(() => useAddFile());
+
+    act(() => {
+      result.current.selectFiles();
+    });
+
+    expect(createdInputs).toHaveLength(1);
+    expect(createdInputs[0]?.type).toBe("file");
+    expect(createdInputs[0]?.multiple).toBe(true);
+  });
+
+  test("selectFiles stores all selected files", () => {
+    const createdInputs = mockFileInput();
+    const { result } = renderHook(() => useAddFile());
+    const files = [
+      new File(["one"], "one.txt", { type: "text/plain" }),
+      new File(["two"], "two.txt", { type: "text/plain" }),
+    ];
+
+    act(() => {
+      result.current.selectFiles();
+    });
+
+    const fileInput = createdInputs[0];
+    Object.defineProperty(fileInput, "files", {
+      value: files,
+      configurable: true,
+    });
+
+    act(() => {
+      fileInput?.onchange?.({ target: fileInput } as unknown as Event);
+    });
+
+    expect(result.current.files).toEqual(files);
+    expect(result.current.filesSelected).toBe(true);
+  });
+});

--- a/turboui/src/ResourceHub/useAddFile.ts
+++ b/turboui/src/ResourceHub/useAddFile.ts
@@ -17,6 +17,7 @@ export function useAddFile(): AddFileProps {
   const selectFiles = () => {
     const fileInput = document.createElement("input");
     fileInput.type = "file";
+    fileInput.multiple = true;
 
     fileInput.onchange = (e: Event) => {
       const target = e.target as HTMLInputElement;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4173.

The "Upload files" action in Documents & Files created a native file picker that only allowed selecting one file at a time. Drag and drop already supported multiple files.

This change sets `multiple` on the hidden file input in `useAddFile`, which is shared by resource hub pages for spaces, projects, and goals.

## Changes

- Set `fileInput.multiple = true` in `turboui/src/ResourceHub/useAddFile.ts`
- Add unit tests covering multiple file selection behavior

## Testing

- `npm run test -- src/ResourceHub/useAddFile.test.ts`
- `npm run test -- src/ResourceHub/AddFileWidget.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33b2f723-1964-45db-aa59-b87a8601e1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33b2f723-1964-45db-aa59-b87a8601e1c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

