### PR TITLE
fix: Prevent comment list flicker when posting comments

### DIFF
--- a/app/assets/js/features/CommentSection/CommentSection.tsx
+++ b/app/assets/js/features/CommentSection/CommentSection.tsx
@@ -44,10 +44,12 @@ export function CommentSection(props: CommentSectionProps) {
     <>
       <div className="flex flex-col">
         {props.form.items.map((item, index) => {
+          const key = commentItemKey(item, index);
+
           if (item.type === "comment") {
             return (
               <Comment
-                key={index}
+                key={key}
                 comment={item.value}
                 form={props.form}
                 commentParentType={props.commentParentType}
@@ -55,11 +57,11 @@ export function CommentSection(props: CommentSectionProps) {
               />
             );
           } else if (item.type === "milestone-completed") {
-            return <MilestoneCompleted key={index} comment={item.value} />;
+            return <MilestoneCompleted key={key} comment={item.value} />;
           } else if (item.type === "milestone-reopened") {
-            return <MilestoneReopened key={index} comment={item.value} />;
+            return <MilestoneReopened key={key} comment={item.value} />;
           } else {
-            return <AckComment key={index} person={item.value} ackAt={item.insertedAt} label={props.ackLabel} />;
+            return <AckComment key={key} person={item.value} ackAt={item.insertedAt} label={props.ackLabel} />;
           }
         })}
 
@@ -67,6 +69,18 @@ export function CommentSection(props: CommentSectionProps) {
       </div>
     </>
   );
+}
+
+function commentItemKey(item: { type: string; insertedAt: Date; value: { id?: string } }, index: number): string {
+  if (item.type === "acknowledgement") {
+    return `acknowledgement-${item.insertedAt.toISOString()}`;
+  }
+
+  if (item.value?.id) {
+    return `${item.type}-${item.value.id}`;
+  }
+
+  return `${item.type}-${index}`;
 }
 
 function Comment({ comment, form, commentParentType, canComment }) {
@@ -346,11 +360,13 @@ function AddCommentActive({ onBlur, onPost, form }) {
     if (!editor) return;
     if (editor.uploading) return;
 
-    const success = await form.postComment(editor.editor.getJSON());
-    if (success === false) return;
-
+    const content = editor.editor.getJSON();
+    // Close the composer before the optimistic comment lands so the new row
+    // never appears while the active comment box is still open.
     editor.clearLocalDraft();
     onPost();
+
+    await form.postComment(content);
   };
 
   const handleCancel = () => {

--- a/app/assets/js/features/CommentSection/useComments.tsx
+++ b/app/assets/js/features/CommentSection/useComments.tsx
@@ -64,7 +64,10 @@ function useLoadAndReloadComments(parentId: string, parentType: Comments.Comment
   useEffect(() => {
     if (!data?.comments) return;
 
-    setItems(parseComments(data.comments));
+    setItems((prev) => {
+      const pending = prev.filter(Comments.isOptimisticComment);
+      return [...parseComments(data.comments), ...pending];
+    });
   }, [data]);
 
   return {

--- a/app/assets/js/features/CommentSection/useForGoalCheckIn.tsx
+++ b/app/assets/js/features/CommentSection/useForGoalCheckIn.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import * as GoalCheckIns from "@/models/goalCheckIns";
 import * as Comments from "@/models/comments";
-import * as Time from "@/utils/time";
 
 import { FormState } from "./form";
 import { useComments } from "./useComments";
@@ -14,15 +13,7 @@ export function useForGoalCheckIn(update: GoalCheckIns.Update): FormState {
     if (!form.items) return [];
     if (!update.acknowledged || !update.acknowledgedAt) return form.items;
 
-    const { before, after } = Comments.splitComments(form.items, update.acknowledgedAt);
-
-    const acknowledgement = {
-      type: "acknowledgement",
-      insertedAt: Time.parse(update.acknowledgedAt)!,
-      value: update.acknowledgingPerson,
-    } as Comments.CommentItem;
-
-    return [...before, acknowledgement, ...after];
+    return Comments.insertAcknowledgement(form.items, update.acknowledgedAt, update.acknowledgingPerson);
   }, [form.items, update]);
 
   return { ...form, items: comments };

--- a/app/assets/js/features/CommentSection/useForGoalRetrospective.tsx
+++ b/app/assets/js/features/CommentSection/useForGoalRetrospective.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import * as Activities from "@/models/activities";
 import * as Comments from "@/models/comments";
 import * as Goals from "@/models/goals";
-import * as Time from "@/utils/time";
 
 import { FormState } from "./form";
 import { useComments } from "./useComments";
@@ -15,15 +14,11 @@ export function useForGoalRetrospective(activity: Activities.Activity, goal: Goa
     if (!form.items) return [];
     if (!activity.commentThread?.acknowledgedAt) return form.items;
 
-    const { before, after } = Comments.splitComments(form.items, activity.commentThread.acknowledgedAt);
-
-    const acknowledgement = {
-      type: "acknowledgement",
-      insertedAt: Time.parse(activity.commentThread.acknowledgedAt)!,
-      value: activity.commentThread.acknowledgedBy,
-    } as Comments.CommentItem;
-
-    return [...before, acknowledgement, ...after];
+    return Comments.insertAcknowledgement(
+      form.items,
+      activity.commentThread.acknowledgedAt,
+      activity.commentThread.acknowledgedBy,
+    );
   }, [form.items, activity.commentThread]);
 
   return { ...form, items: comments };

--- a/app/assets/js/features/CommentSection/useForProjectCheckIn.tsx
+++ b/app/assets/js/features/CommentSection/useForProjectCheckIn.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import * as ProjectCheckIns from "@/models/projectCheckIns";
 import * as Comments from "@/models/comments";
-import * as Time from "@/utils/time";
 
 import { FormState } from "./form";
 import { useComments } from "./useComments";
@@ -14,15 +13,7 @@ export function useForProjectCheckIn(checkIn: ProjectCheckIns.ProjectCheckIn): F
     if (!form.items) return [];
     if (!checkIn.acknowledgedAt) return form.items;
 
-    const { before, after } = Comments.splitComments(form.items, checkIn.acknowledgedAt);
-
-    const acknowledgement = {
-      type: "acknowledgement",
-      insertedAt: Time.parse(checkIn.acknowledgedAt)!,
-      value: checkIn.acknowledgedBy,
-    } as Comments.CommentItem;
-
-    return [...before, acknowledgement, ...after];
+    return Comments.insertAcknowledgement(form.items, checkIn.acknowledgedAt, checkIn.acknowledgedBy);
   }, [form.items, checkIn]);
 
   return { ...form, items: comments };

--- a/app/assets/js/features/CommentSection/useForProjectRetrospective.tsx
+++ b/app/assets/js/features/CommentSection/useForProjectRetrospective.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 
 import * as Projects from "@/models/projects";
 import * as Comments from "@/models/comments";
-import * as Time from "@/utils/time";
 
 import { FormState } from "./form";
 import { useComments } from "./useComments";
@@ -14,15 +13,7 @@ export function useForProjectRetrospective(retrospective: Projects.ProjectRetros
     if (!form.items) return [];
     if (!retrospective.acknowledgedAt) return form.items;
 
-    const { before, after } = Comments.splitComments(form.items, retrospective.acknowledgedAt);
-
-    const acknowledgement = {
-      type: "acknowledgement",
-      insertedAt: Time.parse(retrospective.acknowledgedAt)!,
-      value: retrospective.acknowledgedBy,
-    } as Comments.CommentItem;
-
-    return [...before, acknowledgement, ...after];
+    return Comments.insertAcknowledgement(form.items, retrospective.acknowledgedAt, retrospective.acknowledgedBy);
   }, [form.items, retrospective]);
 
   return { ...form, items: comments };

