### PR TITLE
feat: allow description when pausing a project

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -4820,6 +4820,9 @@ export interface ProjectsMoveToSpaceResult {}
 
 export interface ProjectsPauseInput {
   projectId: Id;
+  message: Json;
+  sendNotificationsToEveryone?: boolean | null;
+  subscriberIds?: Id[] | null;
 }
 
 export interface ProjectsPauseResult {

--- a/app/assets/js/features/activities/CommentAdded/index.tsx
+++ b/app/assets/js/features/activities/CommentAdded/index.tsx
@@ -43,6 +43,9 @@ const CommentAdded: ActivityHandler = {
       .with("project_resuming", () => {
         return commentPath(paths.projectActivityPath(commentedActivity.id), comment);
       })
+      .with("project_pausing", () => {
+        return commentPath(paths.projectActivityPath(commentedActivity.id), comment);
+      })
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -152,6 +155,18 @@ const CommentAdded: ActivityHandler = {
           return feedTitle(activity, action, "on", activityLink, "in the", projectLink(project), "project");
         }
       })
+      .with("project_pausing", () => {
+        const path = paths.projectActivityPath(commentedActivity.id);
+        const action = commentedLink(path, comment);
+        const activityLink = <Link to={path}>project pausing</Link>;
+        const project = Activities.getProject(commentedActivity);
+
+        if (page === "project") {
+          return feedTitle(activity, action, "on", activityLink);
+        } else {
+          return feedTitle(activity, action, "on", activityLink, "in the", projectLink(project), "project");
+        }
+      })
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -190,6 +205,7 @@ const CommentAdded: ActivityHandler = {
       .with("goal_reopening", () => "goal reopening")
       .with("project_discussion_submitted", () => commentedActivity.commentThread!.title)
       .with("project_resuming", () => "project resuming")
+      .with("project_pausing", () => "project pausing")
       .otherwise(() => {
         throw new Error("Comment added not implemented for action: " + commentedActivity.action);
       });
@@ -222,6 +238,10 @@ const CommentAdded: ActivityHandler = {
         return c.title!;
       })
       .with("project_resuming", () => {
+        const project = Activities.getProject(commentedActivity);
+        return project.name!;
+      })
+      .with("project_pausing", () => {
         const project = Activities.getProject(commentedActivity);
         return project.name!;
       })

--- a/app/assets/js/features/activities/ProjectPausing/index.tsx
+++ b/app/assets/js/features/activities/ProjectPausing/index.tsx
@@ -1,25 +1,46 @@
-import type { ActivityContentProjectPausing } from "@/api";
-import type { Activity } from "@/models/activities";
-import type { ActivityHandler } from "../interfaces";
-
+import * as React from "react";
 
 import { feedTitle, projectLink } from "../feedItemLinks";
 
+import type { ActivityContentProjectPausing } from "@/api";
+import type { Activity } from "@/models/activities";
+import type { ActivityHandler } from "../interfaces";
+import { usePaths } from "@/routes/paths";
+import { isContentEmpty, Link, RichContent, Summary } from "turboui";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+
 const ProjectPausing: ActivityHandler = {
   pageHtmlTitle(_activity: Activity) {
-    throw new Error("Not implemented");
+    return "Project paused";
   },
 
   pagePath(paths, activity: Activity): string {
-    return paths.projectPath(content(activity).project!.id!);
+    if (activity.id) {
+      return paths.projectActivityPath(activity.id);
+    }
+
+    const projectId = content(activity).project?.id;
+    return projectId ? paths.projectPath(projectId) : paths.homePath();
   },
 
   PageTitle(_props: { activity: any }) {
-    throw new Error("Not implemented");
+    return <>Project paused</>;
   },
 
-  PageContent(_props: { activity: Activity }) {
-    throw new Error("Not implemented");
+  PageContent({ activity }: { activity: Activity }) {
+    const { mentionedPersonLookup } = useRichEditorHandlers();
+
+    return (
+      <div>
+        {activity.commentThread && !isContentEmpty(activity.commentThread.message) && (
+          <RichContent
+            content={activity.commentThread.message}
+            mentionedPersonLookup={mentionedPersonLookup}
+            parseContent
+          />
+        )}
+      </div>
+    );
   },
 
   PageOptions(_props: { activity: Activity }) {
@@ -27,35 +48,55 @@ const ProjectPausing: ActivityHandler = {
   },
 
   FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const paths = usePaths();
+    const activityPath = activity.id ? paths.projectActivityPath(activity.id) : null;
+    const link = activityPath ? <Link to={activityPath}>paused</Link> : "paused";
+    const project = content(activity).project;
+
     if (page === "project") {
-      return feedTitle(activity, "paused the project");
+      return feedTitle(activity, link, "the project");
+    } else if (project) {
+      return feedTitle(activity, link, "the", projectLink(project), "project");
     } else {
-      return feedTitle(activity, "paused the", projectLink(content(activity).project!), "project");
+      return feedTitle(activity, link, "a project");
     }
   },
 
-  FeedItemContent(_props: { activity: Activity; page: any }) {
-    return null;
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const { mentionedPersonLookup } = useRichEditorHandlers();
+
+    return (
+      <div>
+        {activity.commentThread && !isContentEmpty(activity.commentThread.message) && (
+          <Summary
+            content={activity.commentThread.message}
+            characterCount={300}
+            mentionedPersonLookup={mentionedPersonLookup}
+          />
+        )}
+      </div>
+    );
   },
 
   feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
-    return "items-start";
+    return "items-center";
   },
 
-  commentCount(_activity: Activity): number {
-    throw new Error("Not implemented");
+  commentCount(activity: Activity): number {
+    return activity.commentThread?.commentsCount || 0;
   },
 
-  hasComments(_activity: Activity): boolean {
-    throw new Error("Not implemented");
+  hasComments(activity: Activity): boolean {
+    return !!activity.commentThread;
   },
 
   NotificationTitle({ activity }: { activity: Activity }) {
-    return "Paused the " + content(activity).project!.name! + " project";
+    const projectName = content(activity).project?.name;
+    return projectName ? `Paused the ${projectName} project` : "Paused a project";
   },
 
   NotificationLocation({ activity }: { activity: Activity }) {
-    return content(activity).project!.name!;
+    return content(activity).project?.name || null;
   },
 };
 

--- a/app/assets/js/models/activities/index.tsx
+++ b/app/assets/js/models/activities/index.tsx
@@ -195,6 +195,7 @@ export function getGoal(activity: Activity) {
 export function getProject(activity: Activity) {
   const content = match(activity.action)
     .with("project_resuming", () => activity.content as api.ActivityContentProjectResuming)
+    .with("project_pausing", () => activity.content as api.ActivityContentProjectPausing)
     .otherwise(() => {
       throw new Error("Project not available for activity action: " + activity.action);
     });

--- a/app/assets/js/pages/ProjectPausePage/Form.tsx
+++ b/app/assets/js/pages/ProjectPausePage/Form.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+
+import { Forms, DimmedLink, emptyContent, PrimaryButton, SubscribersSelector } from "turboui";
+import * as Projects from "@/models/projects";
+
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { useSubscriptionsAdapter } from "@/models/subscriptions";
+import { useNavigateTo } from "@/routes/useNavigateTo";
+import { usePaths } from "@/routes/paths";
+
+export function Form({ project }: { project: Projects.Project }) {
+  const paths = usePaths();
+  const projectId = project.id;
+  const potentialSubscribers = project.potentialSubscribers;
+
+  if (!projectId || !potentialSubscribers) {
+    return null;
+  }
+
+  const projectName = project.name || "this project";
+  const subscriptionsState = useSubscriptionsAdapter(potentialSubscribers, {
+    ignoreMe: true,
+    notifyPrioritySubscribers: true,
+    projectName: projectName,
+  });
+
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "project", id: projectId } });
+
+  const [pause] = Projects.usePauseProject();
+  const onSuccess = useNavigateTo(paths.projectPath(projectId));
+
+  const form = Forms.useForm({
+    fields: {
+      message: emptyContent(),
+    },
+    submit: async () => {
+      const message = form.values.message || emptyContent();
+
+      await pause({
+        projectId: projectId,
+        message: JSON.stringify(message),
+        sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
+        subscriberIds: subscriptionsState.currentSubscribersList,
+      });
+      onSuccess();
+    },
+  });
+
+  const isSubmitting = form.state === "submitting" || form.state === "uploading";
+
+  return (
+    <Forms.Form form={form}>
+      <Forms.FieldGroup>
+        <Forms.RichTextArea
+          field="message"
+          label="Why are you pausing this project?"
+          richTextHandlers={richTextHandlers}
+          placeholder="Write here..."
+        />
+      </Forms.FieldGroup>
+
+      <div className="my-10">
+        <SubscribersSelector {...subscriptionsState} />
+      </div>
+
+      <div className="flex items-center gap-6 mt-8">
+        <PrimaryButton onClick={form.actions.submit} testId="pause-project-button" loading={isSubmitting}>
+          Pause project
+        </PrimaryButton>
+        <DimmedLink to={paths.projectPath(projectId)}>Keep it active</DimmedLink>
+      </div>
+    </Forms.Form>
+  );
+}

--- a/app/assets/js/pages/ProjectPausePage/loader.tsx
+++ b/app/assets/js/pages/ProjectPausePage/loader.tsx
@@ -11,6 +11,7 @@ export async function loader({ params }): Promise<LoaderResult> {
       id: params.projectID,
       includeSpace: true,
       includePermissions: true,
+      includePotentialSubscribers: true,
     }).then((data) => data.project!),
   };
 }

