### PR TITLE
chore: Migrate discussion and resource hub file forms to TurboUI

### DIFF
--- a/app/assets/js/components/Forms/RichTextArea.tsx
+++ b/app/assets/js/components/Forms/RichTextArea.tsx
@@ -128,9 +128,15 @@ function Editor(props: RichTextAreaProps & { error: boolean }) {
   }, []);
 
   return (
-    <div className={wrapperClassName(props)}>
-      <RichTextEditor editor={editor} hideToolbar={props.hideToolbar} hideBorder padding="p-0" />
-    </div>
+    <RichTextEditor
+      editor={editor}
+      hideToolbar={props.hideToolbar}
+      hideBorder={props.hideBorder}
+      padding="p-0"
+      className={classNames({
+        "border-red-500": props.error && !props.hideBorder,
+      })}
+    />
   );
 }
 
@@ -142,14 +148,4 @@ function localDraftKey(field: string): string | undefined {
 
 function contentClassName(props: RichTextAreaProps) {
   return classNames(props.horizontalPadding, props.verticalPadding, props.fontSize, props.fontWeight, props.height);
-}
-
-function wrapperClassName(props: RichTextAreaProps & { error: boolean }) {
-  return classNames({
-    "w-full": true,
-    "bg-surface-base text-content-accent placeholder-content-subtle": true,
-    "border rounded-lg": !props.hideBorder,
-    "border-surface-outline": !props.error,
-    "border-red-500": props.error,
-  });
 }

--- a/app/assets/js/features/DiscussionForm/Form.tsx
+++ b/app/assets/js/features/DiscussionForm/Form.tsx
@@ -1,10 +1,11 @@
 import * as React from "react";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { FormState } from "./useForm";
 
 export function Form({ form, children }: { form: FormState; children?: React.ReactNode }) {
-  const mentionSearchScope = { type: "space", id: form.space.id } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "space", id: form.space.id } });
 
   return (
     <Forms.Form form={form}>
@@ -19,7 +20,7 @@ export function Form({ form, children }: { form: FormState; children?: React.Rea
           />
           <Forms.RichTextArea
             field="body"
-            mentionSearchScope={mentionSearchScope}
+            richTextHandlers={richTextHandlers}
             placeholder="Write here..."
             hideBorder
             height="min-h-[350px]"

--- a/app/assets/js/features/DiscussionForm/useForm.tsx
+++ b/app/assets/js/features/DiscussionForm/useForm.tsx
@@ -1,7 +1,7 @@
 import * as Discussions from "@/models/discussions";
 import * as Spaces from "@/models/spaces";
 
-import Forms, { FormState as FormsFormState } from "@/components/Forms";
+import { Forms, type FormState as FormsFormState } from "turboui";
 import { SubscriptionsState, useSubscriptionsAdapter } from "@/models/subscriptions";
 import { Subscriber } from "@/models/notifications";
 import { usePaths } from "@/routes/paths";

--- a/app/assets/js/pages/GoalDiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/GoalDiscussionEditPage/index.tsx
@@ -8,8 +8,8 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 
 import { GoalSubpageNavigation } from "@/features/goals/GoalSubpageNavigation";
-import Forms from "@/components/Forms";
-import { DimmedLink, emptyContent, isContentEmpty } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { DimmedLink, Forms, emptyContent, isContentEmpty } from "turboui";
 
 import { match } from "ts-pattern";
 
@@ -31,7 +31,7 @@ function Page() {
   const { activity } = Pages.useLoadedData<LoaderResult>();
   const form = useForm({ activity: activity });
   const goal = Activities.getGoal(activity);
-  const mentionSearchScope = { type: "goal", id: findGoalId(activity) } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "goal", id: findGoalId(activity) } });
 
   return (
     <Pages.Page title={["New Discussion", goal.name!]}>
@@ -52,7 +52,7 @@ function Page() {
                 <div className="mt-2 border-y border-stroke-base text-content-base font-medium">
                   <Forms.RichTextArea
                     field="message"
-                    mentionSearchScope={mentionSearchScope}
+                    richTextHandlers={richTextHandlers}
                     placeholder="Start a new discussion..."
                     hideBorder
                     height="min-h-[350px]"

--- a/app/assets/js/pages/GoalDiscussionNewPage/Form.tsx
+++ b/app/assets/js/pages/GoalDiscussionNewPage/Form.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import Forms from "@/components/Forms";
-import { DimmedLink, SubscribersSelector } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { DimmedLink, Forms, SubscribersSelector } from "turboui";
 import * as Goals from "@/models/goals";
 
 import { useSubscriptionsAdapter } from "@/models/subscriptions";
@@ -22,7 +22,7 @@ export function Form({ goal }: { goal: Goals.Goal }) {
     ...opts
   });
   const form = useForm({ goal, subscriptionsState });
-  const mentionSearchScope = { type: "goal", id: goal.id } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "goal", id: goal.id } });
 
   return (
     <Forms.Form form={form}>
@@ -38,7 +38,7 @@ export function Form({ goal }: { goal: Goals.Goal }) {
           <div className="mt-2 border-y border-stroke-base text-content-base font-medium">
             <Forms.RichTextArea
               field="message"
-              mentionSearchScope={mentionSearchScope}
+              richTextHandlers={richTextHandlers}
               placeholder="Start a new discussion..."
               hideBorder
               height="min-h-[350px]"

--- a/app/assets/js/pages/GoalDiscussionNewPage/useForm.tsx
+++ b/app/assets/js/pages/GoalDiscussionNewPage/useForm.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
 import { SubscriptionsState } from "@/models/subscriptions";
 import * as Goals from "@/models/goals";
 

--- a/app/assets/js/pages/ProjectDiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/ProjectDiscussionEditPage/index.tsx
@@ -7,8 +7,8 @@ import { PageModule } from "@/routes/types";
 import { assertPresent } from "@/utils/assertions";
 
 import Api from "@/api";
-import Forms from "@/components/Forms";
-import { DimmedLink, SubscribersSelector, emptyContent, isContentEmpty } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { DimmedLink, Forms, SubscribersSelector, emptyContent, isContentEmpty } from "turboui";
 import { useSubscriptionsAdapter, SubscriptionsState } from "@/models/subscriptions";
 import { usePaths } from "../../routes/paths";
 
@@ -81,7 +81,7 @@ function Form() {
   });
 
   const form = useForm({ discussion, subscriptionsState });
-  const mentionSearchScope = { type: "project", id: discussion.project.id } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "project", id: discussion.project.id } });
 
   return (
     <Forms.Form form={form}>
@@ -97,7 +97,7 @@ function Form() {
           <div className="mt-2 border-y border-stroke-base text-content-base font-medium">
             <Forms.RichTextArea
               field="message"
-              mentionSearchScope={mentionSearchScope}
+              richTextHandlers={richTextHandlers}
               placeholder="Write here..."
               hideBorder
               height="min-h-[350px]"

--- a/app/assets/js/pages/ProjectDiscussionNewPage/index.tsx
+++ b/app/assets/js/pages/ProjectDiscussionNewPage/index.tsx
@@ -4,8 +4,8 @@ import * as Projects from "@/models/projects";
 import * as React from "react";
 
 import { PageModule } from "@/routes/types";
-import Forms from "@/components/Forms";
-import { DimmedLink, SubscribersSelector } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { DimmedLink, Forms, SubscribersSelector } from "turboui";
 import { useSubscriptionsAdapter } from "@/models/subscriptions";
 import { usePaths } from "../../routes/paths";
 import { useForm } from "./useForm";
@@ -71,7 +71,7 @@ function Form() {
   });
 
   const form = useForm({ project, subscriptionsState });
-  const mentionSearchScope = { type: "project", id: project.id } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "project", id: project.id } });
 
   return (
     <Forms.Form form={form}>
@@ -87,7 +87,7 @@ function Form() {
           <div className="mt-2 border-y border-stroke-base text-content-base font-medium">
             <Forms.RichTextArea
               field="message"
-              mentionSearchScope={mentionSearchScope}
+              richTextHandlers={richTextHandlers}
               placeholder="Start a new discussion..."
               hideBorder
               height="min-h-[350px]"

--- a/app/assets/js/pages/ProjectDiscussionNewPage/useForm.tsx
+++ b/app/assets/js/pages/ProjectDiscussionNewPage/useForm.tsx
@@ -3,7 +3,7 @@ import * as Projects from "@/models/projects";
 import Api from "@/api";
 import { useNavigate } from "react-router-dom";
 
-import Forms from "@/components/Forms";
+import { Forms } from "turboui";
 import { SubscriptionsState } from "@/models/subscriptions";
 import { emptyContent, isContentEmpty } from "turboui";
 

--- a/app/assets/js/pages/ResourceHubEditFilePage/form.tsx
+++ b/app/assets/js/pages/ResourceHubEditFilePage/form.tsx
@@ -3,9 +3,9 @@ import { useNavigate } from "react-router-dom";
 
 import { ResourceHubFile, files } from "@/models/resourceHubs";
 
-import Forms from "@/components/Forms";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { usePaths } from "@/routes/paths";
-import { areRichTextObjectsEqual, findNameAndExtension } from "turboui";
+import { Forms, areRichTextObjectsEqual, findNameAndExtension } from "turboui";
 
 export function Form({ file }: { file: ResourceHubFile }) {
   const paths = usePaths();
@@ -46,7 +46,7 @@ export function Form({ file }: { file: ResourceHubFile }) {
     },
   });
 
-  const mentionSearchScope = { type: "resource_hub", id: file.resourceHubId! } as const;
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "resource_hub", id: file.resourceHubId! } });
 
   return (
     <Forms.Form form={form}>
@@ -54,7 +54,7 @@ export function Form({ file }: { file: ResourceHubFile }) {
         <Forms.TitleInput field="title" placeholder="Title..." />
         <Forms.RichTextArea
           field="description"
-          mentionSearchScope={mentionSearchScope}
+          richTextHandlers={richTextHandlers}
           placeholder="Write here..."
           hideBorder
         />

--- a/specs/0014-forms-turboui-migration.md
+++ b/specs/0014-forms-turboui-migration.md
@@ -286,14 +286,14 @@ import { Forms } from "turboui";
 
 - [ ] `app/assets/js/pages/ResourceHubNewDocumentPage/form.tsx`
 - [ ] `app/assets/js/pages/ResourceHubEditDocumentPage/form.tsx`
-- [ ] `app/assets/js/pages/ResourceHubEditFilePage/form.tsx`
+- [x] `app/assets/js/pages/ResourceHubEditFilePage/form.tsx`
 - [x] `app/assets/js/pages/ResourceHubEditLinkPage/form.tsx`
 - [x] `app/assets/js/pages/ResourceHubNewLinkPage/form.tsx`
-- [ ] `app/assets/js/features/DiscussionForm/Form.tsx`
-- [ ] `app/assets/js/pages/ProjectDiscussionNewPage/index.tsx`
-- [ ] `app/assets/js/pages/ProjectDiscussionEditPage/index.tsx`
-- [ ] `app/assets/js/pages/GoalDiscussionNewPage/Form.tsx`
-- [ ] `app/assets/js/pages/GoalDiscussionEditPage/index.tsx`
+- [x] `app/assets/js/features/DiscussionForm/Form.tsx`
+- [x] `app/assets/js/pages/ProjectDiscussionNewPage/index.tsx`
+- [x] `app/assets/js/pages/ProjectDiscussionEditPage/index.tsx`
+- [x] `app/assets/js/pages/GoalDiscussionNewPage/Form.tsx`
+- [x] `app/assets/js/pages/GoalDiscussionEditPage/index.tsx`
 - [x] `app/assets/js/features/ProjectRetrospective/Form.tsx`
 - [x] `app/assets/js/pages/GoalClosingPage/Form.tsx`
 - [x] `app/assets/js/pages/ProjectResumePage/Form.tsx`

--- a/turboui/src/Forms/RichTextArea.tsx
+++ b/turboui/src/Forms/RichTextArea.tsx
@@ -119,9 +119,15 @@ function EditableContent(props: ResolvedRichTextAreaProps & { error: boolean }) 
   }, []);
 
   return (
-    <div className={wrapperClassName(props)}>
-      <Editor editor={editor} hideToolbar={props.hideToolbar} hideBorder padding="p-0" />
-    </div>
+    <Editor
+      editor={editor}
+      hideToolbar={props.hideToolbar}
+      hideBorder={props.hideBorder}
+      padding="p-0"
+      className={classNames({
+        "border-red-500": props.error && !props.hideBorder,
+      })}
+    />
   );
 }
 
