### PR TITLE
feat: show goal targets and checklist on Work Map progress hover

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -2457,6 +2457,8 @@ export interface WorkMapItem {
   timeframe: Timeframe | null;
   assignedAt: string | null;
   milestones: Milestone[];
+  targets: Target[];
+  checklist: GoalCheck[];
   children: WorkMapItem[];
   type: WorkMapItemType;
   itemPath: string;

--- a/app/assets/js/models/workMap/index.tsx
+++ b/app/assets/js/models/workMap/index.tsx
@@ -34,6 +34,8 @@ function convertToWorkMapItem(paths: Paths, item: WorkMapItem): WorkMap.Item {
       dueDate: parseContextualDate(milestone.timeframe?.contextualEndDate),
       link: paths.projectMilestonePath(milestone.id),
     })),
+    targets: item.targets || [],
+    checklist: item.checklist || [],
     children: item.children.map((c) => convertToWorkMapItem(paths, c)),
   };
 }
@@ -94,6 +96,8 @@ export function useWorkMapItems(initialItems: WorkMapItem[] = []): [WorkMapItem[
       nextStep: "",
       timeframe: null,
       milestones: [],
+      targets: [],
+      checklist: [],
       children: [],
       isNew: true,
       completedOn: null,
@@ -141,6 +145,8 @@ export function useWorkMapItems(initialItems: WorkMapItem[] = []): [WorkMapItem[
       nextStep: "",
       timeframe: null,
       milestones: [],
+      targets: [],
+      checklist: [],
       children: [],
       isNew: true,
       completedOn: null,

--- a/app/lib/operately/projects/ordering_state.ex
+++ b/app/lib/operately/projects/ordering_state.ex
@@ -24,6 +24,35 @@ defmodule Operately.Projects.OrderingState do
   end
 
   @doc """
+  Returns milestones ordered according to the project's ordering state.
+
+  Unknown IDs in the ordering state are dropped. Before applying the ordering
+  state, milestones are sorted by deadline (earliest first, undated last), then
+  by title. Milestones missing from the ordering state are appended in that
+  fallback order.
+  """
+  def ordered(ordering_state, milestones) when is_list(milestones) do
+    milestones = sort_by_deadline_then_title(milestones)
+    milestones_by_id = Map.new(milestones, &{Paths.milestone_id(&1), &1})
+
+    ordering_state
+    |> normalize(milestones)
+    |> Enum.map(&Map.fetch!(milestones_by_id, &1))
+  end
+
+  defp sort_by_deadline_then_title(milestones) do
+    Enum.sort_by(milestones, fn milestone ->
+      deadline = Operately.ContextualDates.Timeframe.end_date(milestone.timeframe)
+      {deadline_sort_key(deadline), milestone.title || ""}
+    end)
+  end
+
+  # Use {year, month, day} — Date structs do not sort chronologically under term order.
+  # nil deadlines sort after dated milestones.
+  defp deadline_sort_key(nil), do: {1, {9999, 12, 31}}
+  defp deadline_sort_key(date), do: {0, Date.to_erl(date)}
+
+  @doc """
   Returns where each milestone sits in the project's ordering.
 
   The result is a map of `milestone.id => position`, where position is 0 for first, 1 for second, and so on.

--- a/app/lib/operately_web/api/serializers/project.ex
+++ b/app/lib/operately_web/api/serializers/project.ex
@@ -1,4 +1,6 @@
 defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
+  alias Operately.Projects.OrderingState
+
   def serialize(project, level: :essential) do
     %{
       id: OperatelyWeb.Paths.project_id(project),
@@ -28,8 +30,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       champion: OperatelyWeb.Api.Serializer.serialize(project.champion),
       reviewer: OperatelyWeb.Api.Serializer.serialize(project.reviewer),
       goal: OperatelyWeb.Api.Serializer.serialize(project.goal),
-      milestones: OperatelyWeb.Api.Serializer.serialize(project.milestones),
-      milestones_ordering_state: Operately.Projects.OrderingState.load(project.milestones_ordering_state),
+      milestones: serialize_milestones(project),
+      milestones_ordering_state: OrderingState.load(project.milestones_ordering_state),
       contributors: OperatelyWeb.Api.Serializer.serialize(sort_contribs(exclude_suspended(project))),
       last_check_in: OperatelyWeb.Api.Serializer.serialize(project.last_check_in),
       next_milestone: OperatelyWeb.Api.Serializer.serialize(project.next_milestone),
@@ -43,6 +45,15 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
       tasks_kanban_state: OperatelyWeb.Api.Serializer.serialize(%Operately.Tasks.KanbanState{state: project.tasks_kanban_state}),
     })
   end
+
+  defp serialize_milestones(project) do
+    project.milestones_ordering_state
+    |> OrderingState.ordered(loaded_milestones(project))
+    |> OperatelyWeb.Api.Serializer.serialize()
+  end
+
+  defp loaded_milestones(%{milestones: milestones}) when is_list(milestones), do: milestones
+  defp loaded_milestones(_project), do: []
 
   defp exclude_suspended(project) do
     case project.contributors do

--- a/app/lib/operately_web/api/serializers/project.ex
+++ b/app/lib/operately_web/api/serializers/project.ex
@@ -46,14 +46,13 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Projects.Project do
     })
   end
 
-  defp serialize_milestones(project) do
+  defp serialize_milestones(%{milestones: milestones} = project) when is_list(milestones) do
     project.milestones_ordering_state
-    |> OrderingState.ordered(loaded_milestones(project))
+    |> OrderingState.ordered(milestones)
     |> OperatelyWeb.Api.Serializer.serialize()
   end
 
-  defp loaded_milestones(%{milestones: milestones}) when is_list(milestones), do: milestones
-  defp loaded_milestones(_project), do: []
+  defp serialize_milestones(_project), do: nil
 
   defp exclude_suspended(project) do
     case project.contributors do

--- a/app/lib/operately_web/api/serializers/work_map_item.ex
+++ b/app/lib/operately_web/api/serializers/work_map_item.ex
@@ -1,4 +1,5 @@
 defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
+  alias Operately.Projects.OrderingState
   alias OperatelyWeb.Paths
 
   def serialize(item, level: :essential) do
@@ -34,8 +35,10 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
     }
   end
 
-  defp serialize_milestones(%{type: :project, resource: %{milestones: milestones}}) when is_list(milestones) do
-    OperatelyWeb.Api.Serializer.serialize(milestones)
+  defp serialize_milestones(%{type: :project, resource: project = %{milestones: milestones}}) when is_list(milestones) do
+    project.milestones_ordering_state
+    |> OrderingState.ordered(milestones)
+    |> OperatelyWeb.Api.Serializer.serialize()
   end
 
   defp serialize_milestones(_item), do: []

--- a/app/lib/operately_web/api/serializers/work_map_item.ex
+++ b/app/lib/operately_web/api/serializers/work_map_item.ex
@@ -26,6 +26,8 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
       timeframe: OperatelyWeb.Api.Serializer.serialize(item.timeframe),
       assigned_at: OperatelyWeb.Api.Serializer.serialize(item.assigned_at),
       milestones: serialize_milestones(item),
+      targets: serialize_targets(item),
+      checklist: serialize_checklist(item),
       children: OperatelyWeb.Api.Serializer.serialize(item.children),
       privacy: OperatelyWeb.Api.Serializer.serialize(item.privacy),
       assignees: OperatelyWeb.Api.Serializer.serialize(item.assignees)
@@ -37,6 +39,18 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.WorkMaps.WorkMapItem do
   end
 
   defp serialize_milestones(_item), do: []
+
+  defp serialize_targets(%{type: :goal, resource: %{targets: targets}}) when is_list(targets) do
+    OperatelyWeb.Api.Serializer.serialize(targets)
+  end
+
+  defp serialize_targets(_item), do: []
+
+  defp serialize_checklist(%{type: :goal, resource: %{checks: checks}}) when is_list(checks) do
+    OperatelyWeb.Api.Serializer.serialize(checks)
+  end
+
+  defp serialize_checklist(_item), do: []
 
   defp item_id(item) do
     case item.type do

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -2454,6 +2454,8 @@ defmodule OperatelyWeb.Api.Types do
     field :timeframe, :timeframe, null: true
     field :assigned_at, :datetime, null: true
     field :milestones, list_of(:milestone), null: false
+    field :targets, list_of(:target), null: false
+    field :checklist, list_of(:goal_check), null: false
     field :children, list_of(:work_map_item), null: false
     field :type, :work_map_item_type, null: false
     field :item_path, :string, null: false

--- a/app/test/operately/projects/ordering_state_test.exs
+++ b/app/test/operately/projects/ordering_state_test.exs
@@ -1,0 +1,105 @@
+defmodule Operately.Projects.OrderingStateTest do
+  use Operately.DataCase, async: true
+
+  alias Operately.ContextualDates.{ContextualDate, Timeframe}
+  alias Operately.Projects.{Milestone, OrderingState}
+  alias OperatelyWeb.Paths
+
+  describe "ordered/2" do
+    test "with empty ordering sorts by deadline then title, ignoring status" do
+      # Days-of-month intentionally conflict with chronology so term-order Date bugs surface
+      # (e.g. Aug 2 before Jul 20 under struct term ordering).
+      early_done = milestone("Zebra", ~D[2026-07-20], :done)
+      late_pending = milestone("Alpha", ~D[2026-09-15], :pending)
+      mid_pending = milestone("Beta", ~D[2026-08-02], :pending)
+
+      ordered =
+        OrderingState.ordered([], [late_pending, early_done, mid_pending])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["Zebra", "Beta", "Alpha"]
+    end
+
+    test "with empty ordering puts undated milestones after dated ones and sorts undated by title" do
+      dated = milestone("Late", ~D[2026-08-01], :pending)
+      undated_b = milestone("Bravo", nil, :pending)
+      undated_a = milestone("Alpha", nil, :done)
+
+      ordered =
+        OrderingState.ordered([], [undated_b, dated, undated_a])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["Late", "Alpha", "Bravo"]
+    end
+
+    test "with empty ordering sorts chronologically when day-of-month would mislead term order" do
+      aug_second = milestone("Global", ~D[2026-08-02], :done)
+      jul_seventh = milestone("EU", ~D[2026-07-07], :done)
+      aug_fifteenth = milestone("Localized", ~D[2026-08-15], :pending)
+      jul_twentieth = milestone("Product", ~D[2026-07-20], :done)
+
+      ordered =
+        OrderingState.ordered([], [aug_second, jul_seventh, aug_fifteenth, jul_twentieth])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["EU", "Product", "Global", "Localized"]
+    end
+
+    test "with empty ordering breaks deadline ties by title" do
+      same_day_b = milestone("Beta", ~D[2026-08-01], :pending)
+      same_day_a = milestone("Alpha", ~D[2026-08-01], :done)
+
+      ordered =
+        OrderingState.ordered([], [same_day_b, same_day_a])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["Alpha", "Beta"]
+    end
+
+    test "non-empty ordering state wins over deadline fallback" do
+      early = milestone("Early", ~D[2026-07-01], :pending)
+      late = milestone("Late", ~D[2026-09-01], :pending)
+      mid = milestone("Mid", ~D[2026-08-01], :done)
+
+      ordering = [Paths.milestone_id(late), Paths.milestone_id(early), Paths.milestone_id(mid)]
+
+      ordered =
+        OrderingState.ordered(ordering, [early, late, mid])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["Late", "Early", "Mid"]
+    end
+
+    test "milestones missing from ordering are appended by deadline then title" do
+      early = milestone("Early", ~D[2026-07-01], :pending)
+      late = milestone("Late", ~D[2026-09-01], :pending)
+      mid = milestone("Mid", ~D[2026-08-01], :done)
+
+      ordering = [Paths.milestone_id(late)]
+
+      ordered =
+        OrderingState.ordered(ordering, [mid, early, late])
+        |> Enum.map(& &1.title)
+
+      assert ordered == ["Late", "Early", "Mid"]
+    end
+  end
+
+  defp milestone(title, deadline, status) do
+    timeframe =
+      if deadline do
+        %Timeframe{
+          contextual_end_date: ContextualDate.create_day_date(deadline)
+        }
+      else
+        nil
+      end
+
+    %Milestone{
+      id: Ecto.UUID.generate(),
+      title: title,
+      status: status,
+      timeframe: timeframe
+    }
+  end
+end

--- a/app/test/operately_web/api/companies/get_work_map_test.exs
+++ b/app/test/operately_web/api/companies/get_work_map_test.exs
@@ -445,4 +445,70 @@ defmodule OperatelyWeb.Api.Companies.GetWorkMapTest do
       assert empty_goal.checklist == []
     end
   end
+
+  describe "project milestones" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_project_milestone(:milestone_a, :project, title: "Alpha")
+      |> Factory.add_project_milestone(:milestone_b, :project, title: "Beta")
+      |> Factory.add_project_milestone(:milestone_c, :project, title: "Gamma")
+      |> Factory.log_in_person(:creator)
+    end
+
+    test "returns milestones in milestones_ordering_state order", ctx do
+      reordered = [
+        Paths.milestone_id(ctx.milestone_c),
+        Paths.milestone_id(ctx.milestone_a),
+        Paths.milestone_id(ctx.milestone_b)
+      ]
+
+      {:ok, _} = Operately.Projects.update_project(ctx.project, %{milestones_ordering_state: reordered})
+
+      assert {200, res} = query(ctx.conn, [:companies, :get_work_map], %{space_id: Paths.space_id(ctx.space)})
+
+      project = Enum.find(res.work_map, &(&1.id == Paths.project_id(ctx.project)))
+
+      assert Enum.map(project.milestones, & &1.id) == reordered
+      assert Enum.map(project.milestones, & &1.title) == ["Gamma", "Alpha", "Beta"]
+    end
+
+    test "with empty ordering state sorts by deadline then title", ctx do
+      ctx =
+        ctx
+        |> Factory.add_project(:dated_project, :space)
+        |> Factory.add_project_milestone(:late, :dated_project,
+          title: "Zebra",
+          status: :done,
+          timeframe: %{
+            contextual_end_date: Operately.ContextualDates.ContextualDate.create_day_date(~D[2026-09-15])
+          }
+        )
+        |> Factory.add_project_milestone(:early, :dated_project,
+          title: "Late title",
+          status: :pending,
+          timeframe: %{
+            contextual_end_date: Operately.ContextualDates.ContextualDate.create_day_date(~D[2026-07-20])
+          }
+        )
+        |> Factory.add_project_milestone(:mid, :dated_project,
+          title: "Mid",
+          status: :pending,
+          timeframe: %{
+            contextual_end_date: Operately.ContextualDates.ContextualDate.create_day_date(~D[2026-08-02])
+          }
+        )
+
+      dated_project = Operately.Repo.reload(ctx.dated_project)
+      {:ok, _} = Operately.Projects.update_project(dated_project, %{milestones_ordering_state: []})
+
+      assert {200, res} = query(ctx.conn, [:companies, :get_work_map], %{space_id: Paths.space_id(ctx.space)})
+
+      project = Enum.find(res.work_map, &(&1.id == Paths.project_id(ctx.dated_project)))
+
+      assert Enum.map(project.milestones, & &1.title) == ["Late title", "Mid", "Zebra"]
+    end
+  end
 end

--- a/app/test/operately_web/api/companies/get_work_map_test.exs
+++ b/app/test/operately_web/api/companies/get_work_map_test.exs
@@ -396,4 +396,50 @@ defmodule OperatelyWeb.Api.Companies.GetWorkMapTest do
       assert project.space_path == nil
     end
   end
+
+  describe "goal targets and checklist" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_goal(:goal, :space, targets: [])
+      |> Factory.add_goal_target(:target_b, :goal, name: "Retention", from: 0, to: 100, value: 40, unit: "%", index: 2)
+      |> Factory.add_goal_target(:target_a, :goal, name: "Revenue", from: 0, to: 1000, value: 250, unit: "USD", index: 1)
+      |> Factory.add_goal_check(:check_done, :goal, name: "Launch plan", completed: true)
+      |> Factory.add_goal_check(:check_pending, :goal, name: "Hire lead", completed: false)
+      |> Factory.add_project(:project, :space)
+      |> Factory.log_in_person(:creator)
+    end
+
+    test "serializes targets and checklist for goals, sorted by index", ctx do
+      assert {200, res} = query(ctx.conn, [:companies, :get_work_map], %{space_id: Paths.space_id(ctx.space)})
+
+      goal = Enum.find(res.work_map, &(&1.id == Paths.goal_id(ctx.goal)))
+      project = Enum.find(res.work_map, &(&1.id == Paths.project_id(ctx.project)))
+
+      assert Enum.map(goal.targets, & &1.name) == ["Revenue", "Retention"]
+      assert Enum.at(goal.targets, 0).value == 250.0
+      assert Enum.at(goal.targets, 0).unit == "USD"
+
+      assert Enum.map(goal.checklist, & &1.name) == ["Launch plan", "Hire lead"]
+      assert Enum.at(goal.checklist, 0).completed == true
+      assert Enum.at(goal.checklist, 1).completed == false
+
+      assert project.targets == []
+      assert project.checklist == []
+    end
+
+    test "returns empty lists when a goal has no targets or checklist", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal(:empty_goal, :space, name: "Empty goal", targets: [])
+
+      assert {200, res} = query(ctx.conn, [:companies, :get_work_map], %{space_id: Paths.space_id(ctx.space)})
+
+      empty_goal = Enum.find(res.work_map, &(&1.id == Paths.goal_id(ctx.empty_goal)))
+
+      assert empty_goal.targets == []
+      assert empty_goal.checklist == []
+    end
+  end
 end

--- a/app/test/operately_web/api/companies/get_work_map_test.exs
+++ b/app/test/operately_web/api/companies/get_work_map_test.exs
@@ -411,19 +411,22 @@ defmodule OperatelyWeb.Api.Companies.GetWorkMapTest do
       |> Factory.log_in_person(:creator)
     end
 
-    test "serializes targets and checklist for goals, sorted by index", ctx do
+    test "serializes targets and checklist for goals", ctx do
       assert {200, res} = query(ctx.conn, [:companies, :get_work_map], %{space_id: Paths.space_id(ctx.space)})
 
       goal = Enum.find(res.work_map, &(&1.id == Paths.goal_id(ctx.goal)))
       project = Enum.find(res.work_map, &(&1.id == Paths.project_id(ctx.project)))
 
-      assert Enum.map(goal.targets, & &1.name) == ["Revenue", "Retention"]
-      assert Enum.at(goal.targets, 0).value == 250.0
-      assert Enum.at(goal.targets, 0).unit == "USD"
+      targets_by_name = Map.new(goal.targets, &{&1.name, &1})
+      assert Map.keys(targets_by_name) |> Enum.sort() == ["Retention", "Revenue"]
+      assert targets_by_name["Revenue"].value == 250.0
+      assert targets_by_name["Revenue"].unit == "USD"
+      assert targets_by_name["Retention"].value == 40.0
 
-      assert Enum.map(goal.checklist, & &1.name) == ["Launch plan", "Hire lead"]
-      assert Enum.at(goal.checklist, 0).completed == true
-      assert Enum.at(goal.checklist, 1).completed == false
+      checklist_by_name = Map.new(goal.checklist, &{&1.name, &1})
+      assert Map.keys(checklist_by_name) |> Enum.sort() == ["Hire lead", "Launch plan"]
+      assert checklist_by_name["Launch plan"].completed == true
+      assert checklist_by_name["Hire lead"].completed == false
 
       assert project.targets == []
       assert project.checklist == []

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -2337,6 +2337,8 @@ export interface WorkMapItem {
   timeframe: Timeframe | null;
   assignedAt: string | null;
   milestones: Milestone[];
+  targets: Target[];
+  checklist: GoalCheck[];
   children: WorkMapItem[];
   type: WorkMapItemType;
   itemPath: string;

--- a/turboui/src/GoalTargetList/index.tsx
+++ b/turboui/src/GoalTargetList/index.tsx
@@ -25,6 +25,8 @@ import { Textarea } from "../FormElements/Textarea";
 import { Textfield } from "../FormElements/Textfield";
 import { SwitchToggle } from "../SwitchToggle";
 import { createTestId } from "../TestableElement";
+import { calculateTargetProgress, formatValueAndUnit } from "../utils/goalTargetProgress";
+import { formatNumber } from "../utils/formatting";
 
 export namespace GoalTargetList {
   export type Target = {
@@ -479,7 +481,7 @@ function TargetView({ state, target, containerId }: { state: State; target: Targ
 }
 
 function TargetName({ target, truncate }: { target: TargetState; truncate?: boolean }) {
-  const progress = calculateProgress(target);
+  const progress = calculateTargetProgress(target);
   const nameClass = classNames("flex gap-2 flex-1", { truncate: truncate });
 
   return (
@@ -502,17 +504,14 @@ function NameView({ name, truncate }: { name: string; truncate?: boolean }) {
 function TargetValue({ target }: { target: GoalTargetList.Target }) {
   return (
     <div className="flex items-center">
-      <div className="py-1 text-right text-sm">
-        <span className="font-extrabold">{target.value}</span>
-        {target.unit === "%" ? "%" : ` ${target.unit}`}
-      </div>
+      <div className="py-1 text-right text-sm font-extrabold">{formatValueAndUnit(target.value, target.unit)}</div>
     </div>
   );
 }
 
 function TargetDetails({ state, target }: { state: State; target: TargetState }) {
   const { from, to, unit, value } = target;
-  const progress = calculateProgress(target, false);
+  const progress = calculateTargetProgress(target, false);
   const directionText = from! > to! ? "down to" : "to";
 
   return (
@@ -520,7 +519,8 @@ function TargetDetails({ state, target }: { state: State; target: TargetState })
       <div className="flex items-center gap-2">
         <div className="w-20 font-semibold">Target</div>
         <div>
-          From <span className="font-semibold">{from}</span> {directionText} <span className="font-semibold">{to}</span>
+          From <span className="font-semibold">{formatNumber(from!)}</span> {directionText}{" "}
+          <span className="font-semibold">{formatNumber(to!)}</span>
           {unit === "%" ? "%" : ` ${unit}`}
         </div>
       </div>
@@ -539,31 +539,4 @@ function TargetDetails({ state, target }: { state: State; target: TargetState })
       </div>
     </div>
   );
-}
-
-function formatValueAndUnit(value: number, unit: string): string {
-  return `${value}${unit === "%" ? "%" : ` ${unit}`}`;
-}
-
-function calculateProgress(target: GoalTargetList.Target, clamped = true): number {
-  const from = target.from!;
-  const to = target.to!;
-  const value = target.value!;
-
-  let percentage: number;
-  if (from === to) {
-    percentage = 0; // If from and to are equal, progress is 0%
-  } else if (from < to) {
-    percentage = ((value - from) / (to - from)) * 100;
-  } else if (from > to) {
-    percentage = ((from - value) / (from - to)) * 100;
-  } else {
-    percentage = 0; // Fallback case
-  }
-
-  if (clamped) {
-    return Math.max(0, Math.min(100, percentage));
-  }
-
-  return percentage;
 }

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
@@ -34,6 +34,7 @@ describe("GoalProgressSummary", () => {
   it("renders both sections when targets and checklist are present", () => {
     render(<GoalProgressSummary targets={mockGoalTargets} checklist={mockGoalChecklist} />);
 
+    expect(screen.getByTestId("goal-progress-summary-content")).toBeInTheDocument();
     expect(screen.getByText("Targets")).toBeInTheDocument();
     expect(screen.getByText("Checklist")).toBeInTheDocument();
     expect(screen.queryByText("No targets or checklist")).not.toBeInTheDocument();

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
@@ -17,7 +17,7 @@ describe("GoalProgressSummary", () => {
 
     expect(screen.getByText("Targets")).toBeInTheDocument();
     expect(screen.getByText("Revenue")).toBeInTheDocument();
-    expect(screen.getByText("250 USD → 1000 USD")).toBeInTheDocument();
+    expect(screen.getByText("250 USD → 1,000 USD")).toBeInTheDocument();
     expect(screen.getByText("Retention")).toBeInTheDocument();
     expect(screen.getByText("40% → 100%")).toBeInTheDocument();
   });

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { GoalProgressSummary } from "./GoalProgressSummary";
+import { mockGoalChecklist, mockGoalTargets } from "../../tests/mockData";
+
+describe("GoalProgressSummary", () => {
+  it("shows empty state when there are no targets or checklist items", () => {
+    render(<GoalProgressSummary targets={[]} checklist={[]} />);
+
+    expect(screen.getByText("No targets or checklist")).toBeInTheDocument();
+  });
+
+  it("renders target names and value summaries", () => {
+    render(<GoalProgressSummary targets={mockGoalTargets} checklist={[]} />);
+
+    expect(screen.getByText("Targets")).toBeInTheDocument();
+    expect(screen.getByText("Revenue")).toBeInTheDocument();
+    expect(screen.getByText("250 USD → 1000 USD")).toBeInTheDocument();
+    expect(screen.getByText("Retention")).toBeInTheDocument();
+    expect(screen.getByText("40% → 100%")).toBeInTheDocument();
+  });
+
+  it("renders checklist completion summary and item states", () => {
+    render(<GoalProgressSummary targets={[]} checklist={mockGoalChecklist} />);
+
+    expect(screen.getByText("Checklist")).toBeInTheDocument();
+    expect(screen.getByText("1/2 completed (50%)")).toBeInTheDocument();
+    expect(screen.getByText("Launch plan")).toBeInTheDocument();
+    expect(screen.getByText("Hire lead")).toBeInTheDocument();
+  });
+
+  it("renders both sections when targets and checklist are present", () => {
+    render(<GoalProgressSummary targets={mockGoalTargets} checklist={mockGoalChecklist} />);
+
+    expect(screen.getByText("Targets")).toBeInTheDocument();
+    expect(screen.getByText("Checklist")).toBeInTheDocument();
+    expect(screen.queryByText("No targets or checklist")).not.toBeInTheDocument();
+  });
+});

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.test.tsx
@@ -39,4 +39,14 @@ describe("GoalProgressSummary", () => {
     expect(screen.getByText("Checklist")).toBeInTheDocument();
     expect(screen.queryByText("No targets or checklist")).not.toBeInTheDocument();
   });
+
+  it("sorts targets and checklist by index", () => {
+    const unsortedTargets = [mockGoalTargets[1], mockGoalTargets[0]];
+    const unsortedChecklist = [mockGoalChecklist[1], mockGoalChecklist[0]];
+
+    render(<GoalProgressSummary targets={unsortedTargets} checklist={unsortedChecklist} />);
+
+    const names = screen.getAllByText(/Revenue|Retention|Launch plan|Hire lead/).map((node) => node.textContent);
+    expect(names).toEqual(["Revenue", "Retention", "Launch plan", "Hire lead"]);
+  });
 });

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+
+import type { GoalCheck, Target } from "../../../ApiTypes";
+import { IconSquare, IconSquareCheckFilled } from "../../../icons";
+import { PieChart } from "../../../PieChart";
+import classNames from "../../../utils/classnames";
+
+interface GoalProgressSummaryProps {
+  targets: Target[];
+  checklist: GoalCheck[];
+}
+
+export function GoalProgressSummary({ targets, checklist }: GoalProgressSummaryProps) {
+  const hasTargets = targets.length > 0;
+  const hasChecklist = checklist.length > 0;
+
+  if (!hasTargets && !hasChecklist) {
+    return <div className="text-content-dimmed text-xs font-normal">No targets or checklist</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 min-w-[220px] max-w-[320px] font-normal">
+      {hasTargets && <TargetsSection targets={targets} />}
+      {hasChecklist && <ChecklistSection checklist={checklist} />}
+    </div>
+  );
+}
+
+function TargetsSection({ targets }: { targets: Target[] }) {
+  const sorted = [...targets].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+
+  return (
+    <div>
+      <div className="text-xs font-semibold text-content-dimmed uppercase tracking-wide mb-1.5">Targets</div>
+      <div className="flex flex-col gap-1.5">
+        {sorted.map((target) => (
+          <TargetRow key={target.id ?? target.name ?? String(target.index)} target={target} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TargetRow({ target }: { target: Target }) {
+  const progress = calculateTargetProgress(target);
+  const valueSummary = formatTargetValueSummary(target);
+
+  return (
+    <div className="flex items-start gap-2 text-sm">
+      <div className="mt-0.5 flex-shrink-0">
+        <PieChart size={14} slices={[{ percentage: progress, color: "var(--color-green-500)" }]} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-content-accent">{target.name}</div>
+        {valueSummary && <div className="text-xs text-content-subtle mt-0.5">{valueSummary}</div>}
+      </div>
+    </div>
+  );
+}
+
+function ChecklistSection({ checklist }: { checklist: GoalCheck[] }) {
+  const sorted = [...checklist].sort((a, b) => a.index - b.index);
+  const completedCount = sorted.filter((item) => item.completed).length;
+  const totalCount = sorted.length;
+  const completionPercentage = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-1.5">
+        <div className="text-xs font-semibold text-content-dimmed uppercase tracking-wide">Checklist</div>
+        <div className="flex items-center gap-1.5 text-xs text-content-subtle">
+          <PieChart size={12} slices={[{ percentage: completionPercentage, color: "var(--color-green-500)" }]} />
+          <span>
+            {completedCount}/{totalCount} completed ({completionPercentage}%)
+          </span>
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        {sorted.map((item) => (
+          <ChecklistRow key={item.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChecklistRow({ item }: { item: GoalCheck }) {
+  const nameClass = classNames("text-sm truncate", {
+    "line-through text-content-dimmed": item.completed,
+    "text-content-accent": !item.completed,
+  });
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      {item.completed ? (
+        <IconSquareCheckFilled size={14} className="text-accent-1 flex-shrink-0" />
+      ) : (
+        <IconSquare size={14} className="text-content-subtle flex-shrink-0" />
+      )}
+      <span className={nameClass}>{item.name}</span>
+    </div>
+  );
+}
+
+function calculateTargetProgress(target: Target): number {
+  const from = target.from ?? 0;
+  const to = target.to ?? 0;
+  const value = target.value ?? 0;
+
+  if (from === to) return 0;
+
+  const percentage = from < to ? ((value - from) / (to - from)) * 100 : ((from - value) / (from - to)) * 100;
+
+  return Math.max(0, Math.min(100, percentage));
+}
+
+function formatTargetValueSummary(target: Target): string | null {
+  const value = target.value;
+  const to = target.to;
+  const unit = target.unit ?? "";
+
+  if (value == null || to == null) return null;
+
+  const formattedValue = formatValueAndUnit(value, unit);
+  const formattedTo = formatValueAndUnit(to, unit);
+
+  return `${formattedValue} → ${formattedTo}`;
+}
+
+function formatValueAndUnit(value: number, unit: string): string {
+  if (unit === "%") return `${value}%`;
+  if (unit === "") return String(value);
+  return `${value} ${unit}`;
+}

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
@@ -4,6 +4,10 @@ import type { GoalCheck, Target } from "../../../ApiTypes";
 import { IconSquare, IconSquareCheckFilled } from "../../../icons";
 import { PieChart } from "../../../PieChart";
 import classNames from "../../../utils/classnames";
+import {
+  calculateTargetProgress,
+  formatTargetValueSummary,
+} from "../../../utils/goalTargetProgress";
 
 interface GoalProgressSummaryProps {
   targets: Target[];
@@ -107,35 +111,4 @@ function ChecklistRow({ item }: { item: GoalCheck }) {
       <span className={nameClass}>{item.name}</span>
     </div>
   );
-}
-
-function calculateTargetProgress(target: Target): number {
-  const from = target.from ?? 0;
-  const to = target.to ?? 0;
-  const value = target.value ?? 0;
-
-  if (from === to) return 0;
-
-  const percentage = from < to ? ((value - from) / (to - from)) * 100 : ((from - value) / (from - to)) * 100;
-
-  return Math.max(0, Math.min(100, percentage));
-}
-
-function formatTargetValueSummary(target: Target): string | null {
-  const value = target.value;
-  const to = target.to;
-  const unit = target.unit ?? "";
-
-  if (value == null || to == null) return null;
-
-  const formattedValue = formatValueAndUnit(value, unit);
-  const formattedTo = formatValueAndUnit(to, unit);
-
-  return `${formattedValue} → ${formattedTo}`;
-}
-
-function formatValueAndUnit(value: number, unit: string): string {
-  if (unit === "%") return `${value}%`;
-  if (unit === "") return String(value);
-  return `${value} ${unit}`;
 }

--- a/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
+++ b/turboui/src/WorkMap/components/TableRow/GoalProgressSummary.tsx
@@ -15,11 +15,18 @@ export function GoalProgressSummary({ targets, checklist }: GoalProgressSummaryP
   const hasChecklist = checklist.length > 0;
 
   if (!hasTargets && !hasChecklist) {
-    return <div className="text-content-dimmed text-xs font-normal">No targets or checklist</div>;
+    return (
+      <div className="text-content-dimmed text-xs font-normal" data-testid="goal-progress-summary-content">
+        No targets or checklist
+      </div>
+    );
   }
 
   return (
-    <div className="flex flex-col gap-3 min-w-[220px] max-w-[320px] font-normal">
+    <div
+      className="flex flex-col gap-3 min-w-[220px] max-w-[320px] font-normal"
+      data-testid="goal-progress-summary-content"
+    >
       {hasTargets && <TargetsSection targets={targets} />}
       {hasChecklist && <ChecklistSection checklist={checklist} />}
     </div>

--- a/turboui/src/WorkMap/components/TableRow/ProgressCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ProgressCell.tsx
@@ -3,6 +3,7 @@ import { ProgressBar, ProgressBarStatus, Tooltip } from "../../..";
 import { WorkMap } from "..";
 import { useItemStatus } from "../../hooks/useItemStatus";
 import { GoalProgressSummary } from "./GoalProgressSummary";
+import { ProjectProgressSummary } from "./ProjectProgressSummary";
 
 interface ProgressCellProps {
   item: WorkMap.Item;
@@ -24,15 +25,12 @@ export function ProgressCell({ item, hide }: ProgressCellProps) {
     </div>
   );
 
+  const summary = progressSummaryFor(item);
+
   return (
     <td className="py-2 px-2 pr-6 lg:px-4 ">
-      {item.type === "goal" ? (
-        <Tooltip
-          content={<GoalProgressSummary targets={item.targets} checklist={item.checklist} />}
-          size="sm"
-          className="!font-normal"
-          testId="goal-progress-summary"
-        >
+      {summary ? (
+        <Tooltip content={summary.content} size="sm" className="!font-normal" testId={summary.testId}>
           {progressBar}
         </Tooltip>
       ) : (
@@ -40,4 +38,22 @@ export function ProgressCell({ item, hide }: ProgressCellProps) {
       )}
     </td>
   );
+}
+
+function progressSummaryFor(item: WorkMap.Item): { content: React.ReactNode; testId: string } | null {
+  if (item.type === "goal") {
+    return {
+      content: <GoalProgressSummary targets={item.targets} checklist={item.checklist} />,
+      testId: "goal-progress-summary",
+    };
+  }
+
+  if (item.type === "project") {
+    return {
+      content: <ProjectProgressSummary milestones={item.milestones} />,
+      testId: "project-progress-summary",
+    };
+  }
+
+  return null;
 }

--- a/turboui/src/WorkMap/components/TableRow/ProgressCell.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ProgressCell.tsx
@@ -1,28 +1,43 @@
 import React from "react";
-import { ProgressBar, ProgressBarStatus } from "../../..";
+import { ProgressBar, ProgressBarStatus, Tooltip } from "../../..";
 import { WorkMap } from "..";
 import { useItemStatus } from "../../hooks/useItemStatus";
+import { GoalProgressSummary } from "./GoalProgressSummary";
 
 interface ProgressCellProps {
-  progress: WorkMap.Item["progress"];
-  status: WorkMap.Item["status"];
+  item: WorkMap.Item;
   hide?: boolean;
 }
 
-export function ProgressCell({ progress, status, hide }: ProgressCellProps) {
-  const { isCompleted } = useItemStatus(status);
+export function ProgressCell({ item, hide }: ProgressCellProps) {
+  const { isCompleted } = useItemStatus(item.status);
 
   if (hide) return null;
-  
+
   if (isCompleted) {
     return <td className="py-2 px-2 pr-4 md:px-4"></td>;
   }
-  
+
+  const progressBar = (
+    <div className="transform group-hover:scale-[1.02] transition-transform duration-150 w-[70px]">
+      <ProgressBar progress={item.progress ?? 0} status={item.status as ProgressBarStatus} />
+    </div>
+  );
+
   return (
     <td className="py-2 px-2 pr-6 lg:px-4 ">
-      <div className="transform group-hover:scale-[1.02] transition-transform duration-150 w-[70px]">
-        <ProgressBar progress={progress ?? 0} status={status as ProgressBarStatus} />
-      </div>
+      {item.type === "goal" ? (
+        <Tooltip
+          content={<GoalProgressSummary targets={item.targets} checklist={item.checklist} />}
+          size="sm"
+          className="!font-normal"
+          testId="goal-progress-summary"
+        >
+          {progressBar}
+        </Tooltip>
+      ) : (
+        progressBar
+      )}
     </td>
   );
 }

--- a/turboui/src/WorkMap/components/TableRow/ProjectProgressSummary.test.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ProjectProgressSummary.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ProjectProgressSummary } from "./ProjectProgressSummary";
+import { mockProjectMilestones } from "../../tests/mockData";
+
+describe("ProjectProgressSummary", () => {
+  it("shows empty state when there are no milestones", () => {
+    render(<ProjectProgressSummary milestones={[]} />);
+
+    expect(screen.getByText("No milestones")).toBeInTheDocument();
+  });
+
+  it("renders milestone completion summary and item states", () => {
+    render(<ProjectProgressSummary milestones={mockProjectMilestones} />);
+
+    expect(screen.getByTestId("project-progress-summary-content")).toBeInTheDocument();
+    expect(screen.getByText("Milestones")).toBeInTheDocument();
+    expect(screen.getByText("1/2 completed (50%)")).toBeInTheDocument();
+    expect(screen.getByText("Ship design")).toBeInTheDocument();
+    expect(screen.getByText("Launch beta")).toBeInTheDocument();
+  });
+});

--- a/turboui/src/WorkMap/components/TableRow/ProjectProgressSummary.tsx
+++ b/turboui/src/WorkMap/components/TableRow/ProjectProgressSummary.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+import { IconFlag, IconFlagFilled } from "../../../icons";
+import { PieChart } from "../../../PieChart";
+import classNames from "../../../utils/classnames";
+import { WorkMap } from "..";
+
+interface ProjectProgressSummaryProps {
+  milestones: WorkMap.Milestone[];
+}
+
+export function ProjectProgressSummary({ milestones }: ProjectProgressSummaryProps) {
+  if (milestones.length === 0) {
+    return (
+      <div className="text-content-dimmed text-xs font-normal" data-testid="project-progress-summary-content">
+        No milestones
+      </div>
+    );
+  }
+
+  const completedCount = milestones.filter((milestone) => milestone.status === "done").length;
+  const totalCount = milestones.length;
+  const completionPercentage = Math.round((completedCount / totalCount) * 100);
+
+  return (
+    <div
+      className="flex flex-col gap-1.5 min-w-[220px] max-w-[320px] font-normal"
+      data-testid="project-progress-summary-content"
+    >
+      <div className="flex items-center gap-2 mb-0.5">
+        <div className="text-xs font-semibold text-content-dimmed uppercase tracking-wide">Milestones</div>
+        <div className="flex items-center gap-1.5 text-xs text-content-subtle">
+          <PieChart size={12} slices={[{ percentage: completionPercentage, color: "var(--color-green-500)" }]} />
+          <span>
+            {completedCount}/{totalCount} completed ({completionPercentage}%)
+          </span>
+        </div>
+      </div>
+
+      {milestones.map((milestone) => (
+        <MilestoneRow key={milestone.id} milestone={milestone} />
+      ))}
+    </div>
+  );
+}
+
+function MilestoneRow({ milestone }: { milestone: WorkMap.Milestone }) {
+  const isDone = milestone.status === "done";
+  const nameClass = classNames("text-sm truncate", {
+    "line-through text-content-dimmed": isDone,
+    "text-content-accent": !isDone,
+  });
+
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      {isDone ? (
+        <IconFlagFilled size={14} className="text-accent-1 flex-shrink-0" />
+      ) : (
+        <IconFlag size={14} className="text-content-subtle flex-shrink-0" />
+      )}
+      <span className={nameClass}>{milestone.name}</span>
+    </div>
+  );
+}

--- a/turboui/src/WorkMap/components/TableRow/index.tsx
+++ b/turboui/src/WorkMap/components/TableRow/index.tsx
@@ -63,11 +63,7 @@ export function TableRow(props: Props) {
           hideCompanyAccess={props.hideCompanyAccessInQuickAdd}
         />
         <StatusCell item={item} hide={columnOptions?.hideStatus} />
-        <ProgressCell
-          progress={item.progress}
-          status={item.status}
-          hide={tab === "completed" || columnOptions?.hideProgress}
-        />
+        <ProgressCell item={item} hide={tab === "completed" || columnOptions?.hideProgress} />
         <DueDateCell
           tab={tab}
           completedOn={item.completedOn}

--- a/turboui/src/WorkMap/components/index.tsx
+++ b/turboui/src/WorkMap/components/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import type { GoalCheck, Target } from "../../ApiTypes";
 import { Navigation } from "../../Page/Navigation";
 import { PrivacyIndicator } from "../../PrivacyIndicator";
 
@@ -170,6 +171,8 @@ export namespace WorkMap {
     assignedAt: string | null;
     timeframe: Timeframe | null;
     milestones: Milestone[];
+    targets: Target[];
+    checklist: GoalCheck[];
     type: ItemType;
     itemPath: string;
     privacy: PrivacyIndicator.PrivacyLevels;

--- a/turboui/src/WorkMap/stories/TableRow.stories.tsx
+++ b/turboui/src/WorkMap/stories/TableRow.stories.tsx
@@ -191,7 +191,10 @@ export const GoalProgressHoverSummary: Story = {
     </>
   ),
   args: {
-    item: data.mockGoalOnTrack,
+    item: {
+      ...data.mockGoalOnTrack,
+      children: [],
+    },
     level: 0,
     isLast: false,
     tab: "all",
@@ -207,10 +210,14 @@ export const GoalProgressHoverSummary: Story = {
       await userEvent.hover(trigger);
 
       await waitFor(() => {
-        expect(screen.getByText("Targets")).toBeInTheDocument();
-        expect(screen.getByText("Revenue")).toBeInTheDocument();
-        expect(screen.getByText("Checklist")).toBeInTheDocument();
-        expect(screen.getByText("1/2 completed (50%)")).toBeInTheDocument();
+        const summaries = screen.getAllByTestId("goal-progress-summary-content");
+        expect(summaries.length).toBeGreaterThan(0);
+
+        const summary = within(summaries[0]);
+        expect(summary.getByText("Targets")).toBeInTheDocument();
+        expect(summary.getByText("Revenue")).toBeInTheDocument();
+        expect(summary.getByText("Checklist")).toBeInTheDocument();
+        expect(summary.getByText("1/2 completed (50%)")).toBeInTheDocument();
       });
     });
   },

--- a/turboui/src/WorkMap/stories/TableRow.stories.tsx
+++ b/turboui/src/WorkMap/stories/TableRow.stories.tsx
@@ -224,6 +224,48 @@ export const GoalProgressHoverSummary: Story = {
 };
 
 /**
+ * Project progress bar hover shows milestones summary
+ */
+export const ProjectProgressHoverSummary: Story = {
+  render: (args) => (
+    <>
+      <TableHeader tab={args.tab} columnOptions={args.columnOptions} />
+      <tbody>
+        <StoryTableRow {...args} />
+      </tbody>
+    </>
+  ),
+  args: {
+    item: data.mockProjectOnTrack,
+    level: 0,
+    isLast: false,
+    tab: "all",
+    columnOptions: {
+      hideProject: true,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Hover progress bar to reveal milestones summary", async () => {
+      const trigger = canvas.getByTestId("project-progress-summary");
+      await userEvent.hover(trigger);
+
+      await waitFor(() => {
+        const summaries = screen.getAllByTestId("project-progress-summary-content");
+        expect(summaries.length).toBeGreaterThan(0);
+
+        const summary = within(summaries[0]);
+        expect(summary.getByText("Milestones")).toBeInTheDocument();
+        expect(summary.getByText("1/2 completed (50%)")).toBeInTheDocument();
+        expect(summary.getByText("Ship design")).toBeInTheDocument();
+        expect(summary.getByText("Launch beta")).toBeInTheDocument();
+      });
+    });
+  },
+};
+
+/**
  * A goal that missed its target
  */
 export const MissedGoal: Story = {

--- a/turboui/src/WorkMap/stories/TableRow.stories.tsx
+++ b/turboui/src/WorkMap/stories/TableRow.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { PrivacyIndicator } from "../../PrivacyIndicator";
 
 import { TableRow, SetItemExpandedFn, IsItemExpandedFn } from "../components/TableRow";
@@ -45,7 +46,7 @@ function StoryTableRow({
     });
   }, []);
 
-  return <TableRow {...rest}  isExpanded={getItemExpanded} setItemExpanded={updateItemExpanded} />;
+  return <TableRow {...rest} isExpanded={getItemExpanded} setItemExpanded={updateItemExpanded} />;
 }
 
 const meta = {
@@ -174,6 +175,44 @@ export const AchievedGoal: Story = {
     await Steps.assertItemHasLineThrough(canvasElement, step, "Increase website traffic by 50%");
 
     await Steps.assertStatusBadge(canvasElement, step, "Achieved", "green");
+  },
+};
+
+/**
+ * Goal progress bar hover shows targets and checklist summary
+ */
+export const GoalProgressHoverSummary: Story = {
+  render: (args) => (
+    <>
+      <TableHeader tab={args.tab} columnOptions={args.columnOptions} />
+      <tbody>
+        <StoryTableRow {...args} />
+      </tbody>
+    </>
+  ),
+  args: {
+    item: data.mockGoalOnTrack,
+    level: 0,
+    isLast: false,
+    tab: "all",
+    columnOptions: {
+      hideProject: true,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step("Hover progress bar to reveal targets and checklist summary", async () => {
+      const trigger = canvas.getByTestId("goal-progress-summary");
+      await userEvent.hover(trigger);
+
+      await waitFor(() => {
+        expect(screen.getByText("Targets")).toBeInTheDocument();
+        expect(screen.getByText("Revenue")).toBeInTheDocument();
+        expect(screen.getByText("Checklist")).toBeInTheDocument();
+        expect(screen.getByText("1/2 completed (50%)")).toBeInTheDocument();
+      });
+    });
   },
 };
 

--- a/turboui/src/WorkMap/tests/mockData.ts
+++ b/turboui/src/WorkMap/tests/mockData.ts
@@ -53,6 +53,8 @@ function withDefaults(item: any): WorkMap.Item {
     nextStep: "",
     taskStatus: null,
     milestones: [],
+    targets: [],
+    checklist: [],
     privacy: "internal" as PrivacyIndicator.PrivacyLevels,
     ...item,
     children: (item.children || []).map(withDefaults),
@@ -181,6 +183,50 @@ export const mockTasksTabItems: WorkMap.Item[] = (() => {
   ];
 })();
 
+export const mockGoalTargets = [
+  {
+    __typename: "target" as const,
+    id: "target-revenue",
+    name: "Revenue",
+    from: 0,
+    to: 1000,
+    value: 250,
+    unit: "USD",
+    index: 1,
+  },
+  {
+    __typename: "target" as const,
+    id: "target-retention",
+    name: "Retention",
+    from: 0,
+    to: 100,
+    value: 40,
+    unit: "%",
+    index: 2,
+  },
+];
+
+export const mockGoalChecklist = [
+  {
+    __typename: "goal_check" as const,
+    id: "check-launch",
+    name: "Launch plan",
+    completed: true,
+    index: 1,
+    insertedAt: "2025-01-01",
+    updatedAt: "2025-01-02",
+  },
+  {
+    __typename: "goal_check" as const,
+    id: "check-hire",
+    name: "Hire lead",
+    completed: false,
+    index: 2,
+    insertedAt: "2025-01-01",
+    updatedAt: "2025-01-01",
+  },
+];
+
 export const mockSingleItem: WorkMap.Item = withDefaults({
   id: "goal-standalone",
   parentId: null,
@@ -192,6 +238,8 @@ export const mockSingleItem: WorkMap.Item = withDefaults({
   owner: people.alex,
   nextStep: "Working on this standalone goal",
   timeframe: getTimeframe(currentQuarter()),
+  targets: mockGoalTargets,
+  checklist: mockGoalChecklist,
   children: [],
 });
 
@@ -762,7 +810,11 @@ export const createMockItem = (
 };
 
 // Create mock items for each status
-export const mockGoalOnTrack = createMockItem("goal-1", "Improve customer experience", "goal", "on_track", 45, true);
+export const mockGoalOnTrack = withDefaults({
+  ...createMockItem("goal-1", "Improve customer experience", "goal", "on_track", 45, true),
+  targets: mockGoalTargets,
+  checklist: mockGoalChecklist,
+});
 export const mockGoalCompleted = createMockItem("goal-2", "Launch new marketing campaign", "goal", "achieved", 100);
 export const mockGoalAchieved = createMockItem("goal-3", "Increase website traffic by 50%", "goal", "achieved", 100);
 export const mockGoalPartial = createMockItem("goal-4", "Reduce support tickets by 30%", "goal", "missed", 75);

--- a/turboui/src/WorkMap/tests/mockData.ts
+++ b/turboui/src/WorkMap/tests/mockData.ts
@@ -823,7 +823,28 @@ export const mockGoalPaused = createMockItem("goal-6", "Expand to international 
 export const mockGoalCaution = createMockItem("goal-7", "Implement new CRM system", "goal", "caution", 35);
 export const mockGoalIssue = createMockItem("goal-8", "Migrate legacy systems", "goal", "off_track", 15);
 export const mockGoalOutdated = createMockItem("goal-9", "Update legacy documentation", "goal", "outdated", 30);
-export const mockProjectOnTrack = createMockItem("project-1", "Redesign product dashboard", "project", "on_track", 55);
+
+export const mockProjectMilestones: WorkMap.Milestone[] = [
+  {
+    id: "milestone-design",
+    name: "Ship design",
+    status: "done",
+    dueDate: createContextualDate("2025-02-15T00:00:00.000Z", "day"),
+    link: "/milestones/design",
+  },
+  {
+    id: "milestone-beta",
+    name: "Launch beta",
+    status: "pending",
+    dueDate: createContextualDate("2025-04-30T00:00:00.000Z", "day"),
+    link: "/milestones/beta",
+  },
+];
+
+export const mockProjectOnTrack = withDefaults({
+  ...createMockItem("project-1", "Redesign product dashboard", "project", "on_track", 55),
+  milestones: mockProjectMilestones,
+});
 export const mockProjectCompleted = createMockItem("project-2", "Update documentation", "project", "achieved", 100);
 export const mockProjectOutdated = createMockItem("project-3", "Refactor authentication", "project", "outdated", 25);
 

--- a/turboui/src/WorkMap/utils/sort.test.ts
+++ b/turboui/src/WorkMap/utils/sort.test.ts
@@ -73,6 +73,8 @@ function makeTask(overrides: { name: string; dueDate?: string; assignedAt?: stri
       : null,
     assignedAt: overrides.assignedAt || null,
     milestones: [],
+    targets: [],
+    checklist: [],
     type: "task",
     itemPath: `/${overrides.name}`,
     privacy: "internal",

--- a/turboui/src/WorkMap/utils/timelineItem.test.ts
+++ b/turboui/src/WorkMap/utils/timelineItem.test.ts
@@ -76,6 +76,8 @@ function makeItem(overrides: Partial<WorkMap.Item> = {}): WorkMap.Item {
     assignedAt: null,
     timeframe: null,
     milestones: [],
+    targets: [],
+    checklist: [],
     type: "project",
     itemPath: "/project",
     privacy: "internal",

--- a/turboui/src/utils/goalTargetProgress.test.ts
+++ b/turboui/src/utils/goalTargetProgress.test.ts
@@ -1,0 +1,44 @@
+import {
+  calculateTargetProgress,
+  formatTargetValueSummary,
+  formatValueAndUnit,
+} from "./goalTargetProgress";
+
+describe("goalTargetProgress", () => {
+  describe("calculateTargetProgress", () => {
+    it("returns clamped progress for increasing targets", () => {
+      expect(calculateTargetProgress({ from: 0, to: 100, value: 40 })).toBe(40);
+      expect(calculateTargetProgress({ from: 0, to: 100, value: 150 })).toBe(100);
+      expect(calculateTargetProgress({ from: 0, to: 100, value: -10 })).toBe(0);
+    });
+
+    it("supports decreasing targets and unclamped values", () => {
+      expect(calculateTargetProgress({ from: 100, to: 0, value: 25 })).toBe(75);
+      expect(calculateTargetProgress({ from: 0, to: 100, value: 150 }, false)).toBe(150);
+    });
+
+    it("returns 0 when from equals to", () => {
+      expect(calculateTargetProgress({ from: 10, to: 10, value: 10 })).toBe(0);
+    });
+  });
+
+  describe("formatValueAndUnit", () => {
+    it("formats with locale separators and units", () => {
+      expect(formatValueAndUnit(1000, "USD", "en-US")).toBe("1,000 USD");
+      expect(formatValueAndUnit(40, "%", "en-US")).toBe("40%");
+      expect(formatValueAndUnit(1000.5, "", "de-DE")).toBe("1.000,5");
+    });
+  });
+
+  describe("formatTargetValueSummary", () => {
+    it("returns null when value or target is missing", () => {
+      expect(formatTargetValueSummary({ value: 10, to: null, unit: "USD" })).toBeNull();
+      expect(formatTargetValueSummary({ value: null, to: 100, unit: "%" })).toBeNull();
+    });
+
+    it("formats current → target summary", () => {
+      expect(formatTargetValueSummary({ value: 250, to: 1000, unit: "USD" }, "en-US")).toBe("250 USD → 1,000 USD");
+      expect(formatTargetValueSummary({ value: 40, to: 100, unit: "%" }, "en-US")).toBe("40% → 100%");
+    });
+  });
+});

--- a/turboui/src/utils/goalTargetProgress.ts
+++ b/turboui/src/utils/goalTargetProgress.ts
@@ -1,0 +1,60 @@
+import { browserLocale, formatNumber } from "./formatting";
+
+export type TargetProgressFields = {
+  from?: number | null;
+  to?: number | null;
+  value?: number | null;
+  unit?: string | null;
+};
+
+/**
+ * Progress of a goal target from `from` toward `to` based on `value`.
+ * When `clamped` is true, the result is limited to 0–100.
+ */
+export function calculateTargetProgress(target: TargetProgressFields, clamped = true): number {
+  const from = target.from ?? 0;
+  const to = target.to ?? 0;
+  const value = target.value ?? 0;
+
+  let percentage: number;
+  if (from === to) {
+    percentage = 0;
+  } else if (from < to) {
+    percentage = ((value - from) / (to - from)) * 100;
+  } else {
+    percentage = ((from - value) / (from - to)) * 100;
+  }
+
+  if (clamped) {
+    return Math.max(0, Math.min(100, percentage));
+  }
+
+  return percentage;
+}
+
+/**
+ * Formats a target numeric value with its unit, using the browser (or provided) locale.
+ */
+export function formatValueAndUnit(value: number, unit: string, locale: string = browserLocale()): string {
+  const formatted = formatNumber(value, locale);
+
+  if (unit === "%") return `${formatted}%`;
+  if (unit === "") return formatted;
+  return `${formatted} ${unit}`;
+}
+
+/**
+ * Compact "current → target" summary for tooltips and read-only lists.
+ */
+export function formatTargetValueSummary(
+  target: TargetProgressFields,
+  locale: string = browserLocale(),
+): string | null {
+  const value = target.value;
+  const to = target.to;
+  const unit = target.unit ?? "";
+
+  if (value == null || to == null) return null;
+
+  return `${formatValueAndUnit(value, unit, locale)} → ${formatValueAndUnit(to, unit, locale)}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the preferred approach from [#4064](https://github.com/operately/operately/issues/4064#issuecomment-3972172492): hovering the Progress bar on the Work Map shows a compact read-only popup.

- **Goals:** targets + checklist
- **Projects:** completed/open milestones

No nested KR rows, no “Show Targets” toggle, and no slide-in panel.

## Changes

### Backend
- Add `targets` and `checklist` lists to `work_map_item` (always present, like `milestones`)
- Serialize via the same pattern as milestones (`Serializer.serialize/1`); sorting happens on the frontend
- Rebased onto latest `main` (includes shared `:milestone` type for work map items)

### Frontend (TurboUI)
- Goal hover: PieChart + value summary for targets; checkbox state + `X/Y completed (Z%)` for checklist
- Project hover: flag icons + `X/Y completed (Z%)` for milestones
- Empty states: “No targets or checklist” / “No milestones”
- Completed-tab behavior unchanged (progress cell still hidden/empty)

## Test plan
- [x] `get_work_map` API tests (targets/checklist serialization)
- [x] TurboUI unit tests for goal + project progress summaries
- [x] Storybook `TableRow` play tests (goal + project hover)
- [x] Manually hover goal and project progress bars on Work Map
- [x] Confirm tasks do not show a summary popup
- [x] Confirm completed tab still hides progress

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-228ee0ad-c7f6-463e-9304-177f02ba6f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-228ee0ad-c7f6-463e-9304-177f02ba6f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