--- a/app/assets/js/pages/ProjectPausePage/page.tsx
+++ b/app/assets/js/pages/ProjectPausePage/page.tsx
@@ -1,12 +1,10 @@
 import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
-import * as Projects from "@/models/projects";
 import * as React from "react";
 
-import { useNavigateTo } from "@/routes/useNavigateTo";
 import { useLoadedData } from "./loader";
 
-import { DimmedLink, PrimaryButton } from "turboui";
+import { Form } from "./Form";
 
 import { usePaths } from "@/routes/paths";
 export function Page() {
@@ -15,7 +13,7 @@ export function Page() {
 
   return (
     <Pages.Page title={["Pausing", project.name!]}>
-      <Paper.Root size="small">
+      <Paper.Root size="medium">
         <Paper.Navigation items={[{ to: paths.projectPath(project.id!), label: project.name! }]} />
 
         <Paper.Body minHeight="none">
@@ -30,31 +28,11 @@ export function Page() {
             <p className="mt-4">Note: You can resume the project at any time.</p>
           </div>
 
-          <div className="flex items-center gap-6 mt-8">
-            <PauseProject project={project} />
-            <DimmedLink to={paths.projectPath(project.id!)}>Keep it active</DimmedLink>
+          <div className="mt-8">
+            <Form project={project} />
           </div>
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>
-  );
-}
-
-function PauseProject({ project }) {
-  const paths = usePaths();
-  const path = paths.projectPath(project.id);
-  const onSuccess = useNavigateTo(path);
-
-  const [pause, { loading }] = Projects.usePauseProject();
-
-  const handleClick = async () => {
-    await pause({ projectId: project.id });
-    onSuccess();
-  };
-
-  return (
-    <PrimaryButton onClick={handleClick} testId="pause-project-button" loading={loading}>
-      Pause project
-    </PrimaryButton>
   );
 }

--- a/app/lib/operately/activities/notifications/project_pausing.ex
+++ b/app/lib/operately/activities/notifications/project_pausing.ex
@@ -1,16 +1,15 @@
 defmodule Operately.Activities.Notifications.ProjectPausing do
   @moduledoc """
   Notifies the following people:
-  - Project subscribers: People subscribed to notifications for the project
+  - Discussion subscribers: People selected when pausing the project
 
   The person who authored the activity is excluded from notifications.
   """
 
-  alias Operately.Projects.{Project, Notifications}
+  alias Operately.Projects.Notifications
 
   def dispatch(activity) do
-    {:ok, project} = Project.get(:system, id: activity.content["project_id"])
-    subscriber_ids = Notifications.get_project_subscribers(project)
+    subscriber_ids = Notifications.get_discussion_subscribers(activity.comment_thread_id, ignore: [activity.author_id])
 
     subscriber_ids
     |> Enum.uniq_by(& &1)

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -44,6 +44,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     {"goal_reopening", %{resource: :comment_thread, resource_id: {:activity, :comment_thread_id}}},
     {"goal_timeframe_editing", %{resource: :comment_thread, resource_id: {:activity, :comment_thread_id}}},
     {"project_resuming", %{resource: :comment_thread, resource_id: {:activity, :comment_thread_id}}},
+    {"project_pausing", %{resource: :comment_thread, resource_id: {:activity, :comment_thread_id}}},
     {"project_closed", %{resource: :project_retrospective, resource_id: {:content, "retrospective_id"}}},
     {"resource_hub_document_created", %{resource: :resource_hub_document, resource_id: {:content, "document_id"}}},
     {"resource_hub_document_commented", %{resource: :comment, resource_id: {:content, "comment_id"}}},

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -115,7 +115,6 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     "project_milestone_creation",
     "project_milestone_updating",
     "project_moved",
-    "project_pausing",
     "project_permissions_edited",
     "project_renamed",
     "project_retrospective_edited",

--- a/app/lib/operately/operations/project_pausing.ex
+++ b/app/lib/operately/operations/project_pausing.ex
@@ -3,11 +3,15 @@ defmodule Operately.Operations.ProjectPausing do
   alias Operately.Repo
   alias Operately.Projects
   alias Operately.Activities
+  alias Operately.Comments.CommentThread
+  alias Operately.Operations.Notifications.{Subscription, SubscriptionList}
 
-  def run(author, project) do
+  def run(author, project, attrs) do
     changeset = Projects.Project.changeset(project, %{status: "paused"})
 
     Multi.new()
+    |> SubscriptionList.insert(attrs)
+    |> Subscription.insert(author, attrs)
     |> Multi.update(:project, changeset)
     |> Activities.insert_sync(author.id, :project_pausing, fn _changes ->
       %{
@@ -15,7 +19,20 @@ defmodule Operately.Operations.ProjectPausing do
         space_id: project.group_id,
         project_id: project.id,
       }
+    end, include_notification: false)
+    |> Multi.insert(:thread, fn changes -> CommentThread.changeset(%{
+      parent_id: changes.activity.id,
+      parent_type: "activity",
+      message: attrs.content,
+      subscription_list_id: changes.subscription_list.id
+    }) end)
+    |> Multi.update(:activity_with_thread, fn changes ->
+      Activities.Activity.changeset(changes.activity, %{
+        comment_thread_id: changes.thread.id
+      })
     end)
+    |> SubscriptionList.update(:thread)
+    |> Activities.dispatch_notification()
     |> Repo.transaction()
     |> Repo.extract_result(:project)
   end

--- a/app/lib/operately_email/emails/comment_added_email.ex
+++ b/app/lib/operately_email/emails/comment_added_email.ex
@@ -64,6 +64,9 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
       activity.action == "project_resuming" ->
         "commented on the project resumption"
 
+      activity.action == "project_pausing" ->
+        "commented on the project pausing"
+
       true ->
         raise "Unsupported action: #{activity.action}"
     end
@@ -91,6 +94,9 @@ defmodule OperatelyEmail.Emails.CommentAddedEmail do
         Paths.project_discussion_path(company, comment_thread, comment) |> Paths.to_url()
 
       activity.action == "project_resuming" ->
+        Paths.project_activity_path(company, activity, comment) |> Paths.to_url()
+
+      activity.action == "project_pausing" ->
         Paths.project_activity_path(company, activity, comment) |> Paths.to_url()
 
       true ->

--- a/app/lib/operately_email/emails/project_pausing_email.ex
+++ b/app/lib/operately_email/emails/project_pausing_email.ex
@@ -6,6 +6,7 @@ defmodule OperatelyEmail.Emails.ProjectPausingEmail do
     project = Operately.Projects.get_project!(activity.content["project_id"])
     company = Operately.Repo.preload(project, :company).company
     link = OperatelyWeb.Paths.project_path(company, project) |> OperatelyWeb.Paths.to_url()
+    message = Operately.Repo.preload(activity, :comment_thread).comment_thread.message
 
     company
     |> new()
@@ -15,6 +16,7 @@ defmodule OperatelyEmail.Emails.ProjectPausingEmail do
     |> assign(:author, author)
     |> assign(:project, project)
     |> assign(:link, link)
+    |> assign(:message, message)
     |> render("project_pausing")
   end
 
@@ -22,14 +24,16 @@ defmodule OperatelyEmail.Emails.ProjectPausingEmail do
     project = Operately.Projects.get_project!(activity.content["project_id"])
     author = Operately.Repo.preload(activity, :author).author
     company = Operately.Repo.preload(author, :company).company
+    comment_thread = Operately.Repo.preload(activity, :comment_thread).comment_thread
+    %{html: excerpt_html, text: excerpt_text} = OperatelyEmail.RichTextExcerpt.excerpt(comment_thread.message)
 
     %{
       parent_id: project.id,
       parent_type: :project,
       parent_name: project.name,
       headline: "paused the project",
-      excerpt_html: nil,
-      excerpt_text: nil,
+      excerpt_html: excerpt_html,
+      excerpt_text: excerpt_text,
       item_url: OperatelyWeb.Paths.project_path(company, project) |> OperatelyWeb.Paths.to_url(),
       actor_name: Operately.People.Person.short_name(author),
       occurred_at: activity.inserted_at,

--- a/app/lib/operately_email/templates/project_pausing.html.eex
+++ b/app/lib/operately_email/templates/project_pausing.html.eex
@@ -3,5 +3,11 @@
 <%= spacer() %>
 
 <%= row do %>
+  <%= rich_text(@message) %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
   <%= cta_button(@link, "View Project") %>
 <% end %>

--- a/app/lib/operately_web/api/projects/pause.ex
+++ b/app/lib/operately_web/api/projects/pause.ex
@@ -8,6 +8,9 @@ defmodule OperatelyWeb.Api.Projects.Pause do
 
   inputs do
     field :project_id, :id, null: false
+    field :message, :json, null: false
+    field? :send_notifications_to_everyone, :boolean, null: true
+    field? :subscriber_ids, list_of(:id), null: true
   end
 
   outputs do
@@ -16,10 +19,11 @@ defmodule OperatelyWeb.Api.Projects.Pause do
 
   def call(conn, inputs) do
     Action.new()
+    |> run(:attrs, fn -> parse_inputs(inputs) end)
     |> run(:me, fn -> find_me(conn) end)
-    |> run(:project, fn ctx -> Operately.Projects.get_project_with_access_level(inputs.project_id, ctx.me.id) end)
-    |> run(:check_permissions, fn ctx -> Operately.Projects.Permissions.check(ctx.project.requester_access_level, :can_edit, company_read_only: company_read_only(conn)) end)
-    |> run(:operation, fn ctx -> Operately.Operations.ProjectPausing.run(ctx.me, ctx.project) end)
+    |> run(:project, fn ctx -> Operately.Projects.Project.get(ctx.me, id: inputs.project_id) end)
+    |> run(:check_permissions, fn ctx -> Operately.Projects.Permissions.check(ctx.project.request_info.access_level, :can_edit, company_read_only: company_read_only(conn)) end)
+    |> run(:operation, fn ctx -> Operately.Operations.ProjectPausing.run(ctx.me, ctx.project, ctx.attrs) end)
     |> run(:serialized, fn ctx -> {:ok, %{project: OperatelyWeb.Api.Serializer.serialize(ctx.operation)}} end)
     |> respond()
   end
@@ -28,10 +32,20 @@ defmodule OperatelyWeb.Api.Projects.Pause do
     case result do
       {:ok, ctx} -> {:ok, ctx.serialized}
       {:error, :project_id, _} -> {:error, :bad_request}
+      {:error, :attrs, _} -> {:error, :bad_request}
       {:error, :project, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}
     end
+  end
+
+  defp parse_inputs(inputs) do
+    {:ok, %{
+      content: inputs.message,
+      send_to_everyone: inputs[:send_notifications_to_everyone] || false,
+      subscriber_ids: inputs[:subscriber_ids] || [],
+      subscription_parent_type: :comment_thread
+    }}
   end
 end

--- a/app/lib/operately_web/mcp/tools/projects/pause.ex
+++ b/app/lib/operately_web/mcp/tools/projects/pause.ex
@@ -9,7 +9,7 @@ defmodule OperatelyWeb.Mcp.Tools.Projects.Pause do
     Definition.new!(
       name: "pause_project",
       title: "Pause Project",
-      description: "Pauses one project.",
+      description: "Pauses one project and posts a pause message.",
       company_mode: :resource_derived,
       required_scopes: ["mcp:write"],
       safety_classification: :write,
@@ -17,11 +17,14 @@ defmodule OperatelyWeb.Mcp.Tools.Projects.Pause do
       annotations: write_annotations(),
       security_schemes: write_security_schemes(),
       discovery_metadata: %{"category" => "projects"},
-      examples: [%{"title" => "Pause a project", "arguments" => %{"project_id" => "project_123"}}],
+      examples: [%{"title" => "Pause a project", "arguments" => %{"project_id" => "project_123", "message" => "Putting this on hold for now."}}],
       input_schema:
         JsonSchema.object(
-          %{"project_id" => JsonSchema.string("The project identifier.")},
-          required: ["project_id"]
+          %{
+            "project_id" => JsonSchema.string("The project identifier."),
+            "message" => JsonSchema.string("The pause message in plain text or markdown.")
+          },
+          required: ["project_id", "message"]
         ),
       output_schema:
         JsonSchema.object(
@@ -32,9 +35,10 @@ defmodule OperatelyWeb.Mcp.Tools.Projects.Pause do
   end
 
   @impl true
-  def call(conn, %{"project_id" => project_id}) do
-    with {:ok, project_id} <- Helpers.decode_id(project_id) do
-      ProjectPause.call(conn, %{project_id: project_id})
+  def call(conn, %{"project_id" => project_id, "message" => message}) do
+    with {:ok, project_id} <- Helpers.decode_id(project_id),
+         {:ok, message} <- Helpers.markdown_to_rich_text(message) do
+      ProjectPause.call(conn, %{project_id: project_id, message: message, subscriber_ids: []})
     end
   end
 end

--- a/app/test/features/projects/project_page_test.exs
+++ b/app/test/features/projects/project_page_test.exs
@@ -44,6 +44,16 @@ defmodule Operately.Features.Projects.ProjectPageTest do
   end
 
   @tag login_as: :contributor
+  feature "pausing a project without a description", ctx do
+    ctx
+    |> Steps.assert_logged_in_contributor_has_edit_access()
+    |> Steps.visit_project_page()
+    |> Steps.pause_project_without_description()
+    |> Steps.assert_project_paused()
+    |> Steps.assert_pause_without_description_visible_on_feed()
+  end
+
+  @tag login_as: :contributor
   feature "resuming a project", ctx do
     ctx
     |> Steps.assert_logged_in_contributor_has_edit_access()
@@ -81,6 +91,18 @@ defmodule Operately.Features.Projects.ProjectPageTest do
     |> Steps.assert_comment_on_resumption_visible_on_feed()
     |> Steps.assert_comment_on_resumption_received_in_notifications()
     |> Steps.assert_comment_on_resumption_received_in_email()
+  end
+
+  @tag login_as: :commenter
+  feature "comment on project pausing", ctx do
+    ctx
+    |> Steps.assert_logged_in_contributor_has_comment_access()
+    |> Steps.visit_project_page()
+    |> Steps.given_project_is_paused()
+    |> Steps.leave_comment_on_project_pausing()
+    |> Steps.assert_comment_on_pausing_visible_on_feed()
+    |> Steps.assert_comment_on_pausing_received_in_notifications()
+    |> Steps.assert_comment_on_pausing_received_in_email()
   end
 
   @tag login_as: :contributor

--- a/app/test/features/projects/project_page_test.exs
+++ b/app/test/features/projects/project_page_test.exs
@@ -41,6 +41,7 @@ defmodule Operately.Features.Projects.ProjectPageTest do
     |> Steps.assert_pause_notification_sent_to_reviewer()
     |> Steps.assert_pause_visible_on_feed()
     |> Steps.assert_pause_email_sent_to_reviewer()
+    |> Steps.assert_pause_email_contains_description("Pausing the project.")
   end
 
   @tag login_as: :contributor
@@ -51,6 +52,22 @@ defmodule Operately.Features.Projects.ProjectPageTest do
     |> Steps.pause_project_without_description()
     |> Steps.assert_project_paused()
     |> Steps.assert_pause_without_description_visible_on_feed()
+    |> Steps.assert_pause_notification_sent_to_reviewer()
+    |> Steps.assert_pause_email_sent_to_reviewer()
+  end
+
+  @tag login_as: :contributor
+  feature "mentioning a person when pausing a project sends notification and email", ctx do
+    ctx = Steps.given_space_member_exists(ctx)
+
+    ctx
+    |> Steps.assert_logged_in_contributor_has_edit_access()
+    |> Steps.visit_project_page()
+    |> Steps.pause_project_mentioning(ctx.space_member)
+    |> Steps.assert_project_paused()
+    |> Steps.assert_pause_mention_visible_on_feed(ctx.space_member)
+    |> Steps.assert_pause_notification_sent_to_space_member()
+    |> Steps.assert_pause_email_sent_to_space_member()
   end
 
   @tag login_as: :contributor

--- a/app/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
+++ b/app/test/operately/data/change_033_add_space_to_project_resuming_activity_test.exs
@@ -16,7 +16,12 @@ defmodule Operately.Data.Change033AddSpaceToProjectResumingActivityTest do
   test "migration doesn't delete existing data in activity content", ctx do
     projects = Enum.map(1..3, fn _ ->
       p = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id})
-      Operately.Operations.ProjectPausing.run(ctx.creator, p)
+      Operately.Operations.ProjectPausing.run(ctx.creator, p, %{
+        content: RichText.rich_text(""),
+        subscription_parent_type: :comment_thread,
+        send_to_everyone: false,
+        subscriber_ids: []
+      })
       Operately.Operations.ProjectResuming.run(ctx.creator, p, %{
         content: RichText.rich_text("Resuming project"),
         send_to_everyone: false,

--- a/app/test/operately/data/change_034_add_space_project_pausing_to_activity_test.exs
+++ b/app/test/operately/data/change_034_add_space_project_pausing_to_activity_test.exs
@@ -17,7 +17,14 @@ defmodule Operately.Data.Change034AddSpaceProjectPausingToActivityTest do
     test "migration doesn't delete existing data in activity content", ctx do
       projects = Enum.map(1..3, fn _ ->
         p = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.creator.id, group_id: ctx.space.id, name: "name"})
-        {:ok, _} = Operately.Operations.ProjectPausing.run(ctx.creator, p)
+        {:ok, _} =
+          Operately.Operations.ProjectPausing.run(ctx.creator, p, %{
+            content: RichText.rich_text(""),
+            subscription_parent_type: :comment_thread,
+            send_to_everyone: false,
+            subscriber_ids: []
+          })
+
         {:ok, p} = Operately.Projects.rename_project(ctx.creator, p, "new name")
         p
       end)

--- a/app/test/operately/notifications/bulk_create_test.exs
+++ b/app/test/operately/notifications/bulk_create_test.exs
@@ -4,6 +4,7 @@ defmodule Operately.Notifications.BulkCreateTest do
 
   import Operately.ActivitiesFixtures
   import Operately.CompaniesFixtures
+  import Operately.CommentsFixtures
   import Operately.PeopleFixtures
 
   alias Operately.Notifications
@@ -169,6 +170,66 @@ defmodule Operately.Notifications.BulkCreateTest do
 
     description = RichText.rich_text("No mentions in this update")
     activity = activity_fixture(author_id: ctx.person.id, action: "project_description_changed", content: %{"description" => description})
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, [_notification]} =
+               Notifications.bulk_create([
+                 %{person_id: ctx.person.id, activity_id: activity.id, should_send_email: true}
+               ])
+
+      refute_enqueued worker: EmailWorker
+      assert_enqueued worker: BufferedEmailWorker
+    end)
+
+    assert length(Repo.all(EmailBatch)) == 1
+  end
+
+  test "notify_on_mention sends project_pausing mentions immediately", ctx do
+    {:ok, _person} =
+      Operately.People.update_person(ctx.person, %{
+        preferences: %{notifications: %{notify_on_mention: true}}
+      })
+
+    mention_message = RichText.rich_text(mentioned_people: [ctx.person]) |> Jason.decode!()
+    thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: mention_message})
+
+    activity =
+      activity_fixture(%{
+        author_id: ctx.person.id,
+        action: "project_pausing",
+        content: %{"project_id" => Ecto.UUID.generate()},
+        comment_thread_id: thread.id
+      })
+
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      assert {:ok, notifications} =
+               Notifications.bulk_create([
+                 %{person_id: ctx.person.id, activity_id: activity.id, should_send_email: true}
+               ])
+
+      assert_enqueued worker: EmailWorker, args: %{notification_id: hd(notifications).id}
+      refute_enqueued worker: BufferedEmailWorker
+    end)
+
+    assert Repo.all(EmailBatch) == []
+  end
+
+  test "notify_on_mention keeps non-mentioned project_pausing notifications buffered", ctx do
+    {:ok, _person} =
+      Operately.People.update_person(ctx.person, %{
+        preferences: %{notifications: %{notify_on_mention: true}}
+      })
+
+    plain_message = RichText.rich_text("Pausing without mentions")
+    thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: plain_message})
+
+    activity =
+      activity_fixture(%{
+        author_id: ctx.person.id,
+        action: "project_pausing",
+        content: %{"project_id" => Ecto.UUID.generate()},
+        comment_thread_id: thread.id
+      })
 
     Oban.Testing.with_testing_mode(:manual, fn ->
       assert {:ok, [_notification]} =

--- a/app/test/operately/notifications/direct_mention_classifier_test.exs
+++ b/app/test/operately/notifications/direct_mention_classifier_test.exs
@@ -187,6 +187,33 @@ defmodule Operately.Notifications.DirectMentionClassifierTest do
     refute mentions_recipient?(non_mentioned_notification)
   end
 
+  test "project_pausing checks mentions from comment thread message via activity comment_thread_id", ctx do
+    mention_message = RichText.rich_text(mentioned_people: [ctx.recipient]) |> Jason.decode!()
+    plain_message = RichText.rich_text("No one mentioned here")
+
+    mentioned_thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: mention_message})
+    plain_thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: plain_message})
+
+    mentioned_notification =
+      notification_struct(
+        ctx.recipient,
+        "project_pausing",
+        %{},
+        %{comment_thread_id: mentioned_thread.id}
+      )
+
+    non_mentioned_notification =
+      notification_struct(
+        ctx.recipient,
+        "project_pausing",
+        %{},
+        %{comment_thread_id: plain_thread.id}
+      )
+
+    assert mentions_recipient?(mentioned_notification)
+    refute mentions_recipient?(non_mentioned_notification)
+  end
+
   test "goal_closing checks mentions from comment thread message via activity comment_thread_id", ctx do
     mention_message = RichText.rich_text(mentioned_people: [ctx.recipient]) |> Jason.decode!()
     plain_message = RichText.rich_text("No one mentioned here")

