### PR TITLE
feat: add remove feature flags flow to SaaS admin company page

### DIFF
--- a/app/ee/assets/js/admin_api/index.tsx
+++ b/app/ee/assets/js/admin_api/index.tsx
@@ -361,6 +361,15 @@ export interface DemoteAccountFromSiteAdminResult {
   error?: string;
 }
 
+export interface DisableFeaturesInput {
+  companyId: CompanyId;
+  features: string[];
+}
+
+export interface DisableFeaturesResult {
+  success: boolean;
+}
+
 export interface EnableFeatureInput {
   companyId: CompanyId;
   feature: string;
@@ -545,6 +554,10 @@ class ApiNamespaceRoot {
     return this.client.post("/demote_account_from_site_admin", input);
   }
 
+  async disableFeatures(input: DisableFeaturesInput): Promise<DisableFeaturesResult> {
+    return this.client.post("/disable_features", input);
+  }
+
   async enableFeature(input: EnableFeatureInput): Promise<EnableFeatureResult> {
     return this.client.post("/enable_feature", input);
   }
@@ -711,6 +724,10 @@ export class ApiClient {
     return this.apiNamespaceRoot.demoteAccountFromSiteAdmin(input);
   }
 
+  disableFeatures(input: DisableFeaturesInput): Promise<DisableFeaturesResult> {
+    return this.apiNamespaceRoot.disableFeatures(input);
+  }
+
   enableFeature(input: EnableFeatureInput): Promise<EnableFeatureResult> {
     return this.apiNamespaceRoot.enableFeature(input);
   }
@@ -814,6 +831,9 @@ export async function demoteAccountFromSiteAdmin(
   input: DemoteAccountFromSiteAdminInput,
 ): Promise<DemoteAccountFromSiteAdminResult> {
   return defaultApiClient.demoteAccountFromSiteAdmin(input);
+}
+export async function disableFeatures(input: DisableFeaturesInput): Promise<DisableFeaturesResult> {
+  return defaultApiClient.disableFeatures(input);
 }
 export async function enableFeature(input: EnableFeatureInput): Promise<EnableFeatureResult> {
   return defaultApiClient.enableFeature(input);
@@ -955,6 +975,10 @@ export function useDemoteAccountFromSiteAdmin(): UseMutationHookResult<
   );
 }
 
+export function useDisableFeatures(): UseMutationHookResult<DisableFeaturesInput, DisableFeaturesResult> {
+  return useMutation<DisableFeaturesInput, DisableFeaturesResult>((input) => defaultApiClient.disableFeatures(input));
+}
+
 export function useEnableFeature(): UseMutationHookResult<EnableFeatureInput, EnableFeatureResult> {
   return useMutation<EnableFeatureInput, EnableFeatureResult>((input) => defaultApiClient.enableFeature(input));
 }
@@ -1066,6 +1090,8 @@ export default {
   useDeleteSiteMessage,
   demoteAccountFromSiteAdmin,
   useDemoteAccountFromSiteAdmin,
+  disableFeatures,
+  useDisableFeatures,
   enableFeature,
   useEnableFeature,
   promoteAccountToSiteAdmin,

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/EnableFeatureModal.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/EnableFeatureModal.tsx
@@ -8,9 +8,10 @@ import { useLoadedData } from "./loader";
 interface EnableFeatureModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onSaved?: () => void;
 }
 
-export function EnableFeatureModal({ isOpen, onClose }: EnableFeatureModalProps) {
+export function EnableFeatureModal({ isOpen, onClose, onSaved }: EnableFeatureModalProps) {
   const { company } = useLoadedData();
   const [enableFeature] = AdminApi.useEnableFeature();
 
@@ -25,6 +26,7 @@ export function EnableFeatureModal({ isOpen, onClose }: EnableFeatureModalProps)
         feature: form.values.feature,
       });
 
