### PR TITLE
fix: pluralize AssigneesField clear action by count

### DIFF
--- a/turboui/src/AssigneesField/index.test.tsx
+++ b/turboui/src/AssigneesField/index.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { AssigneesField } from ".";
+
+jest.mock("../icons", () => {
+  const React = require("react");
+  const Icon = () => React.createElement("span", { "aria-hidden": "true" });
+
+  return {
+    IconCircleX: Icon,
+    IconSearch: Icon,
+    IconUser: Icon,
+    IconUserPlus: Icon,
+  };
+});
+
+jest.mock("../Avatar", () => ({
+  Avatar: ({ person }: { person: { fullName: string } }) => <span>{person.fullName}</span>,
+  AvatarList: () => <span data-testid="avatar-list" />,
+}));
+
+const alice = { id: "1", fullName: "Alice Johnson", title: "Engineer", avatarUrl: null };
+const bob = { id: "2", fullName: "Bob Smith", title: "Designer", avatarUrl: null };
+
+function getClearButton(container: HTMLElement) {
+  const button = container.ownerDocument.querySelector('[data-test-id="assignees-field-clear"]');
+  if (!button) throw new Error("Expected clear button to render");
+  return button;
+}
+
+describe("AssigneesField", () => {
+  it("says Clear assignee when there is one assignee", () => {
+    const { container } = render(
+      <AssigneesField
+        people={[alice]}
+        setPeople={jest.fn()}
+        searchData={{ people: [], onSearch: jest.fn().mockResolvedValue(undefined) }}
+        testId="assignees-field"
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[data-test-id="assignees-field"]')!);
+
+    expect(getClearButton(container)).toHaveTextContent("Clear assignee");
+  });
+
+  it("says Clear assignees when there are multiple assignees", () => {
+    const { container } = render(
+      <AssigneesField
+        people={[alice, bob]}
+        setPeople={jest.fn()}
+        searchData={{ people: [], onSearch: jest.fn().mockResolvedValue(undefined) }}
+        testId="assignees-field"
+      />,
+    );
+
+    fireEvent.click(container.querySelector('[data-test-id="assignees-field"]')!);
+
+    expect(getClearButton(container)).toHaveTextContent("Clear assignees");
+  });
+});

--- a/turboui/src/AssigneesField/index.tsx
+++ b/turboui/src/AssigneesField/index.tsx
@@ -6,6 +6,7 @@ import { IconCircleX, IconSearch, IconUser, IconUserPlus } from "../icons";
 import { PersonField } from "../PersonField";
 import { createTestId } from "../TestableElement";
 import classNames from "../utils/classnames";
+import { plurarize, plurarizeWord } from "../utils/plurarize";
 
 export namespace AssigneesField {
   export type Person = PersonField.Person;
@@ -225,7 +226,7 @@ function TriggerText({ state }: { state: State }) {
     );
   }
 
-  const label = state.people.length === 1 ? state.people[0]!.fullName : `${state.people.length} assignees`;
+  const label = state.people.length === 1 ? state.people[0]!.fullName : plurarize(state.people.length, "assignee", "assignees");
   const title = state.people.map((person) => person.fullName).join(", ");
 
   return (
@@ -370,7 +371,7 @@ function DialogContent({ state }: { state: State }) {
           data-test-id={createTestId(state.testId, "clear")}
         >
           <IconCircleX size={14} />
-          Clear assignees
+          Clear {plurarizeWord(state.people.length, "assignee", "assignees")}
         </button>
       )}
     </div>

--- a/turboui/src/utils/plurarize.ts
+++ b/turboui/src/utils/plurarize.ts
@@ -1,3 +1,7 @@
+export function plurarizeWord(count: number, singular: string, plural: string) {
+  return count === 1 ? singular : plural;
+}
+
 export function plurarize(count: number, singular: string, plural: string) {
-  return count === 1 ? `${count} ${singular}` : `${count} ${plural}`;
+  return `${count} ${plurarizeWord(count, singular, plural)}`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4873

## Summary
- AssigneesField clear action now says **Clear assignee** for one person and **Clear assignees** for multiple
- Uses the existing `plurarize` helper family (`plurarizeWord` for labels without a numeric prefix)
- Adds unit coverage for both singular and plural clear labels

## Test plan
- [x] `npm run test -- src/AssigneesField/index.test.tsx` in `turboui`
- [x] Manually open a task with one assignee and confirm the clear action reads "Clear assignee"
- [x] Assign a second person and confirm it reads "Clear assignees"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e593c9a-e157-4e26-987f-4e1b33810796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e593c9a-e157-4e26-987f-4e1b33810796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