--- a/app/test/operately/operations/project_pausing_test.exs
+++ b/app/test/operately/operations/project_pausing_test.exs
@@ -103,6 +103,27 @@ defmodule Operately.Operations.ProjectPausingTest do
 
     activity = get_activity(project, "project_pausing")
     assert activity.comment_thread_id
+
+    thread = Operately.Repo.get!(Operately.Comments.CommentThread, activity.comment_thread_id)
+    assert thread.message == RichText.rich_text("Pausing comments")
+  end
+
+  test "ProjectPausing operation subscribes mentioned people", ctx do
+    mentioned = ctx.member1
+
+    {:ok, project} =
+      ProjectPausing.run(ctx.creator, ctx.project, %{
+        content: RichText.rich_text(mentioned_people: [mentioned]) |> Jason.decode!(),
+        subscription_parent_type: :comment_thread,
+        send_to_everyone: false,
+        subscriber_ids: []
+      })
+
+    activity = get_activity(project, "project_pausing")
+    thread = Operately.Repo.preload(activity, :comment_thread).comment_thread
+    subscriptions = Operately.Notifications.list_subscriptions(thread.subscription_list_id)
+
+    assert Enum.any?(subscriptions, &(&1.person_id == mentioned.id))
   end
 
   defp pause_project(ctx, send_to_everyone, subscriber_ids) do

