### PR TITLE
feat: add scheduled posting for discussions and check-ins

### DIFF
--- a/app/assets/js/components/ScheduleFlowControls.tsx
+++ b/app/assets/js/components/ScheduleFlowControls.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
+import type { ScheduleFlow } from "@/hooks/useScheduleFlow";
+import { OptionsButton, ScheduleModal, ScheduleNotice } from "turboui";
+
+interface Props {
+  scheduleFlow: ScheduleFlow;
+  primaryLabel: string;
+  onPrimaryClick: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  testId?: string;
+  secondaryAction?: React.ReactNode;
+}
+
+export function ScheduleFlowControls({
+  scheduleFlow,
+  primaryLabel,
+  onPrimaryClick,
+  loading,
+  disabled,
+  testId,
+  secondaryAction,
+}: Props) {
+  const formattedTimePreferences = useFormattedTimePreferences();
+
+  return (
+    <>
+      {scheduleFlow.isScheduledLocally && scheduleFlow.scheduledAt && (
+        <ScheduleNotice
+          date={scheduleFlow.scheduledAt}
+          onEdit={scheduleFlow.openScheduleModal}
+          formattedTimePreferences={formattedTimePreferences}
+          className="mb-3"
+        />
+      )}
+
+      <div className="flex items-center gap-2">
+        <OptionsButton
+          onClick={onPrimaryClick}
+          loading={loading}
+          disabled={disabled}
+          testId={testId}
+          options={[{ label: "Schedule for later", action: scheduleFlow.openScheduleModal }]}
+        >
+          {scheduleFlow.primaryButtonLabel(primaryLabel)}
+        </OptionsButton>
+
+        {secondaryAction}
+      </div>
+
+      <ScheduleModal
+        open={scheduleFlow.isModalOpen}
+        onOpenChange={scheduleFlow.setIsModalOpen}
+        onSchedule={scheduleFlow.confirmSchedule}
+        onCancel={scheduleFlow.cancelSchedule}
+      />
+    </>
+  );
+}

--- a/app/assets/js/features/DiscussionForm/useForm.tsx
+++ b/app/assets/js/features/DiscussionForm/useForm.tsx
@@ -8,6 +8,8 @@ import { usePaths } from "@/routes/paths";
 import { useNavigate } from "react-router";
 import { emptyContent } from "turboui";
 import { assertPresent } from "@/utils/assertions";
