### PR TITLE
chore: Add document version storage and baseline migration

### DIFF
--- a/app/lib/operately/company_transfers/schema/policy_registry.ex
+++ b/app/lib/operately/company_transfers/schema/policy_registry.ex
@@ -178,6 +178,7 @@ defmodule Operately.CompanyTransfers.Schema.PolicyRegistry do
     "project_retrospectives",
     "projects",
     "resource_documents",
+    "resource_document_versions",
     "resource_files",
     "resource_folders",
     "resource_hubs",

--- a/app/lib/operately/data/change_110_baseline_document_versions.ex
+++ b/app/lib/operately/data/change_110_baseline_document_versions.ex
@@ -1,0 +1,113 @@
+defmodule Operately.Data.Change110BaselineDocumentVersions do
+  @moduledoc """
+  Creates version 1 for every document that has no version rows yet.
+
+  Idempotent: documents that already have at least one version are skipped.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  defmodule Document do
+    use Operately.Schema
+
+    schema "resource_documents" do
+      field :name, :string
+      field :content, :map
+      field :current_version, :integer
+      field :updated_at, :naive_datetime
+    end
+  end
+
+  defmodule DocumentVersion do
+    use Operately.Schema
+
+    schema "resource_document_versions" do
+      field :document_id, :binary_id
+      field :version_number, :integer
+      field :title, :string
+      field :content, :map
+      field :content_schema_version, :integer
+      field :editor_id, :binary_id
+      field :origin, :string
+      field :restored_from_version_number, :integer
+      field :inserted_at, :naive_datetime
+    end
+
+    def changeset(version, attrs) do
+      version
+      |> cast(attrs, [
+        :id,
+        :document_id,
+        :version_number,
+        :title,
+        :content,
+        :content_schema_version,
+        :editor_id,
+        :origin,
+        :restored_from_version_number,
+        :inserted_at
+      ])
+      |> validate_required([
+        :id,
+        :document_id,
+        :version_number,
+        :title,
+        :content,
+        :content_schema_version,
+        :origin,
+        :inserted_at
+      ])
+    end
+  end
+
+  def run do
+    Repo.transaction(fn ->
+      documents_without_versions()
+      |> Enum.each(&insert_baseline_version/1)
+    end)
+  end
+
+  defp documents_without_versions do
+    from(d in Document,
+      left_join: v in DocumentVersion,
+      on: v.document_id == d.id,
+      where: is_nil(v.id),
+      select: d
+    )
+    |> Repo.all()
+  end
+
+  defp insert_baseline_version(document) do
+    inserted_at =
+      case document.updated_at do
+        %DateTime{} = dt ->
+          dt |> DateTime.truncate(:second) |> DateTime.to_naive()
+
+        %NaiveDateTime{} = dt ->
+          NaiveDateTime.truncate(dt, :second)
+
+        nil ->
+          NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      end
+
+    {:ok, _} =
+      %DocumentVersion{}
+      |> DocumentVersion.changeset(%{
+        id: Ecto.UUID.generate(),
+        document_id: document.id,
+        version_number: 1,
+        title: document.name,
+        content: document.content,
+        content_schema_version: 1,
+        editor_id: nil,
+        origin: "migration",
+        inserted_at: inserted_at
+      })
+      |> Repo.insert()
+
+    from(d in Document, where: d.id == ^document.id)
+    |> Repo.update_all(set: [current_version: 1])
+  end
+end

--- a/app/lib/operately/data/change_110_baseline_document_versions.ex
+++ b/app/lib/operately/data/change_110_baseline_document_versions.ex
@@ -82,9 +82,6 @@ defmodule Operately.Data.Change110BaselineDocumentVersions do
   defp insert_baseline_version(document) do
     inserted_at =
       case document.updated_at do
-        %DateTime{} = dt ->
-          dt |> DateTime.truncate(:second) |> DateTime.to_naive()
-
         %NaiveDateTime{} = dt ->
           NaiveDateTime.truncate(dt, :second)
 

--- a/app/lib/operately/resource_hubs.ex
+++ b/app/lib/operately/resource_hubs.ex
@@ -5,7 +5,7 @@ defmodule Operately.ResourceHubs do
   alias Operately.Goals.Goal
   alias Operately.Groups.Group
   alias Operately.Projects.Project
-  alias Operately.ResourceHubs.{ResourceHub, Folder, Node, Document, File, Link}
+  alias Operately.ResourceHubs.{ResourceHub, Folder, Node, Document, DocumentVersion, File, Link}
 
   def list_resource_hubs(%Group{} = space) do
     from(r in ResourceHub, where: r.space_id == ^space.id)
@@ -81,6 +81,12 @@ defmodule Operately.ResourceHubs do
   def create_document(attrs \\ %{}) do
     %Document{}
     |> Document.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def create_document_version(attrs \\ %{}) do
+    %DocumentVersion{}
+    |> DocumentVersion.changeset(attrs)
     |> Repo.insert()
   end
 

--- a/app/lib/operately/resource_hubs/document.ex
+++ b/app/lib/operately/resource_hubs/document.ex
@@ -6,7 +6,7 @@ defmodule Operately.ResourceHubs.Document do
   import Operately.Repo.RequestInfo, only: [request_info: 0]
 
   alias Operately.Notifications
-  alias Operately.ResourceHubs.{Getter, Parent}
+  alias Operately.ResourceHubs.{DocumentVersion, Getter, Parent}
   alias Operately.StateMachine
 
   @valid_states [:draft, :published]
@@ -22,9 +22,11 @@ defmodule Operately.ResourceHubs.Document do
     has_one :resource_hub, through: [:node, :resource_hub]
     has_many :reactions, Operately.Updates.Reaction, where: [entity_type: :resource_hub_document], foreign_key: :entity_id
     has_many :comments, Operately.Updates.Comment, where: [entity_type: :resource_hub_document], foreign_key: :entity_id
+    has_many :versions, DocumentVersion, foreign_key: :document_id
 
     field :name, :string
     field :content, :map
+    field :current_version, :integer, default: 1
     field :state, Ecto.Enum, values: @valid_states
     field :published_at, :utc_datetime
 
@@ -47,7 +49,7 @@ defmodule Operately.ResourceHubs.Document do
 
   def changeset(document, attrs) do
     document
-    |> cast(attrs, [:node_id, :author_id, :subscription_list_id, :name, :content, :state, :published_at])
+    |> cast(attrs, [:node_id, :author_id, :subscription_list_id, :name, :content, :current_version, :state, :published_at])
     |> StateMachine.cast_and_validate(:state, %{
       initial: :draft,
       states: [
@@ -56,6 +58,7 @@ defmodule Operately.ResourceHubs.Document do
       ]
     })
     |> validate_required([:node_id, :author_id, :subscription_list_id, :name, :content])
+    |> validate_number(:current_version, greater_than: 0)
   end
 
   def get(requester, args) do

--- a/app/lib/operately/resource_hubs/document_version.ex
+++ b/app/lib/operately/resource_hubs/document_version.ex
@@ -1,0 +1,91 @@
+defmodule Operately.ResourceHubs.DocumentVersion do
+  use Operately.Schema
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+
+  @valid_origins [:created, :edited, :restored, :migration]
+
+  schema "resource_document_versions" do
+    belongs_to :document, Operately.ResourceHubs.Document, foreign_key: :document_id
+    belongs_to :editor, Operately.People.Person, foreign_key: :editor_id
+
+    field :version_number, :integer
+    field :title, :string
+    field :content, :map
+    field :content_schema_version, :integer
+    field :origin, Ecto.Enum, values: @valid_origins
+    field :restored_from_version_number, :integer
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(attrs) when is_map(attrs) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(version, attrs) do
+    version
+    |> cast(attrs, [
+      :document_id,
+      :version_number,
+      :title,
+      :content,
+      :content_schema_version,
+      :editor_id,
+      :origin,
+      :restored_from_version_number,
+      :inserted_at
+    ])
+    |> validate_required([
+      :document_id,
+      :version_number,
+      :title,
+      :content,
+      :content_schema_version,
+      :origin
+    ])
+    |> validate_number(:version_number, greater_than: 0)
+    |> validate_number(:content_schema_version, greater_than: 0)
+    |> validate_number(:restored_from_version_number, greater_than: 0)
+    |> validate_inclusion(:origin, @valid_origins)
+    |> validate_restored_from_matches_origin()
+    |> unique_constraint([:document_id, :version_number])
+    |> foreign_key_constraint(:document_id)
+    |> foreign_key_constraint(:editor_id)
+  end
+
+  def valid_origins, do: @valid_origins
+
+  def list_for_document(document_id) do
+    from(v in __MODULE__,
+      where: v.document_id == ^document_id,
+      order_by: [desc: v.version_number]
+    )
+    |> Repo.all()
+  end
+
+  def get_by_document_and_number(document_id, version_number) do
+    from(v in __MODULE__,
+      where: v.document_id == ^document_id and v.version_number == ^version_number
+    )
+    |> Repo.one()
+  end
+
+  defp validate_restored_from_matches_origin(changeset) do
+    origin = get_field(changeset, :origin)
+    restored_from = get_field(changeset, :restored_from_version_number)
+
+    cond do
+      origin == :restored and is_nil(restored_from) ->
+        add_error(changeset, :restored_from_version_number, "must be present when origin is restored")
+
+      origin != :restored and not is_nil(restored_from) ->
+        add_error(changeset, :restored_from_version_number, "must be blank unless origin is restored")
+
+      true ->
+        changeset
+    end
+  end
+end

--- a/app/priv/repo/migrations/20260720190000_add_current_version_to_resource_documents.exs
+++ b/app/priv/repo/migrations/20260720190000_add_current_version_to_resource_documents.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.AddCurrentVersionToResourceDocuments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:resource_documents) do
+      add :current_version, :integer, null: false, default: 1
+    end
+
+    create constraint(:resource_documents, :resource_documents_current_version_positive, check: "current_version > 0")
+  end
+end

--- a/app/priv/repo/migrations/20260720190100_create_resource_document_versions.exs
+++ b/app/priv/repo/migrations/20260720190100_create_resource_document_versions.exs
@@ -1,0 +1,41 @@
+defmodule Operately.Repo.Migrations.CreateResourceDocumentVersions do
+  use Ecto.Migration
+
+  def change do
+    create table(:resource_document_versions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :document_id, references(:resource_documents, on_delete: :delete_all, type: :binary_id), null: false
+      add :version_number, :integer, null: false
+      add :title, :text, null: false
+      add :content, :map, null: false
+      add :content_schema_version, :integer, null: false
+      add :editor_id, references(:people, on_delete: :nilify_all, type: :binary_id)
+      add :origin, :string, null: false
+      add :restored_from_version_number, :integer
+
+      timestamps(updated_at: false)
+    end
+
+    create unique_index(:resource_document_versions, [:document_id, :version_number])
+    create index(:resource_document_versions, [:editor_id])
+
+    # History lists load versions for one document newest-first.
+    execute(
+      "CREATE INDEX resource_document_versions_document_id_inserted_at_index ON resource_document_versions (document_id, inserted_at DESC)",
+      "DROP INDEX resource_document_versions_document_id_inserted_at_index"
+    )
+
+    create constraint(:resource_document_versions, :resource_document_versions_version_number_positive,
+      check: "version_number > 0"
+    )
+
+    create constraint(:resource_document_versions, :resource_document_versions_content_schema_version_positive,
+      check: "content_schema_version > 0"
+    )
+
+    # Optional when set, but never zero or negative.
+    create constraint(:resource_document_versions, :resource_document_versions_restored_from_positive,
+      check: "restored_from_version_number IS NULL OR restored_from_version_number > 0"
+    )
+  end
+end

--- a/app/priv/repo/migrations/20260720190200_baseline_document_versions.exs
+++ b/app/priv/repo/migrations/20260720190200_baseline_document_versions.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.BaselineDocumentVersions do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change110BaselineDocumentVersions.run()
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/app/test/operately/company_transfers/export/file_discovery_test.exs
+++ b/app/test/operately/company_transfers/export/file_discovery_test.exs
@@ -80,6 +80,47 @@ defmodule Operately.CompanyTransfers.Export.FileDiscoveryTest do
     refute Enum.any?(discovery.files, &(&1["blob_id"] == ctx.unused_blob.id))
   end
 
+  test "discover/1 finds blobs referenced only by historical document versions", ctx do
+    ctx =
+      ctx
+      |> Factory.add_blob(:historical_blob)
+      |> Factory.add_space(:space)
+      |> Factory.add_resource_hub(:hub, :space, :creator)
+      |> Factory.add_document(:document, :hub, content: %{"type" => "doc", "content" => []})
+
+    assert {:ok, _version} =
+             Operately.ResourceHubs.create_document_version(%{
+               document_id: ctx.document.id,
+               version_number: 1,
+               title: ctx.document.name,
+               content: blob_document(ctx.historical_blob),
+               content_schema_version: 1,
+               editor_id: nil,
+               origin: :migration
+             })
+
+    on_exit(fn ->
+      cleanup_blob_storage([ctx.historical_blob])
+    end)
+
+    upload_blob_payload!(ctx.historical_blob, "historical payload")
+
+    package = Transfers.export!(ctx.company, ctx.account).package
+    discovery = FileDiscovery.discover(package)
+
+    assert Enum.any?(discovery.files, &(&1["blob_id"] == ctx.historical_blob.id))
+
+    assert %{
+             table: "resource_document_versions",
+             row_id: _version_id,
+             column: "content",
+             blob_id: historical_blob_id
+           } =
+             Enum.find(discovery.rich_text_blob_references, &(&1.blob_id == ctx.historical_blob.id))
+
+    assert historical_blob_id == ctx.historical_blob.id
+  end
+
   defp blob_document(blob) do
     %{
       "type" => "doc",

--- a/app/test/operately/company_transfers/import/rich_text_rewriter_test.exs
+++ b/app/test/operately/company_transfers/import/rich_text_rewriter_test.exs
@@ -91,6 +91,53 @@ defmodule Operately.CompanyTransfers.Import.RichTextRewriterTest do
     assert blob_node["attrs"]["src"] == Blob.url(%Blob{id: destination_blob_id})
   end
 
+  test "rewrites mentions and blobs in resource_document_versions content" do
+    source_person = person("Version Mention")
+    destination_person_id = Ecto.UUID.generate()
+    source_blob_id = Ecto.UUID.generate()
+    destination_blob_id = Ecto.UUID.generate()
+
+    row = %{
+      "content" => %{
+        "type" => "doc",
+        "content" => [
+          hd(mention_doc([source_person])["content"]),
+          %{
+            "type" => "blob",
+            "attrs" => %{
+              "id" => ShortUuid.encode!(source_blob_id),
+              "src" => Blob.url(%Blob{id: source_blob_id}),
+              "title" => "attachment.txt"
+            }
+          }
+        ]
+      }
+    }
+
+    plan =
+      translation_plan(%{
+        people: %{source_person.id => destination_person_id},
+        blobs: %{source_blob_id => destination_blob_id}
+      })
+
+    assert map_fields_for("resource_document_versions") == ["content"]
+
+    assert {:ok, rewritten} =
+             RichTextRewriter.rewrite_row_mentions(
+               row,
+               "resource_document_versions",
+               plan,
+               map_fields_for("resource_document_versions")
+             )
+
+    assert RichContent.find_mentioned_ids(rewritten["content"]) == [
+             encoded_person_id("Version Mention", destination_person_id)
+           ]
+
+    [_mention, blob_node] = rewritten["content"]["content"]
+    assert blob_node["attrs"]["id"] == ShortUuid.encode!(destination_blob_id)
+  end
+
   test "rewrites legacy blob src maps in top-level TipTap docs" do
     source_blob_id = Ecto.UUID.generate()
     destination_blob_id = Ecto.UUID.generate()

--- a/app/test/operately/company_transfers/importer_test.exs
+++ b/app/test/operately/company_transfers/importer_test.exs
@@ -21,6 +21,7 @@ defmodule Operately.CompanyTransfers.ImporterTest do
   alias Operately.Goals.{Goal, Update}
   alias Operately.Projects.Project
   alias Operately.ResourceHubs.Document
+  alias Operately.ResourceHubs.DocumentVersion
   alias Operately.Repo
   alias Operately.Support.CompanyTransfer.Helpers, as: Transfers
   alias OperatelyWeb.Paths, as: WebPaths
@@ -603,6 +604,119 @@ defmodule Operately.CompanyTransfers.ImporterTest do
     [blob_node] = imported_document.content["content"]
     assert blob_node["attrs"]["id"] == WebPaths.blob_id(imported_blob)
     assert blob_node["attrs"]["src"] == Blob.url(imported_blob)
+
+    _ = File.rm(storage_path(imported_blob))
+  end
+
+  test "run/1 round-trips document versions including historical-only blobs", ctx do
+    ctx =
+      ctx
+      |> Factory.add_blob(:historical_blob)
+      |> Factory.add_company_member(:editor)
+      |> Factory.add_space(:space)
+      |> Factory.add_resource_hub(:hub, :space, :creator)
+      |> Factory.add_document(:document, :hub, name: "Versioned Doc", content: %{"type" => "doc", "content" => []})
+
+    on_exit(fn ->
+      cleanup_blob_storage([ctx.historical_blob])
+    end)
+
+    upload_blob_payload!(ctx.historical_blob, "historical-only payload")
+
+    assert {:ok, _} =
+             Operately.ResourceHubs.create_document_version(%{
+               document_id: ctx.document.id,
+               version_number: 1,
+               title: "Baseline title",
+               content: %{"type" => "doc", "content" => []},
+               content_schema_version: 1,
+               editor_id: nil,
+               origin: :migration,
+               inserted_at: ~U[2024-01-01 10:00:00Z]
+             })
+
+    assert {:ok, _} =
+             Operately.ResourceHubs.create_document_version(%{
+               document_id: ctx.document.id,
+               version_number: 2,
+               title: "Edited title",
+               content: blob_document(ctx.historical_blob),
+               content_schema_version: 1,
+               editor_id: ctx.editor.id,
+               origin: :edited,
+               inserted_at: ~U[2024-01-02 11:00:00Z]
+             })
+
+    assert {:ok, _} =
+             Operately.ResourceHubs.create_document_version(%{
+               document_id: ctx.document.id,
+               version_number: 3,
+               title: "Restored title",
+               content: %{"type" => "doc", "content" => []},
+               content_schema_version: 1,
+               editor_id: ctx.editor.id,
+               origin: :restored,
+               restored_from_version_number: 1,
+               inserted_at: ~U[2024-01-03 12:00:00Z]
+             })
+
+    {:ok, document} =
+      ctx.document
+      |> Ecto.Changeset.change(%{current_version: 3})
+      |> Repo.update()
+
+    ctx = Map.put(ctx, :document, document)
+
+    assert {:ok, export_run} = CompanyTransfers.create_export_run(ctx.company, ctx.account, %{}, dispatch: false)
+    assert {:ok, export_run} = CompanyTransfers.mark_export_run_running(export_run)
+    assert {:ok, export_run} = Exporter.run(export_run)
+
+    assert {:ok, import_run} =
+             CompanyTransfers.create_import_run(
+               ctx.account,
+               %{
+                 package_blob_id: export_run.package_blob_id
+               },
+               dispatch: false
+             )
+
+    assert {:ok, import_run} = CompanyTransfers.mark_import_run_running(import_run)
+    assert {:ok, completed_run} = Importer.run(import_run)
+
+    imported_document =
+      Repo.one!(
+        from d in Document,
+          join: n in assoc(d, :node),
+          join: h in assoc(n, :resource_hub),
+          join: s in assoc(h, :space),
+          where: s.company_id == ^completed_run.company_id,
+          where: d.name == "Versioned Doc"
+      )
+
+    assert imported_document.current_version == 3
+    assert imported_document.id != ctx.document.id
+
+    imported_versions =
+      from(v in DocumentVersion,
+        where: v.document_id == ^imported_document.id,
+        order_by: [asc: v.version_number]
+      )
+      |> Repo.all()
+
+    assert length(imported_versions) == 3
+    assert Enum.map(imported_versions, & &1.version_number) == [1, 2, 3]
+    assert Enum.map(imported_versions, & &1.origin) == [:migration, :edited, :restored]
+    assert Enum.at(imported_versions, 2).restored_from_version_number == 1
+    assert Enum.at(imported_versions, 0).content_schema_version == 1
+    assert Enum.at(imported_versions, 0).editor_id == nil
+    assert Enum.at(imported_versions, 1).editor_id != nil
+    assert Enum.at(imported_versions, 1).editor_id != ctx.editor.id
+
+    [imported_blob_id] = Operately.RichContent.Blob.find_ids(Enum.at(imported_versions, 1).content)
+    imported_blob = Blobs.get_blob!(imported_blob_id)
+
+    assert imported_blob.id != ctx.historical_blob.id
+    assert File.read!(storage_path(imported_blob)) == "historical-only payload"
 
     _ = File.rm(storage_path(imported_blob))
   end

--- a/app/test/operately/data/change_110_baseline_document_versions_test.exs
+++ b/app/test/operately/data/change_110_baseline_document_versions_test.exs
@@ -1,0 +1,111 @@
+defmodule Operately.Data.Change110BaselineDocumentVersionsTest do
+  use Operately.DataCase
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Data.Change110BaselineDocumentVersions, as: Change
+  alias Operately.ResourceHubs.DocumentVersion
+  alias Operately.Support.Factory
+
+  setup do
+    ctx =
+      Factory.setup(%{})
+      |> Factory.add_space(:space)
+      |> Factory.add_resource_hub(:hub, :space, :creator)
+
+    {:ok, ctx}
+  end
+
+  test "creates exactly one migration baseline per existing document", ctx do
+    ctx =
+      ctx
+      |> Factory.add_document(:doc_a, :hub, name: "Alpha", content: %{"type" => "doc", "content" => []})
+      |> Factory.add_document(:doc_b, :hub, name: "Beta", content: %{"type" => "doc", "content" => [%{"type" => "paragraph"}]})
+
+    Change.run()
+
+    versions =
+      from(v in DocumentVersion, order_by: [asc: v.title])
+      |> Repo.all()
+
+    assert length(versions) == 2
+
+    [alpha, beta] = versions
+
+    assert alpha.title == "Alpha"
+    assert alpha.content == ctx.doc_a.content
+    assert alpha.content_schema_version == 1
+    assert alpha.editor_id == nil
+    assert alpha.origin == :migration
+    assert alpha.version_number == 1
+    assert NaiveDateTime.compare(
+             alpha.inserted_at,
+             NaiveDateTime.truncate(ctx.doc_a.updated_at, :second)
+           ) == :eq
+
+    assert beta.title == "Beta"
+    assert beta.content == ctx.doc_b.content
+    assert beta.origin == :migration
+
+    doc_a = Repo.get!(Operately.ResourceHubs.Document, ctx.doc_a.id)
+    doc_b = Repo.get!(Operately.ResourceHubs.Document, ctx.doc_b.id)
+    assert doc_a.current_version == 1
+    assert doc_b.current_version == 1
+  end
+
+  test "is idempotent and does not duplicate rows", ctx do
+    ctx = Factory.add_document(ctx, :document, :hub)
+
+    Change.run()
+    Change.run()
+
+    count =
+      from(v in DocumentVersion, where: v.document_id == ^ctx.document.id)
+      |> Repo.aggregate(:count, :id)
+
+    assert count == 1
+  end
+
+  test "skips documents that already have versions", ctx do
+    ctx = Factory.add_document(ctx, :document, :hub)
+
+    assert {:ok, existing} =
+             Operately.ResourceHubs.create_document_version(%{
+               document_id: ctx.document.id,
+               version_number: 1,
+               title: "Already versioned",
+               content: %{"type" => "doc", "content" => []},
+               content_schema_version: 1,
+               editor_id: ctx.creator.id,
+               origin: :created
+             })
+
+    Change.run()
+
+    versions =
+      from(v in DocumentVersion, where: v.document_id == ^ctx.document.id)
+      |> Repo.all()
+
+    assert length(versions) == 1
+    assert hd(versions).id == existing.id
+    assert hd(versions).origin == :created
+  end
+
+  test "includes soft-deleted documents and does not join nodes", ctx do
+    ctx = Factory.add_document(ctx, :document, :hub, name: "Soft deleted")
+
+    {:ok, _} =
+      ctx.document
+      |> Ecto.Changeset.change(%{deleted_at: DateTime.utc_now()})
+      |> Repo.update()
+
+    Change.run()
+
+    version =
+      from(v in DocumentVersion, where: v.document_id == ^ctx.document.id)
+      |> Repo.one!()
+
+    assert version.title == "Soft deleted"
+    assert version.origin == :migration
+  end
+end

--- a/app/test/operately/resource_hubs/document_version_test.exs
+++ b/app/test/operately/resource_hubs/document_version_test.exs
@@ -1,0 +1,160 @@
+defmodule Operately.ResourceHubs.DocumentVersionTest do
+  use Operately.DataCase, async: true
+
+  alias Operately.Repo
+  alias Operately.ResourceHubs
+  alias Operately.ResourceHubs.DocumentVersion
+  alias Operately.Support.Factory
+
+  setup do
+    ctx =
+      Factory.setup(%{})
+      |> Factory.add_space(:space)
+      |> Factory.add_resource_hub(:hub, :space, :creator)
+      |> Factory.add_document(:document, :hub)
+
+    {:ok, ctx}
+  end
+
+  test "accepts each valid origin", ctx do
+    Enum.each(DocumentVersion.valid_origins(), fn origin ->
+      attrs = version_attrs(ctx, origin: origin, version_number: origin_to_number(origin))
+
+      attrs =
+        if origin == :restored do
+          Map.put(attrs, :restored_from_version_number, 1)
+        else
+          attrs
+        end
+
+      assert {:ok, version} = ResourceHubs.create_document_version(attrs)
+      assert version.origin == origin
+    end)
+  end
+
+  test "rejects non-positive version and schema version numbers", ctx do
+    assert {:error, changeset} =
+             ResourceHubs.create_document_version(version_attrs(ctx, version_number: 0))
+
+    assert %{version_number: _} = errors_on(changeset)
+
+    assert {:error, changeset} =
+             ResourceHubs.create_document_version(version_attrs(ctx, content_schema_version: 0))
+
+    assert %{content_schema_version: _} = errors_on(changeset)
+  end
+
+  test "enforces unique document/version numbers", ctx do
+    assert {:ok, _} = ResourceHubs.create_document_version(version_attrs(ctx, version_number: 1))
+
+    assert {:error, changeset} =
+             ResourceHubs.create_document_version(version_attrs(ctx, version_number: 1))
+
+    assert %{document_id: _} = errors_on(changeset)
+  end
+
+  test "enforces restored_from constraint with origin", ctx do
+    assert {:error, changeset} =
+             ResourceHubs.create_document_version(
+               version_attrs(ctx, origin: :restored, version_number: 2)
+             )
+
+    assert %{restored_from_version_number: _} = errors_on(changeset)
+
+    assert {:error, changeset} =
+             ResourceHubs.create_document_version(
+               version_attrs(ctx,
+                 origin: :edited,
+                 version_number: 2,
+                 restored_from_version_number: 1
+               )
+             )
+
+    assert %{restored_from_version_number: _} = errors_on(changeset)
+
+    assert {:ok, _} =
+             ResourceHubs.create_document_version(
+               version_attrs(ctx,
+                 origin: :restored,
+                 version_number: 2,
+                 restored_from_version_number: 1
+               )
+             )
+  end
+
+  test "editor_id foreign key nilifies when the editor person is removed", ctx do
+    assert {:ok, version} =
+             ResourceHubs.create_document_version(
+               version_attrs(ctx, version_number: 1, editor_id: ctx.creator.id)
+             )
+
+    assert version.editor_id == ctx.creator.id
+
+    %{rows: [[delete_action]]} =
+      Ecto.Adapters.SQL.query!(
+        Repo,
+        """
+        SELECT confdeltype
+        FROM pg_constraint
+        WHERE conname = 'resource_document_versions_editor_id_fkey'
+        """
+      )
+
+    # PostgreSQL confdeltype 'n' means ON DELETE SET NULL
+    assert delete_action == "n"
+
+    assert {:ok, migration_version} =
+             ResourceHubs.create_document_version(
+               version_attrs(ctx, version_number: 2, editor_id: nil, origin: :edited)
+             )
+
+    assert migration_version.editor_id == nil
+  end
+
+  test "document hard deletion removes versions", ctx do
+    assert {:ok, version} = ResourceHubs.create_document_version(version_attrs(ctx, version_number: 1))
+
+    assert {:ok, _} = Repo.delete(ctx.document)
+
+    assert Repo.get(DocumentVersion, version.id) == nil
+  end
+
+  test "list_for_document and get_by_document_and_number", ctx do
+    assert {:ok, v1} = ResourceHubs.create_document_version(version_attrs(ctx, version_number: 1))
+
+    assert {:ok, v2} =
+             ResourceHubs.create_document_version(version_attrs(ctx, origin: :edited, version_number: 2))
+
+    assert [listed_v2, listed_v1] = DocumentVersion.list_for_document(ctx.document.id)
+    assert listed_v2.id == v2.id
+    assert listed_v1.id == v1.id
+
+    assert DocumentVersion.get_by_document_and_number(ctx.document.id, 2).id == v2.id
+    assert DocumentVersion.get_by_document_and_number(ctx.document.id, 99) == nil
+  end
+
+  test "there is no public update path for versions", _ctx do
+    refute function_exported?(ResourceHubs, :update_document_version, 2)
+    refute function_exported?(DocumentVersion, :update_changeset, 2)
+  end
+
+  defp version_attrs(ctx, overrides) do
+    Map.merge(
+      %{
+        document_id: ctx.document.id,
+        version_number: 1,
+        title: ctx.document.name,
+        content: ctx.document.content,
+        content_schema_version: 1,
+        editor_id: ctx.creator.id,
+        origin: :created
+      },
+      Map.new(overrides)
+    )
+  end
+
+  defp origin_to_number(:created), do: 1
+  defp origin_to_number(:edited), do: 2
+  defp origin_to_number(:restored), do: 3
+  defp origin_to_number(:migration), do: 4
+end

--- a/specs/0016-document-version-history.md
+++ b/specs/0016-document-version-history.md
@@ -1,0 +1,1008 @@
+# Document Version History and Rich-Text Diffs
+
+## Summary
+
+Add immutable version history to native Docs & Files documents so authorized editors can:
+
+- see when a document's title or content changed
+- identify the person responsible for each saved version
+- compare any two versions in a GitHub-style split diff
+- distinguish additions, deletions, replacements, formatting changes, and structural changes
+- restore an earlier title and body without deleting subsequent history
+
+The backend stores complete title-and-content snapshots. The frontend parses two snapshots with Operately's real TipTap/ProseMirror schema, computes a semantic diff with `@tiptap/pm/changeset`, and renders the old and new documents in read-only TurboUI views.
+
+Diffs are computed on demand in the browser. The backend does not compare raw JSON and does not persist pairwise diff results.
+
+---
+
+## Issue Closed
+
+This work closes [#2587 — Docs versioning and history](https://github.com/operately/operately/issues/2587).
+
+---
+
+## Problem
+
+Native resource-hub documents currently keep only their latest title and body on `resource_documents`:
+
+- the title is stored in `resource_documents.name`
+- the TipTap JSON body is stored in `resource_documents.content`
+- editing updates that single canonical row
+- there is no immutable document snapshot table
+
+(The resource node still places the document in the folder tree; it no longer owns the display title. See [0017-migrate-resource-name-from-node.md](0017-migrate-resource-name-from-node.md).)
+
+The `resource_hub_document_edited` activity stores the post-edit body, but it is not a complete or reliable version record:
+
+- the document-created activity stores the title but not the body
+- the document-edited activity stores the body but not the title
+- activity retention and activity presentation have different responsibilities from document history
+- draft creation does not create the same activity trail as a published document
+- existing activity data cannot reconstruct a complete sequence of title-and-body snapshots
+
+Users therefore cannot inspect an earlier document, understand exactly what changed, or recover from an accidental edit. This limits the usefulness of native documents for playbooks, operating procedures, policies, and other long-lived company knowledge.
+
+---
+
+## Goals
+
+- Capture an immutable snapshot whenever a document title or body changes.
+- Capture the first snapshot when a document is created, including drafts and copies.
+- Compare arbitrary saved versions, not only adjacent versions.
+- Preserve rich-text semantics when comparing paragraphs, headings, lists, marks, links, mentions, and blobs.
+- Make formatting-only and structure-only changes visible.
+- Restore an earlier title and body as a new version.
+- Keep version capture atomic with the canonical document write.
+- Prevent concurrent saves from assigning duplicate or out-of-order version numbers.
+- Apply existing document access rules without exposing removed historical content to ordinary viewers.
+- Keep new UI in TurboUI and backend interaction in an app page bridge.
+- Include document versions and their historical blob/mention references in company export and import.
+- Preserve a path for reading snapshots after the TipTap schema evolves.
+
+## Non-goals
+
+- Live collaborative editing or operational transformation.
+- Google Docs-style per-keystroke history.
+- Persisting every ProseMirror transaction or editor undo step.
+- Three-way merging of concurrent edits.
+- Automatic move detection in the first release. Moved content appears as a deletion and an insertion.
+- Restoring document comments, reactions, subscribers, parent folder, publication time, or document state.
+- Copying the source document's complete history when copying a document.
+- Comparing native documents with uploaded Word, PDF, Google Docs, or other external files.
+- Searching historical versions in full-text search. Search continues to index only the current canonical document.
+- A permanent-redaction workflow for removing selected content from retained historical versions. Document/company deletion still removes the complete document history.
+- A unified old-and-new document tree in the first release. The initial diff is a split view.
+
+---
+
+## Important Decisions
+
+### 1. Store complete immutable snapshots
+
+Each version stores the complete document title and TipTap JSON body after a successful save.
+
+Do not store only patches or ProseMirror transactions. Full snapshots are preferable because they:
+
+- allow any two versions to be compared directly
+- remain useful when intermediate versions are unavailable
+- make restoration a simple validated copy
+- avoid coupling durable history to one editor session
+- are easier to export, import, inspect, and repair
+- keep version writes straightforward and transactionally safe
+
+Native document bodies are expected to be small enough that snapshot storage is acceptable. Measure actual table growth after rollout before introducing compression or retention policies.
+
+Version rows are append-only. Application code must never update a version's title, content, author, origin, version number, or timestamp after insertion.
+
+### 2. Activities are not the version store
+
+Do not reconstruct history from `activities` and do not make version reads depend on activity retention.
+
+Normal document edits continue to create the existing `resource_hub_document_edited` activity. Version restoration creates a new `resource_hub_document_version_restored` activity because restoration is a distinct audit event.
+
+The activity references the restored version number but does not duplicate the historical body into activity content.
+
+### 3. Backend owns history; frontend owns diffing
+
+Responsibilities are split as follows:
+
+| Layer | Responsibility |
+| --- | --- |
+| Elixir backend | Store snapshots, assign version numbers, authorize reads, serialize versions, restore snapshots, and enforce concurrency |
+| App page bridge | Load versions, call restore APIs, construct routes, read app contexts, and pass props into TurboUI |
+| TurboUI | Parse snapshots with the editor schema, calculate changed ranges, render the history and diff UI, and manage local version selection |
+
+Do not implement a generic JSON diff in Elixir. Raw JSON comparison would expose serialization details rather than user-visible document changes, and the backend does not own the complete TipTap extension schema used to interpret the content.
+
+### 4. Use ProseMirror's schema-aware change set
+
+Use `ChangeSet` and `simplifyChanges` from `@tiptap/pm/changeset`. `@tiptap/pm` is already a direct TurboUI dependency and exposes the installed `prosemirror-changeset` package.
+
+The library represents each replacement with coordinates in both documents:
+
+- `fromA` and `toA` identify the removed/replaced range in the old document
+- `fromB` and `toB` identify the added/replaced range in the new document
+
+References:
+
+- [TipTap JSON and document structure](https://tiptap.dev/docs/editor/core-concepts/introduction)
+- [ProseMirror changeset API](https://github.com/ProseMirror/prosemirror-changeset#readme)
+- [ProseMirror changeset diff implementation](https://github.com/ProseMirror/prosemirror-changeset/blob/master/src/diff.ts)
+- [ProseMirror decorations](https://prosemirror.net/docs/guide/#view.decorations)
+
+Saved snapshots do not contain the original transaction step maps. Create one synthetic `StepMap` that describes replacement of the complete old document with the complete new document. `ChangeSet` then minimizes that replacement into precise ranges with its token diff.
+
+Do not call the library's internal `computeDiff` function directly.
+
+### 5. Use a custom semantic token encoder
+
+The default `ChangeSet` token encoder compares node types and text characters but ignores marks and attributes. Operately must provide a custom encoder so user-visible semantic changes are not lost.
+
+The encoder includes:
+
+- text characters
+- normalized text marks and their semantic attributes
+- node-opening and node-closing tokens
+- node type
+- heading level
+- ordered-list start value
+- link destination
+- mention person ID and stored label
+- blob ID, filename/alt text, title, file type, and other stable user-visible attributes
+
+The encoder ignores transient or derived attributes, including:
+
+- upload progress
+- temporary upload status
+- expiring or regenerated blob URLs when a stable blob ID exists
+- runtime-only node-view state
+
+Attribute keys and mark collections must be normalized into stable order before token comparison. The encoder must be a small, deterministic module with fixture-driven tests; it must not depend on DOM rendering or React node views.
+
+### 6. Start with a split diff
+
+The first release uses two read-only rich-content views:
+
+- the old version on the left, with removed content highlighted
+- the new version on the right, with added content highlighted
+- a stacked old-then-new layout on narrow screens
+
+This keeps each snapshot as a valid ProseMirror document. It also makes deleted blocks, lists, mentions, and blobs available in their original tree without constructing a third synthetic document.
+
+A unified diff is deferred because deleted content no longer exists in the new tree. Producing a valid unified document requires inserting old slices into the new schema, handling open slice depths, and resolving node-boundary conflicts. The diff engine designed here can support that later without changing the stored version format.
+
+### 7. History is restricted to document editors
+
+Historical content may contain text deliberately removed from the current document. In the first release:
+
+- users with ordinary document-view access can see only the current document
+- users whose access level grants document editing can list and read history
+- company read-only mode does not prevent an otherwise eligible editor from reading history
+- restoration additionally requires current `can_edit_document` permission and a company that is not read-only
+
+Expose a dedicated `can_view_document_history` permission in the full document API response. Calculate it from the access level that normally grants document editing, without treating company billing/read-only state as a reason to deny the read.
+
+The history API must authorize before returning titles, authors, timestamps, or content.
+
+### 8. Restoration appends history
+
+Restoring version 4 while version 9 is current creates version 10. Versions 5 through 9 remain intact.
+
+Restoration copies only:
+
+- title
+- TipTap JSON body
+
+Restoration does not change:
+
+- draft/published state
+- original document author
+- parent folder or resource hub
+- publication timestamp
+- subscriptions
+- comments
+- reactions
+
+The restored snapshot records `origin: restored` and `restored_from_version_number: 4`.
+
+If the selected snapshot is semantically identical to the current title and body, restoration succeeds as an idempotent no-op and does not create a duplicate version or activity.
+
+Restoring content updates the document's mentioned-person subscription state, but it must not send fresh mention notifications merely because old content was restored.
+
+### 9. Version numbering is transactional and concurrency-safe
+
+Add `current_version` to `resource_documents`. It represents the current title/body revision, not the document's publication state.
+
+All write operations that may change title/body must:
+
+1. load and lock the canonical document row inside the transaction
+2. compare the submitted title/body with the locked canonical values
+3. leave `current_version` unchanged when only subscriptions or state changed
+4. increment `current_version` exactly once when title or body changed
+5. insert the matching snapshot using the new number
+6. update the canonical document (`name` / `content`) and snapshot in the same transaction
+
+Add optional `expected_version` input to document update and publish APIs. First-party UI sends it on every title/body save. When supplied and stale, return a version-conflict error instead of silently overwriting a newer save.
+
+Keep `expected_version` optional for backward compatibility with existing CLI/MCP/API clients. Writes without it still lock the row and receive a unique next version, but retain last-write-wins behavior.
+
+The restore API always requires `expected_current_version` because it is a new endpoint and has no compatibility constraint.
+
+### 10. Preserve schema compatibility explicitly
+
+Every snapshot stores `content_schema_version`.
+
+The initial value is `1`. Before calling `schema.nodeFromJSON`, the frontend passes snapshot content through a pure migration pipeline:
+
+```ts
+migrateRichContentSnapshot(content, fromSchemaVersion, CURRENT_RICH_CONTENT_SCHEMA_VERSION)
+```
+
+The first implementation returns schema-version-1 content unchanged. Future editor changes that rename/remove nodes, marks, or required attributes must add deterministic migrations and fixtures before changing the current schema version.
+
+Do not mutate stored snapshots during ordinary reads. Migrations happen in memory. A separate idempotent data migration may rewrite historical rows later if storage normalization becomes necessary.
+
+### 11. Historical rich content participates in export/import and blob retention
+
+Add `resource_document_versions` to the company-transfer schema and dependency graph.
+
+Export/import must:
+
+- translate `document_id` and `editor_id`
+- rewrite mentioned person IDs inside every historical `content` map
+- discover blob IDs referenced only by historical versions
+- export the corresponding blob payloads
+- rewrite blob IDs on import
+- preserve version numbers, origins, restoration source numbers, schema versions, and timestamps
+- set the imported canonical document's `current_version` consistently with the imported version rows
+
+The generic file-discovery traversal already scans schema-backed map fields containing top-level TipTap documents. Registering the version schema must make historical version bodies visible to that traversal; add regression coverage rather than adding a one-off version-specific scanner.
+
+Blob cleanup must consider historical version bodies as live references. A blob must not be removed while any retained document version references it.
+
+Copying a document copies only its current title and content into version 1 of the new document. It does not copy version rows from the source document.
+
+---
+
+## Data Model
+
+### `resource_documents`
+
+Add:
+
+| Column | Type | Constraints | Purpose |
+| --- | --- | --- | --- |
+| `current_version` | integer | not null, default `1`, check `> 0` | Current title/body revision number |
+
+Expose this as `currentVersion` in essential and full document serialization.
+
+### `resource_document_versions`
+
+Create:
+
+| Column | Type | Constraints | Purpose |
+| --- | --- | --- | --- |
+| `id` | binary UUID | primary key | Stable version record ID |
+| `document_id` | binary UUID | not null, FK to `resource_documents`, delete cascade | Owning document |
+| `version_number` | integer | not null, check `> 0` | Monotonic per-document version |
+| `title` | text | not null | Document title (`resource_documents.name`) at this revision |
+| `content` | map/JSONB | not null | Complete TipTap JSON snapshot |
+| `content_schema_version` | integer | not null, check `> 0` | Parser/migration version |
+| `editor_id` | binary UUID | nullable FK to `people`, `on_delete: :nilify_all` | Person who produced the version; null for migration baselines or removed editors |
+| `origin` | enum/string | not null | `created`, `edited`, `restored`, or `migration` |
+| `restored_from_version_number` | integer | nullable, check `> 0` | Source version for a restoration |
+| `inserted_at` | UTC datetime | not null | Version creation time |
+
+Do not add `updated_at`; version rows are immutable.
+
+Indexes and constraints:
+
+- unique `(document_id, version_number)`
+- index `(document_id, inserted_at DESC)`
+- index `editor_id`
+- check that `restored_from_version_number` is present if and only if `origin = restored`
+
+Create `Operately.ResourceHubs.DocumentVersion` with only persistence, validation, and version-query responsibilities. Keep restoration orchestration in an operation module.
+
+### Existing-document baseline
+
+Use an idempotent data migration under `app/lib/operately/data` to create version 1 for every existing document:
+
+- `title`: current `resource_documents.name`
+- `content`: current document content
+- `content_schema_version`: `1`
+- `editor_id`: null
+- `origin`: `migration`
+- `inserted_at`: document `updated_at`
+- `resource_documents.current_version`: `1`
+
+The baseline reads title and body from the document row only; it does not join `resource_nodes`.
+
+The history UI labels this row `History Begins Here` and explains `This is the earliest saved version available.` It does not attribute the row to the original author or imply that it is the original document body.
+
+Per the repository's data-migration rules, the migration must define minimal inline schemas or use direct SQL. It must not depend on the current application `Document`, `Node`, or `DocumentVersion` modules.
+
+Existing activity data is intentionally not used to synthesize older versions because it cannot produce complete title-and-body snapshots.
+
+---
+
+## Version Capture Lifecycle
+
+### Document creation
+
+`ResourceHubDocumentCreating` inserts:
+
+1. resource node (tree placement only; no title write)
+2. canonical document with `name`, `content`, and `current_version: 1`
+3. version 1 with `origin: created` (title copied from `document.name`)
+4. existing subscriptions and activity behavior
+
+Draft creation also creates version 1 even though it does not emit the normal published-document-created activity.
+
+Copied documents create their own version 1 from the copied current title/body.
+
+### Document editing
+
+Refactor `ResourceHubDocumentEditing` so title/body comparison happens against the locked `resource_documents` row inside its transaction.
+
+- If title/body changed, update `resource_documents.name` / `content`, increment `current_version`, insert `origin: edited`, and keep the existing edit activity.
+- If only subscription settings changed, update subscriptions without changing `current_version`, creating a version, or emitting a misleading document-edit activity.
+- If neither changed, return the canonical document without writes.
+
+This backend comparison is required even though the current form avoids most no-op saves. API and MCP callers cannot be assumed to perform the same client-side check.
+
+### Draft publishing
+
+`ResourceHubDocumentPublishing` continues to change state and publication time.
+
+- Publishing with no title/body change does not create a new content version.
+- Publishing with a changed title/body captures one `origin: edited` version in the same transaction.
+- Publishing must not produce two snapshots when both title and content changed.
+
+### Restoration
+
+Create `Operately.Operations.ResourceHubDocumentVersionRestoring`.
+
+The operation:
+
+1. loads and locks the canonical document with its node and resource-hub context (node/hub for access; title lives on the document)
+2. verifies `expected_current_version`
+3. loads the selected version and verifies it belongs to the document
+4. returns success without writes when title/body already match
+5. increments `current_version`
+6. updates `resource_documents.name` and `content` from the snapshot
+7. inserts a version with `origin: restored`
+8. refreshes mentioned-person subscriptions without dispatching mention notifications
+9. inserts `resource_hub_document_version_restored`
+10. commits all changes atomically
+
+The activity feed text is `restored {document} to version {number}`. Its notification handler returns no recipients in the first release.
+
+Implement all five required activity components:
+
+1. content handler
+2. notification handler
+3. API type
+4. serializer
+5. frontend feed handler and registration
+
+---
+
+## API Contract
+
+Add the following operations to the `documents` namespace and regenerate TypeScript API bindings.
+
+### `documents.list_versions`
+
+Input:
+
+```ts
+{
+  documentId: ID;
+  before?: string;
+  limit?: number; // default 50, maximum 100
+}
+```
+
+Output:
+
+```ts
+{
+  versions: DocumentVersionSummary[];
+  nextCursor: string | null;
+}
+```
+
+`DocumentVersionSummary` contains:
+
+```ts
+{
+  id: ID;
+  versionNumber: number;
+  title: string;
+  editor: Person | null;
+  origin: "created" | "edited" | "restored" | "migration";
+  restoredFromVersionNumber: number | null;
+  insertedAt: string;
+  isCurrent: boolean;
+}
+```
+
+Do not include TipTap content in the list response.
+
+Sort by `version_number DESC`, using the version number and ID to construct a stable opaque cursor.
+
+### `documents.get_version`
+
+Input:
+
+```ts
+{
+  documentId: ID;
+  versionNumber: number;
+}
+```
+
+Output adds:
+
+```ts
+{
+  content: JSONValue;
+  contentSchemaVersion: number;
+}
+```
+
+The endpoint verifies that the requested version belongs to the requested document.
+
+### `documents.get_version_comparison`
+
+Input:
+
+```ts
+{
+  documentId: ID;
+  beforeVersionNumber: number;
+  afterVersionNumber: number;
+}
+```
+
+Output:
+
+```ts
+{
+  before: DocumentVersion;
+  after: DocumentVersion;
+}
+```
+
+This endpoint returns the two snapshots in one authorized request. It does not calculate changed ranges on the server.
+
+Reject comparisons where the numbers are equal. Normalize the response so `before.versionNumber < after.versionNumber` regardless of input order.
+
+### `documents.restore_version`
+
+Input:
+
+```ts
+{
+  documentId: ID;
+  versionNumber: number;
+  expectedCurrentVersion: number;
+}
+```
+
+Output:
+
+```ts
+{
+  document: ResourceHubDocument;
+  restoredVersion: DocumentVersionSummary | null;
+}
+```
+
+`restoredVersion` is null for an idempotent no-op.
+
+### Existing write APIs
+
+Add optional `expected_version` to:
+
+- `documents.update`
+- `documents.publish`
+
+Return a distinct conflict response when it does not match the locked document's `current_version`. The first-party edit form shows a persistent error explaining that a newer version exists and offers to reload; it must not silently retry with stale content.
+
+Do not include snapshot bodies, titles, mention labels, or diff fragments in logs, telemetry, or error messages.
+
+---
+
+## Diff Algorithm
+
+### Shared schema construction
+
+Extract a pure `createRichEditorExtensions` function from `turboui/src/RichEditor/useEditor.tsx` so editable content, read-only content, and version diffs construct the same schema.
+
+The factory accepts the existing rich-editor handlers and editable flag. It must not create React state or an editor instance.
+
+The existing `useEditor` consumes this factory. `RichContentDiff` consumes it to build two read-only editors. This avoids duplicating the list of StarterKit, Blob, Link, Mention, Highlight, and other custom extensions.
+
+### Snapshot parsing
+
+For each selected snapshot:
+
+1. validate that `content` is an object with a TipTap `doc` root
+2. migrate it in memory from `contentSchemaVersion` to the current schema version
+3. call `schema.nodeFromJSON`
+4. report a controlled comparison error when parsing fails
+
+The UI must not crash the entire page because one historical snapshot cannot be parsed. Record the document ID, version number, and schema versions in error reporting without including document content.
+
+### Change calculation
+
+The core utility is pure and DOM-independent:
+
+```ts
+function diffRichContent(
+  schema: Schema,
+  before: JSONContent,
+  after: JSONContent,
+): RichContentChange[]
+```
+
+Conceptual implementation:
+
+```ts
+const beforeDoc = schema.nodeFromJSON(before);
+const afterDoc = schema.nodeFromJSON(after);
+
+const replacement = new StepMap([
+  0,
+  beforeDoc.content.size,
+  afterDoc.content.size,
+]);
+
+const changeSet = ChangeSet.create(
+  beforeDoc,
+  combineChangeMetadata,
+  operatelyTokenEncoder,
+).addSteps(afterDoc, [replacement], null);
+
+return simplifyChanges(changeSet.changes, afterDoc);
+```
+
+The returned domain type should not expose library internals beyond the old/new ranges and change kind needed by rendering.
+
+### Change classification
+
+Classify each result as:
+
+- addition: old range empty, new range non-empty
+- deletion: old range non-empty, new range empty
+- replacement: both ranges non-empty
+
+Formatting and attribute changes normally appear as replacements because the visible characters remain while their semantic tokens differ.
+
+When a change affects only a node boundary or block attribute, expand its visual decoration to the nearest affected block so changing a paragraph to a heading, changing a list type, or changing a heading level is visible.
+
+### Rendering
+
+Create decorations independently for each valid document:
+
+- old deletions/replacement-old ranges: `diff-removed`
+- new additions/replacement-new ranges: `diff-added`
+- whole changed blocks: node decoration plus a side indicator
+- inline ranges: inline decoration
+- changed leaf nodes such as mentions/blobs: node or inline-node decoration as appropriate
+
+Use design-system colors and ensure additions/deletions remain distinguishable in light and dark themes. Do not rely on color alone; each pane header and change legend includes `Removed` or `Added`, and screen-reader descriptions identify the change type.
+
+Do not mutate either snapshot by inserting diff marks into its JSON. Decorations are presentation state only.
+
+### Performance behavior
+
+- Calculate only the currently selected comparison.
+- Memoize by document ID, before version number, after version number, and current schema version.
+- Fetch only the two selected bodies; keep history list responses metadata-only.
+- Show a non-blocking comparison loading state.
+- Do not calculate diffs in the history-list render loop.
+- Let `prosemirror-changeset` fall back to a broader replacement range when its edit-distance safety limit is reached.
+- Profile realistic large documents before moving work to a Web Worker.
+- If main-thread calculation repeatedly exceeds the interaction budget, move the pure parser/token/diff utility to a worker without changing the API or persistence design.
+
+Do not cache every pairwise diff in PostgreSQL. A document with `n` versions has `O(n^2)` possible comparisons, and presentation results may change when the semantic encoder improves.
+
+---
+
+## UI Specification
+
+### Entry point and routes
+
+Add `Version History` to the existing document options menu when `canViewDocumentHistory` is true. The title casing matches the nearby `Export as Markdown` action.
+
+Add routes:
+
+```text
+/documents/:id/versions
+/documents/:id/versions/:versionNumber
+```
+
+The first route opens the latest comparison. The second selects the requested version and compares it with the immediately preceding version by default.
+
+Use the existing document breadcrumb and parent-resource navigation so users can return to the current document and its folder/resource hub.
+
+### Page layout
+
+Create a pure `DocumentVersionHistoryPage` in `turboui/src/DocumentVersionHistoryPage/`.
+
+It receives:
+
+- current document metadata and permissions
+- paginated version summaries
+- selected before/after snapshots
+- formatted-time preferences
+- loading and error state
+- callbacks for selection, pagination, restoration, navigation, and retry
+
+The app bridge lives under `app/assets/js/pages/ResourceHubDocumentVersionsPage/`. It owns API hooks, routes, the current user's formatting preferences, restore mutation, and refresh behavior.
+
+TurboUI must not import `@/` modules, call APIs, use React Router, or read app contexts.
+
+### History list
+
+The history list shows newest first. Each row contains:
+
+- `Version {number}`
+- editor name/avatar, `Former member` when the editor no longer exists, or `Existing document` for migration baselines
+- formatted date and time
+- origin context when useful: `Created`, `Restored from Version {number}`, or `History Begins Here`
+- `Current` on the canonical version
+
+The selected version has a clear active state. Loading older history preserves the current selection and appends rows without shifting focus.
+
+### Comparison controls
+
+Above the diff, provide two labeled selectors:
+
+- `Before`
+- `After`
+
+Defaults:
+
+- opening history compares the previous version with the current version
+- selecting a history row compares its predecessor with the selected row
+- version 1 with no predecessor displays the snapshot without a diff and explains that it is the first saved version
+
+Changing a selector updates the route when appropriate and fetches the selected pair. The selectors prevent comparing a version with itself. The older version is always displayed as `Before`.
+
+### Title changes
+
+Render titles above each pane.
+
+- unchanged titles use normal document-title styling
+- a changed old title uses the removed treatment
+- a changed new title uses the added treatment
+
+Do not force title strings into the ProseMirror document diff.
+
+### Rich-content split view
+
+Desktop:
+
+```text
+┌──────────────────────────────┬──────────────────────────────┐
+│ Before · Version 4           │ After · Version 5            │
+│ Removed                      │ Added                        │
+├──────────────────────────────┼──────────────────────────────┤
+│ Read-only old TipTap content │ Read-only new TipTap content │
+└──────────────────────────────┴──────────────────────────────┘
+```
+
+Mobile stacks the old view above the new view. Do not place two unreadably narrow columns beside each other.
+
+The panes initially scroll with the page. Synchronized independent pane scrolling is deferred until user testing demonstrates that it improves long-document comparison without harming keyboard or mobile navigation.
+
+### Restore flow
+
+Show `Restore This Version` only when:
+
+- the selected version is not current
+- the current user can edit the document
+- the company is not read-only
+
+Use explicit confirmation copy:
+
+- title: `Restore Version {number}?`
+- explanation: `This replaces the current title and content with Version {number}. Later versions will stay in the history.`
+- primary action: `Restore Version {number}`
+- escape action: `Keep Current Version`
+
+On success, navigate to or select the newly created current version and show `Version {sourceNumber} restored as the current document.`
+
+On a version conflict, keep the selected snapshots visible and show:
+
+- title: `Document changed since you opened it`
+- explanation: `A newer version was saved. Reload the latest version before trying again.`
+- action: `Reload Latest Version`
+
+Do not retry automatically.
+
+### Empty and error states
+
+- One version: show the current snapshot with the heading `No Earlier Versions` and the explanation `Changes to the title or content will appear here after the document is saved.`
+- Equal selected snapshots after schema migration: show `No changes between these versions.`
+- Version missing/deleted with document: return to history and explain that the version is unavailable.
+- Snapshot parse failure: retain history navigation and show a scoped comparison error with retry.
+- Permission loss: navigate back to the document or show the standard forbidden page without rendering version metadata.
+
+### Storybook coverage
+
+Add stories for:
+
+- one-version history
+- adjacent text edit
+- title-only edit
+- formatting-only edit
+- heading/list structural change
+- mention and blob replacement
+- long split diff
+- restored version
+- migration baseline
+- loading comparison
+- comparison parse error
+- restore confirmation
+- restore conflict
+- mobile stacked layout
+
+---
+
+## Permission and Security Requirements
+
+- Resolve the canonical document through the existing resource-hub access path before querying versions.
+- Never authorize a version solely by version UUID.
+- Verify every requested version belongs to the authorized document.
+- Do not return history metadata to ordinary document viewers.
+- Apply company isolation in the version query even after document authorization.
+- Require current edit permission again inside the restore mutation.
+- Respect company read-only mode for restoration but not history reads.
+- Treat historical content as sensitive in logs, analytics, exceptions, and telemetry.
+- Cascade permanent document/company deletion to version rows.
+- Preserve soft-deleted document history only as long as the soft-deleted canonical document is retained.
+- Document operationally that removing text from the current document does not remove it from history.
+
+---
+
+## Testing
+
+Work test-first within each phase.
+
+### Data model and migration
+
+- version validation accepts each valid origin
+- version validation rejects non-positive numbers/schema versions
+- unique document/version constraint holds
+- restoration source constraint holds
+- removing a later editor preserves the document/version and nulls the version's `editor_id`
+- version rows cannot be changed through the public context
+- existing documents receive exactly one idempotent migration baseline
+- rerunning the data migration does not duplicate rows
+- document hard deletion removes versions
+
+### Version capture operations
+
+- creation captures version 1
+- draft creation captures version 1
+- copied document receives only version 1
+- content edit increments once and snapshots the new content
+- title edit increments once and snapshots title plus unchanged content
+- title-and-content edit creates one version, not two
+- subscription-only edit creates no version/activity
+- no-op edit creates no version/activity
+- state-only publish creates no content version
+- publish with edited body creates one version
+- transaction failure leaves canonical document and versions unchanged
+- two concurrent saves receive unique sequential versions
+- stale `expected_version` returns conflict without writes
+- omitted `expected_version` preserves backward-compatible last-write-wins behavior while keeping sequential versions
+
+### Restoration
+
+- eligible editor restores title and body
+- restoration creates a new current version
+- intermediate/later versions remain unchanged
+- draft remains draft and published document remains published
+- subscriptions/comments/reactions/parent/author/publication time remain unchanged
+- mentioned-person subscription state reflects restored content
+- restored old mentions do not receive new notifications
+- identical restoration is an idempotent no-op
+- stale expected current version conflicts without writes
+- unauthorized viewer cannot restore
+- company read-only mode prevents restore
+- restoration activity contains the source version number
+
+### API
+
+- history list is newest first and cursor-stable
+- history list excludes content
+- get/comparison return only versions belonging to the authorized document
+- comparison normalizes before/after ordering
+- equal-version comparison is rejected
+- ordinary viewer receives forbidden without version metadata
+- eligible editor can read history in company read-only mode
+- restore returns new document/current-version metadata
+- generated TypeScript types match nullability
+
+### Semantic diff utility
+
+Use small, readable TipTap JSON fixtures for:
+
+- identical documents
+- character insertion and deletion
+- word replacement
+- paragraph insertion/deletion
+- multiple distant changes
+- paragraph-to-heading change
+- heading-level change
+- ordered/unordered list change
+- list-item insertion and nesting
+- bold/italic/strike/highlight changes
+- link destination change with unchanged text
+- mention ID and label change
+- blob replacement and caption change
+- ignored blob progress/temporary URL change
+- emoji and other surrogate-pair text
+- reordered blocks represented as deletion plus insertion
+- full-document replacement exceeding the detailed-diff safety threshold
+- stable equality despite object-key ordering
+
+Tests assert ranges and semantic classification, not internal Myers search state.
+
+### TurboUI
+
+- old and new ranges receive the correct accessible decoration treatment
+- changed leaf and block nodes are visibly marked
+- title-only changes render correctly
+- one-version and no-change states render correctly
+- selectors cannot compare a version with itself
+- restore action respects props/permissions
+- keyboard focus remains visible through list and selector interactions
+- loading/error states do not discard history navigation
+- mobile layout stacks panes
+- Storybook interaction tests cover comparison selection and restore confirmation
+
+### Company export/import
+
+- all version rows round-trip with canonical document
+- version content mention IDs are translated
+- version content blob IDs are translated
+- blobs referenced only by history are exported and imported
+- current version number remains consistent
+- restored-from version number remains meaningful
+- copied document does not inherit source history
+
+### Feature tests
+
+- editor creates several versions and compares adjacent versions
+- editor selects two non-adjacent versions
+- editor restores an earlier version and sees the new current version
+- ordinary viewer cannot open the history route
+- stale restore shows conflict and preserves both users' versions
+
+---
+
+## Performance and Observability
+
+Backend:
+
+- paginate version metadata; never preload every body for the history page
+- fetch only selected snapshot bodies
+- index list ordering by document and version/timestamp
+- record version-list, comparison-fetch, and restore latency
+- count version conflicts and restore failures by reason
+- do not attach document content or titles to telemetry
+
+Frontend:
+
+- measure diff duration and token/document sizes without recording text
+- report parse failures with document ID, version number, stored schema version, and current schema version
+- use Sentry boundaries around the comparison area so invalid history does not crash the entire document page
+- profile memory with two long read-only editors before enabling history generally
+
+Define a practical large-document fixture before implementation finishes. If normal comparisons consistently block the main thread, move the pure diff calculation to a Web Worker before rollout.
+
+---
+
+## Rollout and Recovery
+
+1. Ship the schema and idempotent baseline migration without exposing UI.
+2. Add version capture to create/edit/publish paths and verify version counts in development/staging.
+3. Add export/import handling before relying on versions as durable user data.
+4. Ship read-only history and comparison UI.
+5. Ship restoration and its activity after read/compare behavior is stable.
+6. Expose the document options entry point only after baseline creation and version capture are deployed together.
+
+Operational checks (ad-hoc SQL / inspection during rollout; no dedicated app module):
+
+- count documents without a version row
+- count documents whose `current_version` does not equal their highest version number
+- detect duplicate/gapped versions for investigation; gaps are not user-visible corruption but should not occur during normal writes
+- sample snapshot parse success using schema version 1
+- verify blobs referenced only by historical versions survive export/import
+
+Recovery:
+
+- the canonical document remains the read path for normal document pages
+- hiding the history route/menu disables the feature without changing canonical content
+- version capture failures roll back the corresponding canonical write
+- baseline migration is idempotent and can be rerun
+- do not drop version rows during rollback unless the feature has never accepted production writes
+
+---
+
+## Implementation Phases
+
+### Phase 0 — Diff and rendering spike
+
+- extract shared rich-editor extension construction
+- implement the pure semantic token encoder
+- implement snapshot-to-change calculation with fixed fixtures
+- create a minimal split `RichContentDiff` Storybook component
+- validate paragraphs, headings, lists, marks, mentions, and blobs
+- measure a representative large-document fixture
+
+This phase proves comparison quality before persistence/API work commits the product to the UI.
+
+### Phase 1 — Version storage and baseline ✅
+
+- [x] create schema migration and `DocumentVersion`
+- [x] add `current_version`
+- [x] add idempotent existing-document baseline data migration
+- [x] add company export/import and historical blob discovery coverage
+
+### Phase 2 — Transactional version capture and APIs
+
+- refactor document create/edit/publish operations to capture versions
+- lock canonical rows and implement optional expected-version conflicts
+- add permissions and serializers
+- add list/get/comparison endpoints
+- regenerate API types
+- add backend/model tests
+
+### Phase 3 — History and comparison UI
+
+- create pure TurboUI history page and stories
+- create the app page bridge, loader, routes, and paths
+- add `Version History` to document options
+- wire selectors, pagination, responsive split view, errors, and formatted times
+- add TurboUI, navigation, and feature coverage
+
+### Phase 4 — Restoration
+
+- implement restore operation and endpoint
+- implement restoration activity across backend/frontend components
+- add confirmation, conflict, success, and read-only behavior
+- add end-to-end restoration tests
+
+### Phase 5 — Rollout and follow-up
+
+- run the operational checks above and inspect performance telemetry
+- validate company export/import with historical-only blobs
+- decide from user feedback whether to add collapsed unchanged sections, synchronized scrolling, move detection, or a unified diff
+
+---
+
+## Definition of Done
+
+- Every new native document, including drafts and copies, has version 1.
+- Every title/body save creates exactly one immutable version in the same transaction.
+- Subscription-only and publication-state-only changes do not create content versions.
+- Existing documents have a clearly labeled migration baseline.
+- Authorized editors can list versions and compare any two saved snapshots.
+- Ordinary viewers cannot retrieve history metadata or content.
+- The diff detects text, formatting, link, mention, blob, and block-structure changes.
+- Diff rendering is accessible and responsive, with no color-only meaning.
+- Restoration creates a new version and preserves all subsequent history.
+- Stale first-party edits/restores fail visibly instead of overwriting newer work.
+- Historical mentions and blobs survive company export/import.
+- Snapshot schema versions are stored and parsed through a migration boundary.
+- Relevant backend, TurboUI, integration, export/import, and feature tests pass.
+- `make api.gen`, `make test.tsc.lint`, `make turboui.build`, `make turboui.test`, and targeted Elixir/feature tests pass.


### PR DESCRIPTION
Working on https://github.com/operately/operately/issues/2587.