### PR TITLE
fix: Show @mention popup above task slide-in overlays

### DIFF
--- a/turboui/src/RichEditor/extensions/MentionPeople/MentionPopup.test.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/MentionPopup.test.tsx
@@ -1,0 +1,35 @@
+import { ReactRenderer } from "@tiptap/react";
+
+import { MentionPopup, MENTION_POPUP_Z_INDEX } from "./MentionPopup";
+
+jest.mock("@tiptap/react", () => ({
+  ReactRenderer: jest.fn(),
+}));
+
+describe("MentionPopup", () => {
+  it("mounts the popup above slide-in overlays so @mentions are visible", () => {
+    const element = document.createElement("div");
+    const mount = jest.fn(() => jest.fn());
+    const destroy = jest.fn();
+
+    (ReactRenderer as unknown as jest.Mock).mockImplementation(() => ({
+      element,
+      updateProps: jest.fn(),
+      destroy,
+      ref: null,
+    }));
+
+    const popup = new MentionPopup();
+    popup.onStart({
+      clientRect: () => new DOMRect(0, 0, 0, 0),
+      mount,
+      editor: {},
+      items: [],
+      command: jest.fn(),
+    });
+
+    expect(element.style.zIndex).toBe(String(MENTION_POPUP_Z_INDEX));
+    expect(Number(element.style.zIndex)).toBeGreaterThan(50);
+    expect(mount).toHaveBeenCalledWith(element);
+  });
+});

--- a/turboui/src/RichEditor/extensions/MentionPeople/MentionPopup.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/MentionPopup.tsx
@@ -5,6 +5,12 @@ import { MentionList } from "./MentionList";
 type MentionPopupProps = Record<string, any>;
 
 /**
+ * Must sit above SlideIn / Modal overlays (Tailwind z-50) so @mention
+ * suggestions remain visible when editing task descriptions in a slide-in.
+ */
+export const MENTION_POPUP_Z_INDEX = 100;
+
+/**
  * @public
  * Declaring the MentionPopup class public to silence the knip dead code warning.
  */
@@ -27,6 +33,7 @@ export class MentionPopup {
       return;
     }
 
+    this.component.element.style.zIndex = String(MENTION_POPUP_Z_INDEX);
     this.unmount = props.mount(this.component.element);
   }
 

--- a/turboui/src/RichEditor/extensions/MentionPeople/index.test.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/index.test.tsx
@@ -1,0 +1,9 @@
+import MentionPeople from ".";
+
+describe("MentionPeople", () => {
+  it("uses fixed positioning for suggestion popups", () => {
+    const extension = MentionPeople.configure();
+
+    expect(extension.options.suggestion.floatingUi).toEqual({ strategy: "fixed" });
+  });
+});

--- a/turboui/src/RichEditor/extensions/MentionPeople/index.tsx
+++ b/turboui/src/RichEditor/extensions/MentionPeople/index.tsx
@@ -28,6 +28,7 @@ export default {
     }).configure({
       suggestion: {
         placement: "bottom-start",
+        floatingUi: { strategy: "fixed" },
         render: () => new MentionPopup(),
         items: searchFn,
         allowedPrefixes: [",", "\\s"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4876

## Problem

Typing `@` in a task description (especially when the task is opened in the slide-in from the board) appeared to do nothing. No mention picker showed up.

## Cause

After the TipTap v3 migration, mention suggestions use Floating UI's `props.mount()` and append to `document.body` without a z-index. Tippy previously defaulted to a high z-index. The task SlideIn uses `z-50`, so the mention popup rendered behind it and looked invisible.

## Fix

- Set the mention popup element z-index to `100` (above SlideIn/Modal `z-50`, matching other rich-editor overlays like ColorPicker)
- Use Floating UI `fixed` strategy for portaled suggestion popups
- Add a regression test that asserts the popup mounts with a z-index above 50

## Test plan

- [x] `npx jest src/RichEditor/extensions/MentionPeople/MentionPopup.test.tsx`
- [x] `npx jest src/RichEditor/mentionExtensions.test.ts`
- [ ] Manually: open a task from the project board slide-in, edit Notes, type `@` — mention list should appear and be selectable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e244269d-b3d6-4111-ac74-9bde5c6d7eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e244269d-b3d6-4111-ac74-9bde5c6d7eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

