### PR TITLE
feat: add 72-hour full-edit window for project check-ins

### DIFF
--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -88,7 +88,6 @@ function FullEditDisabledMessage({ allowFullEdit, isDraft }: { allowFullEdit: bo
     <InfoCallout
       message="Editing locked after 3 days"
       description="You can edit the status for up to 3 days after submitting your check-in. After that, it's locked in to keep the history clear and decisions accountable. Need to make a change? Leave a comment or create a new check-in."
-      className="mt-8"
     />
   );
 }

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -5,15 +5,27 @@ import { ProjectCheckIn, useEditProjectCheckIn } from "@/models/projectCheckIns"
 import { useNavigate } from "react-router-dom";
 
 import Forms, { FormState } from "@/components/Forms";
+import { Status, StatusOptions } from "@/components/status";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { assertPresent } from "@/utils/assertions";
-import { FormattedTime, GhostButton, PrimaryButton, Spacer, displayDate } from "turboui";
+import { compareIds } from "@/routes/paths";
+import { isWithinTimeframe } from "@/utils/time";
+import { FormattedTime, GhostButton, InfoCallout, PrimaryButton, Spacer, displayDate } from "turboui";
 
 import { usePaths } from "@/routes/paths";
+
 export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
   const paths = usePaths();
   const [edit] = useEditProjectCheckIn();
   const navigate = useNavigate();