+      onSaved?.();
       onClose();
       form.actions.reset();
     },

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.test.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.test.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { RemoveFeatureFlagsModal, removedFeatures, saveRemoveFeatureFlags } from "./RemoveFeatureFlagsModal";
+
+const mockDisableFeatures = jest.fn();
+
+jest.mock("@/ee/admin_api", () => ({
+  useDisableFeatures: () => [mockDisableFeatures, { data: null, loading: false, error: null }],
+}));
+
+jest.mock("@/components/Modal", () => ({
+  __esModule: true,
+  default: ({ isOpen, title, children }: { isOpen: boolean; title?: string; children: React.ReactNode }) =>
+    isOpen ? (
+      <div>
+        <h1>{title}</h1>
+        {children}
+      </div>
+    ) : null,
+}));
+
+jest.mock("turboui", () => ({
+  IconTrash: () => <span>trash</span>,
+  PrimaryButton: ({
+    children,
+    disabled,
+    testId,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    testId?: string;
+  }) => (
+    <button data-test-id={testId} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  SecondaryButton: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+    <button data-test-id={testId}>{children}</button>
+  ),
+}));
+
+describe("RemoveFeatureFlagsModal", () => {
+  beforeEach(() => {
+    mockDisableFeatures.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it("renders all enabled features", () => {
+    const markup = renderToStaticMarkup(
+      <RemoveFeatureFlagsModal
+        isOpen={true}
+        onClose={() => {}}
+        companyId="company-1"
+        enabledFeatures={["feature_a", "feature_b", "feature_c"]}
+      />,
+    );
+
+    expect(markup).toContain("feature_a");
+    expect(markup).toContain("feature_b");
+    expect(markup).toContain("feature_c");
+  });
+
+  it("shows empty state when no features are enabled", () => {
+    const markup = renderToStaticMarkup(
+      <RemoveFeatureFlagsModal isOpen={true} onClose={() => {}} companyId="company-1" enabledFeatures={[]} />,
+    );
+
+    expect(markup).toContain("No feature flags enabled");
+  });
+});
+
+describe("removedFeatures", () => {
+  it("returns an empty list when nothing was removed", () => {
+    expect(removedFeatures(["feature_a", "feature_b"], ["feature_a", "feature_b"])).toEqual([]);
+  });
+
+  it("returns only the features that were removed locally", () => {
+    expect(removedFeatures(["feature_a", "feature_b", "feature_c"], ["feature_a", "feature_c"])).toEqual(["feature_b"]);
+  });
+});
+
+describe("saveRemoveFeatureFlags", () => {
+  beforeEach(() => {
+    mockDisableFeatures.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it("does not call the API when saving with no removals", async () => {
+    const onClose = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveRemoveFeatureFlags({
+      companyId: "company-1",
+      originalFeatures: ["feature_a", "feature_b"],
+      localFeatures: ["feature_a", "feature_b"],
+      disableFeatures: mockDisableFeatures,
+      onClose,
+      onSaved,
+    });
+
+    expect(mockDisableFeatures).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("calls the API with removed features and invokes onSaved", async () => {
+    const onClose = jest.fn();
+    const onSaved = jest.fn();
+
+    await saveRemoveFeatureFlags({
+      companyId: "company-1",
+      originalFeatures: ["feature_a", "feature_b", "feature_c"],
+      localFeatures: ["feature_a", "feature_c"],
+      disableFeatures: mockDisableFeatures,
+      onClose,
+      onSaved,
+    });
+
+    expect(mockDisableFeatures).toHaveBeenCalledWith({
+      companyId: "company-1",
+      features: ["feature_b"],
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.test.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.test.tsx
@@ -20,7 +20,10 @@ jest.mock("@/components/Modal", () => ({
     ) : null,
 }));
 
+const mockShowErrorToast = jest.fn();
+
 jest.mock("turboui", () => ({
+  showErrorToast: (...args: unknown[]) => mockShowErrorToast(...args),
   IconTrash: () => <span>trash</span>,
   PrimaryButton: ({
     children,
@@ -43,6 +46,7 @@ jest.mock("turboui", () => ({
 describe("RemoveFeatureFlagsModal", () => {
   beforeEach(() => {
     mockDisableFeatures.mockReset().mockResolvedValue({ success: true });
+    mockShowErrorToast.mockReset();
   });
 
   it("renders all enabled features", () => {
@@ -121,5 +125,21 @@ describe("saveRemoveFeatureFlags", () => {
     });
     expect(onSaved).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates API errors to the caller", async () => {
+    const apiError = new Error("Network error");
+    mockDisableFeatures.mockRejectedValue(apiError);
+
+    await expect(
+      saveRemoveFeatureFlags({
+        companyId: "company-1",
+        originalFeatures: ["feature_a", "feature_b"],
+        localFeatures: ["feature_a"],
+        disableFeatures: mockDisableFeatures,
+        onClose: jest.fn(),
+        onSaved: jest.fn(),
+      }),
+    ).rejects.toThrow("Network error");
   });
 });

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+
+import Modal from "@/components/Modal";
+import * as AdminApi from "@/ee/admin_api";
+import { IconTrash, PrimaryButton, SecondaryButton } from "turboui";
+
+interface RemoveFeatureFlagsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  companyId: string;
+  enabledFeatures: string[];
+  onSaved?: () => void;
+}
+
+export function removedFeatures(originalFeatures: string[], localFeatures: string[]): string[] {
+  return originalFeatures.filter((feature) => !localFeatures.includes(feature));
+}
+
+export async function saveRemoveFeatureFlags({
+  companyId,
+  originalFeatures,
+  localFeatures,
+  disableFeatures,
+  onClose,
+  onSaved,
+}: {
+  companyId: string;
+  originalFeatures: string[];
+  localFeatures: string[];
+  disableFeatures: (input: AdminApi.DisableFeaturesInput) => Promise<AdminApi.DisableFeaturesResult>;
+  onClose: () => void;
+  onSaved?: () => void;
+}) {
+  const removed = removedFeatures(originalFeatures, localFeatures);
+
+  if (removed.length === 0) {
+    onClose();
+    return;
+  }
+
+  await disableFeatures({ companyId, features: removed });
+  onSaved?.();
+  onClose();
+}
+
+export function RemoveFeatureFlagsModal({
+  isOpen,
+  onClose,
+  companyId,
+  enabledFeatures,
+  onSaved,
+}: RemoveFeatureFlagsModalProps) {
+  const [disableFeatures] = AdminApi.useDisableFeatures();
+  const [localFeatures, setLocalFeatures] = React.useState<string[]>(enabledFeatures);
+  const [saving, setSaving] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setLocalFeatures(enabledFeatures);
+      setSaving(false);
+    }
+  }, [isOpen, enabledFeatures]);
+
+  const handleClose = () => {
+    setLocalFeatures(enabledFeatures);
+    setSaving(false);
+    onClose();
+  };
+
+  const removeFeature = (feature: string) => {
+    setLocalFeatures((features) => features.filter((f) => f !== feature));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+
+    try {
+      await saveRemoveFeatureFlags({
+        companyId,
+        originalFeatures: enabledFeatures,
+        localFeatures,
+        disableFeatures,
+        onClose: handleClose,
+        onSaved,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasEnabledFeatures = enabledFeatures.length > 0;
+
+  return (
+    <Modal title="Remove Feature Flags" isOpen={isOpen} hideModal={handleClose} size="sm">
+      <div className="mb-4 text-sm text-content-accent">
+        Remove experimental feature flags from this company. Changes are saved when you click Save.
+      </div>
+
+      {!hasEnabledFeatures ? (
+        <div className="py-6 text-sm text-content-dimmed text-center" data-test-id="no-feature-flags">
+          No feature flags enabled
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2 mb-6" data-test-id="feature-flags-list">
+          {localFeatures.map((feature) => (
+            <div
+              key={feature}
+              className="flex items-center justify-between gap-3 border border-stroke-base rounded px-3 py-2"
+              data-test-id={`feature-flag-row-${feature}`}
+            >
+              <code className="text-sm text-content-accent">{feature}</code>
+              <button
+                type="button"
+                className="text-content-dimmed hover:text-content-error transition-colors"
+                onClick={() => removeFeature(feature)}
+                data-test-id={`remove-feature-${feature}`}
+                aria-label={`Remove ${feature}`}
+              >
+                <IconTrash size={18} />
+              </button>
+            </div>
+          ))}
+
+          {localFeatures.length === 0 && (
+            <div className="py-4 text-sm text-content-dimmed text-center">All flags marked for removal</div>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <SecondaryButton size="sm" onClick={handleClose} testId="cancel-remove-features">
+          Cancel
+        </SecondaryButton>
+        <PrimaryButton
+          size="sm"
+          onClick={handleSave}
+          loading={saving}
+          disabled={!hasEnabledFeatures}
+          testId="save-remove-features"
+        >
+          Save
+        </PrimaryButton>
+      </div>
+    </Modal>
+  );
+}

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/RemoveFeatureFlagsModal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Modal from "@/components/Modal";
 import * as AdminApi from "@/ee/admin_api";
-import { IconTrash, PrimaryButton, SecondaryButton } from "turboui";
+import { IconTrash, PrimaryButton, SecondaryButton, showErrorToast } from "turboui";
 
 interface RemoveFeatureFlagsModalProps {
   isOpen: boolean;
@@ -83,6 +83,9 @@ export function RemoveFeatureFlagsModal({
         onClose: handleClose,
         onSaved,
       });
+    } catch (error: any) {
+      const message = error?.response?.data?.message || "Failed to remove feature flags. Please try again.";
+      showErrorToast("Failed to remove feature flags", message);
     } finally {
       setSaving(false);
     }

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
@@ -4,8 +4,9 @@ import * as PageOptions from "@/components/PaperContainer/PageOptions";
 import * as AdminApi from "@/ee/admin_api";
 import * as React from "react";
 import { EnableFeatureModal } from "./EnableFeatureModal";
+import { RemoveFeatureFlagsModal } from "./RemoveFeatureFlagsModal";
 
-import { Avatar, IconFlare, SecondaryButton, FormattedTime } from "turboui";
+import { Avatar, IconFlare, IconTrash, SecondaryButton, FormattedTime } from "turboui";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 
 import { useStartSupportSession } from "@/features/SupportSessions";
@@ -152,7 +153,10 @@ function ActivitySection({ company }: { company: AdminApi.Company }) {
 }
 
 function Options() {
+  const { company } = useLoadedData();
+  const refresh = Pages.useRefresh();
   const [showEnableFeatureModal, toggleEnableFeatureModal] = useBoolState(false);
+  const [showRemoveFeatureFlagsModal, toggleRemoveFeatureFlagsModal] = useBoolState(false);
 
   return (
     <>
@@ -163,9 +167,22 @@ function Options() {
           onClick={toggleEnableFeatureModal}
           testId="enable-feature"
         />
+        <PageOptions.Action
+          icon={IconTrash}
+          title="Remove Feature Flags"
+          onClick={toggleRemoveFeatureFlagsModal}
+          testId="remove-feature-flags"
+        />
       </PageOptions.Root>
 
       <EnableFeatureModal isOpen={showEnableFeatureModal} onClose={toggleEnableFeatureModal} />
+      <RemoveFeatureFlagsModal
+        isOpen={showRemoveFeatureFlagsModal}
+        onClose={toggleRemoveFeatureFlagsModal}
+        companyId={company.id!}
+        enabledFeatures={company.enabledFeatures ?? []}
+        onSaved={refresh}
+      />
     </>
   );
 }

--- a/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
+++ b/app/ee/assets/js/pages/SaasAdminCompanyPage/index.tsx
@@ -175,7 +175,11 @@ function Options() {
         />
       </PageOptions.Root>
 
-      <EnableFeatureModal isOpen={showEnableFeatureModal} onClose={toggleEnableFeatureModal} />
+      <EnableFeatureModal
+        isOpen={showEnableFeatureModal}
+        onClose={toggleEnableFeatureModal}
+        onSaved={refresh}
+      />
       <RemoveFeatureFlagsModal
         isOpen={showRemoveFeatureFlagsModal}
         onClose={toggleRemoveFeatureFlagsModal}

--- a/app/ee/lib/admin_api.ex
+++ b/app/ee/lib/admin_api.ex
@@ -22,6 +22,7 @@ defmodule OperatelyEE.AdminApi do
   mutation :promote_account_to_site_admin, M.PromoteAccountToSiteAdmin
   mutation :demote_account_from_site_admin, M.DemoteAccountFromSiteAdmin
   mutation :enable_feature, M.EnableFeature
+  mutation :disable_features, M.DisableFeatures
   mutation :update_email_settings, M.UpdateEmailSettings
   mutation :send_test_email, M.SendTestEmail
   mutation :create_billing_plan_definition, M.CreateBillingPlanDefinition

--- a/app/ee/lib/admin_api/mutations/disable_features.ex
+++ b/app/ee/lib/admin_api/mutations/disable_features.ex
@@ -1,0 +1,48 @@
+defmodule OperatelyEE.AdminApi.Mutations.DisableFeatures do
+  use TurboConnect.Mutation
+  use OperatelyWeb.Api.Helpers
+
+  alias Operately.Companies.Company
+  alias Operately.People.Account
+  alias Operately.Repo
+
+  inputs do
+    field :company_id, :company_id
+    field :features, list_of(:string)
+  end
+
+  outputs do
+    field :success, :boolean
+  end
+
+  def call(conn, inputs) do
+    with {:ok, account} <- find_account(conn),
+         true <- Account.is_site_admin?(account) || {:error, :forbidden},
+         :ok <- validate_features(inputs.features),
+         {:ok, company} <- load(inputs.company_id),
+         {:ok, _updated} <- disable_features(company, inputs.features) do
+      {:ok, %{success: true}}
+    else
+      {:error, :bad_request, message} -> {:error, :bad_request, message}
+      {:error, :not_found} -> {:error, :not_found}
+      {:error, :forbidden} -> {:error, :forbidden}
+      _e -> {:error, :internal_server_error}
+    end
+  end
+
+  defp validate_features(features) when is_list(features) and features != [], do: :ok
+  defp validate_features(_), do: {:error, :bad_request, "Features list cannot be empty"}
+
+  defp load(id) do
+    Company.get(:system, short_id: id)
+  end
+
+  defp disable_features(company, features) do
+    company = Repo.reload(company)
+    remaining = company.enabled_experimental_features -- features
+
+    company
+    |> Company.changeset(%{enabled_experimental_features: remaining})
+    |> Repo.update()
+  end
+end

--- a/app/ee/test/operately_ee/admin_api/mutations/disable_features_test.exs
+++ b/app/ee/test/operately_ee/admin_api/mutations/disable_features_test.exs
@@ -1,0 +1,96 @@
+defmodule OperatelyEE.AdminApi.Mutations.DisableFeaturesTest do
+  use OperatelyWeb.TurboCase
+
+  alias Operately.Companies
+  alias Operately.People.Account
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, "Unauthorized"} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Operately.Companies.ShortId.encode!(999_999_999),
+                 features: ["some_feature"]
+               })
+    end
+
+    test "it requires a site admin", ctx do
+      ctx = Factory.setup(ctx) |> Factory.log_in_account(:account)
+
+      assert {401, "Unauthorized"} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Paths.company_id(ctx.company),
+                 features: ["some_feature"]
+               })
+    end
+  end
+
+  describe "functionality" do
+    setup ctx do
+      ctx = Factory.setup(ctx)
+      {:ok, _} = Account.promote_to_admin(ctx.account)
+
+      ctx
+      |> Map.put(:account, Repo.get!(Account, ctx.account.id))
+      |> Factory.log_in_account(:account)
+    end
+
+    test "removes a single feature from a company with multiple flags", ctx do
+      {:ok, company} = Companies.enable_experimental_feature(ctx.company, "feature_a")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_b")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_c")
+
+      assert {200, %{success: true}} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Paths.company_id(company),
+                 features: ["feature_b"]
+               })
+
+      company = Repo.reload(company)
+      assert Enum.sort(company.enabled_experimental_features) == ["feature_a", "feature_c"]
+    end
+
+    test "removes multiple features in one call", ctx do
+      {:ok, company} = Companies.enable_experimental_feature(ctx.company, "feature_a")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_b")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_c")
+
+      assert {200, %{success: true}} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Paths.company_id(company),
+                 features: ["feature_a", "feature_c"]
+               })
+
+      company = Repo.reload(company)
+      assert company.enabled_experimental_features == ["feature_b"]
+    end
+
+    test "returns not found for an unknown company", ctx do
+      assert {404, _} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Operately.Companies.ShortId.encode!(999_999_999),
+                 features: ["some_feature"]
+               })
+    end
+
+    test "returns bad request for an empty features list", ctx do
+      assert {400, _} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Paths.company_id(ctx.company),
+                 features: []
+               })
+    end
+
+    test "is idempotent when removing a feature that is not enabled", ctx do
+      {:ok, company} = Companies.enable_experimental_feature(ctx.company, "feature_a")
+
+      assert {200, %{success: true}} =
+               admin_mutation(ctx.conn, :disable_features, %{
+                 company_id: Paths.company_id(company),
+                 features: ["missing_feature"]
+               })
+
+      company = Repo.reload(company)
+      assert company.enabled_experimental_features == ["feature_a"]
+    end
+  end
+end

--- a/app/test/operately/companies_test.exs
+++ b/app/test/operately/companies_test.exs
@@ -74,5 +74,17 @@ defmodule Operately.CompaniesTest do
       company = company_fixture(%{}, ctx.account)
       assert %Ecto.Changeset{} = Companies.change_company(company)
     end
+
+    test "disable_experimental_feature/2 removes the flag and leaves others intact", ctx do
+      company = company_fixture(%{}, ctx.account)
+
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_a")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_b")
+      {:ok, company} = Companies.enable_experimental_feature(company, "feature_c")
+
+      assert {:ok, company} = Companies.disable_experimental_feature(company, "feature_b")
+      assert Enum.sort(company.enabled_experimental_features) == ["feature_a", "feature_c"]
+    end
   end
 end
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #2718. Site admins can now remove experimental feature flags from a company on `/admin/companies/:companyId`.

### Backend
- New Admin API mutation `disable_features` (`POST /admin_api/disable_features`)
- Inputs: `company_id`, `features` (string list)
- Auth: authenticated site admin only
- Removes requested flags from `enabled_experimental_features` in one DB update (idempotent)
- Rejects empty `features` list with 400

### Frontend
- New **Remove Feature Flags** page option (next to Enable Feature)
- Modal lists current flags; trash removes rows locally
- Save with no changes closes without a network call
- Save with removals calls the API and refreshes the Enabled Features display

### Tests
- Backend: auth, site admin, single/multiple removal, 404, empty list 400, idempotency
- Domain: `disable_experimental_feature/2` leaves other flags intact
- Frontend Jest coverage for render, empty state, and save helpers

## Test plan
- [x] `mix test ee/test/operately_ee/admin_api/mutations/disable_features_test.exs` (and companies test)
- [x] Jest: `RemoveFeatureFlagsModal.test.tsx`
- [x] `npx tsc --noEmit -p tsconfig.lint.json`
- [ ] Manually: open company admin page → Remove Feature Flags → remove one or more → Save → Enabled Features updates

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0aecb0-9e2b-4ed9-926d-8d7be1c099a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0aecb0-9e2b-4ed9-926d-8d7be1c099a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

