### PR TITLE
chore: Return a clear error when a manager cycle is rejected

### DIFF
--- a/app/lib/operately/people.ex
+++ b/app/lib/operately/people.ex
@@ -7,7 +7,7 @@ defmodule Operately.People do
   alias Operately.Billing
   alias Operately.Companies
   alias Operately.Companies.Company
-  alias Operately.People.{Account, AccountToken, ApiToken, Person}
+  alias Operately.People.{Account, AccountToken, ApiToken, ManagerCycle, Person}
   alias Operately.Access.Binding
   alias Operately.Access.Fetch
 
@@ -137,9 +137,18 @@ defmodule Operately.People do
   end
 
   def update_person(%Person{} = person, attrs) do
-    person
-    |> Person.changeset(attrs)
-    |> Repo.update()
+    changeset = Person.changeset(person, attrs)
+
+    try do
+      Repo.update(changeset)
+    rescue
+      e in Postgrex.Error ->
+        if ManagerCycle.postgres_cycle_error?(e) do
+          {:error, ManagerCycle.add_changeset_error(changeset)}
+        else
+          reraise e, __STACKTRACE__
+        end
+    end
   end
 
   def get_manager(%Person{} = person) do

--- a/app/lib/operately/people/manager_cycle.ex
+++ b/app/lib/operately/people/manager_cycle.ex
@@ -1,10 +1,12 @@
 defmodule Operately.People.ManagerCycle do
   @cycle_error_message "This would create a circular reporting relationship"
+  @cycle_check_function "check_manager_cycle"
 
   def cycle_error_message, do: @cycle_error_message
 
-  def postgres_cycle_error?(%Postgrex.Error{postgres: %{message: message}}) when is_binary(message),
-    do: String.contains?(message, "Cycle detected")
+  def postgres_cycle_error?(%Postgrex.Error{postgres: %{code: :raise_exception, where: where}})
+      when is_binary(where),
+      do: String.contains?(where, @cycle_check_function)
 
   def postgres_cycle_error?(_), do: false
 

--- a/app/lib/operately/people/manager_cycle.ex
+++ b/app/lib/operately/people/manager_cycle.ex
@@ -1,0 +1,14 @@
+defmodule Operately.People.ManagerCycle do
+  @cycle_error_message "This would create a circular reporting relationship"
+
+  def cycle_error_message, do: @cycle_error_message
+
+  def postgres_cycle_error?(%Postgrex.Error{postgres: %{message: message}}) when is_binary(message),
+    do: String.contains?(message, "Cycle detected")
+
+  def postgres_cycle_error?(_), do: false
+
+  def add_changeset_error(changeset) do
+    Ecto.Changeset.add_error(changeset, :manager_id, @cycle_error_message)
+  end
+end

--- a/app/lib/operately_web/api/people/update.ex
+++ b/app/lib/operately_web/api/people/update.ex
@@ -60,6 +60,9 @@ defmodule OperatelyWeb.Api.People.Update do
       {:error, :inputs, _} -> {:error, :bad_request}
       {:error, :person, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :updated_person, %{error: %Ecto.Changeset{} = changeset}} ->
+        {:error, :bad_request, changeset_error_message(changeset)}
+
       {:error, :updated_person, _} -> {:error, :bad_request}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}
@@ -112,5 +115,12 @@ defmodule OperatelyWeb.Api.People.Update do
 
   defp put_preference(inputs, key, value) do
     put_preferences(inputs, %{key => value})
+  end
+
+  defp changeset_error_message(%Ecto.Changeset{} = changeset) do
+    case changeset.errors do
+      [{:manager_id, {message, _}} | _] -> message
+      _ -> "Invalid profile update"
+    end
   end
 end

--- a/app/lib/operately_web/api/people/update.ex
+++ b/app/lib/operately_web/api/people/update.ex
@@ -118,9 +118,12 @@ defmodule OperatelyWeb.Api.People.Update do
   end
 
   defp changeset_error_message(%Ecto.Changeset{} = changeset) do
