### PR TITLE
feat: refine Kanban board visual hierarchy

### DIFF
--- a/app/test/features/milestone_kanban/statuses_test.exs
+++ b/app/test/features/milestone_kanban/statuses_test.exs
@@ -32,7 +32,7 @@ defmodule Operately.Features.MilestoneKanban.StatusesTest do
     ctx
     |> Steps.visit_kanban_page()
     |> Steps.edit_status(status_value: secondary_status, new_label: "In Motion", appearance: "blue")
-    |> Steps.assert_status_label(status_value: secondary_status, label: "IN MOTION")
+    |> Steps.assert_status_label(status_value: secondary_status, label: "In Motion")
   end
 
   feature "cannot delete the last remaining status", ctx do

--- a/app/test/features/space_kanban/statuses_test.exs
+++ b/app/test/features/space_kanban/statuses_test.exs
@@ -32,7 +32,7 @@ defmodule Operately.Features.SpaceKanban.StatusesTest do
     ctx
     |> Steps.visit_kanban_page()
     |> Steps.edit_status(status_value: secondary_status, new_label: "In Motion", appearance: "blue")
-    |> Steps.assert_status_label(status_value: secondary_status, label: "IN MOTION")
+    |> Steps.assert_status_label(status_value: secondary_status, label: "In Motion")
   end
 
   feature "cannot delete the last remaining status", ctx do

--- a/turboui/src/TaskBoard/KanbanView/Card.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Card.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { IconFileText, IconMessageCircle } from "../../icons";
+import { IconFileText, IconGripVertical, IconMessageCircle } from "../../icons";
 import { DateField } from "../../DateField";
 import { AssigneesField } from "../../AssigneesField";
 import classNames from "../../utils/classnames";