--- a/app/test/operately/operations/project_pausing_test.exs
+++ b/app/test/operately/operations/project_pausing_test.exs
@@ -1,0 +1,123 @@
+defmodule Operately.Operations.ProjectPausingTest do
+  use Operately.DataCase
+  use Operately.Support.Notifications
+
+  import Ecto.Query, only: [from: 2]
+  import Operately.PeopleFixtures
+  import Operately.ProjectsFixtures
+
+  alias Operately.Access.Binding
+  alias Operately.Operations.ProjectPausing
+  alias Operately.Repo
+  alias Operately.Support.RichText
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_space_member(:champion, :space)
+    |> Factory.add_space_member(:reviewer, :space)
+    |> Factory.add_project(:project, :space, champion: :champion, reviewer: :reviewer)
+    |> Factory.add_project_contributor(:member1, :project, :as_person)
+    |> Factory.add_project_contributor(:member2, :project, :as_person)
+    |> Factory.add_project_contributor(:member3, :project, :as_person)
+  end
+
+  describe "notifications" do
+    test "Pausing project notifies everyone", ctx do
+      contributors = Operately.Projects.list_project_contributors(ctx.project)
+      subscriber_ids = Enum.map(contributors, & &1.person_id)
+
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        pause_project(ctx, true, subscriber_ids)
+      end)
+
+      action = "project_pausing"
+      activity = get_activity(ctx.project, action)
+
+      assert notifications_count(action: action) == 0
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+      notified_people_ids = Enum.map(notifications, & &1.person_id)
+
+      contributors
+      |> Enum.map(& &1.person_id)
+      |> Enum.reject(&(&1 == ctx.creator.id))
+      |> Enum.each(fn person_id ->
+        assert Enum.member?(notified_people_ids, person_id)
+      end)
+
+      assert notifications_count(action: action) == 5
+    end
+
+    test "Pausing project notifies selected people", ctx do
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        pause_project(ctx, false, [ctx.reviewer.id, ctx.champion.id])
+      end)
+
+      action = "project_pausing"
+      activity = get_activity(ctx.project, action)
+
+      assert notifications_count(action: action) == 0
+
+      perform_job(activity.id)
+      notifications = fetch_notifications(activity.id, action: action)
+      notified_people_ids = Enum.map(notifications, & &1.person_id)
+
+      assert notifications_count(action: action) == 2
+      assert ctx.reviewer.id in notified_people_ids
+      assert ctx.champion.id in notified_people_ids
+    end
+
+    test "person without permissions is not notified", ctx do
+      project =
+        project_fixture(%{
+          company_id: ctx.company.id,
+          creator_id: ctx.creator.id,
+          group_id: ctx.space.id,
+          company_access_level: Binding.no_access(),
+          space_access_level: Binding.no_access(),
+        })
+
+      person = person_fixture_with_account(%{company_id: ctx.company.id})
+
+      pause_project(%{ctx | project: project}, false, [person.id])
+
+      action = "project_pausing"
+      activity = get_activity(project, action)
+
+      notifications = fetch_notifications(activity.id, action: action)
+      notified_people_ids = Enum.map(notifications, & &1.person_id)
+
+      refute person.id in notified_people_ids
+    end
+  end
+
+  test "ProjectPausing operation updates project and attaches comment thread", ctx do
+    assert ctx.project.status == "active"
+
+    {:ok, project} = pause_project(ctx, false, [])
+
+    assert project.status == "paused"
+
+    activity = get_activity(project, "project_pausing")
+    assert activity.comment_thread_id
+  end
+
+  defp pause_project(ctx, send_to_everyone, subscriber_ids) do
+    ProjectPausing.run(ctx.creator, ctx.project, %{
+      content: RichText.rich_text("Pausing comments"),
+      subscription_parent_type: :comment_thread,
+      send_to_everyone: send_to_everyone,
+      subscriber_ids: subscriber_ids
+    })
+  end
+
+  defp get_activity(project, action) do
+    from(a in Operately.Activities.Activity,
+      where: a.action == ^action and a.content["project_id"] == ^project.id
+    )
+    |> Repo.one()
+  end
+end

