### PR TITLE
feat: enable tasks by default on General space

### DIFF
--- a/app/lib/operately/operations/company_adding.ex
+++ b/app/lib/operately/operations/company_adding.ex
@@ -54,6 +54,11 @@ defmodule Operately.Operations.CompanyAdding do
       name: "General",
       mission: "Organization-wide announcements and resources",
       company_permissions: Binding.view_access(),
+      tools: %{
+        tasks_enabled: true,
+        discussions_enabled: true,
+        resource_hub_enabled: true
+      }
     }
 
     multi

--- a/app/test/operately/operations/company_adding_test.exs
+++ b/app/test/operately/operations/company_adding_test.exs
@@ -64,6 +64,17 @@ defmodule Operately.Operations.CompanyAddingTest do
     assert Groups.get_group(company.company_space_id)
   end
 
+  test "CompanyAdding operation enables tasks on the General space" do
+    {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
+
+    space = Groups.get_group!(company.company_space_id)
+
+    assert space.name == "General"
+    assert space.tools.tasks_enabled == true
+    assert space.tools.discussions_enabled == true
+    assert space.tools.resource_hub_enabled == true
+  end
+
   test "CompanyAdding operation creates admin user's access group and membership" do
     {:ok, company} = Operately.Operations.CompanyAdding.run(@company_attrs)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4872

## Problem
After signup, skipping the onboarding wizard leaves only the General space. Tasks were off by default there, so new users never saw that Operately supports tasks.

## Solution
When creating a company, enable tasks (along with discussions and resource hub) on the General space in `CompanyAdding.insert_space/1`.

Other newly created spaces keep the existing default (`tasks_enabled: false`).

## Testing
- Added unit coverage in `company_adding_test.exs` asserting General has `tasks_enabled: true`
- Ran: `make test FILE=app/test/operately/operations/company_adding_test.exs` — 13 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b634cec-7a9c-4080-81e5-8992e0d95e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b634cec-7a9c-4080-81e5-8992e0d95e9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