@@ -142,7 +142,7 @@ export function Card({
     <div
       ref={ref as React.RefObject<HTMLDivElement>}
       className={classNames(
-        "relative rounded-md border bg-surface-base px-4 py-2 shadow-xs group w-full cursor-grab focus-visible:outline-none transition-colors",
+        "relative rounded-lg border bg-surface-base px-3.5 py-3 shadow-xs group w-full cursor-grab focus-visible:outline-none transition-[border-color,box-shadow] hover:border-surface-outline hover:shadow-sm",
         selected
           ? "border-brand-1 bg-[rgba(224,242,254,0.75)] shadow-[inset_0_0_0_2px_var(--color-brand-1)] dark:bg-[rgba(37,99,235,0.20)]"
           : "border-surface-subtle dark:border-stroke-base",
@@ -158,11 +158,16 @@ export function Card({
       aria-selected={selected}
     >
       {dropIndicatorEdge && <DropIndicator edge={dropIndicatorEdge} />}
-      <div className="flex items-start">
+      <div className="flex items-start gap-2">
+        <IconGripVertical
+          size={16}
+          className="mt-0.5 flex-shrink-0 text-content-subtle opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+          aria-hidden="true"
+        />
         <div className="flex-1 min-w-0 flex flex-col gap-2">
           <div onMouseDown={stopDragFromInteractive}>
             <div
-              className="block text-[13px] text-content-base hover:text-link-hover transition-colors leading-snug break-words cursor-pointer hover:underline"
+              className="block text-[15px] font-medium leading-5 text-content-base hover:text-link-hover transition-colors break-words cursor-pointer hover:underline"
               title={task.title}
               onClick={(e) => {
                 e.preventDefault();
@@ -174,17 +179,21 @@ export function Card({
             </div>
           </div>
 
-          <div className="flex items-center justify-between gap-2 text-[11px] text-content-dimmed leading-none">
+          <div className="flex items-center justify-between gap-2 text-xs text-content-dimmed leading-4">
             <div className="flex items-center gap-2">
               {shouldShowDescriptionIndicator && (
-                <span className="inline-flex items-center gap-1" data-test-id="description-indicator">
-                  <IconFileText size={12} />
+                <span
+                  className="inline-flex items-center gap-1"
+                  title="Has description"
+                  data-test-id="description-indicator"
+                >
+                  <IconFileText size={14} />
                 </span>
               )}
 
               {shouldShowCommentsIndicator && (
-                <span className="inline-flex items-center gap-1" data-test-id="comments-indicator">
-                  <IconMessageCircle size={12} />
+                <span className="inline-flex items-center gap-1" title="Has comments" data-test-id="comments-indicator">
+                  <IconMessageCircle size={14} />
                   {shouldShowCommentCount && <span>{task.commentCount}</span>}
                 </span>
               )}
@@ -214,7 +223,7 @@ export function Card({
                 <AssigneesField
                   people={currentAssignees}
                   setPeople={handleAssigneesChange}
-                  avatarSize={22}
+                  avatarSize={24}
                   avatarOnly={true}
                   {...(assigneePersonSearch ? { searchData: assigneePersonSearch } : { readonly: true as const })}
                   testId={createTestId("kanban-card-assignee", task.id)}

--- a/turboui/src/TaskBoard/KanbanView/Column.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Column.tsx
@@ -73,12 +73,7 @@ export function Column({
     containerId,
   });
 
-  const isColumnEmpty = visibleTasks.length === 0;
-  const isDraggingOverThisColumn = Boolean(
-    draggedItemId && targetLocation && targetLocation.containerId === containerId,
-  );
-  const shouldCenterEmptyState = isColumnEmpty && placeholderIndex === null && !isDraggingOverThisColumn && !isCreating;
-  const shouldShowEmptyPlaceholder = isColumnEmpty && !isDraggingOverThisColumn && !isCreating && !disableDnD;
+  const canCreateTasksInColumn = Boolean(canCreateTask && onCreateTask);
   const effectivePlaceholderIndex = disableDnD ? null : placeholderIndex;
   const shouldShowDropIndicator = !disableDnD && placeholderIndex === null;
 
@@ -115,23 +110,29 @@ export function Column({
   return (
     <div
       ref={!disableDnD ? columnRef : null}
-      className="relative flex flex-col gap-2 bg-surface-dimmed min-h-[78vh] flex-shrink-0 p-3 rounded-lg dark:border dark:border-stroke-base"
+      className="relative flex flex-col gap-3 bg-surface-dimmed min-h-[72vh] flex-shrink-0 p-3 rounded-lg dark:border dark:border-stroke-base"
       style={{ width: columnWidth }}
       data-test-id={createTestId("kanban-column", status.value)}
     >
       <div
         ref={dragHandleRef}
         className={classNames(
-          "flex items-center justify-between text-xs font-semibold text-content-dimmed uppercase tracking-wide px-1 min-h-[24px]",
+          "flex items-center justify-between px-1 min-h-[28px]",
           isStatusDraggable && "cursor-grab active:cursor-grabbing",
         )}
         data-test-id={createTestId("kanban-column-header", status.value)}
       >
-        <div className="flex items-center gap-1.5">
+        <div className="flex min-w-0 items-center gap-1.5">
           {!hideStatusIcon && (
             <StatusSelector status={status} statusOptions={allStatuses} onChange={() => {}} readonly={true} size="sm" />
           )}
-          <span>{title}</span>
+          <span className="truncate text-sm font-semibold text-content-base">{title}</span>
+          <span
+            className="rounded-full border border-surface-outline bg-surface-base px-1.5 py-0.5 text-xs font-medium tabular-nums text-content-dimmed"
+            data-test-id={createTestId("kanban-column-task-count", status.value)}
+          >
+            {tasks.length}
+          </span>
         </div>
 
         <ColumnMenu
@@ -143,58 +144,44 @@ export function Column({
       </div>
 
       <div className="flex-1 flex flex-col">
-        <div
-          className={classNames("space-y-2 flex-1", {
-            "flex items-center": shouldCenterEmptyState,
-          })}
-        >
-          {visibleTasks.length > 0
-            ? visibleTasks.map((task, index) => (
-                <React.Fragment key={task.id}>
-                  {effectivePlaceholderIndex === index && (
-                    <DropPlaceholder containerId={containerId} index={index} height={placeholderHeight} />
-                  )}
-                  <Card
-                    task={task}
-                    containerId={containerId}
-                    index={index}
-                    draggedItemId={draggedItemId}
-                    onTaskAssigneeChange={onTaskAssigneeChange}
-                    onTaskDueDateChange={onTaskDueDateChange}
-                    assigneePersonSearch={assigneePersonSearch}
-                    showDropIndicator={shouldShowDropIndicator}
-                    onTaskClick={onTaskClick}
-                    selected={selectedTaskId === task.id}
-                  />
-                </React.Fragment>
-              ))
-            : shouldShowEmptyPlaceholder && (
-                <div
-                  className={classNames(
-                    "w-full text-center text-xs text-content-subtle py-4 bg-surface-dimmed rounded-md",
-                    "border border-dashed border-surface-outline max-w-[220px] mx-auto",
-                  )}
-                >
-                  Drop tasks here
-                </div>
+        <div className="space-y-2 flex-1">
+          {visibleTasks.map((task, index) => (
+            <React.Fragment key={task.id}>
+              {effectivePlaceholderIndex === index && (
+                <DropPlaceholder containerId={containerId} index={index} height={placeholderHeight} />
               )}
+              <Card
+                task={task}
+                containerId={containerId}
+                index={index}
+                draggedItemId={draggedItemId}
+                onTaskAssigneeChange={onTaskAssigneeChange}
+                onTaskDueDateChange={onTaskDueDateChange}
+                assigneePersonSearch={assigneePersonSearch}
+                showDropIndicator={shouldShowDropIndicator}
+                onTaskClick={onTaskClick}
+                selected={selectedTaskId === task.id}
+              />
+            </React.Fragment>
+          ))}
 
           {!disableDnD && placeholderIndex !== null && placeholderIndex === visibleTasks.length && (
             <DropPlaceholder containerId={containerId} index={visibleTasks.length} height={placeholderHeight} />
           )}
-        </div>
 
-        <TaskCreationForm
-          onCreateTask={onCreateTask}
-          statusValue={status.value}
-          isCreating={isCreating}
-          onModeChange={setIsCreating}
-          canCreateTask={canCreateTask}
-        />
+          <TaskCreationForm
+            onCreateTask={onCreateTask}
+            statusValue={status.value}
+            isCreating={isCreating}
+            onModeChange={setIsCreating}
+            canCreateTask={canCreateTasksInColumn}
+          />
+        </div>
       </div>
     </div>
   );
 }
+
 interface TaskCreationFormProps {
   onCreateTask?: (title: string) => void;
   statusValue: string;
@@ -278,12 +265,14 @@ function TaskCreationForm({
   if (onCreateTask) {
     return (
       <button
-        className="flex items-center gap-1.5 text-xs text-content-dimmed hover:text-content-base px-2 py-1.5 rounded hover:bg-surface-highlight transition-colors w-full text-left mt-2"
+        className="flex w-full items-center gap-1.5 rounded px-2 py-2 text-left text-sm font-medium text-content-dimmed transition-colors hover:bg-surface-base hover:text-content-base"
         onClick={() => handleModeChange(true)}
         data-test-id={createTestId("add-task-button", statusValue)}
       >
-        <span className="text-lg leading-none">+</span>
-        Add new task
+        <span className="text-lg leading-none" aria-hidden="true">
+          +
+        </span>
+        Add task
       </button>
     );
   }

--- a/turboui/src/TaskBoard/KanbanView/Kanban.test.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Kanban.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Kanban } from "./Kanban";
+import type { StatusSelector } from "../../StatusSelector";
+
+jest.mock("@atlaskit/pragmatic-drag-and-drop/element/adapter", () => ({
+  dropTargetForElements: () => () => {},
+}));
+
+jest.mock("../../utils/PragmaticDragAndDrop", () => ({
+  DropIndicator: () => null,
+  useHorizontalAutoScroll: () => ({ current: null }),
+  useSortableItem: () => ({
+    ref: { current: null },
+    dragHandleRef: { current: null },
+    isDragging: false,
+    closestEdge: null,
+  }),
+  projectItemsWithPlaceholder: ({ items }: { items: unknown[] }) => ({
+    items,
+    placeholderIndex: null,
+  }),
+}));
+
+jest.mock("../hooks/useTaskKeyboardNavigation", () => ({
+  useTaskKeyboardNavigation: () => ({
+    containerRef: { current: null },
+    selectedTaskId: null,
+    scopeBind: {},
+  }),
+}));
+
+const pendingStatus: StatusSelector.StatusOption = {
+  id: "pending",
+  value: "pending",
+  label: "Not started",
+  color: "gray",
+  icon: "circleDashed",
+  index: 0,
+};
+
+const doneStatus: StatusSelector.StatusOption = {
+  id: "done",
+  value: "done",
+  label: "Done",
+  color: "green",
+  icon: "circleCheck",
+  index: 1,
+  closed: true,
+};
+
+describe("Kanban", () => {
+  it("keeps empty closed statuses out of the working board until requested", () => {
+    const onTaskCreate = jest.fn();
+    const { container } = render(
+      <Kanban
+        milestone={null}
+        columns={{ pending: [], done: [] }}
+        draggedItemId={null}
+        targetLocation={null}
+        placeholderHeight={null}
+        statuses={[pendingStatus, doneStatus]}
+        onTaskCreate={onTaskCreate}
+        onTaskClick={jest.fn()}
+        isTaskSlideInOpen={false}
+        canEdit={true}
+      />,
+    );
+
+    expect(container.querySelector('[data-test-id="kanban-column-pending"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-test-id="kanban-column-done"]')).not.toBeInTheDocument();
+    const closedStatusesToggle = container.querySelector('[data-test-id="toggle-closed-statuses"]');
+
+    expect(closedStatusesToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: "Add task" })).toBeInTheDocument();
+    expect(screen.queryByText("No tasks here yet")).not.toBeInTheDocument();
+    expect(container.querySelector('[data-test-id="kanban-task-count"]')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add task" }));
+
+    expect(screen.getByPlaceholderText("What needs to be done?")).toBeInTheDocument();
+
+    fireEvent.click(closedStatusesToggle!);
+
+    expect(container.querySelector('[data-test-id="kanban-column-done"]')).toBeInTheDocument();
+    expect(closedStatusesToggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("shows a task count in each visible column header", () => {
+    const { container } = render(
+      <Kanban
+        milestone={null}
+        columns={{ pending: [], done: [] }}
+        draggedItemId={null}
+        targetLocation={null}
+        placeholderHeight={null}
+        statuses={[pendingStatus, doneStatus]}
+        onTaskClick={jest.fn()}
+        isTaskSlideInOpen={false}
+        canEdit={false}
+      />,
+    );
+
+    expect(container.querySelector('[data-test-id="kanban-column-task-count-pending"]')).toHaveTextContent("0");
+  });
+});

--- a/turboui/src/TaskBoard/KanbanView/Kanban.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Kanban.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
 
-import { IconPlus } from "../../icons";
+import { IconChevronDown, IconChevronRight, IconPlus } from "../../icons";
 import { createTestId } from "../../TestableElement";
 import type { TaskBoard } from "../components";
 import type { TaskBoardProps } from "../types";
@@ -66,6 +66,17 @@ export function Kanban({
 
   const unknownStatus = statuses.find((status) => status.value === "unknown-status");
   const regularStatuses = statuses.filter((status) => status.value !== "unknown-status");
+  const activeStatuses = regularStatuses.filter((status) => !status.closed);
+  const closedStatuses = regularStatuses.filter((status) => status.closed);
+  const hasClosedTasks = closedStatuses.some((status) => (columns[status.value] || []).length > 0);
+  const [areClosedStatusesVisible, setAreClosedStatusesVisible] = React.useState(hasClosedTasks);
+
+  React.useEffect(() => {
+    if (hasClosedTasks) setAreClosedStatusesVisible(true);
+  }, [hasClosedTasks]);
+
+  const visibleStatuses = areClosedStatusesVisible ? regularStatuses : activeStatuses;
+  const canManageStatuses = Boolean(onAddStatusClick);
 
   const setScrollContainerRefs = React.useCallback(
     (element: HTMLDivElement | null) => {
@@ -91,7 +102,7 @@ export function Kanban({
 
   return (
     <section className="bg-surface-base min-h-[80vh]" data-test-id={testId}>
-      <div ref={setScrollContainerRefs} className="px-3 pt-3 pb-6 overflow-x-auto h-[80vh]" {...scopeBind}>
+      <div ref={setScrollContainerRefs} className="h-[80vh] overflow-x-auto px-3 py-3" {...scopeBind}>
         <div className="flex gap-3 min-w-max items-start">
           {unknownStatus && (
             <Column
@@ -118,8 +129,8 @@ export function Kanban({
             />
           )}
 
-          {regularStatuses.map((status, index) => (
-            <SortableStatusColumn key={status.value} status={status} index={index} canReorder={Boolean(canEdit)}>
+          {visibleStatuses.map((status, index) => (
+            <SortableStatusColumn key={status.value} status={status} index={index} canReorder={canManageStatuses}>
               {(dragHandleRef) => (
                 <Column
                   status={status}
@@ -132,9 +143,9 @@ export function Kanban({
                   assigneePersonSearch={assigneePersonSearch}
                   onCreateTask={onTaskCreate ? (title) => handleTaskCreate(title, status.value) : undefined}
                   dragHandleRef={dragHandleRef}
-                  isStatusDraggable={Boolean(canEdit)}
+                  isStatusDraggable={canManageStatuses}
                   allStatuses={statuses}
-                  canManageStatuses={canEdit}
+                  canManageStatuses={canManageStatuses}
                   canCreateTask={canEdit}
                   onEditStatus={onEditStatus}
                   onDeleteStatus={onDeleteStatus}
@@ -145,17 +156,29 @@ export function Kanban({
             </SortableStatusColumn>
           ))}
 
-          {canEdit && (
+          {closedStatuses.length > 0 && (
             <button
               type="button"
-              onClick={onAddStatusClick}
-              className="flex flex-col items-center justify-start gap-1.5 px-2 py-2 rounded-md border border-dashed border-surface-outline text-content-dimmed hover:border-brand-1/60 hover:text-brand-1 transition min-w-[100px] h-full"
-              data-test-id={"add-status"}
+              className="mt-1 flex shrink-0 items-center gap-1.5 rounded px-2 py-2 text-sm font-medium text-content-dimmed transition-colors hover:bg-surface-dimmed hover:text-content-base"
+              onClick={() => setAreClosedStatusesVisible((isVisible) => !isVisible)}
+              aria-expanded={areClosedStatusesVisible}
+              data-test-id="toggle-closed-statuses"
             >
-              <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-surface-dimmed">
-                <IconPlus size={14} />
-              </span>
-              <span className="text-xs font-medium mt-0.5">Add status</span>
+              {areClosedStatusesVisible ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />}
+              <span>Closed</span>
+              <span className="text-xs tabular-nums">{closedStatuses.length}</span>
+            </button>
+          )}
+
+          {canEdit && onAddStatusClick && (
+            <button
+              type="button"
+              className="mt-1 flex shrink-0 items-center gap-1.5 rounded px-2 py-2 text-sm font-medium text-content-dimmed transition-colors hover:bg-surface-dimmed hover:text-content-base"
+              onClick={onAddStatusClick}
+              data-test-id="add-status"
+            >
+              <IconPlus size={16} />
+              Add status
             </button>
           )}
         </div>

--- a/turboui/src/TaskBoard/KanbanView/Kanban.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Kanban.tsx
@@ -30,6 +30,7 @@ interface Props {
   onTaskClick: (taskId: string) => void;
   isTaskSlideInOpen: boolean;
   canEdit: boolean;
+  canManageStatuses?: boolean;
 }
 
 export function Kanban({
@@ -49,6 +50,7 @@ export function Kanban({
   onTaskClick,
   isTaskSlideInOpen,
   canEdit,
+  canManageStatuses = false,
 }: Props) {
   const testId = useMemo(
     () => (milestone ? createTestId("milestone", milestone.id) : "kanban-no-milestone"),
@@ -76,7 +78,6 @@ export function Kanban({
   }, [hasClosedTasks]);
 
   const visibleStatuses = areClosedStatusesVisible ? regularStatuses : activeStatuses;
-  const canManageStatuses = Boolean(onAddStatusClick);
 
   const setScrollContainerRefs = React.useCallback(
     (element: HTMLDivElement | null) => {
@@ -170,7 +171,7 @@ export function Kanban({
             </button>
           )}
 
-          {canEdit && onAddStatusClick && (
+          {canManageStatuses && onAddStatusClick && (
             <button
               type="button"
               className="mt-1 flex shrink-0 items-center gap-1.5 rounded px-2 py-2 text-sm font-medium text-content-dimmed transition-colors hover:bg-surface-dimmed hover:text-content-base"

--- a/turboui/src/TaskBoard/KanbanView/index.tsx
+++ b/turboui/src/TaskBoard/KanbanView/index.tsx
@@ -109,6 +109,7 @@ export function KanbanBoard(props: KanbanBoardProps) {
         assigneePersonSearch={props.assigneePersonSearch}
         onTaskCreate={props.onTaskCreate}
         canEdit={props.canEdit}
+        canManageStatuses={canReorderStatuses}
         onAddStatusClick={
           canReorderStatuses
             ? () => {

--- a/turboui/src/TaskBoard/KanbanView/index.tsx
+++ b/turboui/src/TaskBoard/KanbanView/index.tsx
@@ -110,7 +110,7 @@ export function KanbanBoard(props: KanbanBoardProps) {
         onTaskCreate={props.onTaskCreate}
         canEdit={props.canEdit}
         onAddStatusClick={
-          props.canEdit
+          canReorderStatuses
             ? () => {
                 setEditingStatus(undefined);
                 setIsAddStatusModalOpen(true);
@@ -118,7 +118,7 @@ export function KanbanBoard(props: KanbanBoardProps) {
             : undefined
         }
         onEditStatus={
-          props.canEdit
+          canReorderStatuses
             ? (status) => {
                 setEditingStatus(status);
                 setIsAddStatusModalOpen(true);
@@ -126,7 +126,7 @@ export function KanbanBoard(props: KanbanBoardProps) {
             : undefined
         }
         onDeleteStatus={
-          props.canEdit
+          canReorderStatuses
             ? (status) => {
                 setDeletingStatus(status);
               }

--- a/turboui/src/TaskBoard/stories/TaskBoardKanban.stories.tsx
+++ b/turboui/src/TaskBoard/stories/TaskBoardKanban.stories.tsx
@@ -122,6 +122,14 @@ const filterTasksByMilestone = (tasks: Types.Task[], milestone: Types.Milestone 
   tasks.filter((task) => !task._isHelperTask && (milestone ? task.milestone?.id === milestone.id : !task.milestone));
 
 export const BasicKanban: Story = {
+  name: "Working board",
+  parameters: {
+    docs: {
+      description: {
+        story: "Shows the stronger card hierarchy, column counts, and persistent board actions with active work.",
+      },
+    },
+  },
   render: () => {
     const milestone = mockMilestones.q2Release;
     if (!milestone) return <div>Missing mock milestone data</div>;
@@ -299,6 +307,14 @@ export const AutoScrollEdgeColumns: Story = {
 };
 
 export const EmptyStates: Story = {
+  name: "Empty board",
+  parameters: {
+    docs: {
+      description: {
+        story: "Shows the inline Add task action and collapsed closed statuses used when a board has no work yet.",
+      },
+    },
+  },
   render: () => {
     const milestone = mockMilestones.emptyMilestone;
     if (!milestone) return <div>Missing mock milestone data</div>;


### PR DESCRIPTION
Improve task-card readability, inline task creation, column counts, and closed-status disclosure. Update Kanban stories and coverage.

<img width="2508" height="1714" alt="CleanShot 2026-07-22 at 11 57 16@2x" src="https://github.com/user-attachments/assets/f54b9b3b-f330-404d-9947-ea1fe8c4b836" />