--- a/app/test/operately_email/project_pausing_email_test.exs
+++ b/app/test/operately_email/project_pausing_email_test.exs
@@ -1,0 +1,85 @@
+defmodule OperatelyEmail.ProjectPausingEmailTest do
+  use Operately.DataCase
+
+  import Operately.ActivitiesFixtures
+  import Operately.CommentsFixtures
+  import Swoosh.TestAssertions
+
+  alias Operately.Support.Factory
+  alias Operately.Support.RichText
+  alias OperatelyEmail.Emails.ProjectPausingEmail
+  alias OperatelyWeb.Paths
+
+  setup ctx do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_project(:project, :space, name: "Paper Expansion")
+
+    {:ok, ctx}
+  end
+
+  test "buffered item includes pause message excerpt", ctx do
+    message = RichText.rich_text("Pausing for budget review")
+    thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: message})
+
+    activity =
+      activity_fixture(%{
+        author_id: ctx.creator.id,
+        action: "project_pausing",
+        content: %{
+          "company_id" => ctx.company.id,
+          "space_id" => ctx.space.id,
+          "project_id" => ctx.project.id
+        },
+        comment_thread_id: thread.id
+      })
+
+    item = ProjectPausingEmail.buffered_item(ctx.creator, activity)
+
+    assert item.parent_id == ctx.project.id
+    assert item.parent_type == :project
+    assert item.parent_name == ctx.project.name
+    assert item.headline == "paused the project"
+    assert item.excerpt_text =~ "Pausing for budget review"
+    assert item.item_url == Paths.project_path(ctx.company, ctx.project) |> Paths.to_url()
+  end
+
+  test "send renders pause message in email body", ctx do
+    message = RichText.rich_text("Pausing for budget review")
+    thread = comment_thread_fixture(%{parent_id: Ecto.UUID.generate(), message: message})
+
+    activity =
+      activity_fixture(%{
+        author_id: ctx.creator.id,
+        action: "project_pausing",
+        content: %{
+          "company_id" => ctx.company.id,
+          "space_id" => ctx.space.id,
+          "project_id" => ctx.project.id
+        },
+        comment_thread_id: thread.id
+      })
+      |> Operately.Repo.preload([:author, :comment_thread])
+
+    flush_emails()
+    ProjectPausingEmail.send(ctx.creator, activity)
+
+    assert_email_sent(fn email ->
+      assert email.subject =~ "paused the project"
+      assert email.subject =~ ctx.project.name
+      assert email.html_body =~ "Pausing for budget review"
+      true
+    end)
+  end
+
+  defp flush_emails do
+    receive do
+      {:email, _email} -> flush_emails()
+      {:emails, _emails} -> flush_emails()
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/app/test/operately_web/api/external_mutations/mutations/projects/pause.ex
+++ b/app/test/operately_web/api/external_mutations/mutations/projects/pause.ex
@@ -11,12 +11,16 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Projects.Pause do
     |> Factory.setup()
     |> Factory.add_space(:space)
     |> Factory.add_project(:project, :space)