+
+  assertPresent(checkIn.project, "project must be present in checkIn");
+
+  const allowFullEdit =
+    checkIn.state === "draft" ||
+    (checkIn.project.lastCheckIn?.id
+      ? compareIds(checkIn.project.lastCheckIn.id, checkIn.id) && isWithinTimeframe(displayDate(checkIn), 72)
+      : false);
 
   const form = Forms.useForm({
     fields: {
@@ -21,7 +33,7 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
       description: JSON.parse(checkIn.description!),
     },
     validate: (addError) => {
-      if (!form.values.status) {
+      if (allowFullEdit && !form.values.status) {
         addError("status", "Status is required");
       }
       if (!form.values.description) {
@@ -51,8 +63,14 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
     <Forms.Form form={form}>
       <Header checkIn={checkIn} />
 
+      <FullEditDisabledMessage allowFullEdit={allowFullEdit} isDraft={checkIn.state === "draft"} />
+
       <Forms.FieldGroup>
-        <StatusSection reviewer={checkIn.project?.reviewer || undefined} />
+        <StatusSection
+          reviewer={checkIn.project?.reviewer || undefined}
+          allowFullEdit={allowFullEdit}
+          checkIn={checkIn}
+        />
         <DescriptionSection checkIn={checkIn} />
       </Forms.FieldGroup>
 
@@ -60,6 +78,18 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
 
       <SubmitButtons form={form} isDraft={checkIn.state === "draft"} />
     </Forms.Form>
+  );
+}
+
+function FullEditDisabledMessage({ allowFullEdit, isDraft }: { allowFullEdit: boolean; isDraft: boolean }) {
+  if (isDraft || allowFullEdit) return null;
+
+  return (
+    <InfoCallout
+      message="Editing locked after 3 days"
+      description="You can edit the status for up to 3 days after submitting your check-in. After that, it's locked in to keep the history clear and decisions accountable. Need to make a change? Leave a comment or create a new check-in."
+      className="mt-8"
+    />
   );
 }
 
@@ -116,15 +146,34 @@ function Header({ checkIn }: { checkIn: ProjectCheckIn }) {
   );
 }
 
-function StatusSection({ reviewer }: { reviewer?: Person }) {
+function StatusSection({
+  reviewer,
+  allowFullEdit,
+  checkIn,
+}: {
+  reviewer?: Person;
+  allowFullEdit: boolean;
+  checkIn: ProjectCheckIn;
+}) {
+  if (allowFullEdit) {
+    return (
+      <div className="mt-8 mb-4">
+        <Forms.SelectStatus
+          label="1. How's the project going?"
+          field="status"
+          reviewer={reviewer}
+          options={["on_track", "caution", "off_track"]}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="mt-8 mb-4">
-      <Forms.SelectStatus
-        label="1. How's the project going?"
-        field="status"
-        reviewer={reviewer}
-        options={["on_track", "caution", "off_track"]}
-      />
+      <div className="font-bold">1. How's the project going?</div>
+      <div className="mt-2 flex flex-col gap-2 rounded-lg border border-stroke-base p-2">
+        <Status status={checkIn.status as StatusOptions} reviewer={reviewer} />
+      </div>
     </div>
   );
 }

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -139,7 +139,8 @@ function Header({ checkIn }: { checkIn: ProjectCheckIn }) {
   return (
     <div>
       <div className="text-2xl font-bold mx-auto">
-        Editing the Check-In from <FormattedTime {...formattedTimePreferences} time={displayDate(checkIn)} format="long-date" />
+        Editing the Check-In from{" "}
+        <FormattedTime {...formattedTimePreferences} time={displayDate(checkIn)} format="long-date" />
       </div>
     </div>
   );

--- a/app/lib/operately/operations/project_check_in_edit.ex
+++ b/app/lib/operately/operations/project_check_in_edit.ex
@@ -1,7 +1,8 @@
 defmodule Operately.Operations.ProjectCheckInEdit do
   alias Ecto.Multi
 
-  alias Operately.{Repo, Activities}
+  alias Operately.{Repo, Activities, Time}
+  alias Operately.Drafts
   alias Operately.Projects.Project
   alias Operately.Projects.CheckIn
   alias Operately.Notifications.SubscriptionList
@@ -16,13 +17,8 @@ defmodule Operately.Operations.ProjectCheckInEdit do
       )
 
     Multi.new()
-    |> Multi.update(:check_in, fn _ ->
-      CheckIn.changeset(check_in, %{
-        status: attrs.status,
-        description: attrs.description,
-        state: state(check_in, attrs)
-      })
-    end)
+    |> set_if_full_edit_allowed(project, check_in)
+    |> update_check_in(check_in, attrs)
     |> maybe_update_project(project, check_in, attrs, next_check_in)
     |> Multi.run(:subscription_list, fn _, changes ->
       SubscriptionList.get(:system,
@@ -39,6 +35,38 @@ defmodule Operately.Operations.ProjectCheckInEdit do
     |> broadcast_if_published(author)
   end
 
+  #
+  # Edits to the status are allowed within 3 days of the check-in display date
+  # and only if it is the latest check-in. Otherwise, only the description can
+  # be edited.
+  #
+  defp set_if_full_edit_allowed(multi, project, check_in) do
+    edit_start = Drafts.display_date(check_in)
+    edit_deadline = DateTime.add(edit_start, 3, :day)
+
+    is_latest = project.last_check_in_id == check_in.id
+    is_in_edit_deadline = DateTime.compare(Time.utc_datetime_now(), edit_deadline) == :lt
+
+    Multi.put(multi, :full_edit_allowed, check_in.state == :draft or (is_latest and is_in_edit_deadline))
+  end
+
+  defp update_check_in(multi, check_in, attrs) do
+    Multi.update(multi, :check_in, fn changes ->
+      if changes.full_edit_allowed do
+        CheckIn.changeset(check_in, %{
+          status: attrs.status,
+          description: attrs.description,
+          state: state(check_in, attrs)
+        })
+      else
+        CheckIn.changeset(check_in, %{
+          description: attrs.description,
+          state: state(check_in, attrs)
+        })
+      end
+    end)
+  end
+
   defp maybe_update_project(multi, project, check_in, attrs, next_check_in) do
     Multi.update(multi, :project, fn changes ->
       cond do
@@ -52,10 +80,13 @@ defmodule Operately.Operations.ProjectCheckInEdit do
             next_check_in_scheduled_at: next_check_in
           })
 
-        true ->
+        changes.full_edit_allowed ->
           Project.changeset(project, %{
-            last_check_in_status: attrs.status
+            last_check_in_status: changes.check_in.status
           })
+
+        true ->
+          Project.changeset(project, %{})
       end
     end)
   end

--- a/app/lib/operately/operations/project_check_in_edit.ex
+++ b/app/lib/operately/operations/project_check_in_edit.ex
@@ -19,7 +19,7 @@ defmodule Operately.Operations.ProjectCheckInEdit do
     Multi.new()
     |> set_if_full_edit_allowed(project, check_in)
     |> update_check_in(check_in, attrs)
-    |> maybe_update_project(project, check_in, attrs, next_check_in)
+    |> maybe_update_project(project, check_in, next_check_in)
     |> Multi.run(:subscription_list, fn _, changes ->
       SubscriptionList.get(:system,
         parent_id: changes.check_in.id,

--- a/app/lib/operately/operations/project_check_in_edit.ex
+++ b/app/lib/operately/operations/project_check_in_edit.ex
@@ -67,7 +67,7 @@ defmodule Operately.Operations.ProjectCheckInEdit do
     end)
   end
 
-  defp maybe_update_project(multi, project, check_in, attrs, next_check_in) do
+  defp maybe_update_project(multi, project, check_in, next_check_in) do
     Multi.update(multi, :project, fn changes ->
       cond do
         changes.check_in.state == :draft ->

--- a/app/lib/operately_web/api/projects/get_check_in.ex
+++ b/app/lib/operately_web/api/projects/get_check_in.ex
@@ -58,7 +58,7 @@ defmodule OperatelyWeb.Api.Projects.GetCheckIn do
     Inputs.parse_includes(inputs,
       include_author: [:author],
       include_acknowledged_by: [:acknowledged_by],
-      include_project: [project: [:champion, :reviewer, [contributors: :person]]],
+      include_project: [project: [:champion, :reviewer, :last_check_in, [contributors: :person]]],
       include_reactions: [reactions: :person],
       include_subscriptions_list: :subscription_list
     )

--- a/app/test/operately_web/api/projects/update_check_in_test.exs
+++ b/app/test/operately_web/api/projects/update_check_in_test.exs
@@ -158,6 +158,74 @@ defmodule OperatelyWeb.Api.Projects.UpdateCheckInTest do
     end
   end
 
+  describe "full edit window after publish" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.log_in_person(:creator)
+      |> Factory.add_space(:space)
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_project_check_in(:check_in, :project, :creator)
+    end
+
+    test "allows status edits within 3 days of published_at for a late-published check-in", ctx do
+      check_in =
+        ctx.check_in
+        |> set_check_in_dates(
+          inserted_at: days_ago_naive(10),
+          published_at: Operately.Time.utc_datetime_now()
+        )
+
+      {:ok, project} =
+        Operately.Projects.update_project(ctx.project, %{
+          last_check_in_id: check_in.id,
+          last_check_in_status: check_in.status
+        })
+
+      assert {200, _} =
+               mutation(ctx.conn, [:projects, :update_check_in], %{
+                 check_in_id: Paths.project_check_in_id(check_in),
+                 status: "off_track",
+                 description: RichText.rich_text("Edited description", :as_string)
+               })
+
+      check_in = Repo.reload(check_in)
+      project = Repo.reload(project)
+
+      assert check_in.status == :off_track
+      assert project.last_check_in_status == :off_track
+    end
+
+    test "limits edits to description only outside the 3-day window from published_at", ctx do
+      check_in =
+        ctx.check_in
+        |> set_check_in_dates(
+          inserted_at: days_ago_naive(1),
+          published_at: Operately.Time.days_ago(4)
+        )
+
+      {:ok, project} =
+        Operately.Projects.update_project(ctx.project, %{
+          last_check_in_id: check_in.id,
+          last_check_in_status: check_in.status
+        })
+
+      assert {200, _} =
+               mutation(ctx.conn, [:projects, :update_check_in], %{
+                 check_in_id: Paths.project_check_in_id(check_in),
+                 status: "off_track",
+                 description: RichText.rich_text("Edited description", :as_string)
+               })
+
+      check_in = Repo.reload(check_in)
+      project = Repo.reload(project)
+
+      assert check_in.status == :on_track
+      assert check_in.description == RichText.rich_text("Edited description")
+      assert project.last_check_in_status == :on_track
+    end
+  end
+
   #
   # Helpers
   #
@@ -202,5 +270,20 @@ defmodule OperatelyWeb.Api.Projects.UpdateCheckInTest do
 
   defp create_check_in(creator, project) do
     check_in_fixture(%{author_id: creator.id, project_id: project.id})
+  end
+
+  defp set_check_in_dates(check_in, dates) do
+    {:ok, check_in} =
+      Ecto.Changeset.change(check_in, %{
+        inserted_at: dates[:inserted_at],
+        published_at: dates[:published_at]
+      })
+      |> Repo.update()
+
+    check_in
+  end
+
+  defp days_ago_naive(days) do
+    NaiveDateTime.utc_now() |> NaiveDateTime.add(-days, :day) |> NaiveDateTime.truncate(:second)
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4762 by mirroring goal check-in edit rules for project check-ins.

Project check-ins now follow the same 72-hour full-edit window as goal check-ins, using `Drafts.display_date/1` so late-published drafts count from submit time (`published_at`), not draft creation.

## Behavior

- **Draft**: status and description fully editable
- **Published + latest check-in**: status and description editable within 72 hours of display date
- **Otherwise**: description-only edits (status locked)

## Changes

### Backend
- `Operately.Operations.ProjectCheckInEdit`: added `set_if_full_edit_allowed/3` matching `GoalCheckInEdit`, restricting status updates and project `last_check_in_status` changes outside the window

### Frontend
- `ProjectCheckInEditPage/Form.tsx`: added `allowFullEdit` guard (same logic as `GoalCheckInPage/Form.tsx`), read-only status display after the window, and an info callout explaining the lock

### API
- `GetCheckIn`: preload `last_check_in` on project so the edit page can determine whether the check-in is latest

### Tests
- Added `full edit window after publish` cases to `update_check_in_test.exs`, mirroring goal check-in coverage

## Testing

- [ ] `make test FILE=app/test/operately_web/api/projects/update_check_in_test.exs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75821c2c-5dbd-44f8-99ee-d6aa7c6c90ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75821c2c-5dbd-44f8-99ee-d6aa7c6c90ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