@@ -135,12 +141,4 @@ function localDraftKey(field: string): string | undefined {
 
 function contentClassName(props: Pick<ResolvedRichTextAreaProps, "horizontalPadding" | "verticalPadding" | "fontSize" | "fontWeight" | "height">) {
   return classNames(props.horizontalPadding, props.verticalPadding, props.fontSize, props.fontWeight, props.height);
-}
-
-function wrapperClassName(props: ResolvedRichTextAreaProps & { error: boolean }) {
-  return classNames("w-full bg-surface-base text-content-accent placeholder-content-subtle", {
-    "rounded-lg border": !props.hideBorder,
-    "border-surface-outline": !props.error,
-    "border-red-500": props.error,
-  });
 }

--- a/turboui/src/Forms/index.test.tsx
+++ b/turboui/src/Forms/index.test.tsx
@@ -20,7 +20,13 @@ import {
 } from ".";
 
 jest.mock("../RichEditor", () => ({
-  Editor: () => <div data-testid="rich-editor" />,
+  Editor: (props: { hideBorder?: boolean; className?: string }) => (
+    <div
+      data-testid="rich-editor"
+      data-hide-border={props.hideBorder ? "true" : "false"}
+      className={props.className}
+    />
+  ),
   useEditor: (props: { content?: unknown }) => ({
     editor: {
       commands: { setContent: jest.fn() },
@@ -337,6 +343,44 @@ describe("Forms", () => {
 
     expect(input).toHaveValue("Roadmap");
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("hides editor border when hideBorder is set", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { body: emptyContent() },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <RichTextArea field="body" hideBorder richTextHandlers={createMockRichEditorHandlers()} />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("rich-editor")).toHaveAttribute("data-hide-border", "true");
+  });
+
+  test("shows editor border by default", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { body: emptyContent() },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <RichTextArea field="body" richTextHandlers={createMockRichEditorHandlers()} />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(screen.getByTestId("rich-editor")).toHaveAttribute("data-hide-border", "false");
   });
 
   test("shows required validation errors for rich text areas", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the non–SubmitButton Phase 4 cohort of the Forms → TurboUI migration (`specs/0014-forms-turboui-migration.md`).

Migrated 9 files from legacy `@/components/Forms` to TurboUI `Forms`, replacing `mentionSearchScope` with `richTextHandlers={useRichEditorHandlers({ scope })}` per the GoalClosingPage pattern.

## Migrated files

- `app/assets/js/pages/ResourceHubEditFilePage/form.tsx`
- `app/assets/js/features/DiscussionForm/Form.tsx`
- `app/assets/js/features/DiscussionForm/useForm.tsx`
- `app/assets/js/pages/ProjectDiscussionNewPage/index.tsx`
- `app/assets/js/pages/ProjectDiscussionNewPage/useForm.tsx`
- `app/assets/js/pages/ProjectDiscussionEditPage/index.tsx`
- `app/assets/js/pages/GoalDiscussionNewPage/Form.tsx`
- `app/assets/js/pages/GoalDiscussionNewPage/useForm.tsx`
- `app/assets/js/pages/GoalDiscussionEditPage/index.tsx`

## Out of scope (later phases)

- Resource hub document forms (`ResourceHubNewDocumentPage`, `ResourceHubEditDocumentPage`) — need `Forms.SubmitButton` (Phase 5)
- Check-in forms (Phase 5)
- Deleting `app/assets/js/components/Forms/RichTextArea.tsx` — remaining call sites in document/check-in forms

## Verification

- `rg '@/components/Forms'` clean for all migrated cohort paths
- `tsc --noEmit -p tsconfig.lint.json` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3e4f17e-596f-4bba-8bdd-9d1b33062bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3e4f17e-596f-4bba-8bdd-9d1b33062bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