+    |> Factory.add_company_member(:member)
   end
 
   @impl true
   def inputs(ctx) do
     %{
-      project_id: Paths.project_id(ctx.project)
+      project_id: Paths.project_id(ctx.project),
+      message: rich_text_string("Updated content"),
+      send_notifications_to_everyone: false,
+      subscriber_ids: [Paths.person_id(ctx.member)]
     }
   end
 
@@ -25,4 +29,6 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Projects.Pause do
     assert response.project.id
     refute Map.has_key?(response, :error)
   end
+
+  defp rich_text_string(text), do: Operately.Support.RichText.rich_text(text, :as_string)
 end

--- a/app/test/operately_web/api/projects/pause_test.exs
+++ b/app/test/operately_web/api/projects/pause_test.exs
@@ -6,6 +6,7 @@ defmodule OperatelyWeb.Api.Projects.PauseTest do
   import Operately.ProjectsFixtures
 
   alias Operately.Access.Binding
+  alias Operately.Support.RichText
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -40,7 +41,11 @@ defmodule OperatelyWeb.Api.Projects.PauseTest do
         space = create_space(ctx)
         project = create_project(ctx, space, @test.company, @test.space, @test.project)
 
-        assert {code, res} = mutation(ctx.conn, [:projects, :pause], %{project_id: Paths.project_id(project)})
+        assert {code, res} = mutation(ctx.conn, [:projects, :pause], %{
+          project_id: Paths.project_id(project),
+          message: RichText.rich_text("test message", :as_string),
+        })
+
         assert code == @test.expected
 
         project = Operately.Repo.reload(project)