--- a/app/assets/js/features/CommentSection/utils/useCreateComment.tsx
+++ b/app/assets/js/features/CommentSection/utils/useCreateComment.tsx
@@ -35,9 +35,18 @@ export function useCreateComment({ setComments, entityId, entityType }: UseCreat
       const resComment = await post(content);
 
       setComments((comments) => {
+        const alreadyPersisted = comments.some((c) => c.value.id === resComment.id);
+        if (alreadyPersisted) {
+          return comments.filter((c) => c.value.id !== tempId);
+        }
+
         return comments.map((c) => {
           if (c.value.id === tempId) {
-            const comment = { ...c.value, id: resComment.id };
+            const comment = {
+              ...c.value,
+              id: resComment.id,
+              insertedAt: resComment.insertedAt ?? c.value.insertedAt,
+            };
             return parseComment(comment);
           } else {
             return c;

--- a/app/assets/js/models/comments/index.test.ts
+++ b/app/assets/js/models/comments/index.test.ts
@@ -1,4 +1,10 @@
-import { parseCommentContent, stringifyCommentContent } from "./index";
+import {
+  insertAcknowledgement,
+  isOptimisticComment,
+  parseCommentContent,
+  stringifyCommentContent,
+  type CommentItem,
+} from "./index";
 
 describe("comment content helpers", () => {
   beforeEach(() => {
@@ -27,5 +33,64 @@ describe("comment content helpers", () => {
     const content = { type: "doc", content: [] };
 
     expect(stringifyCommentContent(content)).toBe(JSON.stringify(content));
+  });
+});
+
+describe("insertAcknowledgement", () => {
+  const person = { id: "person-1", fullName: "Reviewer" };
+
+  function comment(id: string, insertedAt: string): CommentItem {
+    return {
+      type: "comment",
+      insertedAt: new Date(insertedAt),
+      value: { id, insertedAt, content: "{}", author: person, reactions: [] },
+    };
+  }
+
+  it("inserts acknowledgement between earlier and later comments", () => {
+    const items = [comment("c1", "2024-01-01T10:00:00.000Z"), comment("c2", "2024-01-01T12:00:00.000Z")];
+
+    const result = insertAcknowledgement(items, "2024-01-01T11:00:00.000Z", person);
+
+    expect(result.map((item) => (item.type === "comment" ? item.value.id : item.type))).toEqual([
+      "c1",
+      "acknowledgement",
+      "c2",
+    ]);
+  });
+
+  it("keeps optimistic comments after acknowledgement even when their timestamp is earlier", () => {
+    const items = [
+      comment("c1", "2024-01-01T10:00:00.000Z"),
+      comment("c2", "2024-01-01T12:00:00.000Z"),
+      comment("temp-123", "2024-01-01T10:30:00.000Z"),
+    ];
+
+    const result = insertAcknowledgement(items, "2024-01-01T11:00:00.000Z", person);
+
+    expect(result.map((item) => (item.type === "comment" ? item.value.id : item.type))).toEqual([
+      "c1",
+      "acknowledgement",
+      "c2",
+      "temp-123",
+    ]);
+    expect(isOptimisticComment(result[3]!)).toBe(true);
+  });
+
+  it("appends optimistic comments after later comments", () => {
+    const items = [
+      comment("c1", "2024-01-01T10:00:00.000Z"),
+      comment("c2", "2024-01-01T12:00:00.000Z"),
+      comment("temp-456", "2024-01-01T13:00:00.000Z"),
+    ];
+
+    const result = insertAcknowledgement(items, "2024-01-01T11:00:00.000Z", person);
+
+    expect(result.map((item) => (item.type === "comment" ? item.value.id : item.type))).toEqual([
+      "c1",
+      "acknowledgement",
+      "c2",
+      "temp-456",
+    ]);
   });
 });

--- a/app/assets/js/models/comments/index.tsx
+++ b/app/assets/js/models/comments/index.tsx
@@ -28,7 +28,7 @@ export interface CommentItem {
   value: any;
 }
 
-export function splitComments(
+function splitComments(
   comments: CommentItem[],
   timestamp: string,
 ): { before: CommentItem[]; after: CommentItem[] } {

--- a/app/assets/js/models/comments/index.tsx
+++ b/app/assets/js/models/comments/index.tsx
@@ -43,6 +43,34 @@ export function splitComments(
   return { before, after };
 }
 
+export function isOptimisticComment(item: CommentItem): boolean {
+  return typeof item.value?.id === "string" && item.value.id.startsWith("temp-");
+}
+
+/**
+ * Inserts an acknowledgement between comments by timestamp, while keeping
+ * in-flight optimistic comments pinned after the acknowledgement. That avoids
+ * the ack row jumping when a temp comment's client timestamp would otherwise
+ * place it before the acknowledgement.
+ */
+export function insertAcknowledgement(
+  comments: CommentItem[],
+  acknowledgedAt: string,
+  acknowledgingPerson: CommentItem["value"],
+): CommentItem[] {
+  const pending = comments.filter(isOptimisticComment);
+  const confirmed = comments.filter((comment) => !isOptimisticComment(comment));
+  const { before, after } = splitComments(confirmed, acknowledgedAt);
+
+  const acknowledgement: CommentItem = {
+    type: "acknowledgement",
+    insertedAt: Time.parse(acknowledgedAt)!,
+    value: acknowledgingPerson,
+  };
+
+  return [...before, acknowledgement, ...after, ...pending];
+}
+
 export function parseCommentContent(content: string | null | undefined) {
   if (!content || content.trim() === "") {
     return null;

--- a/app/test/support/features/subscriptions_steps.ex
+++ b/app/test/support/features/subscriptions_steps.ex
@@ -35,6 +35,7 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
   step :submit_check_in_form, ctx do
     ctx
     |> UI.click(testid: "submit")
+    |> UI.wait_until_testid(testid: "project-check-in-page")
   end
 
   step :visit_project_discussions_page, ctx do
@@ -99,6 +100,7 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
   step :submit_goal_update_form, ctx do
     ctx
     |> UI.click(testid: "submit")
+    |> UI.wait_until_testid(testid: "goal-check-in-page")
   end
 
   #
@@ -108,16 +110,19 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
   step :select_all_people, ctx do
     ctx
     |> UI.click(testid: "subscribe-all")
+    |> wait_until_subscription_option_selected("subscribe-all")
   end
 
   step :select_specific_people, ctx do
     ctx
     |> UI.click(testid: "subscribe-specific-people")
+    |> wait_until_subscription_option_selected("subscribe-specific-people")
   end
 
   step :select_no_one, ctx do
     ctx
     |> UI.click(testid: "subscribe-no-one")
+    |> wait_until_subscription_option_selected("subscribe-no-one")
   end
 
   step :toggle_person_checkbox, ctx, person do
@@ -181,7 +186,7 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
       end
 
     ctx
-    |> UI.assert_text("#{text} will be notified when someone comments on this #{attrs.resource}.")
+    |> UI.wait_until_text("#{text} will be notified when someone comments on this #{attrs.resource}.")
   end
 
   step :exercise_current_subscriptions_widget, ctx, resource do
@@ -208,5 +213,9 @@ defmodule Operately.Support.Features.SubscriptionsSteps do
     |> select_everyone()
     |> save_people_selection()
     |> assert_current_subscribers(%{count: 5, resource: resource})
+  end
+
+  defp wait_until_subscription_option_selected(ctx, testid) do
+    UI.wait_until_has(ctx, Query.css("[data-test-id=\"#{testid}\"]:checked"))
   end
 end

--- a/turboui/src/CommentSection/CommentInput.tsx
+++ b/turboui/src/CommentSection/CommentInput.tsx
@@ -79,13 +79,13 @@ function CommentInputActive({
     if (!content || editor.empty) return;
     if (uploading) return;
 
-    try {
-      const success = await form.postComment(content);
-      if (success === false) return;
+    // Close the composer before the optimistic comment lands so the new row
+    // never appears while the active comment box is still open.
+    editor.clearLocalDraft();
+    onPost();
 
-      editor.clearLocalDraft();
-      editor.setContent("");
-      onPost();
+    try {
+      await form.postComment(content);
     } catch (error) {
       console.error("Failed to post comment:", error);
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4821

## Problem

Two related flickers when posting a comment:

1. The optimistic comment appeared in the list while the comment box was still open.
2. On goal/project check-ins (and retrospectives), the acknowledgement row could briefly jump when a new comment was posted, then snap back.

## Fix

- Close the comment composer before applying the optimistic update (CommentSection + TurboUI CommentInput), so the new comment never shows during the active “commenting” state.
- Add `insertAcknowledgement` that pins in-flight `temp-*` comments after the acknowledgement, so client timestamps cannot move the ack row.
- Use stable React keys for comment list items.
- Preserve optimistic comments across `reload_comments` refetches, and prefer the server `insertedAt` when swapping temp → real IDs.
- Keep `splitComments` private so knip does not flag it as an unused export.

## Test plan

- [x] Unit tests for `insertAcknowledgement` (ack placement + optimistic pinning)
- [x] `npm run knip` passes (no unused `splitComments` export)
- [ ] Manually post a comment on a goal/project check-in that has an acknowledgement between comments and confirm the ack row stays put
- [ ] Confirm the comment box closes before the new comment appears in the list

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-485f6f42-5e0c-4c4f-b109-ce36886be1e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-485f6f42-5e0c-4c4f-b109-ce36886be1e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