-    case changeset.errors do
-      [{:manager_id, {message, _}} | _] -> message
-      _ -> "Invalid profile update"
+    case Enum.find_value(changeset.errors, fn
+           {:manager_id, {message, _}} -> message
+           _ -> nil
+         end) do
+      nil -> "Invalid profile update"
+      message -> message
     end
   end
 end

--- a/app/test/operately/people/manager_cycle_test.exs
+++ b/app/test/operately/people/manager_cycle_test.exs
@@ -1,0 +1,38 @@
+defmodule Operately.People.ManagerCycleTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.People
+  alias Operately.People.{ManagerCycle, Person}
+  alias Operately.Repo
+
+  describe "postgres_cycle_error?/1" do
+    setup do
+      company = company_fixture()
+      alice = person_fixture(%{full_name: "Alice", company_id: company.id})
+      bob = person_fixture(%{full_name: "Bob", company_id: company.id})
+      carol = person_fixture(%{full_name: "Carol", company_id: company.id})
+
+      {:ok, _} = People.update_person(bob, %{manager_id: alice.id})
+      {:ok, _} = People.update_person(carol, %{manager_id: bob.id})
+
+      {:ok, %{alice: alice, carol: carol}}
+    end
+
+    test "detects the manager cycle trigger error from postgres metadata", %{alice: alice, carol: carol} do
+      error =
+        try do
+          alice
+          |> Person.changeset(%{manager_id: carol.id})
+          |> Repo.update!()
+        rescue
+          e in Postgrex.Error -> e
+        end
+
+      assert ManagerCycle.postgres_cycle_error?(error)
+      refute ManagerCycle.postgres_cycle_error?(%Postgrex.Error{postgres: %{code: :raise_exception, where: "other function"}})
+    end
+  end
+end

--- a/app/test/operately/people_test.exs
+++ b/app/test/operately/people_test.exs
@@ -564,9 +564,8 @@ defmodule Operately.PeopleTest do
     end
 
     test "cannot set a person as their own manager", %{alice: alice} do
-      assert_raise Postgrex.Error, ~r/Cycle detected: setting this manager would create a circular reference/, fn ->
-        People.update_person(alice, %{manager_id: alice.id})
-      end
+      assert {:error, changeset} = People.update_person(alice, %{manager_id: alice.id})
+      assert "This would create a circular reporting relationship" in errors_on(changeset).manager_id
     end
 
     test "cannot create a cycle in the management chain", %{alice: alice, bob: bob, carol: carol} do
@@ -575,9 +574,8 @@ defmodule Operately.PeopleTest do
       {:ok, _carol_with_manager} = People.update_person(carol, %{manager_id: bob.id})
 
       # Now try to create a cycle by setting Alice's manager to Carol
-      assert_raise Postgrex.Error, ~r/Cycle detected: setting this manager would create a circular reference/, fn ->
-        People.update_person(alice, %{manager_id: carol.id})
-      end
+      assert {:error, changeset} = People.update_person(alice, %{manager_id: carol.id})
+      assert "This would create a circular reporting relationship" in errors_on(changeset).manager_id
     end
 
     test "can change manager to someone else without creating a cycle", %{alice: alice, bob: bob, carol: carol, dave: dave} do

--- a/app/test/operately_web/api/people/update_test.exs
+++ b/app/test/operately_web/api/people/update_test.exs
@@ -195,6 +195,16 @@ defmodule OperatelyWeb.Api.People.UpdateTest do
                  daily_summary_delivery_time: "18:45"
                })
     end
+
+    test "it rejects a manager that would create a reporting cycle", ctx do
+      report = person_fixture(%{company_id: ctx.company.id, full_name: "Report Person", manager_id: ctx.person.id})
+
+      assert {400, %{message: "This would create a circular reporting relationship"}} =
+               mutation(ctx.conn, [:people, :update], %{
+                 id: Paths.person_id(ctx.person),
+                 manager_id: Paths.person_id(report)
+               })
+    end
   end
 
   defp promote_me_to_admin(ctx) do


### PR DESCRIPTION
Closes https://github.com/operately/operately/issues/1984.

The cycles had been handled at the DB level a while ago. This PR simply improves the error handling.