+import type { ScheduleFlow } from "@/hooks/useScheduleFlow";
+import { useScheduleFlow } from "@/hooks/useScheduleFlow";
 
 interface UseFormOptions {
   mode: "create" | "edit";
@@ -21,12 +23,14 @@ type FormValues = {
   body: any;
 };
 
-type FormAction = "post-message" | "post-draft" | "save-changes" | "publish-draft";
+type FormAction = "post-message" | "post-draft" | "save-changes" | "publish-draft" | "schedule";
 
 export interface FormState extends FormsFormState<FormValues> {
   mode: "create" | "edit";
   space: Spaces.Space;
   subscriptionsState: SubscriptionsState;
+  scheduleFlow: ScheduleFlow;
+  canSchedule: boolean;
 
   cancelPath: string;
 
@@ -34,11 +38,13 @@ export interface FormState extends FormsFormState<FormValues> {
   postAsDraft: () => void;
   saveChanges: () => void;
   publishDraft: () => void;
+  confirmSchedule: () => void;
 
   postMessageSubmitting: boolean;
   postAsDraftSubmitting: boolean;
   saveChangesSubmitting: boolean;
   publishDraftSubmitting: boolean;
+  scheduleSubmitting: boolean;
 }
 
 export function useForm({ space, mode, discussion, potentialSubscribers = [] }: UseFormOptions): FormState {
@@ -46,6 +52,11 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
   const navigate = useNavigate();
   const [post] = Discussions.usePostDiscussion();
   const [edit] = Discussions.useEditDiscussion();
+
+  const canSchedule = mode === "create" || discussion?.state === "draft" || discussion?.state === "scheduled";
+  const scheduleFlow = useScheduleFlow({
+    initialScheduledAt: canSchedule ? discussion?.scheduledAt : null,
+  });
 
   const subscriptionsState = useSubscriptionsAdapter(potentialSubscribers, { ignoreMe: true, spaceName: space.name });
   const initialBody = discussion?.body ? JSON.parse(discussion.body) : emptyContent();
@@ -60,9 +71,11 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
 
       switch (resolvedAction) {
         case "post-message":
-        case "post-draft": {
+        case "post-draft":
+        case "schedule": {
           assertPresent(space.id, "space id must be present in discussion form");
           const spaceId = space.id;
+          const shouldSchedule = resolvedAction === "schedule" || scheduleFlow.isScheduledLocally;
 
           const res = await post({
             spaceId,
@@ -71,6 +84,7 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
             body: JSON.stringify(form.values.body),
             sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
             subscriberIds: subscriptionsState.currentSubscribersList,
+            scheduledAt: shouldSchedule && resolvedAction !== "post-draft" ? scheduleFlow.scheduledAtIso : undefined,
           });
 
           navigate(paths.discussionPath(res.discussion.id));
@@ -85,6 +99,11 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
             id: discussionId,
             title: form.values.title,
             body: JSON.stringify(form.values.body),
+            ...(canSchedule && scheduleFlow.isScheduledLocally
+              ? { state: "scheduled" as const, scheduledAt: scheduleFlow.scheduledAtIso }
+              : canSchedule && discussion.state === "scheduled"
+                ? { state: "draft" as const, scheduledAt: null }
+                : {}),
           });
 
           navigate(paths.discussionPath(res.discussion.id));
@@ -94,6 +113,19 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
           assertPresent(discussion, "discussion must be present in edit mode");
           assertPresent(discussion.id, "discussion id must be present in edit mode");
           const discussionId = discussion.id;
+
+          if (scheduleFlow.isScheduledLocally) {
+            const res = await edit({
+              id: discussionId,
+              title: form.values.title,
+              body: JSON.stringify(form.values.body),
+              state: "scheduled",
+              scheduledAt: scheduleFlow.scheduledAtIso,
+            });
+
+            navigate(paths.discussionPath(res.discussion.id));
+            break;
+          }
 
           const res = await edit({
             id: discussionId,
@@ -119,6 +151,7 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
   const postAsDraftSubmitting = isSubmitting && form.trigger === "post-draft";
   const saveChangesSubmitting = isSubmitting && form.trigger === "save-changes";
   const publishDraftSubmitting = isSubmitting && form.trigger === "publish-draft";
+  const scheduleSubmitting = isSubmitting && form.trigger === "schedule";
 
   let cancelPath: string;
   if (mode === "edit") {
@@ -135,14 +168,24 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     mode,
     space,
     subscriptionsState,
+    scheduleFlow,
+    canSchedule,
     cancelPath,
-    postMessage: () => submitWith("post-message"),
+    postMessage: () => {
+      if (scheduleFlow.isScheduledLocally) {
+        submitWith("schedule");
+      } else {
+        submitWith("post-message");
+      }
+    },
     postAsDraft: () => submitWith("post-draft"),
     saveChanges: () => submitWith("save-changes"),
     publishDraft: () => submitWith("publish-draft"),
+    confirmSchedule: () => submitWith("schedule"),
     postMessageSubmitting,
     postAsDraftSubmitting,
     saveChangesSubmitting,
     publishDraftSubmitting,
+    scheduleSubmitting,
   };
 }

--- a/app/assets/js/features/DiscussionForm/useForm.tsx
+++ b/app/assets/js/features/DiscussionForm/useForm.tsx
@@ -38,7 +38,6 @@ export interface FormState extends FormsFormState<FormValues> {
   postAsDraft: () => void;
   saveChanges: () => void;
   publishDraft: () => void;
-  confirmSchedule: () => void;
 
   postMessageSubmitting: boolean;
   postAsDraftSubmitting: boolean;
@@ -181,7 +180,6 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     postAsDraft: () => submitWith("post-draft"),
     saveChanges: () => submitWith("save-changes"),
     publishDraft: () => submitWith("publish-draft"),
-    confirmSchedule: () => submitWith("schedule"),
     postMessageSubmitting,
     postAsDraftSubmitting,
     saveChangesSubmitting,

--- a/app/assets/js/features/DiscussionForm/useForm.tsx
+++ b/app/assets/js/features/DiscussionForm/useForm.tsx
@@ -23,7 +23,14 @@ type FormValues = {
   body: any;
 };
 
-type FormAction = "post-message" | "post-draft" | "save-changes" | "publish-draft" | "schedule";
+type FormAction =
+  | "post-message"
+  | "post-draft"
+  | "save-changes"
+  | "publish-draft"
+  | "publish-now"
+  | "save-as-draft"
+  | "schedule";
 
 export interface FormState extends FormsFormState<FormValues> {
   mode: "create" | "edit";
@@ -38,6 +45,8 @@ export interface FormState extends FormsFormState<FormValues> {
   postAsDraft: () => void;
   saveChanges: () => void;
   publishDraft: () => void;
+  publishNow: () => void;
+  saveAsDraft: () => void;
 
   postMessageSubmitting: boolean;
   postAsDraftSubmitting: boolean;
@@ -136,6 +145,22 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
           navigate(paths.discussionPath(res.discussion.id));
           break;
         }
+        case "publish-now":
+        case "save-as-draft": {
+          assertPresent(discussion, "discussion must be present in edit mode");
+          assertPresent(discussion.id, "discussion id must be present in edit mode");
+
+          const res = await edit({
+            id: discussion.id,
+            title: form.values.title,
+            body: JSON.stringify(form.values.body),
+            state: resolvedAction === "publish-now" ? "published" : "draft",
+            scheduledAt: null,
+          });
+
+          navigate(paths.discussionPath(res.discussion.id));
+          break;
+        }
       }
     },
   });
@@ -180,6 +205,8 @@ export function useForm({ space, mode, discussion, potentialSubscribers = [] }: 
     postAsDraft: () => submitWith("post-draft"),
     saveChanges: () => submitWith("save-changes"),
     publishDraft: () => submitWith("publish-draft"),
+    publishNow: () => submitWith("publish-now"),
+    saveAsDraft: () => submitWith("save-as-draft"),
     postMessageSubmitting,
     postAsDraftSubmitting,
     saveChangesSubmitting,

--- a/app/assets/js/features/documents/DocumentTitle.tsx
+++ b/app/assets/js/features/documents/DocumentTitle.tsx
@@ -1,19 +1,20 @@
 import * as React from "react";
 import * as People from "@/models/people";
-import { Avatar, BulletDot, FormattedTime } from "turboui";
+import { Avatar, BulletDot, FormattedTime, StatusBadge } from "turboui";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 
-const validStates = ["draft", "published"];
+const validStates = ["draft", "scheduled", "published"];
 
 interface TitleProps {
   title: string;
   state: string;
   author: People.Person | null;
   publishedAt?: string;
+  scheduledAt?: string | null;
   modifiedAt?: string | null;
 }
 
-export function DocumentTitle({ title, author, state, publishedAt, modifiedAt }: TitleProps) {
+export function DocumentTitle({ title, author, state, publishedAt, scheduledAt, modifiedAt }: TitleProps) {
   const formattedTimePreferences = useFormattedTimePreferences();
   verifyState(state);
   verifyPublishedAt(state, publishedAt);
@@ -21,7 +22,10 @@ export function DocumentTitle({ title, author, state, publishedAt, modifiedAt }:
 
   return (
     <div className="flex flex-col items-center">
-      <div className="text-content-accent text-xl sm:text-2xl md:text-3xl font-extrabold text-center">{title}</div>
+      <div className="flex flex-wrap items-center justify-center gap-2 text-content-accent text-xl sm:text-2xl md:text-3xl font-extrabold text-center">
+        <span>{title}</span>
+        {state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
+      </div>
       <div className="flex flex-wrap justify-center gap-1 items-center mt-2 text-content-accent font-medium text-sm sm:text-[16px]">
         {author && (
           <div className="flex items-center gap-1">
@@ -29,7 +33,7 @@ export function DocumentTitle({ title, author, state, publishedAt, modifiedAt }:
           </div>
         )}
 
-        {state !== "draft" && (
+        {state === "published" && (
           <>
             {author && <BulletDot margin="mx-0.5" />}
             <span>Posted</span>
@@ -37,7 +41,17 @@ export function DocumentTitle({ title, author, state, publishedAt, modifiedAt }:
           </>
         )}
 
-        {state !== "draft" && showModifiedAt && (
+        {state === "scheduled" && scheduledAt && (
+          <>
+            {author && <BulletDot margin="mx-0.5" />}
+            <span>Scheduled for</span>
+            <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="long-date" />
+            <span>at</span>
+            <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="time-only" />
+          </>
+        )}
+
+        {state === "published" && showModifiedAt && (
           <>
             <BulletDot margin="mx-0.5" />
             <span>Edited</span>

--- a/app/assets/js/features/documents/DocumentTitle.tsx
+++ b/app/assets/js/features/documents/DocumentTitle.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as People from "@/models/people";
-import { Avatar, BulletDot, FormattedTime, StatusBadge } from "turboui";
+import { Avatar, BulletDot, FormattedTime, ScheduledPostDate, ScheduledPostLabel } from "turboui";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 
 const validStates = ["draft", "scheduled", "published"];
@@ -24,7 +24,7 @@ export function DocumentTitle({ title, author, state, publishedAt, scheduledAt, 
     <div className="flex flex-col items-center">
       <div className="flex flex-wrap items-center justify-center gap-2 text-content-accent text-xl sm:text-2xl md:text-3xl font-extrabold text-center">
         <span>{title}</span>
-        {state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
+        {state === "scheduled" && <ScheduledPostLabel />}
       </div>
       <div className="flex flex-wrap justify-center gap-1 items-center mt-2 text-content-accent font-medium text-sm sm:text-[16px]">
         {author && (
@@ -44,10 +44,10 @@ export function DocumentTitle({ title, author, state, publishedAt, scheduledAt, 
         {state === "scheduled" && scheduledAt && (
           <>
             {author && <BulletDot margin="mx-0.5" />}
-            <span>Scheduled for</span>
-            <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="long-date" />
-            <span>at</span>
-            <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="time-only" />
+            <ScheduledPostDate
+              scheduledAt={scheduledAt}
+              formattedTimePreferences={formattedTimePreferences}
+            />
           </>
         )}
 

--- a/app/assets/js/features/drafts/OngoingDraftActions.tsx
+++ b/app/assets/js/features/drafts/OngoingDraftActions.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export function OngoingDraftActions({ resource, editResourcePath, publish }: Props) {
-  if (resource.state !== "draft") return null;
+  if (resource.state !== "draft" && resource.state !== "scheduled") return null;
 
   const [state, setState] = React.useState<State>("actions");
 
@@ -44,14 +44,31 @@ interface ContinueProps {
 
 function ContinueEditingActions({ resource, setLinkVisible, editResourcePath, publish }: ContinueProps) {
   const formattedTimePreferences = useFormattedTimePreferences();
+  const isScheduled = resource.state === "scheduled";
 
   return (
     <div className="mb-4 bg-surface-dimmed p-4 rounded-2xl">
       <div className="text-center">
-        <span className="font-bold">This is an unpublished draft.</span>{" "}
-        <span className="">
-          Last edit was made <FormattedTime {...formattedTimePreferences} time={resource.updatedAt!} format="relative-time-or-date" />.
-        </span>
+        {isScheduled ? (
+          <>
+            <span className="font-bold">This post is scheduled.</span>{" "}
+            {"scheduledAt" in resource && resource.scheduledAt && (
+              <span>
+                It will be posted on{" "}
+                <FormattedTime {...formattedTimePreferences} time={resource.scheduledAt} format="long-date" /> at{" "}
+                <FormattedTime {...formattedTimePreferences} time={resource.scheduledAt} format="time-only" />.
+              </span>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="font-bold">This is an unpublished draft.</span>{" "}
+            <span className="">
+              Last edit was made{" "}
+              <FormattedTime {...formattedTimePreferences} time={resource.updatedAt!} format="relative-time-or-date" />.
+            </span>
+          </>
+        )}
       </div>
       <div className="flex items-center justify-center gap-2 mt-4">
         <ContinueEditingButton path={editResourcePath} />

--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -80,13 +80,16 @@ function SubmitSection(props: Props) {
   if (props.mode === "view") return null;
 
   const formattedTimePreferences = useFormattedTimePreferences();
-  const submit = (action: "submit" | "save-draft" | "publish-draft" | "schedule") => {
+  const submit = (
+    action: "submit" | "save-draft" | "publish-draft" | "schedule" | "save-changes" | "publish-now" | "save-as-draft",
+  ) => {
     props.form.actions.setTrigger(action);
     props.form.actions.submit(action);
   };
 
   const isSubmitting = props.form.state === "submitting";
   const { scheduleFlow, canSchedule } = props.form;
+  const isScheduled = props.form.isScheduled;
 
   if (props.mode === "new") {
     return (
@@ -118,20 +121,39 @@ function SubmitSection(props: Props) {
       <div className="mt-8">
         <ScheduleFlowControls
           scheduleFlow={scheduleFlow}
-          primaryLabel="Submit check-in"
-          onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish-draft")}
-          loading={isSubmitting && (props.form.trigger === "publish-draft" || props.form.trigger === "schedule")}
+          primaryLabel={isScheduled ? "Save Changes" : "Submit check-in"}
+          onPrimaryClick={() =>
+            submit(isScheduled ? "save-changes" : scheduleFlow.isScheduledLocally ? "schedule" : "publish-draft")
+          }
+          loading={
+            isSubmitting &&
+            (props.form.trigger === "save-changes" ||
+              props.form.trigger === "publish-draft" ||
+              props.form.trigger === "schedule")
+          }
           testId="publish-draft"
           formattedTimePreferences={formattedTimePreferences}
+          scheduledPrimaryLabel={isScheduled ? "Save Changes" : undefined}
+          showScheduleOption={!isScheduled}
           secondaryAction={
-            <GhostButton
-              loading={isSubmitting && props.form.trigger === "save-draft"}
-              testId="save-draft"
-              size="base"
-              onClick={() => submit("save-draft")}
-            >
-              Save draft
-            </GhostButton>
+            !isScheduled && (
+              <GhostButton
+                loading={isSubmitting && props.form.trigger === "save-draft"}
+                testId="save-draft"
+                size="base"
+                onClick={() => submit("save-draft")}
+              >
+                Save draft
+              </GhostButton>
+            )
+          }
+          options={
+            isScheduled
+              ? [
+                  { label: "Publish now", action: () => submit("publish-now"), testId: "publish-now-option" },
+                  { label: "Save as draft", action: () => submit("save-as-draft"), testId: "save-as-draft-option" },
+                ]
+              : []
           }
         />
       </div>

--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -9,6 +9,7 @@ import { usePaths } from "@/routes/paths";
 import { GoalTargetsField } from "@/features/goals/GoalTargetsV2";
 import { durationHumanized } from "@/utils/time";
 import { match } from "ts-pattern";
+import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import {
   ActionLink,
   Checklist,
@@ -19,24 +20,23 @@ import {
   IconInfoCircle,
   InfoCallout,
   Link,
-  PrimaryButton,
   RichContent,
   StatusBadge,
   Tooltip,
   SubscribersSelector,
-  type FormState,
 } from "turboui";
 import { StatusSelector } from "./StatusSelector";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import type { GoalCheckInFormState } from "./useForm";
 
 interface Props {
-  form: FormState<any>;
+  form: GoalCheckInFormState;
   mode: "new" | "view" | "edit";
   goal: Goals.Goal;
   children?: React.ReactNode;
   subscriptionsState?: SubscriptionsState;
-  isDraft?: boolean;
+  isUnpublished?: boolean;
 
   // Full editing is allowed only for the latest check-in,
   // and allows editing the status, due date, and targets.
@@ -79,57 +79,58 @@ export function Form(props: Props) {
 function SubmitSection(props: Props) {
   if (props.mode === "view") return null;
 
-  const submit = (action: "submit" | "save-draft" | "publish-draft") => {
+  const submit = (action: "submit" | "save-draft" | "publish-draft" | "schedule") => {
     props.form.actions.setTrigger(action);
     props.form.actions.submit(action);
   };
 
   const isSubmitting = props.form.state === "submitting";
+  const { scheduleFlow, canSchedule } = props.form;
 
   if (props.mode === "new") {
     return (
-      <div className="mt-8 flex items-center gap-2">
-        <PrimaryButton
-          loading={isSubmitting && props.form.trigger === "submit"}
+      <div className="mt-8">
+        <ScheduleFlowControls
+          scheduleFlow={scheduleFlow}
+          primaryLabel="Check-in"
+          onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "submit")}
+          loading={isSubmitting && (props.form.trigger === "submit" || props.form.trigger === "schedule")}
           testId="submit"
-          size="base"
-          onClick={() => submit("submit")}
-        >
-          Check-in
-        </PrimaryButton>
-
-        <GhostButton
-          loading={isSubmitting && props.form.trigger === "save-draft"}
-          testId="save-as-draft"
-          size="base"
-          onClick={() => submit("save-draft")}
-        >
-          Save as draft
-        </GhostButton>
+          secondaryAction={
+            <GhostButton
+              loading={isSubmitting && props.form.trigger === "save-draft"}
+              testId="save-as-draft"
+              size="base"
+              onClick={() => submit("save-draft")}
+            >
+              Save as draft
+            </GhostButton>
+          }
+        />
       </div>
     );
   }
 
-  if (props.isDraft) {
+  if (props.isUnpublished && canSchedule) {
     return (
-      <div className="mt-8 flex items-center gap-2">
-        <PrimaryButton
-          loading={isSubmitting && props.form.trigger === "save-draft"}
-          testId="save-draft"
-          size="base"
-          onClick={() => submit("save-draft")}
-        >
-          Save draft
-        </PrimaryButton>
-
-        <GhostButton
-          loading={isSubmitting && props.form.trigger === "publish-draft"}
+      <div className="mt-8">
+        <ScheduleFlowControls
+          scheduleFlow={scheduleFlow}
+          primaryLabel="Submit check-in"
+          onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish-draft")}
+          loading={isSubmitting && (props.form.trigger === "publish-draft" || props.form.trigger === "schedule")}
           testId="publish-draft"
-          size="base"
-          onClick={() => submit("publish-draft")}
-        >
-          Submit check-in
-        </GhostButton>
+          secondaryAction={
+            <GhostButton
+              loading={isSubmitting && props.form.trigger === "save-draft"}
+              testId="save-draft"
+              size="base"
+              onClick={() => submit("save-draft")}
+            >
+              Save draft
+            </GhostButton>
+          }
+        />
       </div>
     );
   }

--- a/app/assets/js/features/goals/GoalCheckIn/Form.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/Form.tsx
@@ -9,7 +9,6 @@ import { usePaths } from "@/routes/paths";
 import { GoalTargetsField } from "@/features/goals/GoalTargetsV2";
 import { durationHumanized } from "@/utils/time";
 import { match } from "ts-pattern";
-import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import {
   ActionLink,
   Checklist,
@@ -21,6 +20,7 @@ import {
   InfoCallout,
   Link,
   RichContent,
+  ScheduleFlowControls,
   StatusBadge,
   Tooltip,
   SubscribersSelector,
@@ -79,6 +79,7 @@ export function Form(props: Props) {
 function SubmitSection(props: Props) {
   if (props.mode === "view") return null;
 
+  const formattedTimePreferences = useFormattedTimePreferences();
   const submit = (action: "submit" | "save-draft" | "publish-draft" | "schedule") => {
     props.form.actions.setTrigger(action);
     props.form.actions.submit(action);
@@ -96,6 +97,7 @@ function SubmitSection(props: Props) {
           onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "submit")}
           loading={isSubmitting && (props.form.trigger === "submit" || props.form.trigger === "schedule")}
           testId="submit"
+          formattedTimePreferences={formattedTimePreferences}
           secondaryAction={
             <GhostButton
               loading={isSubmitting && props.form.trigger === "save-draft"}
@@ -120,6 +122,7 @@ function SubmitSection(props: Props) {
           onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish-draft")}
           loading={isSubmitting && (props.form.trigger === "publish-draft" || props.form.trigger === "schedule")}
           testId="publish-draft"
+          formattedTimePreferences={formattedTimePreferences}
           secondaryAction={
             <GhostButton
               loading={isSubmitting && props.form.trigger === "save-draft"}

--- a/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
@@ -11,6 +11,8 @@ import { validateTargets } from "../GoalTargetsV2/targetErrors";
 
 import { usePaths } from "@/routes/paths";
 import { Forms, emptyContent } from "turboui";
+import type { ScheduleFlow } from "@/hooks/useScheduleFlow";
+import { useScheduleFlow } from "@/hooks/useScheduleFlow";
 
 interface NewProps {
   mode: "new";
@@ -33,6 +35,13 @@ export function useForm(props: EditProps | NewProps) {
   const navigate = useNavigate();
   const setPageMode = Pages.useSetPageMode();
 
+  const canSchedule =
+    mode === "new" ||
+    (props.mode === "edit" && (props.update.state === "draft" || props.update.state === "scheduled"));
+  const scheduleFlow = useScheduleFlow({
+    initialScheduledAt: mode === "edit" && canSchedule ? props.update.scheduledAt : null,
+  });
+
   const timeframe = props.mode === "edit" ? props.update.timeframe : props.goal.timeframe;
 
   const form = Forms.useForm({
@@ -53,7 +62,7 @@ export function useForm(props: EditProps | NewProps) {
     validate: (addErrors) => {
       validateTargets(form.values.targets || [], addErrors);
     },
-    submit: async (action: "submit" | "save-draft" | "publish-draft" = "submit") => {
+    submit: async (action: "submit" | "save-draft" | "publish-draft" | "schedule" = "submit") => {
       const status = form.values.status;
       if (!status) return;
 
@@ -75,25 +84,43 @@ export function useForm(props: EditProps | NewProps) {
 
       if (mode === "new") {
         const { subscriptionsState } = props;
+        const shouldSchedule = action === "schedule" || (action === "submit" && scheduleFlow.isScheduledLocally);
         const payload = {
           ...commonAttrs,
           goalId: goal.id,
           postAsDraft: action === "save-draft",
           sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
           subscriberIds: subscriptionsState.currentSubscribersList,
+          scheduledAt: shouldSchedule && action !== "save-draft" ? scheduleFlow.scheduledAtIso : undefined,
         };
 
         const res = await post(payload);
 
         navigate(paths.goalCheckInPath(res.update!.id));
       } else {
-        const state: CheckInState | undefined =
-          props.update.state === "draft" ? (action === "publish-draft" ? "published" : "draft") : undefined;
+        const isUnpublished = props.update.state === "draft" || props.update.state === "scheduled";
+        const shouldSchedule = action === "schedule" || (action === "publish-draft" && scheduleFlow.isScheduledLocally);
+
+        let state: CheckInState | undefined;
+        let scheduledAt: string | null | undefined;
+
+        if (isUnpublished) {
+          if (shouldSchedule) {
+            state = "scheduled";
+            scheduledAt = scheduleFlow.scheduledAtIso;
+          } else if (action === "publish-draft") {
+            state = "published";
+          } else {
+            state = "draft";
+            scheduledAt = null;
+          }
+        }
 
         const payload = {
           ...commonAttrs,
           id: props.update.id!,
           state,
+          scheduledAt,
         };
         await edit(payload);
 
@@ -102,9 +129,11 @@ export function useForm(props: EditProps | NewProps) {
     },
   });
 
-  return form;
+  return { ...form, scheduleFlow, canSchedule };
 }
 
 function sortByIndex(items: any[]) {
   return [...items].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
 }
+
+export type GoalCheckInFormState = ReturnType<typeof useForm> & { scheduleFlow: ScheduleFlow; canSchedule: boolean };

--- a/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
@@ -91,7 +91,7 @@ export function useForm(props: EditProps | NewProps) {
           postAsDraft: action === "save-draft",
           sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
           subscriberIds: subscriptionsState.currentSubscribersList,
-          scheduledAt: shouldSchedule && action !== "save-draft" ? scheduleFlow.scheduledAtIso : undefined,
+          scheduledAt: shouldSchedule ? scheduleFlow.scheduledAtIso : undefined,
         };
 
         const res = await post(payload);

--- a/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
+++ b/app/assets/js/features/goals/GoalCheckIn/useForm.tsx
@@ -36,8 +36,7 @@ export function useForm(props: EditProps | NewProps) {
   const setPageMode = Pages.useSetPageMode();
 
   const canSchedule =
-    mode === "new" ||
-    (props.mode === "edit" && (props.update.state === "draft" || props.update.state === "scheduled"));
+    mode === "new" || (props.mode === "edit" && (props.update.state === "draft" || props.update.state === "scheduled"));
   const scheduleFlow = useScheduleFlow({
     initialScheduledAt: mode === "edit" && canSchedule ? props.update.scheduledAt : null,
   });
@@ -62,7 +61,16 @@ export function useForm(props: EditProps | NewProps) {
     validate: (addErrors) => {
       validateTargets(form.values.targets || [], addErrors);
     },
-    submit: async (action: "submit" | "save-draft" | "publish-draft" | "schedule" = "submit") => {
+    submit: async (
+      action:
+        | "submit"
+        | "save-draft"
+        | "publish-draft"
+        | "schedule"
+        | "save-changes"
+        | "publish-now"
+        | "save-as-draft" = "submit",
+    ) => {
       const status = form.values.status;
       if (!status) return;
 
@@ -99,12 +107,21 @@ export function useForm(props: EditProps | NewProps) {
         navigate(paths.goalCheckInPath(res.update!.id));
       } else {
         const isUnpublished = props.update.state === "draft" || props.update.state === "scheduled";
-        const shouldSchedule = action === "schedule" || (action === "publish-draft" && scheduleFlow.isScheduledLocally);
+        const shouldSchedule =
+          action === "schedule" ||
+          action === "save-changes" ||
+          (action === "publish-draft" && scheduleFlow.isScheduledLocally);
 
         let state: CheckInState | undefined;
         let scheduledAt: string | null | undefined;
 
-        if (isUnpublished) {
+        if (action === "publish-now") {
+          state = "published";
+          scheduledAt = null;
+        } else if (action === "save-as-draft") {
+          state = "draft";
+          scheduledAt = null;
+        } else if (isUnpublished) {
           if (shouldSchedule) {
             state = "scheduled";
             scheduledAt = scheduleFlow.scheduledAtIso;
@@ -129,7 +146,12 @@ export function useForm(props: EditProps | NewProps) {
     },
   });
 
-  return { ...form, scheduleFlow, canSchedule };
+  return {
+    ...form,
+    scheduleFlow,
+    canSchedule,
+    isScheduled: mode === "edit" && props.update.state === "scheduled",
+  };
 }
 
 function sortByIndex(items: any[]) {

--- a/app/assets/js/hooks/useScheduleFlow.ts
+++ b/app/assets/js/hooks/useScheduleFlow.ts
@@ -1,0 +1,69 @@
+import { useState } from "react";
+
+export interface UseScheduleFlowOptions {
+  initialScheduledAt?: string | Date | null;
+}
+
+export interface ScheduleFlow {
+  isModalOpen: boolean;
+  setIsModalOpen: (open: boolean) => void;
+  isScheduledLocally: boolean;
+  scheduledAt: Date | null;
+  scheduledAtIso: string | null;
+  openScheduleModal: () => void;
+  closeScheduleModal: () => void;
+  confirmSchedule: (date: Date) => void;
+  cancelSchedule: () => void;
+  clearSchedule: () => void;
+  primaryButtonLabel: (immediateLabel: string) => string;
+}
+
+function parseScheduledAt(value?: string | Date | null): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function useScheduleFlow({ initialScheduledAt = null }: UseScheduleFlowOptions = {}): ScheduleFlow {
+  const initialDate = parseScheduledAt(initialScheduledAt);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [scheduledAt, setScheduledAt] = useState<Date | null>(initialDate);
+  const [isScheduledLocally, setIsScheduledLocally] = useState(initialDate !== null);
+
+  const openScheduleModal = () => setIsModalOpen(true);
+  const closeScheduleModal = () => setIsModalOpen(false);
+
+  const confirmSchedule = (date: Date) => {
+    setScheduledAt(date);
+    setIsScheduledLocally(true);
+    setIsModalOpen(false);
+  };
+
+  const cancelSchedule = () => {
+    setIsModalOpen(false);
+  };
+
+  const clearSchedule = () => {
+    setScheduledAt(null);
+    setIsScheduledLocally(false);
+    setIsModalOpen(false);
+  };
+
+  return {
+    isModalOpen,
+    setIsModalOpen,
+    isScheduledLocally,
+    scheduledAt,
+    scheduledAtIso: scheduledAt ? scheduledAt.toISOString() : null,
+    openScheduleModal,
+    closeScheduleModal,
+    confirmSchedule,
+    cancelSchedule,
+    clearSchedule,
+    primaryButtonLabel: (immediateLabel: string) => (isScheduledLocally ? "Confirm" : immediateLabel),
+  };
+}

--- a/app/assets/js/hooks/useScheduleFlow.ts
+++ b/app/assets/js/hooks/useScheduleFlow.ts
@@ -1,21 +1,16 @@
+import type { ScheduleFlowState } from "turboui";
+
 import { useState } from "react";
 
 export interface UseScheduleFlowOptions {
   initialScheduledAt?: string | Date | null;
 }
 
-export interface ScheduleFlow {
-  isModalOpen: boolean;
-  setIsModalOpen: (open: boolean) => void;
-  isScheduledLocally: boolean;
-  scheduledAt: Date | null;
+export interface ScheduleFlow extends ScheduleFlowState {
   scheduledAtIso: string | null;
+  clearSchedule: () => void;
   openScheduleModal: () => void;
   closeScheduleModal: () => void;
-  confirmSchedule: (date: Date) => void;
-  cancelSchedule: () => void;
-  clearSchedule: () => void;
-  primaryButtonLabel: (immediateLabel: string) => string;
 }
 
 function parseScheduledAt(value?: string | Date | null): Date | null {

--- a/app/assets/js/hooks/useScheduleFlow.ts
+++ b/app/assets/js/hooks/useScheduleFlow.ts
@@ -2,7 +2,7 @@ import type { ScheduleFlowState } from "turboui";
 
 import { useState } from "react";
 
-export interface UseScheduleFlowOptions {
+interface UseScheduleFlowOptions {
   initialScheduledAt?: string | Date | null;
 }
 

--- a/app/assets/js/models/goalCheckIns/index.tsx
+++ b/app/assets/js/models/goalCheckIns/index.tsx
@@ -26,6 +26,7 @@ export function parseCheckInsForTurboUi(paths: Paths, checkIns: api.GoalProgress
       commentCount: checkIn.commentsCount!,
       status: checkIn.status!,
       state: checkIn.state,
+      scheduledAt: checkIn.scheduledAt,
     };
   });
 }

--- a/app/assets/js/models/projectCheckIns/index.tsx
+++ b/app/assets/js/models/projectCheckIns/index.tsx
@@ -28,6 +28,7 @@ export function parseCheckInsForTurboUi(paths: Paths, checkIns: api.ProjectCheck
       commentCount: checkIn.commentsCount || 0,
       status: checkIn.status,
       state: checkIn.state,
+      scheduledAt: checkIn.scheduledAt,
     };
   });
 }

--- a/app/assets/js/pages/DiscussionDraftsPage/index.tsx
+++ b/app/assets/js/pages/DiscussionDraftsPage/index.tsx
@@ -151,14 +151,7 @@ function DiscussionListItem({ discussion }: { discussion: Discussion }) {
         )}
 
         <div className="flex-1 h-full min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <div className="font-semibold leading-none">{discussion.title}</div>
-            {discussion.state === "scheduled" && (
-              <span className="text-xs font-medium text-content-dimmed border border-stroke-base rounded px-1.5 py-0.5">
-                Scheduled
-              </span>
-            )}
-          </div>
+          <div className="font-semibold leading-none mb-1">{discussion.title}</div>
           <div className="break-words line-clamp-2">
             <span className="font-medium text-content-dimmed">
               Last edited on <FormattedTime {...formattedTimePreferences} time={discussion.updatedAt!} format="relative-time-or-date" /> &mdash;{" "}

--- a/app/assets/js/pages/DiscussionDraftsPage/index.tsx
+++ b/app/assets/js/pages/DiscussionDraftsPage/index.tsx
@@ -151,7 +151,14 @@ function DiscussionListItem({ discussion }: { discussion: Discussion }) {
         )}
 
         <div className="flex-1 h-full min-w-0">
-          <div className="font-semibold leading-none mb-1">{discussion.title}</div>
+          <div className="flex items-center gap-2 mb-1">
+            <div className="font-semibold leading-none">{discussion.title}</div>
+            {discussion.state === "scheduled" && (
+              <span className="text-xs font-medium text-content-dimmed border border-stroke-base rounded px-1.5 py-0.5">
+                Scheduled
+              </span>
+            )}
+          </div>
           <div className="break-words line-clamp-2">
             <span className="font-medium text-content-dimmed">
               Last edited on <FormattedTime {...formattedTimePreferences} time={discussion.updatedAt!} format="relative-time-or-date" /> &mdash;{" "}

--- a/app/assets/js/pages/DiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/DiscussionEditPage/index.tsx
@@ -4,11 +4,11 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Discussions from "@/models/discussions";
 
-import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Form, FormState, useForm } from "@/features/DiscussionForm";
 import { useBoolState } from "@/hooks/useBoolState";
+import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { PageModule } from "@/routes/types";
-import { DiscardDiscussionDraftModal, GhostButton, Link, PrimaryButton } from "turboui";
+import { DiscardDiscussionDraftModal, GhostButton, Link, PrimaryButton, ScheduleFlowControls } from "turboui";
 import { useNavigate } from "react-router";
 
 import { usePaths } from "@/routes/paths";
@@ -54,6 +54,7 @@ function Page() {
 function Submit({ form }: { form: FormState }) {
   const { discussion } = Pages.useLoadedData<LoaderResult>();
   const isUnpublished = discussion.state === "draft" || discussion.state === "scheduled";
+  const formattedTimePreferences = useFormattedTimePreferences();
 
   return (
     <Paper.DimmedSection>
@@ -66,6 +67,7 @@ function Submit({ form }: { form: FormState }) {
               onPrimaryClick={form.publishDraft}
               loading={form.publishDraftSubmitting || form.scheduleSubmitting}
               testId="publish-now"
+              formattedTimePreferences={formattedTimePreferences}
               secondaryAction={
                 <GhostButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
                   Save Changes

--- a/app/assets/js/pages/DiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/DiscussionEditPage/index.tsx
@@ -4,6 +4,7 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Discussions from "@/models/discussions";
 
+import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Form, FormState, useForm } from "@/features/DiscussionForm";
 import { useBoolState } from "@/hooks/useBoolState";
 import { PageModule } from "@/routes/types";
@@ -52,19 +53,36 @@ function Page() {
 
 function Submit({ form }: { form: FormState }) {
   const { discussion } = Pages.useLoadedData<LoaderResult>();
+  const isUnpublished = discussion.state === "draft" || discussion.state === "scheduled";
 
   return (
     <Paper.DimmedSection>
       <div className="flex flex-col gap-8">
         <div>
-          <div className="flex items-center gap-2">
-            <SaveChanges form={form} />
-            <PublishNow form={form} />
-          </div>
+          {form.canSchedule ? (
+            <ScheduleFlowControls
+              scheduleFlow={form.scheduleFlow}
+              primaryLabel="Publish Now"
+              onPrimaryClick={form.publishDraft}
+              loading={form.publishDraftSubmitting || form.scheduleSubmitting}
+              testId="publish-now"
+              secondaryAction={
+                <GhostButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
+                  Save Changes
+                </GhostButton>
+              }
+            />
+          ) : (
+            <div className="flex items-center gap-2">
+              <PrimaryButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
+                Save Changes
+              </PrimaryButton>
+            </div>
+          )}
 
           <div className="mt-4">
             Or, <CancelLink form={form} />
-            {discussion.state === "draft" && (
+            {isUnpublished && (
               <>
                 {" "}
                 or <DiscardDraftLink discussion={discussion} />
@@ -74,25 +92,6 @@ function Submit({ form }: { form: FormState }) {
         </div>
       </div>
     </Paper.DimmedSection>
-  );
-}
-
-function SaveChanges({ form }: { form: FormState }) {
-  return (
-    <PrimaryButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
-      Save Changes
-    </PrimaryButton>
-  );
-}
-
-function PublishNow({ form }: { form: FormState }) {
-  const { discussion } = Pages.useLoadedData<LoaderResult>();
-  if (discussion.state !== "draft") return null;
-
-  return (
-    <GhostButton loading={form.publishDraftSubmitting} testId="publish-now" onClick={form.publishDraft}>
-      Publish Now
-    </GhostButton>
   );
 }
 

--- a/app/assets/js/pages/DiscussionEditPage/index.tsx
+++ b/app/assets/js/pages/DiscussionEditPage/index.tsx
@@ -54,6 +54,7 @@ function Page() {
 function Submit({ form }: { form: FormState }) {
   const { discussion } = Pages.useLoadedData<LoaderResult>();
   const isUnpublished = discussion.state === "draft" || discussion.state === "scheduled";
+  const isScheduled = discussion.state === "scheduled";
   const formattedTimePreferences = useFormattedTimePreferences();
 
   return (
@@ -63,15 +64,29 @@ function Submit({ form }: { form: FormState }) {
           {form.canSchedule ? (
             <ScheduleFlowControls
               scheduleFlow={form.scheduleFlow}
-              primaryLabel="Publish Now"
-              onPrimaryClick={form.publishDraft}
-              loading={form.publishDraftSubmitting || form.scheduleSubmitting}
+              primaryLabel={isScheduled ? "Save Changes" : "Publish Now"}
+              onPrimaryClick={isScheduled ? form.saveChanges : form.publishDraft}
+              loading={
+                isScheduled ? form.saveChangesSubmitting : form.publishDraftSubmitting || form.scheduleSubmitting
+              }
               testId="publish-now"
               formattedTimePreferences={formattedTimePreferences}
+              scheduledPrimaryLabel={isScheduled ? "Save Changes" : undefined}
+              showScheduleOption={!isScheduled}
               secondaryAction={
-                <GhostButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
-                  Save Changes
-                </GhostButton>
+                !isScheduled && (
+                  <GhostButton loading={form.saveChangesSubmitting} testId="save-changes" onClick={form.saveChanges}>
+                    Save Changes
+                  </GhostButton>
+                )
+              }
+              options={
+                isScheduled
+                  ? [
+                      { label: "Publish now", action: form.publishNow, testId: "publish-now-option" },
+                      { label: "Save as draft", action: form.saveAsDraft, testId: "save-as-draft-option" },
+                    ]
+                  : []
               }
             />
           ) : (

--- a/app/assets/js/pages/DiscussionNewPage/index.tsx
+++ b/app/assets/js/pages/DiscussionNewPage/index.tsx
@@ -4,10 +4,10 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
 
-import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Form, FormState, useForm } from "@/features/DiscussionForm";
+import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { PageModule } from "@/routes/types";
-import { GhostButton, Link, SubscribersSelector } from "turboui";
+import { GhostButton, Link, ScheduleFlowControls, SubscribersSelector } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export default { name: "DiscussionNewPage", loader, Page } as PageModule;
@@ -57,6 +57,8 @@ function Footer({ form }: { form: FormState }) {
 }
 
 function Submit({ form }: { form: FormState }) {
+  const formattedTimePreferences = useFormattedTimePreferences();
+
   return (
     <div>
       <ScheduleFlowControls
@@ -65,6 +67,7 @@ function Submit({ form }: { form: FormState }) {
         onPrimaryClick={form.postMessage}
         loading={form.postMessageSubmitting || form.scheduleSubmitting}
         testId="post-discussion"
+        formattedTimePreferences={formattedTimePreferences}
         secondaryAction={
           <GhostButton loading={form.postAsDraftSubmitting} testId="save-as-draft" onClick={form.postAsDraft}>
             Save as draft

--- a/app/assets/js/pages/DiscussionNewPage/index.tsx
+++ b/app/assets/js/pages/DiscussionNewPage/index.tsx
@@ -4,9 +4,10 @@ import * as Pages from "@/components/Pages";
 import * as Paper from "@/components/PaperContainer";
 import * as Spaces from "@/models/spaces";
 
+import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Form, FormState, useForm } from "@/features/DiscussionForm";
 import { PageModule } from "@/routes/types";
-import { GhostButton, Link, PrimaryButton, SubscribersSelector } from "turboui";
+import { GhostButton, Link, SubscribersSelector } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export default { name: "DiscussionNewPage", loader, Page } as PageModule;
@@ -58,31 +59,23 @@ function Footer({ form }: { form: FormState }) {
 function Submit({ form }: { form: FormState }) {
   return (
     <div>
-      <div className="flex items-center gap-2">
-        <PostButton form={form} />
-        <SaveAsDraftButton form={form} />
-      </div>
+      <ScheduleFlowControls
+        scheduleFlow={form.scheduleFlow}
+        primaryLabel="Post"
+        onPrimaryClick={form.postMessage}
+        loading={form.postMessageSubmitting || form.scheduleSubmitting}
+        testId="post-discussion"
+        secondaryAction={
+          <GhostButton loading={form.postAsDraftSubmitting} testId="save-as-draft" onClick={form.postAsDraft}>
+            Save as draft
+          </GhostButton>
+        }
+      />
 
       <div className="mt-4">
         Or, <DiscardLink form={form} />
       </div>
     </div>
-  );
-}
-
-function PostButton({ form }: { form: FormState }) {
-  return (
-    <PrimaryButton loading={form.postMessageSubmitting} testId="post-discussion" onClick={form.postMessage}>
-      Post discussion
-    </PrimaryButton>
-  );
-}
-
-function SaveAsDraftButton({ form }: { form: FormState }) {
-  return (
-    <GhostButton loading={form.postAsDraftSubmitting} testId="save-as-draft" onClick={form.postAsDraft}>
-      Save as draft
-    </GhostButton>
   );
 }
 

--- a/app/assets/js/pages/DiscussionPage/page.tsx
+++ b/app/assets/js/pages/DiscussionPage/page.tsx
@@ -51,7 +51,7 @@ export function Page() {
           <DiscussionReactions />
           <DicusssionComments />
 
-          {discussion.state !== "draft" && <DiscussionSubscriptions />}
+          {discussion.state === "published" && <DiscussionSubscriptions />}
         </Paper.Body>
       </Paper.Root>
     </Pages.Page>
@@ -107,7 +107,7 @@ function DiscussionSubscriptions() {
 function DiscussionReactions() {
   const { discussion } = useLoadedData();
 
-  if (discussion.state === "draft") return null;
+  if (discussion.state !== "published") return null;
 
   const reactions = discussion.reactions!.map((r) => r!);
   const entity = Reactions.entity(discussion.id!, "message");
@@ -132,6 +132,7 @@ function DiscussionTitle() {
       author={discussion.author || null}
       state={discussion.state}
       publishedAt={displayDate(discussion)}
+      scheduledAt={discussion.scheduledAt}
     />
   );
 }
@@ -156,7 +157,7 @@ function Options() {
   const [archive] = Discussions.useArchiveMessage();
   const [showDiscardModal, toggleDiscardModal] = useBoolState(false);
 
-  const isDraft = discussion.state === "draft";
+  const isUnpublished = discussion.state === "draft" || discussion.state === "scheduled";
 
   const handleArchive = async () => {
     await archive({ id: discussion.id });
@@ -185,7 +186,7 @@ function Options() {
           keepOutsideOnBigScreen
         />
 
-        {isDraft ? (
+        {isUnpublished ? (
           <PageOptions.Action
             icon={IconTrash}
             title="Discard draft"
@@ -197,7 +198,7 @@ function Options() {
         )}
       </PageOptions.Root>
 
-      {isDraft && (
+      {isUnpublished && (
         <DiscardDiscussionDraftModal
           isOpen={showDiscardModal}
           onClose={toggleDiscardModal}
@@ -213,7 +214,7 @@ function DicusssionComments() {
   const { discussion } = useLoadedData();
   const commentsForm = useComments({ discussion: discussion, parentType: "message" });
 
-  if (discussion.state === "draft") return null;
+  if (discussion.state !== "published") return null;
 
   assertPresent(discussion.permissions?.canComment, "permissions must be present in discussion");
 

--- a/app/assets/js/pages/GoalCheckInPage/Form.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Form.tsx
@@ -15,14 +15,21 @@ export function Form() {
   assertPresent(update.insertedAt, "insertedAt must be present in update");
 
   const mode = Pages.useIsViewMode() ? "view" : "edit";
+  const isUnpublished = update.state === "draft" || update.state === "scheduled";
   const allowFullEdit =
-    update.state === "draft" ||
+    isUnpublished ||
     (goal.lastCheckInId
       ? compareIds(goal.lastCheckInId, update.id) && isWithinTimeframe(displayDate(update), 72)
       : false);
   const form = useForm({ mode: "edit", goal, update });
 
   return (
-    <CheckInForm form={form} goal={goal} mode={mode} allowFullEdit={allowFullEdit} isDraft={update.state === "draft"} />
+    <CheckInForm
+      form={form}
+      goal={goal}
+      mode={mode}
+      allowFullEdit={allowFullEdit}
+      isUnpublished={isUnpublished}
+    />
   );
 }

--- a/app/assets/js/pages/GoalCheckInPage/Header.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Header.tsx
@@ -29,6 +29,7 @@ function Title({ update }: { update: Update }) {
           Check-In for <FormattedTime {...formattedTimePreferences} time={displayDate(update)} format="long-date" />
         </span>
         {update.state === "draft" && <StatusBadge status="pending" customLabel="Draft" hideIcon />}
+        {update.state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
       </h1>
     </div>
   );
@@ -40,7 +41,7 @@ function Subtitle({ update }: { update: Update }) {
   return (
     <div className="flex gap-1.5 items-center mt-1 font-medium text-sm sm:text-base">
       <AvatarAndName person={update.author} />
-      {update.state !== "draft" && (
+      {update.state === "published" && (
         <>
           <BulletDot />
           <Acknowledgement update={update} />

--- a/app/assets/js/pages/GoalCheckInPage/Header.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Header.tsx
@@ -1,5 +1,14 @@
 import * as React from "react";
-import { IconSquareCheckFilled, StatusBadge, Avatar, FormattedTime, BulletDot, displayDate } from "turboui";
+import {
+  IconSquareCheckFilled,
+  StatusBadge,
+  Avatar,
+  FormattedTime,
+  BulletDot,
+  ScheduledPostDate,
+  ScheduledPostLabel,
+  displayDate,
+} from "turboui";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 
 import { useLoadedData } from "./loader";
@@ -29,7 +38,7 @@ function Title({ update }: { update: Update }) {
           Check-In for <FormattedTime {...formattedTimePreferences} time={displayDate(update)} format="long-date" />
         </span>
         {update.state === "draft" && <StatusBadge status="pending" customLabel="Draft" hideIcon />}
-        {update.state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
+        {update.state === "scheduled" && <ScheduledPostLabel />}
       </h1>
     </div>
   );
@@ -37,10 +46,17 @@ function Title({ update }: { update: Update }) {
 
 function Subtitle({ update }: { update: Update }) {
   assertPresent(update.author, "Update author must be defined");
+  const formattedTimePreferences = useFormattedTimePreferences();
 
   return (
     <div className="flex gap-1.5 items-center mt-1 font-medium text-sm sm:text-base">
       <AvatarAndName person={update.author} />
+      {update.state === "scheduled" && update.scheduledAt && (
+        <>
+          <BulletDot />
+          <ScheduledPostDate scheduledAt={update.scheduledAt} formattedTimePreferences={formattedTimePreferences} />
+        </>
+      )}
       {update.state === "published" && (
         <>
           <BulletDot />

--- a/app/assets/js/pages/GoalCheckInPage/Options.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/Options.tsx
@@ -21,10 +21,10 @@ export function Options() {
   const setPageMode = Pages.useSetPageMode();
   const me = useMe()!;
 
-  const isDraft = update.state === "draft";
+  const isUnpublished = update.state === "draft" || update.state === "scheduled";
   const isAuthor = compareIds(me.id, update.author?.id);
   const isEditVisible = isAuthor && mode === "view";
-  const isDiscardVisible = isDraft && mode === "view";
+  const isDiscardVisible = isUnpublished && mode === "view";
 
   if (!isEditVisible && !isDiscardVisible) return null;
 

--- a/app/assets/js/pages/GoalCheckInPage/page.tsx
+++ b/app/assets/js/pages/GoalCheckInPage/page.tsx
@@ -39,7 +39,7 @@ function Body() {
       <Header />
       <Form />
 
-      {mode === "view" && update.state !== "draft" && (
+      {mode === "view" && update.state === "published" && (
         <>
           <AckCTA />
           <CheckInReactions />

--- a/app/assets/js/pages/GoalPage/index.tsx
+++ b/app/assets/js/pages/GoalPage/index.tsx
@@ -427,6 +427,7 @@ function prepareCheckIns(paths: Paths, checkIns: GoalProgressUpdate[]): GoalPage
       commentCount: checkIn.commentsCount!,
       status: checkIn.status!,
       state: checkIn.state,
+      scheduledAt: checkIn.scheduledAt,
     };
   });
 }

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -59,23 +59,30 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
     cancel: () => {
       navigate(paths.projectCheckInPath(checkIn.id!));
     },
-    submit: async (action: "save" | "publish" | "schedule" = "save") => {
+    submit: async (
+      action: "save" | "publish" | "schedule" | "save-changes" | "publish-now" | "save-as-draft" = "save",
+    ) => {
       const status = form.values.status;
       const description = form.values.description;
       if (!status || !description) return;
 
-      const shouldSchedule = action === "schedule" || (action === "publish" && scheduleFlow.isScheduledLocally);
+      const shouldSchedule =
+        action === "schedule" || action === "save-changes" || (action === "publish" && scheduleFlow.isScheduledLocally);
 
       const res = await edit({
         checkInId: checkIn.id,
         status,
         description: JSON.stringify(description),
         ...(isUnpublished
-          ? shouldSchedule
-            ? { state: "scheduled" as const, scheduledAt: scheduleFlow.scheduledAtIso }
-            : action === "publish"
-              ? { state: "published" as const }
-              : { state: "draft" as const, scheduledAt: null }
+          ? action === "publish-now"
+            ? { state: "published" as const, scheduledAt: null }
+            : action === "save-as-draft"
+              ? { state: "draft" as const, scheduledAt: null }
+              : shouldSchedule
+                ? { state: "scheduled" as const, scheduledAt: scheduleFlow.scheduledAtIso }
+                : action === "publish"
+                  ? { state: "published" as const }
+                  : { state: "draft" as const, scheduledAt: null }
           : {}),
       });
 
@@ -100,7 +107,12 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
 
       <Spacer size={4} />
 
-      <SubmitButtons form={form} canSchedule={canSchedule} scheduleFlow={scheduleFlow} />
+      <SubmitButtons
+        form={form}
+        canSchedule={canSchedule}
+        scheduleFlow={scheduleFlow}
+        isScheduled={checkIn.state === "scheduled"}
+      />
     </Forms.Form>
   );
 }
@@ -126,13 +138,15 @@ function SubmitButtons({
   form,
   canSchedule,
   scheduleFlow,
+  isScheduled,
 }: {
   form: FormState<{ status: ProjectCheckIn["status"]; description: any }>;
   canSchedule: boolean;
   scheduleFlow: ReturnType<typeof useScheduleFlow>;
+  isScheduled: boolean;
 }) {
   const formattedTimePreferences = useFormattedTimePreferences();
-  const submit = (action: "save" | "publish" | "schedule") => {
+  const submit = (action: "save" | "publish" | "schedule" | "save-changes" | "publish-now" | "save-as-draft") => {
     form.actions.setTrigger(action);
     form.actions.submit(action);
   };
@@ -147,20 +161,36 @@ function SubmitButtons({
     <div className="mt-8">
       <ScheduleFlowControls
         scheduleFlow={scheduleFlow}
-        primaryLabel="Submit check-in"
-        onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish")}
-        loading={isSubmitting && (form.trigger === "publish" || form.trigger === "schedule")}
+        primaryLabel={isScheduled ? "Save Changes" : "Submit check-in"}
+        onPrimaryClick={() =>
+          submit(isScheduled ? "save-changes" : scheduleFlow.isScheduledLocally ? "schedule" : "publish")
+        }
+        loading={
+          isSubmitting && (form.trigger === "save-changes" || form.trigger === "publish" || form.trigger === "schedule")
+        }
         testId="publish-draft"
         formattedTimePreferences={formattedTimePreferences}
+        scheduledPrimaryLabel={isScheduled ? "Save Changes" : undefined}
+        showScheduleOption={!isScheduled}
         secondaryAction={
-          <GhostButton
-            loading={isSubmitting && form.trigger === "save"}
-            testId="save-draft"
-            size="base"
-            onClick={() => submit("save")}
-          >
-            Save draft
-          </GhostButton>
+          !isScheduled && (
+            <GhostButton
+              loading={isSubmitting && form.trigger === "save"}
+              testId="save-draft"
+              size="base"
+              onClick={() => submit("save")}
+            >
+              Save draft
+            </GhostButton>
+          )
+        }
+        options={
+          isScheduled
+            ? [
+                { label: "Publish now", action: () => submit("publish-now"), testId: "publish-now-option" },
+                { label: "Save as draft", action: () => submit("save-as-draft"), testId: "save-as-draft-option" },
+              ]
+            : []
         }
       />
     </div>

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -4,9 +4,11 @@ import { Person } from "@/models/people";
 import { ProjectCheckIn, useEditProjectCheckIn } from "@/models/projectCheckIns";
 import { useNavigate } from "react-router";
 
+import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Status, StatusOptions } from "@/components/status";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { useScheduleFlow } from "@/hooks/useScheduleFlow";
 import { assertPresent } from "@/utils/assertions";
 import { compareIds } from "@/routes/paths";
 import { isWithinTimeframe } from "@/utils/time";
@@ -15,7 +17,6 @@ import {
   Forms,
   GhostButton,
   InfoCallout,
-  PrimaryButton,
   Spacer,
   displayDate,
   type FormState,
@@ -30,8 +31,14 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
 
   assertPresent(checkIn.project, "project must be present in checkIn");
 
+  const isUnpublished = checkIn.state === "draft" || checkIn.state === "scheduled";
+  const canSchedule = isUnpublished;
+  const scheduleFlow = useScheduleFlow({
+    initialScheduledAt: canSchedule ? checkIn.scheduledAt : null,
+  });
+
   const allowFullEdit =
-    checkIn.state === "draft" ||
+    isUnpublished ||
     (checkIn.project.lastCheckIn?.id
       ? compareIds(checkIn.project.lastCheckIn.id, checkIn.id) && isWithinTimeframe(displayDate(checkIn), 72)
       : false);
@@ -52,16 +59,24 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
     cancel: () => {
       navigate(paths.projectCheckInPath(checkIn.id!));
     },
-    submit: async (action: "save" | "publish" = "save") => {
+    submit: async (action: "save" | "publish" | "schedule" = "save") => {
       const status = form.values.status;
       const description = form.values.description;
       if (!status || !description) return;
+
+      const shouldSchedule = action === "schedule" || (action === "publish" && scheduleFlow.isScheduledLocally);
 
       const res = await edit({
         checkInId: checkIn.id,
         status,
         description: JSON.stringify(description),
-        state: checkIn.state === "draft" ? (action === "publish" ? "published" : "draft") : undefined,
+        ...(isUnpublished
+          ? shouldSchedule
+            ? { state: "scheduled" as const, scheduledAt: scheduleFlow.scheduledAtIso }
+            : action === "publish"
+              ? { state: "published" as const }
+              : { state: "draft" as const, scheduledAt: null }
+          : {}),
       });
 
       navigate(paths.projectCheckInPath(res.checkIn.id));
@@ -72,7 +87,7 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
     <Forms.Form form={form}>
       <Header checkIn={checkIn} />
 
-      <FullEditDisabledMessage allowFullEdit={allowFullEdit} isDraft={checkIn.state === "draft"} />
+      <FullEditDisabledMessage allowFullEdit={allowFullEdit} isUnpublished={isUnpublished} />
 
       <Forms.FieldGroup>
         <StatusSection
@@ -85,13 +100,19 @@ export function Form({ checkIn }: { checkIn: ProjectCheckIn }) {
 
       <Spacer size={4} />
 
-      <SubmitButtons form={form} isDraft={checkIn.state === "draft"} />
+      <SubmitButtons form={form} canSchedule={canSchedule} scheduleFlow={scheduleFlow} />
     </Forms.Form>
   );
 }
 
-function FullEditDisabledMessage({ allowFullEdit, isDraft }: { allowFullEdit: boolean; isDraft: boolean }) {
-  if (isDraft || allowFullEdit) return null;
+function FullEditDisabledMessage({
+  allowFullEdit,
+  isUnpublished,
+}: {
+  allowFullEdit: boolean;
+  isUnpublished: boolean;
+}) {
+  if (isUnpublished || allowFullEdit) return null;
 
   return (
     <InfoCallout
@@ -103,41 +124,43 @@ function FullEditDisabledMessage({ allowFullEdit, isDraft }: { allowFullEdit: bo
 
 function SubmitButtons({
   form,
-  isDraft,
+  canSchedule,
+  scheduleFlow,
 }: {
   form: FormState<{ status: ProjectCheckIn["status"]; description: any }>;
-  isDraft: boolean;
+  canSchedule: boolean;
+  scheduleFlow: ReturnType<typeof useScheduleFlow>;
 }) {
-  const submit = (action: "save" | "publish") => {
+  const submit = (action: "save" | "publish" | "schedule") => {
     form.actions.setTrigger(action);
     form.actions.submit(action);
   };
 
   const isSubmitting = form.state === "submitting";
 
-  if (!isDraft) {
+  if (!canSchedule) {
     return <Forms.Submit saveText="Submit" buttonSize="base" />;
   }
 
   return (
-    <div className="mt-8 flex items-center gap-2">
-      <PrimaryButton
-        loading={isSubmitting && form.trigger === "save"}
-        testId="save-draft"
-        size="base"
-        onClick={() => submit("save")}
-      >
-        Save draft
-      </PrimaryButton>
-
-      <GhostButton
-        loading={isSubmitting && form.trigger === "publish"}
+    <div className="mt-8">
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow}
+        primaryLabel="Submit check-in"
+        onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish")}
+        loading={isSubmitting && (form.trigger === "publish" || form.trigger === "schedule")}
         testId="publish-draft"
-        size="base"
-        onClick={() => submit("publish")}
-      >
-        Submit check-in
-      </GhostButton>
+        secondaryAction={
+          <GhostButton
+            loading={isSubmitting && form.trigger === "save"}
+            testId="save-draft"
+            size="base"
+            onClick={() => submit("save")}
+          >
+            Save draft
+          </GhostButton>
+        }
+      />
     </div>
   );
 }

--- a/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInEditPage/Form.tsx
@@ -4,7 +4,6 @@ import { Person } from "@/models/people";
 import { ProjectCheckIn, useEditProjectCheckIn } from "@/models/projectCheckIns";
 import { useNavigate } from "react-router";
 
-import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { Status, StatusOptions } from "@/components/status";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
@@ -17,6 +16,7 @@ import {
   Forms,
   GhostButton,
   InfoCallout,
+  ScheduleFlowControls,
   Spacer,
   displayDate,
   type FormState,
@@ -131,6 +131,7 @@ function SubmitButtons({
   canSchedule: boolean;
   scheduleFlow: ReturnType<typeof useScheduleFlow>;
 }) {
+  const formattedTimePreferences = useFormattedTimePreferences();
   const submit = (action: "save" | "publish" | "schedule") => {
     form.actions.setTrigger(action);
     form.actions.submit(action);
@@ -150,6 +151,7 @@ function SubmitButtons({
         onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "publish")}
         loading={isSubmitting && (form.trigger === "publish" || form.trigger === "schedule")}
         testId="publish-draft"
+        formattedTimePreferences={formattedTimePreferences}
         secondaryAction={
           <GhostButton
             loading={isSubmitting && form.trigger === "save"}

--- a/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
@@ -5,7 +5,6 @@ import { parseCheckInsForTurboUi, usePostProjectCheckIn, ProjectCheckInStatus } 
 import { Project } from "@/models/projects";
 import { useNavigate } from "react-router";
 
-import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { useScheduleFlow } from "@/hooks/useScheduleFlow";
@@ -17,6 +16,7 @@ import {
   GhostButton,
   Link,
   RichContent,
+  ScheduleFlowControls,
   Spacer,
   StatusBadge,
   SubscribersSelector,
@@ -113,6 +113,7 @@ function SubmitButtons({
   form: FormState<{ status: ProjectCheckInStatus | null; description: any }>;
   scheduleFlow: ReturnType<typeof useScheduleFlow>;
 }) {
+  const formattedTimePreferences = useFormattedTimePreferences();
   const submit = (action: "submit" | "draft" | "schedule") => {
     form.actions.setTrigger(action);
     form.actions.submit(action);
@@ -128,6 +129,7 @@ function SubmitButtons({
         onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "submit")}
         loading={isSubmitting && (form.trigger === "submit" || form.trigger === "schedule")}
         testId="submit"
+        formattedTimePreferences={formattedTimePreferences}
         secondaryAction={
           <GhostButton
             loading={isSubmitting && form.trigger === "draft"}

--- a/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
@@ -75,7 +75,7 @@ export function Form({ project }: { project: Project }) {
         postAsDraft: action === "draft",
         sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
         subscriberIds: subscriptionsState.currentSubscribersList,
-        scheduledAt: shouldSchedule && action !== "draft" ? scheduleFlow.scheduledAtIso : undefined,
+        scheduledAt: shouldSchedule ? scheduleFlow.scheduledAtIso : undefined,
       });
 
       navigate(paths.projectCheckInPath(res.checkIn.id));

--- a/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
+++ b/app/assets/js/pages/ProjectCheckInNewPage/Form.tsx
@@ -5,7 +5,10 @@ import { parseCheckInsForTurboUi, usePostProjectCheckIn, ProjectCheckInStatus } 
 import { Project } from "@/models/projects";
 import { useNavigate } from "react-router";
 
+import { ScheduleFlowControls } from "@/components/ScheduleFlowControls";
+import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { useScheduleFlow } from "@/hooks/useScheduleFlow";
 import { useSubscriptionsAdapter } from "@/models/subscriptions";
 import {
   ActionLink,
@@ -13,14 +16,12 @@ import {
   Forms,
   GhostButton,
   Link,
-  PrimaryButton,
   RichContent,
   Spacer,
   StatusBadge,
   SubscribersSelector,
   type FormState,
 } from "turboui";
-import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { assertPresent } from "@/utils/assertions";
 
 import { usePaths } from "@/routes/paths";
@@ -32,6 +33,7 @@ export function Form({ project }: { project: Project }) {
 
   const [post] = usePostProjectCheckIn();
   const navigate = useNavigate();
+  const scheduleFlow = useScheduleFlow();
   const lastCheckIns = project.lastCheckIn ? parseCheckInsForTurboUi(paths, [project.lastCheckIn]) : [];
 
   const subscriptionsState = useSubscriptionsAdapter(project.potentialSubscribers, {
@@ -59,10 +61,12 @@ export function Form({ project }: { project: Project }) {
     cancel: () => {
       navigate(paths.projectCheckInsPath(project.id!));
     },
-    submit: async (action: "submit" | "draft" = "submit") => {
+    submit: async (action: "submit" | "draft" | "schedule" = "submit") => {
       const status = form.values.status;
       const description = form.values.description;
       if (!status || !description) return;
+
+      const shouldSchedule = action === "schedule" || (action === "submit" && scheduleFlow.isScheduledLocally);
 
       const res = await post({
         projectId: project.id,
@@ -71,6 +75,7 @@ export function Form({ project }: { project: Project }) {
         postAsDraft: action === "draft",
         sendNotificationsToEveryone: subscriptionsState.notifyEveryone,
         subscriberIds: subscriptionsState.currentSubscribersList,
+        scheduledAt: shouldSchedule && action !== "draft" ? scheduleFlow.scheduledAtIso : undefined,
       });
 
       navigate(paths.projectCheckInPath(res.checkIn.id));
@@ -96,13 +101,19 @@ export function Form({ project }: { project: Project }) {
 
       <Forms.FormError message="Fill out all the required fields" className="-mb-6 mt-4" />
 
-      <SubmitButtons form={form} />
+      <SubmitButtons form={form} scheduleFlow={scheduleFlow} />
     </Forms.Form>
   );
 }
 
-function SubmitButtons({ form }: { form: FormState<{ status: ProjectCheckInStatus | null; description: any }> }) {
-  const submit = (action: "submit" | "draft") => {
+function SubmitButtons({
+  form,
+  scheduleFlow,
+}: {
+  form: FormState<{ status: ProjectCheckInStatus | null; description: any }>;
+  scheduleFlow: ReturnType<typeof useScheduleFlow>;
+}) {
+  const submit = (action: "submit" | "draft" | "schedule") => {
     form.actions.setTrigger(action);
     form.actions.submit(action);
   };
@@ -110,24 +121,24 @@ function SubmitButtons({ form }: { form: FormState<{ status: ProjectCheckInStatu
   const isSubmitting = form.state === "submitting";
 
   return (
-    <div className="mt-8 flex items-center gap-2">
-      <PrimaryButton
-        loading={isSubmitting && form.trigger === "submit"}
+    <div className="mt-8">
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow}
+        primaryLabel="Submit"
+        onPrimaryClick={() => submit(scheduleFlow.isScheduledLocally ? "schedule" : "submit")}
+        loading={isSubmitting && (form.trigger === "submit" || form.trigger === "schedule")}
         testId="submit"
-        size="base"
-        onClick={() => submit("submit")}
-      >
-        Submit
-      </PrimaryButton>
-
-      <GhostButton
-        loading={isSubmitting && form.trigger === "draft"}
-        testId="save-as-draft"
-        size="base"
-        onClick={() => submit("draft")}
-      >
-        Save as draft
-      </GhostButton>
+        secondaryAction={
+          <GhostButton
+            loading={isSubmitting && form.trigger === "draft"}
+            testId="save-as-draft"
+            size="base"
+            onClick={() => submit("draft")}
+          >
+            Save as draft
+          </GhostButton>
+        }
+      />
     </div>
   );
 }

--- a/app/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -60,7 +60,7 @@ export function Page() {
           <StatusSection checkIn={checkIn} reviewer={checkIn.project!.reviewer} />
           <DescriptionSection checkIn={checkIn} />
 
-          {checkIn.state !== "draft" && (
+          {checkIn.state === "published" && (
             <>
               <AckCTA />
 
@@ -140,12 +140,13 @@ function Title() {
           Check-In from <FormattedTime {...formattedTimePreferences} time={displayDate(checkIn)} format="long-date" />
         </span>
         {checkIn.state === "draft" && <StatusBadge status="pending" customLabel="Draft" hideIcon />}
+        {checkIn.state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
       </div>
       <div className="flex gap-0.5 flex-row items-center mt-1 text-content-accent font-medium">
         <div className="flex items-center gap-2">
           <Avatar person={checkIn.author!} size="tiny" /> {checkIn.author!.fullName}
         </div>
-        {checkIn.state !== "draft" && (
+        {checkIn.state === "published" && (
           <>
             <TextSeparator />
             <Acknowledgement />
@@ -197,9 +198,9 @@ function Options({ showDeleteModal }: { showDeleteModal: () => void }) {
   const me = useMe()!;
 
   const isAuthor = compareIds(me.id!, checkIn.author!.id!);
-  const isDraft = checkIn.state === "draft";
+  const isUnpublished = checkIn.state === "draft" || checkIn.state === "scheduled";
   const canEdit = isAuthor;
-  const canDelete = isDraft || checkIn.project?.permissions?.hasFullAccess || false;
+  const canDelete = isUnpublished || checkIn.project?.permissions?.hasFullAccess || false;
 
   if (!canEdit && !canDelete) return null;
 
@@ -217,7 +218,7 @@ function Options({ showDeleteModal }: { showDeleteModal: () => void }) {
       {canDelete && (
         <PageOptions.Action
           icon={IconTrash}
-          title={isDraft ? "Discard draft" : "Delete check-in"}
+          title={isUnpublished ? "Discard draft" : "Delete check-in"}
           onClick={showDeleteModal}
           testId="delete-check-in"
         />
@@ -244,7 +245,7 @@ function DeleteCheckInModal({ isOpen, toggleModal }: DeleteCheckInModalProps) {
     cancel: toggleModal,
     submit: async () => {
       await remove({ checkInId: checkIn.id });
-      if (checkIn.state === "draft") {
+      if (checkIn.state === "draft" || checkIn.state === "scheduled") {
         showSuccessToast("Draft discarded", "The draft has been discarded.");
       } else {
         showSuccessToast("Check-in deleted", "The check-in has been successfully deleted.");
@@ -257,11 +258,14 @@ function DeleteCheckInModal({ isOpen, toggleModal }: DeleteCheckInModalProps) {
     <Modal isOpen={isOpen} hideModal={toggleModal}>
       <Forms.Form form={form}>
         <p>
-          {checkIn.state === "draft"
+          {checkIn.state === "draft" || checkIn.state === "scheduled"
             ? "Are you sure you want to discard this draft?"
             : "Are you sure you want to delete this check-in?"}
         </p>
-        <Forms.Submit saveText={checkIn.state === "draft" ? "Discard draft" : "Delete"} cancelText="Cancel" />
+        <Forms.Submit
+          saveText={checkIn.state === "draft" || checkIn.state === "scheduled" ? "Discard draft" : "Delete"}
+          cancelText="Cancel"
+        />
       </Forms.Form>
     </Modal>
   );

--- a/app/assets/js/pages/ProjectCheckInPage/page.tsx
+++ b/app/assets/js/pages/ProjectCheckInPage/page.tsx
@@ -19,6 +19,8 @@ import {
   CurrentSubscriptions,
   Spacer,
   showSuccessToast,
+  ScheduledPostDate,
+  ScheduledPostLabel,
   StatusBadge,
   TextSeparator,
   displayDate,
@@ -140,12 +142,18 @@ function Title() {
           Check-In from <FormattedTime {...formattedTimePreferences} time={displayDate(checkIn)} format="long-date" />
         </span>
         {checkIn.state === "draft" && <StatusBadge status="pending" customLabel="Draft" hideIcon />}
-        {checkIn.state === "scheduled" && <StatusBadge status="pending" customLabel="Scheduled" hideIcon />}
+        {checkIn.state === "scheduled" && <ScheduledPostLabel />}
       </div>
       <div className="flex gap-0.5 flex-row items-center mt-1 text-content-accent font-medium">
         <div className="flex items-center gap-2">
           <Avatar person={checkIn.author!} size="tiny" /> {checkIn.author!.fullName}
         </div>
+        {checkIn.state === "scheduled" && checkIn.scheduledAt && (
+          <>
+            <TextSeparator />
+            <ScheduledPostDate scheduledAt={checkIn.scheduledAt} formattedTimePreferences={formattedTimePreferences} />
+          </>
+        )}
         {checkIn.state === "published" && (
           <>
             <TextSeparator />

--- a/app/assets/js/pages/SpaceDiscussionsPage/page.tsx
+++ b/app/assets/js/pages/SpaceDiscussionsPage/page.tsx
@@ -5,7 +5,17 @@ import * as React from "react";
 import { SpacePageNavigation } from "@/components/SpacePageNavigation";
 import { Discussion } from "@/models/discussions";
 import { usePaths } from "@/routes/paths";
-import { DivLink, Link, PrimaryButton, Avatar, Summary, FormattedTime, displayDate } from "turboui";
+import {
+  DivLink,
+  Link,
+  PrimaryButton,
+  Avatar,
+  Summary,
+  FormattedTime,
+  displayDate,
+  ScheduledPostDate,
+  ScheduledPostLabel,
+} from "turboui";
 import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 
@@ -123,7 +133,10 @@ function DiscussionListItem({ discussion }: { discussion: Discussion }) {
       )}
 
       <div className="flex-1 h-full">
-        <div className="font-semibold leading-none mb-1">{discussion.title}</div>
+        <div className="flex items-center gap-2 mb-1">
+          <div className="font-semibold leading-none">{discussion.title}</div>
+          {discussion.state === "scheduled" && <ScheduledPostLabel />}
+        </div>
         <div className="break-words">
           <Summary content={discussion.body!} characterCount={150} mentionedPersonLookup={mentionedPersonLookup} />
         </div>
@@ -135,9 +148,20 @@ function DiscussionListItem({ discussion }: { discussion: Discussion }) {
               <div className="text-sm text-content-dimmed">·</div>
             </>
           )}
-          <div className="text-sm text-content-dimmed">
-            <FormattedTime {...formattedTimePreferences} time={displayDate(discussion)} format="relative-weekday-or-date" />
-          </div>
+          {discussion.state === "scheduled" && discussion.scheduledAt ? (
+            <ScheduledPostDate
+              scheduledAt={discussion.scheduledAt}
+              formattedTimePreferences={formattedTimePreferences}
+            />
+          ) : (
+            <div className="text-sm text-content-dimmed">
+              <FormattedTime
+                {...formattedTimePreferences}
+                time={displayDate(discussion)}
+                format="relative-weekday-or-date"
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/app/lib/operately/drafts.ex
+++ b/app/lib/operately/drafts.ex
@@ -9,6 +9,10 @@ defmodule Operately.Drafts do
     Time.as_datetime(inserted_at)
   end
 
+  def display_date(%{state: :scheduled, scheduled_at: scheduled_at, inserted_at: inserted_at}) do
+    (scheduled_at || inserted_at) |> Time.as_datetime()
+  end
+
   def display_date(%{state: :published, published_at: published_at, inserted_at: inserted_at}) do
     (published_at || inserted_at) |> Time.as_datetime()
   end

--- a/app/lib/operately/operations/discussion_editing.ex
+++ b/app/lib/operately/operations/discussion_editing.ex
@@ -6,8 +6,15 @@ defmodule Operately.Operations.DiscussionEditing do
   alias Operately.Notifications.SubscriptionList
 
   def run(creator, message, attrs) do
+    update_attrs = %{
+      title: attrs[:title] || message.title,
+      body: attrs[:body] || message.body,
+      state: state(message, attrs),
+      scheduled_at: scheduled_at(message, attrs)
+    }
+
     Multi.new()
-    |> Multi.update(:message, Message.changeset(message, attrs))
+    |> Multi.update(:message, Message.changeset(message, update_attrs))
     |> Multi.run(:subscription_list, fn _, changes ->
       SubscriptionList.get(:system,
         parent_id: changes.message.id,
@@ -16,9 +23,9 @@ defmodule Operately.Operations.DiscussionEditing do
         ]
       )
     end)
-    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(attrs.body)
-    |> record_activity(creator, message, attrs)
-    |> handle_oban_jobs(message, attrs)
+    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(update_attrs.body)
+    |> record_activity(creator, message, update_attrs)
+    |> handle_oban_jobs(message, update_attrs)
     |> Repo.transaction()
     |> Repo.extract_result(:message)
   end
@@ -45,8 +52,25 @@ defmodule Operately.Operations.DiscussionEditing do
         end)
 
       true ->
-        # it is a draft and it is not being published, do nothing
+        # it is a draft/scheduled and it is not being published, do nothing
         multi
+    end
+  end
+
+  defp state(message, attrs) do
+    cond do
+      not is_nil(attrs[:state]) -> attrs[:state]
+      not is_nil(attrs[:scheduled_at]) -> :scheduled
+      true -> message.state
+    end
+  end
+
+  defp scheduled_at(message, attrs) do
+    cond do
+      Map.has_key?(attrs, :scheduled_at) and not is_nil(attrs[:scheduled_at]) -> attrs[:scheduled_at]
+      attrs[:state] in [:draft, :published] -> nil
+      Map.has_key?(attrs, :scheduled_at) -> attrs[:scheduled_at]
+      true -> message.scheduled_at
     end
   end
 

--- a/app/lib/operately/operations/discussion_editing.ex
+++ b/app/lib/operately/operations/discussion_editing.ex
@@ -25,7 +25,7 @@ defmodule Operately.Operations.DiscussionEditing do
     end)
     |> Operately.Operations.Notifications.Subscription.update_mentioned_people(update_attrs.body)
     |> record_activity(creator, message, update_attrs)
-    |> handle_oban_jobs(message, update_attrs)
+    |> handle_oban_jobs(message, attrs)
     |> Repo.transaction()
     |> Repo.extract_result(:message)
   end
@@ -67,18 +67,17 @@ defmodule Operately.Operations.DiscussionEditing do
 
   defp scheduled_at(message, attrs) do
     cond do
-      Map.has_key?(attrs, :scheduled_at) and not is_nil(attrs[:scheduled_at]) -> attrs[:scheduled_at]
+      not is_nil(attrs[:scheduled_at]) -> attrs[:scheduled_at]
       attrs[:state] in [:draft, :published] -> nil
-      Map.has_key?(attrs, :scheduled_at) -> attrs[:scheduled_at]
       true -> message.scheduled_at
     end
   end
 
   defp handle_oban_jobs(multi, message, attrs) do
-    new_state = attrs[:state] || message.state
-    new_time = if Map.has_key?(attrs, :scheduled_at), do: attrs.scheduled_at, else: message.scheduled_at
+    new_state = state(message, attrs)
+    new_time = scheduled_at(message, attrs)
 
-    if message.state == :scheduled or new_state == :scheduled do
+    if scheduled?(message.state) or scheduled?(new_state) do
       multi
       |> Multi.delete_all(:delete_oban_job, fn _ ->
         import Ecto.Query
@@ -89,7 +88,7 @@ defmodule Operately.Operations.DiscussionEditing do
           where: fragment("args->>'id' = ?", ^message.id)
       end)
       |> Multi.run(:insert_oban_job, fn _repo, changes ->
-        if new_state == :scheduled and not is_nil(new_time) do
+        if scheduled?(new_state) and not is_nil(new_time) do
           Operately.AsyncPublishing.Worker.new(
             %{"type" => "message", "id" => changes.message.id},
             scheduled_at: new_time
@@ -103,4 +102,8 @@ defmodule Operately.Operations.DiscussionEditing do
       multi
     end
   end
+
+  # Widen to atom() so Dialyzer accepts :scheduled before call sites create those values.
+  @spec scheduled?(atom()) :: boolean()
+  defp scheduled?(state), do: state == :scheduled
 end

--- a/app/lib/operately/operations/discussion_publishing.ex
+++ b/app/lib/operately/operations/discussion_publishing.ex
@@ -6,7 +6,8 @@ defmodule Operately.Operations.DiscussionPublishing do
 
   def run(creator, discussion) do
     Multi.new()
-    |> Multi.update(:message, Message.changeset(discussion, %{state: :published}))
+    |> Multi.update(:message, Message.changeset(discussion, %{state: :published, scheduled_at: nil}))
+    |> maybe_cancel_oban_job(discussion)
     |> Activities.insert_sync(creator.id, :discussion_posting, fn _changes -> %{
       company_id: creator.company_id,
       space_id: discussion.space.id,
@@ -15,5 +16,20 @@ defmodule Operately.Operations.DiscussionPublishing do
     } end)
     |> Repo.transaction()
     |> Repo.extract_result(:message)
+  end
+
+  defp maybe_cancel_oban_job(multi, discussion) do
+    if discussion.state == :scheduled do
+      Multi.delete_all(multi, :delete_oban_job, fn _ ->
+        import Ecto.Query
+
+        from j in Oban.Job,
+          where: j.worker == "Operately.AsyncPublishing.Worker",
+          where: fragment("args->>'type' = ?", "message"),
+          where: fragment("args->>'id' = ?", ^discussion.id)
+      end)
+    else
+      multi
+    end
   end
 end

--- a/app/lib/operately_web/api/helpers.ex
+++ b/app/lib/operately_web/api/helpers.ex
@@ -67,7 +67,10 @@ defmodule OperatelyWeb.Api.Helpers do
   def extend_map_if(m1, true, fun), do: Map.merge(m1, fun.())
   def extend_map_if(m1, _, _), do: m1
 
-  def check_draft_access(%{state: :draft, author_id: author_id}, %{id: person_id}) when author_id != person_id, do: {:error, :not_found}
+  def check_draft_access(%{state: state, author_id: author_id}, %{id: person_id})
+      when state in [:draft, :scheduled] and author_id != person_id,
+      do: {:error, :not_found}
+
   def check_draft_access(_resource, _person), do: {:ok, :allowed}
 
   def check_published(%{state: :published}), do: {:ok, :published}

--- a/app/lib/operately_web/api/projects/list_check_ins.ex
+++ b/app/lib/operately_web/api/projects/list_check_ins.ex
@@ -41,7 +41,7 @@ defmodule OperatelyWeb.Api.Projects.ListCheckIns do
 
     drafts =
       from(p in CheckIn,
-        where: p.project_id == ^id and p.state == :draft and p.author_id == ^person.id,
+        where: p.project_id == ^id and p.state in [:draft, :scheduled] and p.author_id == ^person.id,
         preload: [:acknowledged_by]
       )
       |> include_requested(requested)

--- a/app/lib/operately_web/api/queries/list_goal_check_ins.ex
+++ b/app/lib/operately_web/api/queries/list_goal_check_ins.ex
@@ -34,7 +34,7 @@ defmodule OperatelyWeb.Api.Queries.ListGoalCheckIns do
   defp load(goal_id, person) do
     from(u in Update,
       where: u.goal_id == ^goal_id,
-      where: u.state == :published or (u.state == :draft and u.author_id == ^person.id),
+      where: u.state == :published or (u.state in [:draft, :scheduled] and u.author_id == ^person.id),
       preload: [:author]
     )
     |> Repo.all()

--- a/app/lib/operately_web/api/serializers/goal_update.ex
+++ b/app/lib/operately_web/api/serializers/goal_update.ex
@@ -8,6 +8,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Goals.Update do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(update.inserted_at),
       updated_at: OperatelyWeb.Api.Serializer.serialize(update.updated_at),
       published_at: OperatelyWeb.Api.Serializer.serialize(update.published_at),
+      scheduled_at: OperatelyWeb.Api.Serializer.serialize(update.scheduled_at),
       goal_target_updates: serialize_targets(update.targets),
       checklist: serialize_checks(update.checks),
       timeframe: OperatelyWeb.Api.Serializer.serialize(update.timeframe),

--- a/app/lib/operately_web/api/serializers/message.ex
+++ b/app/lib/operately_web/api/serializers/message.ex
@@ -8,6 +8,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Messages.Message do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(message.inserted_at),
       updated_at: OperatelyWeb.Api.Serializer.serialize(message.updated_at),
       published_at: OperatelyWeb.Api.Serializer.serialize(message.published_at),
+      scheduled_at: OperatelyWeb.Api.Serializer.serialize(message.scheduled_at),
       author: OperatelyWeb.Api.Serializer.serialize(message.author),
       comments_count: message.comments_count,
     }

--- a/app/lib/operately_web/api/serializers/project_check_in.ex
+++ b/app/lib/operately_web/api/serializers/project_check_in.ex
@@ -8,6 +8,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.CheckIn do
       inserted_at: OperatelyWeb.Api.Serializer.serialize(check_in.inserted_at),
       updated_at: OperatelyWeb.Api.Serializer.serialize(check_in.updated_at),
       published_at: OperatelyWeb.Api.Serializer.serialize(check_in.published_at),
+      scheduled_at: OperatelyWeb.Api.Serializer.serialize(check_in.scheduled_at),
       acknowledged_at: OperatelyWeb.Api.Serializer.serialize(check_in.acknowledged_at),
       acknowledged_by: OperatelyWeb.Api.Serializer.serialize(check_in.acknowledged_by),
       project: OperatelyWeb.Api.Serializer.serialize(check_in.project, level: :full),

--- a/app/lib/operately_web/api/spaces/get_discussion.ex
+++ b/app/lib/operately_web/api/spaces/get_discussion.ex
@@ -31,6 +31,7 @@ defmodule OperatelyWeb.Api.Spaces.GetDiscussion do
     |> run(:me, fn -> find_me(conn) end)
     |> run(:message, fn ctx -> load(ctx, inputs, company_read_only(conn)) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.message.request_info.access_level, :can_view, company_read_only: company_read_only(conn)) end)
+    |> run(:check_draft_access, fn ctx -> check_draft_access(ctx.message, ctx.me) end)
     |> run(:serialized, fn ctx -> {:ok, %{discussion: OperatelyWeb.Api.Serializer.serialize(ctx.message, level: :full)}} end)
     |> respond()
    end
@@ -41,6 +42,7 @@ defmodule OperatelyWeb.Api.Spaces.GetDiscussion do
       {:error, :id, _} -> {:error, :bad_request}
       {:error, :message, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :not_found}
+      {:error, :check_draft_access, _} -> {:error, :not_found}
       _ -> {:error, :not_found}
     end
   end

--- a/app/lib/operately_web/api/spaces/list_discussions.ex
+++ b/app/lib/operately_web/api/spaces/list_discussions.ex
@@ -38,7 +38,7 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussions do
   defp load_messages(me, inputs) do
     from(m in Message,
       join: b in assoc(m, :messages_board),
-      where: b.space_id == ^inputs.space_id and m.state != :draft,
+      where: b.space_id == ^inputs.space_id and m.state == :published,
       preload: ^preload(inputs),
       order_by: [desc: m.published_at]
     )
@@ -50,7 +50,7 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussions do
   defp load_my_drafts(me, inputs) do
     from(m in Message,
       join: b in assoc(m, :messages_board),
-      where: b.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state == :draft,
+      where: b.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state in [:draft, :scheduled],
       preload: ^preload(inputs),
       order_by: [desc: m.inserted_at]
     )

--- a/app/lib/operately_web/api/spaces/list_discussions.ex
+++ b/app/lib/operately_web/api/spaces/list_discussions.ex
@@ -38,9 +38,15 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussions do
   defp load_messages(me, inputs) do
     from(m in Message,
       join: b in assoc(m, :messages_board),
-      where: b.space_id == ^inputs.space_id and m.state == :published,
+      where:
+        b.space_id == ^inputs.space_id and
+          (m.state == :published or (m.state == :scheduled and m.author_id == ^me.id)),
       preload: ^preload(inputs),
-      order_by: [desc: m.published_at]
+      order_by: [
+        desc: m.state,
+        asc: m.scheduled_at,
+        desc: m.published_at
+      ]
     )
     |> Filters.filter_by_view_access(me.id)
     |> Repo.all()
@@ -50,7 +56,7 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussions do
   defp load_my_drafts(me, inputs) do
     from(m in Message,
       join: b in assoc(m, :messages_board),
-      where: b.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state in [:draft, :scheduled],
+      where: b.space_id == ^inputs.space_id and m.author_id == ^me.id and m.state == :draft,
       preload: ^preload(inputs),
       order_by: [desc: m.inserted_at]
     )

--- a/app/lib/operately_web/api/spaces/list_tools.ex
+++ b/app/lib/operately_web/api/spaces/list_tools.ex
@@ -142,7 +142,7 @@ defmodule OperatelyWeb.Api.Spaces.ListTools do
   defp load_messages_boards(space_id, me) do
     subquery =
       from(m in Message,
-        where: m.state != :draft,
+        where: m.state == :published,
         preload: :author,
         order_by: [desc: m.published_at]
       )

--- a/app/lib/operately_web/api/spaces/publish_discussion.ex
+++ b/app/lib/operately_web/api/spaces/publish_discussion.ex
@@ -34,7 +34,7 @@ defmodule OperatelyWeb.Api.Spaces.PublishDiscussion do
 
   defp authorize(me, discussion) do
     cond do
-      discussion.state != :draft -> {:error, :forbidden}
+      discussion.state not in [:draft, :scheduled] -> {:error, :forbidden}
       discussion.author_id != me.id -> {:error, :forbidden}
       true -> {:ok, :allowed}
     end

--- a/app/lib/operately_web/api/spaces/update_discussion.ex
+++ b/app/lib/operately_web/api/spaces/update_discussion.ex
@@ -27,6 +27,7 @@ defmodule OperatelyWeb.Api.Spaces.UpdateDiscussion do
     |> run(:me, fn -> find_me(conn) end)
     |> run(:message, fn ctx -> Message.get(ctx.me, id: inputs.id, opts: [preload: :space]) end)
     |> run(:check_permissions, fn ctx -> Permissions.check(ctx.message.request_info.access_level, :can_edit, company_read_only: company_read_only(conn)) end)
+    |> run(:check_draft_access, fn ctx -> check_draft_access(ctx.message, ctx.me) end)
     |> run(:operation, fn ctx -> DiscussionEditing.run(ctx.me, ctx.message, inputs) end)
     |> run(:serialized, fn ctx -> {:ok, %{discussion: Serializer.serialize(ctx.operation, level: :essential)}} end)
     |> respond()
@@ -38,6 +39,7 @@ defmodule OperatelyWeb.Api.Spaces.UpdateDiscussion do
       {:error, :id, _} -> {:error, :bad_request}
       {:error, :message, _} -> {:error, :not_found}
       {:error, :check_permissions, _} -> {:error, :forbidden}
+      {:error, :check_draft_access, _} -> {:error, :not_found}
       {:error, :operation, _} -> {:error, :internal_server_error}
       _ -> {:error, :internal_server_error}
     end

--- a/app/test/features/discussions/drafts_test.exs
+++ b/app/test/features/discussions/drafts_test.exs
@@ -52,6 +52,29 @@ defmodule Operately.Features.Discussions.DraftsTest do
     |> Steps.assert_draft_edit_is_saved(:draft_discussion_1)
   end
 
+  feature "scheduled discussion is shown in the discussion list for its author", ctx do
+    ctx
+    |> Steps.given_a_scheduled_discussion_exists()
+    |> Steps.visit_the_discussion_board()
+    |> Steps.assert_scheduled_discussion_is_in_the_discussion_list()
+    |> Steps.assert_scheduled_discussion_is_not_in_drafts()
+    |> Steps.assert_scheduled_discussion_is_hidden_from_reader()
+  end
+
+  feature "scheduled discussion can be published immediately", ctx do
+    ctx
+    |> Steps.given_a_scheduled_discussion_exists()
+    |> Steps.publish_scheduled_discussion_now()
+    |> Steps.assert_scheduled_discussion_is_published()
+  end
+
+  feature "scheduled discussion can be saved as a draft", ctx do
+    ctx
+    |> Steps.given_a_scheduled_discussion_exists()
+    |> Steps.save_scheduled_discussion_as_draft()
+    |> Steps.assert_scheduled_discussion_is_a_draft()
+  end
+
   feature "publish a draft discussion (without editing)", ctx do
     ctx
     |> Steps.post_a_draft_discussion()

--- a/app/test/features/goal_check_ins/scheduling_test.exs
+++ b/app/test/features/goal_check_ins/scheduling_test.exs
@@ -1,0 +1,30 @@
+defmodule Operately.Features.GoalCheckIns.SchedulingTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.GoalCheckInsSteps, as: Steps
+
+  setup ctx, do: Steps.setup(ctx)
+
+  feature "scheduled goal check-in shows its status and publication date", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.assert_scheduled_check_in_details()
+  end
+
+  feature "scheduled goal check-in can be published immediately", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.publish_scheduled_check_in_now()
+    |> Steps.assert_scheduled_check_in_is_published()
+  end
+
+  feature "scheduled goal check-in can be saved as a draft", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.save_scheduled_check_in_as_draft()
+    |> Steps.assert_scheduled_check_in_is_a_draft()
+  end
+end

--- a/app/test/features/project_check_ins/scheduling_test.exs
+++ b/app/test/features/project_check_ins/scheduling_test.exs
@@ -1,0 +1,34 @@
+defmodule Operately.Features.ProjectCheckIns.SchedulingTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.ProjectCheckInsSteps, as: Steps
+
+  setup ctx do
+    ctx
+    |> Steps.given_a_project_exists()
+    |> Steps.log_in_as_champion()
+  end
+
+  feature "scheduled project check-in shows its status and publication date", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.assert_scheduled_check_in_details()
+  end
+
+  feature "scheduled project check-in can be published immediately", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.publish_scheduled_check_in_now()
+    |> Steps.assert_scheduled_check_in_is_published()
+  end
+
+  feature "scheduled project check-in can be saved as a draft", ctx do
+    ctx
+    |> Steps.given_a_scheduled_check_in_exists()
+    |> Steps.visit_scheduled_check_in()
+    |> Steps.save_scheduled_check_in_as_draft()
+    |> Steps.assert_scheduled_check_in_is_a_draft()
+  end
+end

--- a/app/test/operately/drafts_test.exs
+++ b/app/test/operately/drafts_test.exs
@@ -21,6 +21,17 @@ defmodule Operately.DraftsTest do
              }) == published_at
     end
 
+    test "returns scheduled_at for scheduled resources" do
+      inserted_at = ~N[2026-01-01 10:00:00]
+      scheduled_at = ~U[2026-01-10 09:00:00Z]
+
+      assert Drafts.display_date(%{
+               state: :scheduled,
+               inserted_at: inserted_at,
+               scheduled_at: scheduled_at
+             }) == scheduled_at
+    end
+
     test "falls back to inserted_at when published_at is nil" do
       inserted_at = ~N[2026-01-01 10:00:00]
 

--- a/app/test/operately/operations/scheduled_posting_idempotency_test.exs
+++ b/app/test/operately/operations/scheduled_posting_idempotency_test.exs
@@ -1,0 +1,282 @@
+defmodule Operately.Operations.ScheduledPostingIdempotencyTest do
+  use Operately.DataCase
+
+  import Ecto.Query
+  alias Operately.Support.{Factory, RichText}
+  alias Operately.Operations.{
+    DiscussionEditing,
+    DiscussionPosting,
+    GoalCheckIn,
+    GoalCheckInEdit,
+    ProjectCheckIn,
+    ProjectCheckInEdit
+  }
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_project(:project, :space)
+    |> Factory.add_goal(:goal, :space)
+    |> Factory.add_messages_board(:messages_board, :space)
+  end
+
+  test "idempotency of oban jobs when editing a scheduled discussion", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      # 1. Create a scheduled discussion
+      time1 = DateTime.utc_now() |> DateTime.add(2, :day)
+
+      {:ok, message} = DiscussionPosting.run(ctx.creator, ctx.space, %{
+        messages_board_id: ctx.messages_board.id,
+        title: "Title",
+        content: RichText.rich_text("Content"),
+        post_as_draft: false,
+        send_to_everyone: true,
+        subscription_parent_type: :message,
+        subscriber_ids: [],
+        scheduled_at: time1
+      })
+
+      # Preload space to simulate what the API controller does
+      message = Repo.preload(message, :space)
+
+      assert message.state == :scheduled
+      assert_scheduled_job("message", message.id, time1)
+
+      # 2. Reschedule to a new time
+      time2 = DateTime.utc_now() |> DateTime.add(3, :day)
+      {:ok, message} = DiscussionEditing.run(ctx.creator, message, %{
+        title: "Title (Updated)",
+        body: RichText.rich_text("Content (Updated)"),
+        scheduled_at: time2
+      })
+
+      assert message.state == :scheduled
+      assert_scheduled_job("message", message.id, time2)
+
+      # 3. Reschedule again
+      time3 = DateTime.utc_now() |> DateTime.add(4, :day)
+      {:ok, message} = DiscussionEditing.run(ctx.creator, message, %{
+        title: "Title (Updated again)",
+        body: RichText.rich_text("Content (Updated again)"),
+        scheduled_at: time3
+      })
+
+      assert message.state == :scheduled
+      assert_scheduled_job("message", message.id, time3)
+
+      # 4. Cancel scheduling (convert to draft)
+      {:ok, message} = DiscussionEditing.run(ctx.creator, message, %{
+        state: :draft,
+        body: message.body
+      })
+
+      assert message.state == :draft
+      assert count_oban_jobs("message", message.id) == 0
+
+      # 5. Reschedule from draft
+      {:ok, message} = DiscussionEditing.run(ctx.creator, message, %{
+        state: :scheduled,
+        scheduled_at: time1,
+        body: message.body
+      })
+
+      assert message.state == :scheduled
+      assert_scheduled_job("message", message.id, time1)
+
+      # 6. Publish immediately
+      {:ok, message} = DiscussionEditing.run(ctx.creator, message, %{
+        state: :published,
+        body: message.body
+      })
+
+      assert message.state == :published
+      assert count_oban_jobs("message", message.id) == 0
+    end)
+  end
+
+  test "idempotency of oban jobs when editing a scheduled project check-in", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      time1 = DateTime.utc_now() |> DateTime.add(2, :day)
+
+      {:ok, check_in} =
+        ProjectCheckIn.run(ctx.creator, ctx.project, %{
+          status: "on_track",
+          content: RichText.rich_text("Content"),
+          post_as_draft: false,
+          send_to_everyone: true,
+          subscription_parent_type: :project_check_in,
+          subscriber_ids: [],
+          scheduled_at: time1
+        })
+
+      assert check_in.state == :scheduled
+      assert_scheduled_job("project_check_in", check_in.id, time1)
+
+      time2 = DateTime.utc_now() |> DateTime.add(3, :day)
+
+      {:ok, check_in} =
+        ProjectCheckInEdit.run(ctx.creator, check_in, %{
+          status: "on_track",
+          description: RichText.rich_text("Content (Updated)"),
+          scheduled_at: time2
+        })
+
+      assert check_in.state == :scheduled
+      assert_scheduled_job("project_check_in", check_in.id, time2)
+
+      time3 = DateTime.utc_now() |> DateTime.add(4, :day)
+
+      {:ok, check_in} =
+        ProjectCheckInEdit.run(ctx.creator, check_in, %{
+          status: "on_track",
+          description: RichText.rich_text("Content (Updated again)"),
+          scheduled_at: time3
+        })
+
+      assert check_in.state == :scheduled
+      assert_scheduled_job("project_check_in", check_in.id, time3)
+
+      {:ok, check_in} =
+        ProjectCheckInEdit.run(ctx.creator, check_in, %{
+          state: :draft,
+          status: check_in.status,
+          description: check_in.description
+        })
+
+      assert check_in.state == :draft
+      assert count_oban_jobs("project_check_in", check_in.id) == 0
+
+      {:ok, check_in} =
+        ProjectCheckInEdit.run(ctx.creator, check_in, %{
+          state: :scheduled,
+          status: check_in.status,
+          description: check_in.description,
+          scheduled_at: time1
+        })
+
+      assert check_in.state == :scheduled
+      assert_scheduled_job("project_check_in", check_in.id, time1)
+
+      {:ok, check_in} =
+        ProjectCheckInEdit.run(ctx.creator, check_in, %{
+          state: :published,
+          status: check_in.status,
+          description: check_in.description
+        })
+
+      assert check_in.state == :published
+      assert count_oban_jobs("project_check_in", check_in.id) == 0
+    end)
+  end
+
+  test "idempotency of oban jobs when editing a scheduled goal check-in", ctx do
+    Oban.Testing.with_testing_mode(:manual, fn ->
+      time1 = DateTime.utc_now() |> DateTime.add(2, :day)
+
+      {:ok, update} =
+        GoalCheckIn.run(ctx.creator, ctx.goal, %{
+          status: "on_track",
+          content: RichText.rich_text("Content"),
+          target_values: nil,
+          checklist: nil,
+          post_as_draft: false,
+          send_to_everyone: true,
+          subscription_parent_type: :goal_update,
+          subscriber_ids: [],
+          scheduled_at: time1
+        })
+
+      assert update.state == :scheduled
+      assert_scheduled_job("goal_update", update.id, time1)
+
+      time2 = DateTime.utc_now() |> DateTime.add(3, :day)
+
+      {:ok, update} =
+        GoalCheckInEdit.run(ctx.creator, ctx.goal, update, %{
+          status: "on_track",
+          content: RichText.rich_text("Content (Updated)"),
+          new_target_values: [],
+          checklist: [],
+          scheduled_at: time2
+        })
+
+      assert update.state == :scheduled
+      assert_scheduled_job("goal_update", update.id, time2)
+
+      time3 = DateTime.utc_now() |> DateTime.add(4, :day)
+
+      {:ok, update} =
+        GoalCheckInEdit.run(ctx.creator, ctx.goal, update, %{
+          status: "on_track",
+          content: RichText.rich_text("Content (Updated again)"),
+          new_target_values: [],
+          checklist: [],
+          scheduled_at: time3
+        })
+
+      assert update.state == :scheduled
+      assert_scheduled_job("goal_update", update.id, time3)
+
+      {:ok, update} =
+        GoalCheckInEdit.run(ctx.creator, ctx.goal, update, %{
+          state: :draft,
+          status: update.status,
+          content: update.message,
+          new_target_values: [],
+          checklist: []
+        })
+
+      assert update.state == :draft
+      assert count_oban_jobs("goal_update", update.id) == 0
+
+      {:ok, update} =
+        GoalCheckInEdit.run(ctx.creator, ctx.goal, update, %{
+          state: :scheduled,
+          status: update.status,
+          content: update.message,
+          new_target_values: [],
+          checklist: [],
+          scheduled_at: time1
+        })
+
+      assert update.state == :scheduled
+      assert_scheduled_job("goal_update", update.id, time1)
+
+      {:ok, update} =
+        GoalCheckInEdit.run(ctx.creator, ctx.goal, update, %{
+          state: :published,
+          status: update.status,
+          content: update.message,
+          new_target_values: [],
+          checklist: []
+        })
+
+      assert update.state == :published
+      assert count_oban_jobs("goal_update", update.id) == 0
+    end)
+  end
+
+  defp assert_scheduled_job(type, id, scheduled_at) do
+    assert count_oban_jobs(type, id) == 1
+    assert scheduled_job(type, id).scheduled_at == scheduled_at
+  end
+
+  defp count_oban_jobs(type, id) do
+    from(j in Oban.Job,
+      where: j.worker == "Operately.AsyncPublishing.Worker",
+      where: fragment("args->>'type' = ?", ^type),
+      where: fragment("args->>'id' = ?", ^id)
+    )
+    |> Repo.aggregate(:count, :id)
+  end
+
+  defp scheduled_job(type, id) do
+    from(j in Oban.Job,
+      where: j.worker == "Operately.AsyncPublishing.Worker",
+      where: fragment("args->>'type' = ?", ^type),
+      where: fragment("args->>'id' = ?", ^id)
+    )
+    |> Repo.one!()
+  end
+end

--- a/app/test/operately_web/api/projects/create_check_in_test.exs
+++ b/app/test/operately_web/api/projects/create_check_in_test.exs
@@ -1,5 +1,6 @@
 defmodule OperatelyWeb.Api.Projects.CreateCheckInTest do
   use OperatelyWeb.TurboCase
+  use Oban.Testing, repo: Operately.Repo
 
   import Ecto.Query, only: [from: 1]
   import Operately.ProjectsFixtures
@@ -108,6 +109,29 @@ defmodule OperatelyWeb.Api.Projects.CreateCheckInTest do
       refute check_in.published_at
       refute project.last_check_in_id
       refute project.last_check_in_status
+    end
+
+    test "schedules a project check-in for later", ctx do
+      project = project_fixture(%{company_id: ctx.company.id, creator_id: ctx.person.id, group_id: ctx.company.company_space_id})
+      scheduled_at = DateTime.utc_now() |> DateTime.add(2, :day) |> DateTime.truncate(:second)
+
+      assert {200, res} =
+               mutation(ctx.conn, [:projects, :create_check_in], %{
+                 project_id: Paths.project_id(project),
+                 status: "on_track",
+                 description: RichText.rich_text("Scheduled description", :as_string),
+                 scheduled_at: DateTime.to_iso8601(scheduled_at)
+               })
+
+      check_in = Repo.one!(from(p in CheckIn))
+      project = Repo.reload(project)
+
+      assert res.check_in.state == "scheduled"
+      assert check_in.state == :scheduled
+      assert check_in.scheduled_at
+      refute check_in.published_at
+      refute project.last_check_in_id
+      assert_enqueued(worker: Operately.AsyncPublishing.Worker, args: %{"type" => "project_check_in", "id" => check_in.id})
     end
   end
 

--- a/app/test/operately_web/api/projects/get_check_in_test.exs
+++ b/app/test/operately_web/api/projects/get_check_in_test.exs
@@ -224,6 +224,37 @@ defmodule OperatelyWeb.Api.Projects.GetCheckInTest do
       assert res.project_check_in.project.permissions
     end
 
+    test "scheduled check-ins are not found for non-authors", ctx do
+      ctx =
+        ctx
+        |> Factory.add_company_member(:viewer)
+        |> Factory.log_in_person(:viewer)
+
+      scheduled =
+        check_in_fixture(%{
+          author_id: ctx.creator.id,
+          project_id: ctx.project.id,
+          state: :scheduled,
+          scheduled_at: Operately.Time.days_from_now(1)
+        })
+
+      assert {404, _} = query(ctx.conn, [:projects, :get_check_in], %{id: Paths.project_check_in_id(scheduled)})
+    end
+
+    test "authors can get their scheduled check-ins", ctx do
+      scheduled =
+        check_in_fixture(%{
+          author_id: ctx.creator.id,
+          project_id: ctx.project.id,
+          state: :scheduled,
+          scheduled_at: Operately.Time.days_from_now(1)
+        })
+
+      assert {200, res} = query(ctx.conn, [:projects, :get_check_in], %{id: Paths.project_check_in_id(scheduled)})
+      assert res.project_check_in.state == "scheduled"
+      assert res.project_check_in.scheduled_at
+    end
+
     test "include_subscriptions_list", ctx do
       assert {200, res} = query(ctx.conn, [:projects, :get_check_in], %{id: Paths.project_check_in_id(ctx.check_in)})
       refute res.project_check_in.subscription_list

--- a/app/test/operately_web/api/projects/list_check_ins_test.exs
+++ b/app/test/operately_web/api/projects/list_check_ins_test.exs
@@ -115,6 +115,26 @@ defmodule OperatelyWeb.Api.Projects.ListCheckInsTest do
       assert length(ids) == 4
     end
 
+    test "scheduled check-ins are visible only to their author", ctx do
+      viewer = person_fixture_with_account(%{company_id: ctx.company.id})
+      {project_id, [published_check_in | _]} = create_project_and_check_ins(ctx, company_access: Binding.view_access())
+
+      scheduled =
+        check_in_fixture(%{
+          author_id: ctx.person.id,
+          project_id: published_check_in.project_id,
+          state: :scheduled,
+          scheduled_at: Operately.Time.days_from_now(1)
+        })
+
+      assert {200, res} = query(ctx.conn, [:projects, :list_check_ins], %{project_id: project_id})
+      assert Enum.map(res.project_check_ins, & &1.id) |> Enum.member?(Paths.project_check_in_id(scheduled))
+
+      viewer_conn = log_in_account(ctx.conn, Repo.preload(viewer, :account).account)
+      assert {200, res} = query(viewer_conn, [:projects, :list_check_ins], %{project_id: project_id})
+      refute Enum.map(res.project_check_ins, & &1.id) |> Enum.member?(Paths.project_check_in_id(scheduled))
+    end
+
     test "published check-ins are sorted by published_at desc", ctx do
       {project_id, [older_check_in, middle_check_in, newer_check_in]} =
         create_project_and_check_ins(ctx, company_access: Binding.view_access())

--- a/app/test/operately_web/api/spaces/list_discussions_test.exs
+++ b/app/test/operately_web/api/spaces/list_discussions_test.exs
@@ -127,6 +127,20 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussionsTest do
 
       assert discussion.comments_count == 2
     end
+
+    test "scheduled discussions are excluded from the public list and included in my_drafts for the author", ctx do
+      scheduled =
+        message_fixture(ctx.creator.id, ctx.messages_board.id, state: :scheduled, scheduled_at: Operately.Time.days_from_now(1))
+
+      assert {200, res} = query(ctx.conn, [:spaces, :list_discussions], %{
+        space_id: Paths.space_id(ctx.space),
+        include_my_drafts: true
+      })
+
+      refute Enum.any?(res.discussions, &(&1.id == Paths.message_id(scheduled)))
+      assert Enum.any?(res.my_drafts, &(&1.id == Paths.message_id(scheduled)))
+      assert Enum.find(res.my_drafts, &(&1.id == Paths.message_id(scheduled))).state == "scheduled"
+    end
   end
 
   #

--- a/app/test/operately_web/api/spaces/list_discussions_test.exs
+++ b/app/test/operately_web/api/spaces/list_discussions_test.exs
@@ -128,18 +128,34 @@ defmodule OperatelyWeb.Api.Spaces.ListDiscussionsTest do
       assert discussion.comments_count == 2
     end
 
-    test "scheduled discussions are excluded from the public list and included in my_drafts for the author", ctx do
+    test "scheduled discussions are listed first for the author and excluded from my_drafts", ctx do
       scheduled =
         message_fixture(ctx.creator.id, ctx.messages_board.id, state: :scheduled, scheduled_at: Operately.Time.days_from_now(1))
+
+      draft = message_fixture(ctx.creator.id, ctx.messages_board.id, state: :draft)
 
       assert {200, res} = query(ctx.conn, [:spaces, :list_discussions], %{
         space_id: Paths.space_id(ctx.space),
         include_my_drafts: true
       })
 
+      assert hd(res.discussions).id == Paths.message_id(scheduled)
+      assert Enum.any?(res.my_drafts, &(&1.id == Paths.message_id(draft)))
+      refute Enum.any?(res.my_drafts, &(&1.id == Paths.message_id(scheduled)))
+    end
+
+    test "scheduled discussions are hidden from other people", ctx do
+      ctx =
+        ctx
+        |> Factory.add_space_member(:other, :space)
+        |> Factory.log_in_person(:other)
+
+      scheduled =
+        message_fixture(ctx.creator.id, ctx.messages_board.id, state: :scheduled, scheduled_at: Operately.Time.days_from_now(1))
+
+      assert {200, res} = query(ctx.conn, [:spaces, :list_discussions], %{space_id: Paths.space_id(ctx.space)})
+
       refute Enum.any?(res.discussions, &(&1.id == Paths.message_id(scheduled)))
-      assert Enum.any?(res.my_drafts, &(&1.id == Paths.message_id(scheduled)))
-      assert Enum.find(res.my_drafts, &(&1.id == Paths.message_id(scheduled))).state == "scheduled"
     end
   end
 

--- a/app/test/support/features/discussions_steps.ex
+++ b/app/test/support/features/discussions_steps.ex
@@ -302,6 +302,77 @@ defmodule Operately.Support.Features.DiscussionsSteps do
     )
   end
 
+  step :given_a_scheduled_discussion_exists, ctx do
+    ctx
+    |> Factory.add_messages_board(:messages_board, :marketing_space)
+    |> Factory.add_message(:scheduled_discussion, :messages_board,
+      state: :scheduled,
+      scheduled_at: Operately.Time.days_from_now(1),
+      creator: ctx.author,
+      title: "Scheduled discussion"
+    )
+  end
+
+  step :assert_scheduled_discussion_is_in_the_discussion_list, ctx do
+    ctx
+    |> UI.assert_text("Scheduled discussion")
+    |> UI.assert_text("Scheduled")
+    |> UI.assert_text("Will be posted on")
+  end
+
+  step :assert_scheduled_discussion_is_not_in_drafts, ctx do
+    ctx
+    |> UI.visit(Paths.space_discussions_drafts_path(ctx.company, ctx.marketing_space))
+    |> UI.assert_text("You don't have any drafts.")
+    |> UI.refute_text("Scheduled discussion")
+  end
+
+  step :assert_scheduled_discussion_is_hidden_from_reader, ctx do
+    ctx
+    |> UI.login_as(ctx.reader)
+    |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
+    |> UI.refute_text("Scheduled discussion")
+  end
+
+  step :publish_scheduled_discussion_now, ctx do
+    ctx
+    |> UI.login_as(ctx.author)
+    |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
+    |> UI.click_text("Scheduled discussion")
+    |> UI.click(testid: "edit-discussion")
+    |> UI.click(testid: "publish-now-options")
+    |> UI.click(testid: "publish-now-option")
+  end
+
+  step :save_scheduled_discussion_as_draft, ctx do
+    ctx
+    |> UI.login_as(ctx.author)
+    |> UI.visit(Paths.space_discussions_path(ctx.company, ctx.marketing_space))
+    |> UI.click_text("Scheduled discussion")
+    |> UI.click(testid: "edit-discussion")
+    |> UI.click(testid: "publish-now-options")
+    |> UI.click(testid: "save-as-draft-option")
+  end
+
+  step :assert_scheduled_discussion_is_published, ctx do
+    {:ok, message} = Message.get(:system, id: ctx.scheduled_discussion.id)
+    assert message.state == :published
+
+    ctx
+    |> UI.assert_page(Paths.message_path(ctx.company, message))
+    |> UI.assert_text("Scheduled discussion")
+  end
+
+  step :assert_scheduled_discussion_is_a_draft, ctx do
+    {:ok, message} = Message.get(:system, id: ctx.scheduled_discussion.id)
+    assert message.state == :draft
+    assert message.scheduled_at == nil
+
+    ctx
+    |> UI.assert_page(Paths.message_path(ctx.company, message))
+    |> UI.assert_text("Scheduled discussion")
+  end
+
   step :click_on_continue_editing_draft, ctx do
     ctx
     |> UI.click(testid: "continue-editing-draft")

--- a/app/test/support/features/goal_check_ins_steps.ex
+++ b/app/test/support/features/goal_check_ins_steps.ex
@@ -263,6 +263,66 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
     |> UI.assert_text("Editing locked after 3 days")
   end
 
+  step :given_a_scheduled_check_in_exists, ctx do
+    {:ok, check_in} =
+      Operately.Operations.GoalCheckIn.run(ctx.champion, ctx.goal, %{
+        status: "on_track",
+        content: Operately.Support.RichText.rich_text("Scheduled goal check-in"),
+        target_values: nil,
+        checklist: nil,
+        post_as_draft: false,
+        send_to_everyone: false,
+        subscription_parent_type: :goal_update,
+        subscriber_ids: [],
+        scheduled_at: Operately.Time.days_from_now(1)
+      })
+
+    Map.put(ctx, :check_in, check_in)
+  end
+
+  step :visit_scheduled_check_in, ctx do
+    UI.visit(ctx, Paths.goal_check_in_path(ctx.company, ctx.check_in))
+  end
+
+  step :assert_scheduled_check_in_details, ctx do
+    ctx
+    |> UI.assert_text("Scheduled")
+    |> UI.assert_text("Will be posted on")
+  end
+
+  step :publish_scheduled_check_in_now, ctx do
+    ctx
+    |> UI.click(testid: "edit-check-in")
+    |> UI.click(testid: "publish-draft-options")
+    |> UI.click(testid: "publish-now-option")
+  end
+
+  step :save_scheduled_check_in_as_draft, ctx do
+    ctx
+    |> UI.click(testid: "edit-check-in")
+    |> UI.click(testid: "publish-draft-options")
+    |> UI.click(testid: "save-as-draft-option")
+  end
+
+  step :assert_scheduled_check_in_is_published, ctx do
+    update = Operately.Goals.Update.get!(:system, id: ctx.check_in.id)
+    assert update.state == :published
+
+    ctx
+    |> UI.assert_page(Paths.goal_check_in_path(ctx.company, update))
+    |> UI.assert_text("Scheduled goal check-in")
+  end
+
+  step :assert_scheduled_check_in_is_a_draft, ctx do
+    update = Operately.Goals.Update.get!(:system, id: ctx.check_in.id)
+    assert update.state == :draft
+    assert update.scheduled_at == nil
+
+    ctx
+    |> UI.assert_page(Paths.goal_check_in_path(ctx.company, update))
+    |> UI.assert_text("Scheduled goal check-in")
+  end
+
   step :given_a_reviewer_submitted_check_in, ctx do
     ctx
     |> UI.login_as(ctx.reviewer)

--- a/app/test/support/features/goal_check_ins_steps.ex
+++ b/app/test/support/features/goal_check_ins_steps.ex
@@ -281,7 +281,9 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
   end
 
   step :visit_scheduled_check_in, ctx do
-    UI.visit(ctx, Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    ctx
+    |> UI.visit(Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
   end
 
   step :assert_scheduled_check_in_details, ctx do
@@ -292,6 +294,8 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
 
   step :publish_scheduled_check_in_now, ctx do
     ctx
+    |> UI.visit(Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
     |> UI.click(testid: "edit-check-in")
     |> UI.click(testid: "publish-draft-options")
     |> UI.click(testid: "publish-now-option")
@@ -299,13 +303,16 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
 
   step :save_scheduled_check_in_as_draft, ctx do
     ctx
+    |> UI.visit(Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
     |> UI.click(testid: "edit-check-in")
     |> UI.click(testid: "publish-draft-options")
     |> UI.click(testid: "save-as-draft-option")
   end
 
   step :assert_scheduled_check_in_is_published, ctx do
-    update = Operately.Goals.Update.get!(:system, id: ctx.check_in.id)
+    ctx = UI.assert_page(ctx, Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    update = wait_for_update_state(ctx.check_in.id, :published)
     assert update.state == :published
 
     ctx
@@ -314,7 +321,8 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
   end
 
   step :assert_scheduled_check_in_is_a_draft, ctx do
-    update = Operately.Goals.Update.get!(:system, id: ctx.check_in.id)
+    ctx = UI.assert_page(ctx, Paths.goal_check_in_path(ctx.company, ctx.check_in))
+    update = wait_for_update_state(ctx.check_in.id, :draft)
     assert update.state == :draft
     assert update.scheduled_at == nil
 
@@ -516,6 +524,23 @@ defmodule Operately.Support.Features.GoalCheckInsSteps do
 
   defp last_comment(ctx) do
     Operately.Updates.list_comments(ctx.check_in.id, :goal_update) |> List.last()
+  end
+
+  defp wait_for_update_state(id, expected_state, attempts \\ 10)
+
+  defp wait_for_update_state(id, _expected_state, 0) do
+    Operately.Goals.Update.get!(:system, id: id)
+  end
+
+  defp wait_for_update_state(id, expected_state, attempts) do
+    update = Operately.Goals.Update.get!(:system, id: id)
+
+    if update.state == expected_state do
+      update
+    else
+      Process.sleep(200)
+      wait_for_update_state(id, expected_state, attempts - 1)
+    end
   end
 
   defp status_label("on_track"), do: "On track"

--- a/app/test/support/features/goal_creation_steps.ex
+++ b/app/test/support/features/goal_creation_steps.ex
@@ -20,7 +20,9 @@ defmodule Operately.Support.Features.GoalCreationTestSteps do
   end
 
   step :visit_goal_page, ctx do
-    ctx |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    ctx
+    |> UI.visit(Paths.goal_path(ctx.company, ctx.goal))
+    |> wait_until_goal_page()
   end
 
   step :click_add_goal_in_related_work, ctx do
@@ -76,7 +78,7 @@ defmodule Operately.Support.Features.GoalCreationTestSteps do
 
   step :assert_subgoal_form_title_and_subtitle, ctx do
     ctx
-    |> UI.wait_until_testid(testid: "goal-add-page")
+    |> wait_until_subgoal_form()
     |> UI.assert_text("Add a subgoal", testid: "goal-add-page")
     |> UI.assert_text("Adding under", testid: "goal-add-page")
     |> UI.assert_text(ctx.goal.name, testid: "goal-add-page")
@@ -144,5 +146,25 @@ defmodule Operately.Support.Features.GoalCreationTestSteps do
       goal ->
         goal
     end
+  end
+
+  defp wait_until_subgoal_form(ctx, attempts \\ 2) do
+    wait_until_page(ctx, "goal-add-page", attempts)
+  end
+
+  defp wait_until_goal_page(ctx, attempts \\ 2) do
+    wait_until_page(ctx, "goal-page", attempts)
+  end
+
+  defp wait_until_page(ctx, testid, attempts) do
+    UI.wait_until_testid(ctx, testid: testid)
+  rescue
+    e in RuntimeError ->
+      if attempts == 1 do
+        reraise e, __STACKTRACE__
+      else
+        :timer.sleep(250)
+        wait_until_page(ctx, testid, attempts - 1)
+      end
   end
 end

--- a/app/test/support/features/project_check_ins_steps.ex
+++ b/app/test/support/features/project_check_ins_steps.ex
@@ -123,6 +123,64 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
     |> UI.refute_has(testid: UI.testid(["nav-item", ctx.secret_space.name]))
   end
 
+  step :given_a_scheduled_check_in_exists, ctx do
+    {:ok, check_in} =
+      Operately.Operations.ProjectCheckIn.run(ctx.champion, ctx.project, %{
+        status: "on_track",
+        content: RichText.rich_text("Scheduled project check-in"),
+        post_as_draft: false,
+        send_to_everyone: false,
+        subscription_parent_type: :project_check_in,
+        subscriber_ids: [],
+        scheduled_at: Operately.Time.days_from_now(1)
+      })
+
+    Map.put(ctx, :check_in, check_in)
+  end
+
+  step :visit_scheduled_check_in, ctx do
+    UI.visit(ctx, Paths.project_check_in_path(ctx.company, ctx.check_in))
+  end
+
+  step :assert_scheduled_check_in_details, ctx do
+    ctx
+    |> UI.assert_text("Scheduled")
+    |> UI.assert_text("Will be posted on")
+  end
+
+  step :publish_scheduled_check_in_now, ctx do
+    ctx
+    |> UI.click(testid: "edit-check-in")
+    |> UI.click(testid: "publish-draft-options")
+    |> UI.click(testid: "publish-now-option")
+  end
+
+  step :save_scheduled_check_in_as_draft, ctx do
+    ctx
+    |> UI.click(testid: "edit-check-in")
+    |> UI.click(testid: "publish-draft-options")
+    |> UI.click(testid: "save-as-draft-option")
+  end
+
+  step :assert_scheduled_check_in_is_published, ctx do
+    check_in = Operately.Projects.CheckIn.get!(:system, id: ctx.check_in.id)
+    assert check_in.state == :published
+
+    ctx
+    |> UI.assert_page(Paths.project_check_in_path(ctx.company, check_in))
+    |> UI.assert_text("Scheduled project check-in")
+  end
+
+  step :assert_scheduled_check_in_is_a_draft, ctx do
+    check_in = Operately.Projects.CheckIn.get!(:system, id: ctx.check_in.id)
+    assert check_in.state == :draft
+    assert check_in.scheduled_at == nil
+
+    ctx
+    |> UI.assert_page(Paths.project_check_in_path(ctx.company, check_in))
+    |> UI.assert_text("Scheduled project check-in")
+  end
+
   step :assert_check_in_visible_on_project_page, ctx, %{description: description} do
     ctx
     |> UI.visit(Paths.project_path(ctx.company, ctx.project))

--- a/app/test/support/features/project_check_ins_steps.ex
+++ b/app/test/support/features/project_check_ins_steps.ex
@@ -139,7 +139,9 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   end
 
   step :visit_scheduled_check_in, ctx do
-    UI.visit(ctx, Paths.project_check_in_path(ctx.company, ctx.check_in))
+    ctx
+    |> UI.visit(Paths.project_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
   end
 
   step :assert_scheduled_check_in_details, ctx do
@@ -150,6 +152,8 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
 
   step :publish_scheduled_check_in_now, ctx do
     ctx
+    |> UI.visit(Paths.project_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
     |> UI.click(testid: "edit-check-in")
     |> UI.click(testid: "publish-draft-options")
     |> UI.click(testid: "publish-now-option")
@@ -157,13 +161,16 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
 
   step :save_scheduled_check_in_as_draft, ctx do
     ctx
+    |> UI.visit(Paths.project_check_in_path(ctx.company, ctx.check_in))
+    |> UI.wait_until_testid(testid: "edit-check-in")
     |> UI.click(testid: "edit-check-in")
     |> UI.click(testid: "publish-draft-options")
     |> UI.click(testid: "save-as-draft-option")
   end
 
   step :assert_scheduled_check_in_is_published, ctx do
-    check_in = Operately.Projects.CheckIn.get!(:system, id: ctx.check_in.id)
+    ctx = UI.assert_page(ctx, Paths.project_check_in_path(ctx.company, ctx.check_in))
+    check_in = wait_for_check_in_state(ctx.check_in.id, :published)
     assert check_in.state == :published
 
     ctx
@@ -172,7 +179,8 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
   end
 
   step :assert_scheduled_check_in_is_a_draft, ctx do
-    check_in = Operately.Projects.CheckIn.get!(:system, id: ctx.check_in.id)
+    ctx = UI.assert_page(ctx, Paths.project_check_in_path(ctx.company, ctx.check_in))
+    check_in = wait_for_check_in_state(ctx.check_in.id, :draft)
     assert check_in.state == :draft
     assert check_in.scheduled_at == nil
 
@@ -489,5 +497,22 @@ defmodule Operately.Support.Features.ProjectCheckInsSteps do
 
   defp last_comment(ctx) do
     Operately.Updates.list_comments(ctx.check_in.id, :project_check_in) |> List.last()
+  end
+
+  defp wait_for_check_in_state(id, expected_state, attempts \\ 10)
+
+  defp wait_for_check_in_state(id, _expected_state, 0) do
+    Operately.Projects.CheckIn.get!(:system, id: id)
+  end
+
+  defp wait_for_check_in_state(id, expected_state, attempts) do
+    check_in = Operately.Projects.CheckIn.get!(:system, id: id)
+
+    if check_in.state == expected_state do
+      check_in
+    else
+      Process.sleep(200)
+      wait_for_check_in_state(id, expected_state, attempts - 1)
+    end
   end
 end

--- a/app/test/support/features/projects_steps.ex
+++ b/app/test/support/features/projects_steps.ex
@@ -1207,20 +1207,15 @@ defmodule Operately.Support.Features.ProjectSteps do
   end
 
   defp assert_reviewer_field_ready(ctx, text) do
-    ctx
-    |> UI.wait_until_has(css: "button[data-test-id=\"reviewer-field\"]")
-    |> UI.wait_until_text(text, testid: "reviewer-field")
+    wait_until_reviewer_field(ctx, text)
   end
 
   defp wait_until_reviewer_field(ctx, text, attempts \\ [50, 100, 200, 400, 800, 1600, 3200]) do
-    ctx =
+    try do
       ctx
       |> UI.visit(Paths.project_path(ctx.company, ctx.project))
       |> UI.wait_until_testid(testid: "project-page")
       |> UI.wait_until_has(css: "button[data-test-id=\"reviewer-field\"]")
-
-    try do
-      ctx
       |> UI.find(UI.query(testid: "reviewer-field"), fn el ->
         UI.assert_text(el, text)
       end)

--- a/turboui/src/Button/OptionsButton.tsx
+++ b/turboui/src/Button/OptionsButton.tsx
@@ -7,10 +7,11 @@ import { Spinner } from "./Spinner";
 export interface OptionsButtonProps {
   children: React.ReactNode;
   onClick: () => void;
-  options: { label: string; action: () => void }[];
+  options: { label: string; action: () => void; testId?: string }[];
   loading?: boolean;
   disabled?: boolean;
   testId?: string;
+  dropdownTestId?: string;
   size?: "sm" | "base";
 }
 
@@ -21,6 +22,7 @@ export function OptionsButton({
   loading,
   disabled,
   testId,
+  dropdownTestId,
   size = "base",
 }: OptionsButtonProps) {
   const isBase = size === "base";
@@ -35,7 +37,7 @@ export function OptionsButton({
       "hover:bg-blue-600": !loading && !disabled,
       "bg-blue-400 border-blue-400 cursor-default": loading,
       "bg-blue-500 border-blue-500 opacity-50 cursor-not-allowed": disabled,
-    }
+    },
   );
 
   const dropdownClass = classNames(
@@ -48,7 +50,7 @@ export function OptionsButton({
       "hover:bg-blue-600": !loading && !disabled,
       "bg-blue-400 border-blue-400 cursor-default": loading,
       "bg-blue-500 border-blue-500 opacity-50 cursor-not-allowed": disabled,
-    }
+    },
   );
 
   return (
@@ -60,13 +62,19 @@ export function OptionsButton({
 
       <Menu
         customTrigger={
-          <button type="button" className={dropdownClass} disabled={loading || disabled}>
+          <button
+            type="button"
+            className={dropdownClass}
+            disabled={loading || disabled}
+            data-testid={dropdownTestId}
+            data-test-id={dropdownTestId}
+          >
             <IconChevronDown size={isBase ? 16 : 14} />
           </button>
         }
       >
-        {options.map((option, index) => (
-          <MenuActionItem key={index} onClick={option.action}>
+        {options.map((option) => (
+          <MenuActionItem key={option.label} onClick={option.action} testId={option.testId}>
             {option.label}
           </MenuActionItem>
         ))}

--- a/turboui/src/CheckInCard/__tests__/index.test.tsx
+++ b/turboui/src/CheckInCard/__tests__/index.test.tsx
@@ -8,7 +8,7 @@ import { CheckInCard } from "..";
 import { defaultFormattedTimePreferences } from "../../utils/storybook/formattedTime";
 
 describe("CheckInCard", () => {
-  function renderCard(author = null) {
+  function renderCard(author = null, scheduledAt: string | null = null) {
     return render(
       <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
         <CheckInCard
@@ -22,6 +22,8 @@ describe("CheckInCard", () => {
             content: JSON.stringify({ type: "doc", content: [] }),
             commentCount: 3,
             status: "on_track",
+            state: scheduledAt ? "scheduled" : "published",
+            scheduledAt,
           }}
         />
       </MemoryRouter>
@@ -33,5 +35,12 @@ describe("CheckInCard", () => {
 
     expect(screen.getByText(/Check-In for/)).toBeInTheDocument();
     expect(screen.queryByTitle("?")).not.toBeInTheDocument();
+  });
+
+  it("renders the scheduled label and publication date", () => {
+    renderCard(null, "2026-05-10T12:00:00Z");
+
+    expect(screen.getByText("Scheduled")).toBeInTheDocument();
+    expect(screen.getByText(/Will be posted on/)).toBeInTheDocument();
   });
 });

--- a/turboui/src/CheckInCard/index.tsx
+++ b/turboui/src/CheckInCard/index.tsx
@@ -8,6 +8,7 @@ import { Summary } from "../RichContent";
 import FormattedTime, { type FormattedTimePreferences } from "../FormattedTime";
 import { CommentCountIndicator } from "../CommentCountIndicator";
 import { StatusBadge, BadgeStatus } from "../StatusBadge";
+import { ScheduledPostDate, ScheduledPostLabel } from "../SchedulePosting";
 
 namespace CheckInCard {
   interface CheckIn {
@@ -18,6 +19,7 @@ namespace CheckInCard {
     commentCount: number;
     status: BadgeStatus;
     state?: "draft" | "scheduled" | "published" | null;
+    scheduledAt?: string | null;
   }
 
   export interface Props {
@@ -53,9 +55,7 @@ export function CheckInCard({ checkIn, mentionedPersonLookup, type, formattedTim
             {checkIn.state === "draft" && (
               <StatusBadge status="pending" customLabel="Draft" hideIcon className="scale-95 inline-block shrink-0" />
             )}
-            {checkIn.state === "scheduled" && (
-              <StatusBadge status="pending" customLabel="Scheduled" hideIcon className="scale-95 inline-block shrink-0" />
-            )}
+            {checkIn.state === "scheduled" && <ScheduledPostLabel />}
             <StatusBadge status={checkIn.status} hideIcon className="scale-95 inline-block shrink-0" />
           </div>
           <div className="break-words">
@@ -69,9 +69,16 @@ export function CheckInCard({ checkIn, mentionedPersonLookup, type, formattedTim
                 <div className="text-sm text-content-dimmed">·</div>
               </>
             )}
-            <div className="text-sm text-content-dimmed">
-              <FormattedTime {...formattedTimePreferences} time={checkIn.date} format="relative-weekday-or-date" />
-            </div>
+            {checkIn.state === "scheduled" && checkIn.scheduledAt ? (
+              <ScheduledPostDate
+                scheduledAt={checkIn.scheduledAt}
+                formattedTimePreferences={formattedTimePreferences}
+              />
+            ) : (
+              <div className="text-sm text-content-dimmed">
+                <FormattedTime {...formattedTimePreferences} time={checkIn.date} format="relative-weekday-or-date" />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/turboui/src/CheckInCard/index.tsx
+++ b/turboui/src/CheckInCard/index.tsx
@@ -53,6 +53,9 @@ export function CheckInCard({ checkIn, mentionedPersonLookup, type, formattedTim
             {checkIn.state === "draft" && (
               <StatusBadge status="pending" customLabel="Draft" hideIcon className="scale-95 inline-block shrink-0" />
             )}
+            {checkIn.state === "scheduled" && (
+              <StatusBadge status="pending" customLabel="Scheduled" hideIcon className="scale-95 inline-block shrink-0" />
+            )}
             <StatusBadge status={checkIn.status} hideIcon className="scale-95 inline-block shrink-0" />
           </div>
           <div className="break-words">

--- a/turboui/src/DiscussionCard/index.tsx
+++ b/turboui/src/DiscussionCard/index.tsx
@@ -7,6 +7,7 @@ import { DivLink } from "../Link";
 import { Summary } from "../RichContent";
 import FormattedTime, { type FormattedTimePreferences } from "../FormattedTime";
 import { CommentCountIndicator } from "../CommentCountIndicator";
+import { StatusBadge } from "../StatusBadge";
 
 namespace DiscussionCard {
   interface Discussion {
@@ -17,6 +18,7 @@ namespace DiscussionCard {
     link: string;
     content: string;
     commentCount: number;
+    state?: "draft" | "scheduled" | "published" | null;
   }
 
   export interface Props {
@@ -44,7 +46,15 @@ export function DiscussionCard({ discussion, mentionedPersonLookup, formattedTim
         )}
 
         <div className="flex-1 h-full">
-          <div className="font-semibold leading-none mb-1">{discussion.title}</div>
+          <div className="flex items-center gap-2 mb-1">
+            <div className="font-semibold leading-none">{discussion.title}</div>
+            {discussion.state === "draft" && (
+              <StatusBadge status="pending" customLabel="Draft" hideIcon className="scale-95 inline-block shrink-0" />
+            )}
+            {discussion.state === "scheduled" && (
+              <StatusBadge status="pending" customLabel="Scheduled" hideIcon className="scale-95 inline-block shrink-0" />
+            )}
+          </div>
           <div className="break-words">
             <Summary content={discussion.content} characterCount={130} mentionedPersonLookup={mentionedPersonLookup} />
           </div>

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -85,6 +85,7 @@ export namespace GoalPage {
     commentCount: number;
     status: BadgeStatus;
     state?: "draft" | "scheduled" | "published" | null;
+    scheduledAt?: string | null;
   }
 
   export interface Discussion {

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -48,6 +48,7 @@ export namespace ProjectPage {
     commentCount: number;
     status: BadgeStatus;
     state?: "draft" | "scheduled" | "published" | null;
+    scheduledAt?: string | null;
   }
 
   export interface Discussion {

--- a/turboui/src/SchedulePosting/ScheduleFlowControls.tsx
+++ b/turboui/src/SchedulePosting/ScheduleFlowControls.tsx
@@ -1,13 +1,30 @@
 import React from "react";
 
-import { useFormattedTimePreferences } from "@/hooks/useFormattedTimePreferences";
-import type { ScheduleFlow } from "@/hooks/useScheduleFlow";
-import { OptionsButton, ScheduleModal, ScheduleNotice } from "turboui";
+import { OptionsButton } from "../Button";
+import type { FormattedTimePreferences } from "../FormattedTime";
+import { ScheduleModal } from "./ScheduleModal";
+import { ScheduleNotice } from "./ScheduleNotice";
 
-interface Props {
-  scheduleFlow: ScheduleFlow;
+/**
+ * UI state for the schedule flow. App bridges typically provide this from a
+ * shared hook (e.g. useScheduleFlow) via structural typing.
+ */
+export interface ScheduleFlowState {
+  isModalOpen: boolean;
+  setIsModalOpen: (open: boolean) => void;
+  isScheduledLocally: boolean;
+  scheduledAt: Date | null;
+  openScheduleModal: () => void;
+  confirmSchedule: (date: Date) => void;
+  cancelSchedule: () => void;
+  primaryButtonLabel: (immediateLabel: string) => string;
+}
+
+export interface ScheduleFlowControlsProps {
+  scheduleFlow: ScheduleFlowState;
   primaryLabel: string;
   onPrimaryClick: () => void;
+  formattedTimePreferences: FormattedTimePreferences;
   loading?: boolean;
   disabled?: boolean;
   testId?: string;
@@ -18,13 +35,12 @@ export function ScheduleFlowControls({
   scheduleFlow,
   primaryLabel,
   onPrimaryClick,
+  formattedTimePreferences,
   loading,
   disabled,
   testId,
   secondaryAction,
-}: Props) {
-  const formattedTimePreferences = useFormattedTimePreferences();
-
+}: ScheduleFlowControlsProps) {
   return (
     <>
       {scheduleFlow.isScheduledLocally && scheduleFlow.scheduledAt && (

--- a/turboui/src/SchedulePosting/ScheduleFlowControls.tsx
+++ b/turboui/src/SchedulePosting/ScheduleFlowControls.tsx
@@ -29,6 +29,9 @@ export interface ScheduleFlowControlsProps {
   disabled?: boolean;
   testId?: string;
   secondaryAction?: React.ReactNode;
+  options?: { label: string; action: () => void; testId?: string }[];
+  scheduledPrimaryLabel?: string;
+  showScheduleOption?: boolean;
 }
 
 export function ScheduleFlowControls({
@@ -40,7 +43,18 @@ export function ScheduleFlowControls({
   disabled,
   testId,
   secondaryAction,
+  options = [],
+  scheduledPrimaryLabel,
+  showScheduleOption = true,
 }: ScheduleFlowControlsProps) {
+  const buttonLabel =
+    scheduleFlow.isScheduledLocally && scheduledPrimaryLabel
+      ? scheduledPrimaryLabel
+      : scheduleFlow.primaryButtonLabel(primaryLabel);
+  const buttonOptions = showScheduleOption
+    ? [...options, { label: "Schedule for later", action: scheduleFlow.openScheduleModal }]
+    : options;
+
   return (
     <>
       {scheduleFlow.isScheduledLocally && scheduleFlow.scheduledAt && (
@@ -58,9 +72,10 @@ export function ScheduleFlowControls({
           loading={loading}
           disabled={disabled}
           testId={testId}
-          options={[{ label: "Schedule for later", action: scheduleFlow.openScheduleModal }]}
+          dropdownTestId={testId ? `${testId}-options` : undefined}
+          options={buttonOptions}
         >
-          {scheduleFlow.primaryButtonLabel(primaryLabel)}
+          {buttonLabel}
         </OptionsButton>
 
         {secondaryAction}

--- a/turboui/src/SchedulePosting/ScheduleModal.tsx
+++ b/turboui/src/SchedulePosting/ScheduleModal.tsx
@@ -32,25 +32,23 @@ export function ScheduleModal({ children, open, onOpenChange, onSchedule, onCanc
     onOpenChange(false);
   };
 
-  const isInvalid = !selectedDate || (() => {
-    if (!selectedDate?.date) return false;
-    const [hours = "09", minutes = "00"] = time.split(":");
-    const finalDate = new Date(selectedDate.date);
-    finalDate.setHours(parseInt(hours, 10));
-    finalDate.setMinutes(parseInt(minutes, 10));
-    return finalDate <= new Date();
-  })();
+  const isInvalid =
+    !selectedDate ||
+    (() => {
+      if (!selectedDate?.date) return false;
+      const [hours = "09", minutes = "00"] = time.split(":");
+      const finalDate = new Date(selectedDate.date);
+      finalDate.setHours(parseInt(hours, 10));
+      finalDate.setMinutes(parseInt(minutes, 10));
+      return finalDate <= new Date();
+    })();
 
   return (
     <>
       {children}
       <Modal isOpen={open} onClose={() => onOpenChange(false)} title="Schedule Post" size="xx-small">
         <div className="mb-4 mt-2">
-          <InlineCalendar
-            selectedDate={selectedDate}
-            setSelectedDate={setSelectedDate}
-            minDateLimit={new Date()}
-          />
+          <InlineCalendar selectedDate={selectedDate} setSelectedDate={setSelectedDate} minDateLimit={new Date()} />
         </div>
 
         <div className="mb-6 flex items-center justify-between">
@@ -64,11 +62,13 @@ export function ScheduleModal({ children, open, onOpenChange, onSchedule, onCanc
         </div>
 
         <div className="flex justify-end gap-2 mt-4 items-center">
-          {isInvalid && selectedDate && (
-            <span className="text-red-500 text-xs mr-auto">Time must be in the future</span>
-          )}
-          <SecondaryButton onClick={handleCancel} size="sm">Cancel</SecondaryButton>
-          <PrimaryButton onClick={handleSchedule} size="sm" disabled={isInvalid}>Schedule</PrimaryButton>
+          {isInvalid && selectedDate && <span className="text-red-500 text-xs mr-auto">Time must be in the future</span>}
+          <SecondaryButton onClick={handleCancel} size="sm">
+            Cancel
+          </SecondaryButton>
+          <PrimaryButton onClick={handleSchedule} size="sm" disabled={isInvalid}>
+            Schedule
+          </PrimaryButton>
         </div>
       </Modal>
     </>

--- a/turboui/src/SchedulePosting/ScheduleNotice.tsx
+++ b/turboui/src/SchedulePosting/ScheduleNotice.tsx
@@ -12,14 +12,19 @@ export interface ScheduleNoticeProps {
 
 export function ScheduleNotice({ date, onEdit, className = "", formattedTimePreferences }: ScheduleNoticeProps) {
   return (
-    <div className={`flex items-center justify-between gap-3 bg-surface-dimmed border border-stroke-base p-3 rounded-lg ${className}`}>
+    <div
+      className={`flex items-center justify-between gap-3 bg-surface-dimmed border border-stroke-base p-3 rounded-lg ${className}`}
+    >
       <div className="flex items-center gap-3">
         <IconCalendarEvent size={20} className="text-content-dimmed" />
         <span className="text-sm font-medium">
-          Will be posted on <FormattedTime {...formattedTimePreferences} time={date} format="long-date" /> at <FormattedTime {...formattedTimePreferences} time={date} format="time-only" />
+          Will be posted on <FormattedTime {...formattedTimePreferences} time={date} format="long-date" /> at{" "}
+          <FormattedTime {...formattedTimePreferences} time={date} format="time-only" />
         </span>
       </div>
-      <GhostButton size="sm" onClick={onEdit}>Edit</GhostButton>
+      <GhostButton size="sm" onClick={onEdit}>
+        Edit
+      </GhostButton>
     </div>
   );
 }

--- a/turboui/src/SchedulePosting/ScheduledPostDate.tsx
+++ b/turboui/src/SchedulePosting/ScheduledPostDate.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import { FormattedTime, type FormattedTimePreferences } from "../FormattedTime";
+
+export interface ScheduledPostDateProps {
+  scheduledAt: string | Date;
+  formattedTimePreferences: FormattedTimePreferences;
+}
+
+export function ScheduledPostDate({ scheduledAt, formattedTimePreferences }: ScheduledPostDateProps) {
+  return (
+    <div className="text-sm text-content-dimmed">
+      Will be posted on <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="long-date" /> at{" "}
+      <FormattedTime {...formattedTimePreferences} time={scheduledAt} format="time-only" />
+    </div>
+  );
+}

--- a/turboui/src/SchedulePosting/ScheduledPostLabel.tsx
+++ b/turboui/src/SchedulePosting/ScheduledPostLabel.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+import { StatusBadge } from "../StatusBadge";
+
+export function ScheduledPostLabel() {
+  return <StatusBadge status="pending" customLabel="Scheduled" hideIcon className="scale-95 inline-block shrink-0" />;
+}

--- a/turboui/src/SchedulePosting/__tests__/ScheduleFlowControls.test.tsx
+++ b/turboui/src/SchedulePosting/__tests__/ScheduleFlowControls.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { ScheduleFlowControls, type ScheduleFlowState } from "../ScheduleFlowControls";
+import { defaultFormattedTimePreferences } from "../../utils/storybook/formattedTime";
+
+function scheduleFlow(): ScheduleFlowState {
+  return {
+    isModalOpen: false,
+    setIsModalOpen: jest.fn(),
+    isScheduledLocally: true,
+    scheduledAt: new Date("2026-08-01T09:00:00Z"),
+    openScheduleModal: jest.fn(),
+    confirmSchedule: jest.fn(),
+    cancelSchedule: jest.fn(),
+    primaryButtonLabel: () => "Confirm",
+  };
+}
+
+describe("ScheduleFlowControls", () => {
+  it("renders configurable scheduled-post actions", async () => {
+    const publishNow = jest.fn();
+    const saveAsDraft = jest.fn();
+
+    render(
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow()}
+        primaryLabel="Confirm"
+        scheduledPrimaryLabel="Save Changes"
+        onPrimaryClick={jest.fn()}
+        formattedTimePreferences={defaultFormattedTimePreferences}
+        testId="scheduled-post"
+        showScheduleOption={false}
+        options={[
+          { label: "Publish now", action: publishNow, testId: "publish-now-option" },
+          { label: "Save as draft", action: saveAsDraft, testId: "save-as-draft-option" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("scheduled-post-options"));
+
+    expect(screen.queryByRole("menuitem", { name: "Schedule for later" })).not.toBeInTheDocument();
+
+    await user.click(await screen.findByRole("menuitem", { name: "Publish now" }));
+    expect(publishNow).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId("scheduled-post-options"));
+    await user.click(await screen.findByRole("menuitem", { name: "Save as draft" }));
+    expect(saveAsDraft).toHaveBeenCalledTimes(1);
+  });
+});

--- a/turboui/src/SchedulePosting/index.stories.tsx
+++ b/turboui/src/SchedulePosting/index.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React, { useState } from "react";
+
+import { GhostButton } from "../Button";
+import { defaultFormattedTimePreferences } from "../FormattedTime/types";
+import { ScheduleFlowControls, type ScheduleFlowState } from "./ScheduleFlowControls";
+import { ScheduleModal } from "./ScheduleModal";
+import { ScheduleNotice } from "./ScheduleNotice";
+
+const meta = {
+  title: "Components/SchedulePosting",
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+
+function useStoryScheduleFlow(initialScheduledAt: Date | null = null): ScheduleFlowState {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [scheduledAt, setScheduledAt] = useState<Date | null>(initialScheduledAt);
+  const [isScheduledLocally, setIsScheduledLocally] = useState(initialScheduledAt !== null);
+
+  return {
+    isModalOpen,
+    setIsModalOpen,
+    isScheduledLocally,
+    scheduledAt,
+    openScheduleModal: () => setIsModalOpen(true),
+    confirmSchedule: (date: Date) => {
+      setScheduledAt(date);
+      setIsScheduledLocally(true);
+      setIsModalOpen(false);
+    },
+    cancelSchedule: () => setIsModalOpen(false),
+    primaryButtonLabel: (immediateLabel: string) => (isScheduledLocally ? "Confirm" : immediateLabel),
+  };
+}
+
+function ScheduleModalDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="p-4">
+      <GhostButton onClick={() => setOpen(true)}>Open schedule modal</GhostButton>
+      <ScheduleModal
+        open={open}
+        onOpenChange={setOpen}
+        onSchedule={(date) => {
+          console.log("Scheduled for", date.toISOString());
+          setOpen(false);
+        }}
+        onCancel={() => setOpen(false)}
+      />
+    </div>
+  );
+}
+
+function FlowImmediateDemo() {
+  const scheduleFlow = useStoryScheduleFlow();
+
+  return (
+    <div className="w-[480px]">
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow}
+        primaryLabel="Post"
+        onPrimaryClick={() => console.log("Post now")}
+        formattedTimePreferences={defaultFormattedTimePreferences}
+        testId="post-discussion"
+        secondaryAction={<GhostButton onClick={() => console.log("Save draft")}>Save as draft</GhostButton>}
+      />
+    </div>
+  );
+}
+
+function FlowScheduledDemo() {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(9, 0, 0, 0);
+  const scheduleFlow = useStoryScheduleFlow(tomorrow);
+
+  return (
+    <div className="w-[480px]">
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow}
+        primaryLabel="Post"
+        onPrimaryClick={() => console.log("Confirm schedule", scheduleFlow.scheduledAt)}
+        formattedTimePreferences={defaultFormattedTimePreferences}
+        testId="post-discussion"
+        secondaryAction={<GhostButton onClick={() => console.log("Save draft")}>Save as draft</GhostButton>}
+      />
+    </div>
+  );
+}
+
+function FlowInteractiveDemo() {
+  const scheduleFlow = useStoryScheduleFlow();
+
+  return (
+    <div className="w-[480px] space-y-3">
+      <p className="text-sm text-content-dimmed">
+        Use the dropdown to schedule, then edit the date from the notice banner.
+      </p>
+      <ScheduleFlowControls
+        scheduleFlow={scheduleFlow}
+        primaryLabel="Submit"
+        onPrimaryClick={() => {
+          if (scheduleFlow.isScheduledLocally) {
+            console.log("Confirm schedule", scheduleFlow.scheduledAt);
+          } else {
+            console.log("Submit now");
+          }
+        }}
+        formattedTimePreferences={defaultFormattedTimePreferences}
+        secondaryAction={<GhostButton onClick={() => console.log("Save draft")}>Save as draft</GhostButton>}
+      />
+    </div>
+  );
+}
+
+/**
+ * Modal for picking a future date and time to publish a post.
+ */
+export const Modal: StoryObj = {
+  render: () => <ScheduleModalDemo />,
+};
+
+/**
+ * Banner shown above submit buttons after a schedule date has been chosen.
+ */
+export const Notice: StoryObj = {
+  render: () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(9, 0, 0, 0);
+
+    return (
+      <div className="w-[480px]">
+        <ScheduleNotice
+          date={tomorrow}
+          onEdit={() => console.log("Edit schedule")}
+          formattedTimePreferences={defaultFormattedTimePreferences}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * Immediate post state: OptionsButton with "Schedule for later" in the dropdown.
+ */
+export const FlowImmediate: StoryObj = {
+  name: "Flow / Immediate",
+  render: () => <FlowImmediateDemo />,
+};
+
+/**
+ * Scheduled state: notice above the button row, primary label switches to "Confirm".
+ */
+export const FlowScheduled: StoryObj = {
+  name: "Flow / Scheduled",
+  render: () => <FlowScheduledDemo />,
+};
+
+/**
+ * Interactive flow: open the modal from the dropdown, confirm a date, then edit it.
+ */
+export const FlowInteractive: StoryObj = {
+  name: "Flow / Interactive",
+  render: () => <FlowInteractiveDemo />,
+};

--- a/turboui/src/SchedulePosting/index.tsx
+++ b/turboui/src/SchedulePosting/index.tsx
@@ -1,0 +1,8 @@
+export { ScheduleModal } from "./ScheduleModal";
+export type { ScheduleModalProps } from "./ScheduleModal";
+
+export { ScheduleNotice } from "./ScheduleNotice";
+export type { ScheduleNoticeProps } from "./ScheduleNotice";
+
+export { ScheduleFlowControls } from "./ScheduleFlowControls";
+export type { ScheduleFlowControlsProps, ScheduleFlowState } from "./ScheduleFlowControls";

--- a/turboui/src/SchedulePosting/index.tsx
+++ b/turboui/src/SchedulePosting/index.tsx
@@ -4,5 +4,10 @@ export type { ScheduleModalProps } from "./ScheduleModal";
 export { ScheduleNotice } from "./ScheduleNotice";
 export type { ScheduleNoticeProps } from "./ScheduleNotice";
 
+export { ScheduledPostDate } from "./ScheduledPostDate";
+export type { ScheduledPostDateProps } from "./ScheduledPostDate";
+
+export { ScheduledPostLabel } from "./ScheduledPostLabel";
+
 export { ScheduleFlowControls } from "./ScheduleFlowControls";
 export type { ScheduleFlowControlsProps, ScheduleFlowState } from "./ScheduleFlowControls";

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -162,6 +162,17 @@ export { PasteHtmlImagesPlugin } from "./RichEditor/Blob/PasteHtmlImagesPlugin";
 import BlobExtension, { isUploadInProgress } from "./RichEditor/Blob";
 export { BlobExtension, isUploadInProgress };
 
-export { ScheduleModal, ScheduleNotice, ScheduleFlowControls } from "./SchedulePosting";
-export type { ScheduleModalProps, ScheduleNoticeProps, ScheduleFlowControlsProps, ScheduleFlowState } from "./SchedulePosting";
-
+export {
+  ScheduleModal,
+  ScheduleNotice,
+  ScheduleFlowControls,
+  ScheduledPostDate,
+  ScheduledPostLabel,
+} from "./SchedulePosting";
+export type {
+  ScheduleModalProps,
+  ScheduleNoticeProps,
+  ScheduleFlowControlsProps,
+  ScheduleFlowState,
+  ScheduledPostDateProps,
+} from "./SchedulePosting";

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -162,5 +162,6 @@ export { PasteHtmlImagesPlugin } from "./RichEditor/Blob/PasteHtmlImagesPlugin";
 import BlobExtension, { isUploadInProgress } from "./RichEditor/Blob";
 export { BlobExtension, isUploadInProgress };
 
-export { ScheduleModal } from "./ScheduleModal";
-export { ScheduleNotice } from "./ScheduleModal/ScheduleNotice";
+export { ScheduleModal, ScheduleNotice, ScheduleFlowControls } from "./SchedulePosting";
+export type { ScheduleModalProps, ScheduleNoticeProps, ScheduleFlowControlsProps, ScheduleFlowState } from "./SchedulePosting";
+

--- a/turboui/src/utils/drafts.ts
+++ b/turboui/src/utils/drafts.ts
@@ -2,11 +2,16 @@ export type DraftableResource = {
   state?: string | null;
   insertedAt?: string | null;
   publishedAt?: string | null;
+  scheduledAt?: string | null;
 };
 
 export function displayDate(resource: DraftableResource): string {
   if (resource.state === "draft") {
     return resource.insertedAt ?? "";
+  }
+
+  if (resource.state === "scheduled") {
+    return resource.scheduledAt ?? resource.insertedAt ?? "";
   }
 
   return resource.publishedAt ?? resource.insertedAt ?? "";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements scheduled posting for Space Discussions, Project Check-ins, and Goal Check-ins so authors can prepare a post and publish it at a future date/time.

### Frontend

- Shared `useScheduleFlow` hook in the app
- TurboUI `SchedulePosting` module: `ScheduleModal`, `ScheduleNotice`, and pure `ScheduleFlowControls` (preferences passed as props)
- Storybook coverage for modal, notice, and immediate/scheduled/interactive flow states
- Integrated into create/edit forms; schedule option only for new + unpublished posts
- View pages treat scheduled items like drafts; Scheduled badges on cards/titles

### Backend

- Exclude `:scheduled` from public lists; include in author drafts
- Non-authors get 404 for scheduled posts
- Serialize `scheduled_at`; derive schedule state on discussion edits

### CI / review follow-ups

- Removed unused `confirmSchedule` from Discussion `FormState` (Sourcery review)
- Unexported unused `UseScheduleFlowOptions` (knip/lint)
- Fixed Dialyzer `guard_fail` in `DiscussionEditing` by aligning Oban job handling with check-in operations

### Tests

- Related Elixir tests passed; app tsc clean; turboui unit tests passed; knip clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d642201b-a01d-4b5c-b506-efd3ed717daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d642201b-a01d-4b5c-b506-efd3ed717daa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

https://github.com/operately/operately/issues/4655