--- a/app/test/operately_web/mcp/tools/projects/pause_test.exs
+++ b/app/test/operately_web/mcp/tools/projects/pause_test.exs
@@ -15,7 +15,8 @@ defmodule OperatelyWeb.Mcp.Tools.Projects.PauseTest do
 
     assert {:ok, %{project: project}} =
              Pause.call(ToolConnHelper.conn(ctx), %{
-               "project_id" => Paths.project_id(ctx.project)
+               "project_id" => Paths.project_id(ctx.project),
+               "message" => "Putting this on hold for now"
              })
 
     assert project.id == Paths.project_id(ctx.project)

--- a/app/test/support/factory/projects.ex
+++ b/app/test/support/factory/projects.ex
@@ -265,10 +265,17 @@ defmodule Operately.Support.Factory.Projects do
   def pause_project(ctx, project_name) do
     project = Map.fetch!(ctx, project_name)
 
-    {:ok, project} = Operately.Operations.ProjectPausing.run(ctx.creator, project)
+    {:ok, project} =
+      Operately.Operations.ProjectPausing.run(ctx.creator, project, %{
+        content: Operately.Support.RichText.rich_text(""),
+        subscription_parent_type: :comment_thread,
+        send_to_everyone: false,
+        subscriber_ids: []
+      })
 
     Map.put(ctx, project_name, project)
   end
+
 
   def close_project_milestone(ctx, milestone_name, creator_name \\ :creator) do
     creator = Map.fetch!(ctx, creator_name)

--- a/app/test/support/features/feed_steps.ex
+++ b/app/test/support/features/feed_steps.ex
@@ -80,8 +80,16 @@ defmodule Operately.Support.Features.FeedSteps do
     ctx |> assert_feed_item_exists(author, "paused the project", "")
   end
 
+  def assert_project_paused(ctx, author: author, content: content) do
+    ctx |> assert_feed_item_exists(author, "paused the project", content)
+  end
+
   def assert_project_paused(ctx, author: author, project_name: project_name) do
     ctx |> assert_feed_item_exists(author, "paused the #{project_name} project", "")
+  end
+
+  def assert_project_paused(ctx, author: author, project_name: project_name, content: content) do
+    ctx |> assert_feed_item_exists(author, "paused the #{project_name} project", content)
   end
 
   def assert_project_resumed(ctx, author: author) do
@@ -108,6 +116,13 @@ defmodule Operately.Support.Features.FeedSteps do
     assert_feed_item_exists(ctx, author, "commented on project resuming in the #{project_name} project", comment)
   end
 
+  def assert_project_pausing_commented(ctx, author: author, comment: comment) do
+    assert_feed_item_exists(ctx, author, "commented on project pausing", comment)
+  end
+
+  def assert_project_pausing_commented(ctx, author: author, comment: comment, project_name: project_name) do
+    assert_feed_item_exists(ctx, author, "commented on project pausing in the #{project_name} project", comment)
+  end
   def assert_project_milestone_commented(ctx, author: author, milestone_tile: milestone_title, comment: comment) do
     ctx |> assert_feed_item_exists(author, "commented on the #{milestone_title} milestone", comment)
   end

--- a/app/test/support/features/goal_closing_steps.ex
+++ b/app/test/support/features/goal_closing_steps.ex
@@ -21,9 +21,16 @@ defmodule Operately.Support.Features.GoalClosingSteps do
     |> Factory.add_project(:project_paused, :product, goal: :goal, name: "Paused Project")
     |> then(fn ctx ->
       # Pause one project
-      Operately.Operations.ProjectPausing.run(ctx.creator, ctx.project_paused)
+      Operately.Operations.ProjectPausing.run(ctx.creator, ctx.project_paused, %{
+        content: RichText.rich_text(""),
+        subscription_parent_type: :comment_thread,
+        send_to_everyone: false,
+        subscriber_ids: []
+      })
+
       ctx
     end)
+
   end
 
   step :given_closed_goal_exists, ctx do

--- a/app/test/support/features/goal_tree_steps.ex
+++ b/app/test/support/features/goal_tree_steps.ex
@@ -22,9 +22,16 @@ defmodule Operately.Support.Features.GoalTreeSteps do
   end
 
   step :given_project_is_paused, ctx, project do
-    Operately.Operations.ProjectPausing.run(ctx.creator, project)
+    Operately.Operations.ProjectPausing.run(ctx.creator, project, %{
+      content: Operately.Support.RichText.rich_text(""),
+      subscription_parent_type: :comment_thread,
+      send_to_everyone: false,
+      subscriber_ids: []
+    })
+
     ctx
   end
+
 
   step :given_project_is_closed, ctx, project_name do
     {:ok, _} =

--- a/app/test/support/features/projects_steps.ex
+++ b/app/test/support/features/projects_steps.ex
@@ -192,9 +192,17 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :given_project_is_paused, ctx do
-    {:ok, project} = Operately.Operations.ProjectPausing.run(ctx.champion, ctx.project)
+    {:ok, project} =
+      Operately.Operations.ProjectPausing.run(ctx.champion, ctx.project, %{
+        content: Operately.Support.RichText.rich_text("Pausing project"),
+        subscription_parent_type: :comment_thread,
+        send_to_everyone: true,
+        subscriber_ids: []
+      })
+
     Map.put(ctx, :project, project)
   end
+
 
   step :given_project_is_resumed, ctx do
     {:ok, project} =
@@ -734,6 +742,14 @@ defmodule Operately.Support.Features.ProjectSteps do
     ctx
     |> UI.click_text("Pause project")
     |> UI.assert_page(Paths.pause_project_path(ctx.company, ctx.project))
+    |> UI.fill_rich_text("Pausing the project.")
+    |> UI.click_button("Pause project")
+  end
+
+  step :pause_project_without_description, ctx do
+    ctx
+    |> UI.click_text("Pause project")
+    |> UI.assert_page(Paths.pause_project_path(ctx.company, ctx.project))
     |> UI.click_button("Pause project")
   end
 
@@ -765,6 +781,22 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   step :assert_pause_visible_on_feed, ctx do
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> UI.find(UI.query(testid: "project-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.contributor, content: "Pausing the project.")
+    end)
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> UI.find(UI.query(testid: "space-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.contributor, project_name: ctx.project.name, content: "Pausing the project.")
+    end)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> UI.find(UI.query(testid: "company-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.contributor, project_name: ctx.project.name, content: "Pausing the project.")
+    end)
+  end
+
+  step :assert_pause_without_description_visible_on_feed, ctx do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
     |> UI.find(UI.query(testid: "project-feed"), fn el ->
@@ -1496,6 +1528,50 @@ defmodule Operately.Support.Features.ProjectSteps do
       where: ctx.project.name,
       to: ctx.champion,
       action: "commented on the project resumption",
+      author: ctx.commenter
+    })
+  end
+
+  step :leave_comment_on_project_pausing, ctx do
+    activity = Operately.Repo.one!(from a in Operately.Activities.Activity, where: a.action == "project_pausing" and a.content["project_id"] == ^ctx.project.id)
+    path = Paths.project_activity_path(ctx.company, activity)
+
+    ctx
+    |> UI.visit(path)
+    |> UI.click(testid: "add-comment")
+    |> UI.fill_rich_text("This is a comment on pausing.")
+    |> UI.click(testid: "post-comment")
+    |> UI.refute_has(testid: "post-comment")
+    |> UI.sleep(300)
+  end
+
+  step :assert_comment_on_pausing_visible_on_feed, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> FeedSteps.assert_project_pausing_commented(author: ctx.commenter, comment: "This is a comment on pausing.")
+    |> UI.visit(Paths.space_path(ctx.company, ctx.group))
+    |> FeedSteps.assert_project_pausing_commented(author: ctx.commenter, comment: "This is a comment on pausing.", project_name: ctx.project.name)
+    |> UI.visit(Paths.feed_path(ctx.company))
+    |> FeedSteps.assert_project_pausing_commented(author: ctx.commenter, comment: "This is a comment on pausing.", project_name: ctx.project.name)
+  end
+
+  step :assert_comment_on_pausing_received_in_notifications, ctx do
+    ctx
+    |> UI.login_as(ctx.champion)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.commenter,
+      action: "Re: project pausing"
+    })
+  end
+
+  step :assert_comment_on_pausing_received_in_email, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.champion,
+      action: "commented on the project pausing",
       author: ctx.commenter
     })
   end

--- a/app/test/support/features/projects_steps.ex
+++ b/app/test/support/features/projects_steps.ex
@@ -753,6 +753,14 @@ defmodule Operately.Support.Features.ProjectSteps do
     |> UI.click_button("Pause project")
   end
 
+  step :pause_project_mentioning, ctx, person do
+    ctx
+    |> UI.click_text("Pause project")
+    |> UI.assert_page(Paths.pause_project_path(ctx.company, ctx.project))
+    |> UI.mention_person_in_rich_text(person)
+    |> UI.click_button("Pause project")
+  end
+
   step :assert_project_paused, ctx do
     ctx
     |> UI.find(UI.query(testid: "paused-status-banner"), fn el ->
@@ -778,6 +786,42 @@ defmodule Operately.Support.Features.ProjectSteps do
       action: "paused the project",
       author: ctx.contributor
     })
+  end
+
+  step :assert_pause_email_contains_description, ctx, description do
+    email = UI.Emails.last_sent_email(to: ctx.reviewer.email)
+    assert email.html =~ description
+    ctx
+  end
+
+  step :assert_pause_notification_sent_to_space_member, ctx do
+    ctx
+    |> UI.login_as(ctx.space_member)
+    |> NotificationsSteps.visit_notifications_page()
+    |> NotificationsSteps.assert_activity_notification(%{
+      author: ctx.contributor,
+      action: "Paused the #{ctx.project.name} project"
+    })
+  end
+
+  step :assert_pause_email_sent_to_space_member, ctx do
+    ctx
+    |> EmailSteps.assert_activity_email_sent(%{
+      where: ctx.project.name,
+      to: ctx.space_member,
+      action: "paused the project",
+      author: ctx.contributor
+    })
+  end
+
+  step :assert_pause_mention_visible_on_feed, ctx, person do
+    person_first_name = Person.first_name(person)
+
+    ctx
+    |> UI.visit(Paths.project_path(ctx.company, ctx.project, tab: "activity"))
+    |> UI.find(UI.query(testid: "project-feed"), fn el ->
+      el |> FeedSteps.assert_project_paused(author: ctx.contributor, content: person_first_name)
+    end)
   end
 
   step :assert_pause_visible_on_feed, ctx do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add optional rich-text description and subscriber selection when pausing a project
- Mirror project-resume behavior: activity page link in feed, content preview when provided
- Align pause notifications/emails with discussion-subscriber pattern
- Fix `Activities.getProject` so pause activity pages load correctly

Fixes #1972

## Test plan
- [x] Operation tests: pause status, comment thread, subscriber notifications
- [x] API pause permission table with message field
- [x] MCP `pause_project` with message
- [x] Feature: pause with description → feed + email + notifications
- [x] Feature: pause without description → linked title, no content body
- [x] Feature: comment on project pausing
- [x] Existing pause/resume feature tests pass
- [ ] Manual: subscriber selector notifies selected people

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efa19008-8a44-4a73-81c7-6893c436b8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efa19008-8a44-4a73-81c7-6893c436b8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

