### PR TITLE
fix: Label migration baselines as History Begins Here

### DIFF
--- a/turboui/src/DocumentVersionHistoryPage/VersionTimeline.tsx
+++ b/turboui/src/DocumentVersionHistoryPage/VersionTimeline.tsx
@@ -7,7 +7,13 @@ import type { FormattedTimePreferences } from "../FormattedTime";
 import { Link } from "../Link";
 import { IconArrowRight } from "../icons";
 
-import { eventActionText, previousVersion } from "./types";
+import {
+  eventActionText,
+  isMigrationBaseline,
+  migrationBaselineExplanation,
+  migrationBaselineTitle,
+  previousVersion,
+} from "./types";
 
 type Props = {
   versions: DocumentVersion[];
@@ -24,10 +30,12 @@ export function VersionTimeline(props: Props) {
         {props.versions.map((version, index) => {
           const isLast = index === props.versions.length - 1;
           const previous = previousVersion(props.versions, version);
+          const migrationBaseline = isMigrationBaseline(version);
           const actionText = eventActionText(version, previous);
           const person = version.editor ?? { fullName: "Former member" };
           const canCompare = version.versionNumber > 1;
           const isSelected = version.versionNumber === props.selectedVersionNumber;
+          const previewLabel = migrationBaseline ? migrationBaselineTitle() : actionText;
 
           return (
             <li
@@ -40,7 +48,7 @@ export function VersionTimeline(props: Props) {
                 type="button"
                 className="absolute inset-0 z-0 cursor-pointer rounded-md"
                 aria-pressed={isSelected}
-                aria-label={`Preview version ${version.versionNumber}: ${actionText}`}
+                aria-label={`Preview version ${version.versionNumber}: ${previewLabel}`}
                 onClick={() => props.onSelectVersion(version.versionNumber)}
                 data-test-id={`select-version-${version.versionNumber}`}
               />
@@ -67,17 +75,24 @@ export function VersionTimeline(props: Props) {
                   )}
                 </div>
 
-                <div className="mt-2 text-sm leading-5 text-content-accent">
-                  <AvatarWithName
-                    person={person}
-                    size="tiny"
-                    textSize="normal"
-                    nameFormat="full"
-                    inline
-                    className="text-sm text-content-accent"
-                  />{" "}
-                  {actionText}
-                </div>
+                {migrationBaseline ? (
+                  <div className="mt-2 text-sm leading-5" data-test-id="migration-baseline-label">
+                    <div className="font-semibold text-content-accent">{migrationBaselineTitle()}</div>
+                    <div className="mt-0.5 text-content-dimmed">{migrationBaselineExplanation()}</div>
+                  </div>
+                ) : (
+                  <div className="mt-2 text-sm leading-5 text-content-accent">
+                    <AvatarWithName
+                      person={person}
+                      size="tiny"
+                      textSize="normal"
+                      nameFormat="full"
+                      inline
+                      className="text-sm text-content-accent"
+                    />{" "}
+                    {actionText}
+                  </div>
+                )}
 
                 {canCompare && (
                   <div className="mt-2.5 pointer-events-auto">

--- a/turboui/src/DocumentVersionHistoryPage/__tests__/index.test.tsx
+++ b/turboui/src/DocumentVersionHistoryPage/__tests__/index.test.tsx
@@ -157,4 +157,18 @@ describe("DocumentVersionHistoryPage", () => {
     expect(byTestId("view-version-1")).not.toBeInTheDocument();
     expect(byTestId("see-what-changed-1")).not.toBeInTheDocument();
   });
+
+  test("migration baseline shows History Begins Here instead of Former member", () => {
+    renderPage({
+      versions: M.migrationBaselineList,
+    });
+
+    expect(byTestId("version-row-1")).toHaveTextContent("History Begins Here");
+    expect(byTestId("version-row-1")).toHaveTextContent("This is the earliest saved version available.");
+    expect(byTestId("version-row-1")).not.toHaveTextContent("Former member");
+    expect(byTestId("version-row-1")).not.toHaveTextContent("created this document");
+    expect(byTestId("migration-baseline-label")).toBeInTheDocument();
+    expect(byTestId("see-what-changed-1")).not.toBeInTheDocument();
+    expect(byTestId("version-row-2")).toHaveTextContent("Grace Wilson");
+  });
 });

--- a/turboui/src/DocumentVersionHistoryPage/__tests__/types.test.ts
+++ b/turboui/src/DocumentVersionHistoryPage/__tests__/types.test.ts
@@ -4,6 +4,9 @@ import {
   editorLabel,
   eventActionText,
   eventDescription,
+  isMigrationBaseline,
+  migrationBaselineExplanation,
+  migrationBaselineTitle,
   resolveSelection,
   versionPreviewContent,
 } from "../types";
@@ -140,9 +143,16 @@ describe("event copy", () => {
     expect(eventDescription(created, null)).toBe("Ada Lovelace created this document");
     expect(eventDescription(edited, created)).toBe("Ada Lovelace updated this document");
     expect(editorLabel(version({ versionNumber: 1, editor: null }))).toBe("Former member");
+  });
 
+  test("labels migration baselines without attributing an author", () => {
     const migrated = version({ versionNumber: 1, origin: "migration", editor: null });
-    expect(eventActionText(migrated, null)).toBe("created this document");
-    expect(eventDescription(migrated, null)).toBe("Former member created this document");
+
+    expect(isMigrationBaseline(migrated)).toBe(true);
+    expect(migrationBaselineTitle()).toBe("History Begins Here");
+    expect(migrationBaselineExplanation()).toBe("This is the earliest saved version available.");
+    expect(eventActionText(migrated, null)).toBe("This is the earliest saved version available.");
+    expect(eventDescription(migrated, null)).toBe("History Begins Here");
+    expect(editorLabel(migrated)).toBe("History Begins Here");
   });
 });

--- a/turboui/src/DocumentVersionHistoryPage/index.stories.tsx
+++ b/turboui/src/DocumentVersionHistoryPage/index.stories.tsx
@@ -97,6 +97,12 @@ export const OneVersion: Story = {
   }),
 };
 
+export const MigrationBaseline: Story = {
+  args: baseProps({
+    versions: M.migrationBaselineList,
+  }),
+};
+
 export const MobileStacked: Story = {
   args: baseProps(),
   parameters: {

--- a/turboui/src/DocumentVersionHistoryPage/index.tsx
+++ b/turboui/src/DocumentVersionHistoryPage/index.tsx
@@ -21,6 +21,9 @@ export {
   editorLabel,
   eventActionText,
   eventDescription,
+  isMigrationBaseline,
+  migrationBaselineExplanation,
+  migrationBaselineTitle,
 } from "./types";
 export type { ComparisonStatus, VersionSnapshot, DocumentVersionHistoryPageProps, RestoreResult } from "./types";
 

--- a/turboui/src/DocumentVersionHistoryPage/mockData.ts
+++ b/turboui/src/DocumentVersionHistoryPage/mockData.ts
@@ -172,6 +172,26 @@ export const oneVersionList: DocumentVersion[] = [
   }),
 ];
 
+export const migrationBaselineList: DocumentVersion[] = [
+  version({
+    versionNumber: 2,
+    title: titles.current,
+    origin: "edited",
+    isCurrent: true,
+    editor: grace,
+    titleChanged: true,
+    contentChanged: true,
+    content: contentV2,
+  }),
+  version({
+    versionNumber: 1,
+    title: titles.original,
+    origin: "migration",
+    editor: null,
+    content: contentV1,
+  }),
+];
+
 export const multiVersionList: DocumentVersion[] = [
   version({
     versionNumber: 5,

--- a/turboui/src/DocumentVersionHistoryPage/types.ts
+++ b/turboui/src/DocumentVersionHistoryPage/types.ts
@@ -81,7 +81,20 @@ export function resolveSelection(
   return { selected: after, before, after };
 }
 
+export function isMigrationBaseline(version: DocumentVersion): boolean {
+  return version.origin === "migration";
+}
+
+export function migrationBaselineTitle(): string {
+  return "History Begins Here";
+}
+
+export function migrationBaselineExplanation(): string {
+  return "This is the earliest saved version available.";
+}
+
 export function editorLabel(version: DocumentVersion): string {
+  if (isMigrationBaseline(version)) return migrationBaselineTitle();
   if (!version.editor) return "Former member";
   return version.editor.fullName || "Former member";
 }
@@ -96,6 +109,10 @@ export function previousVersion(
 
 /** Action text after the editor name. */
 export function eventActionText(version: DocumentVersion, previous: DocumentVersion | null): string {
+  if (isMigrationBaseline(version)) {
+    return migrationBaselineExplanation();
+  }
+
   if (version.origin === "created" || version.versionNumber === 1) {
     return "created this document";
   }
@@ -112,5 +129,9 @@ export function eventActionText(version: DocumentVersion, previous: DocumentVers
 }
 
 export function eventDescription(version: DocumentVersion, previous: DocumentVersion | null = null): string {
+  if (isMigrationBaseline(version)) {
+    return migrationBaselineTitle();
+  }
+
   return `${editorLabel(version)} ${eventActionText(version, previous)}`;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #4892 — older documents showed **"Former member created this document"** on the version history page.

Pre-feature documents received a migration baseline version with `editor_id: null` and `origin: migration`. The history UI treated any missing editor as a removed person and version 1 as a create event, producing the misleading copy.

Per [spec 0016](specs/0016-document-version-history.md), migration baselines should instead show:

- **History Begins Here**
- *This is the earliest saved version available.*

They should not attribute the synthetic baseline to the document author or imply it is the original creation event.

## Changes

- Special-case `origin === "migration"` in history event copy helpers
- Render migration rows without an avatar / "Former member" label in `VersionTimeline`
- Add unit coverage and a Storybook story for the migration baseline case

## Test plan

- [x] `npm test -- --testPathPattern='DocumentVersionHistoryPage'` in `turboui/`
- [ ] Manually open version history for a pre-feature document and confirm "History Begins Here" appears for version 1
- [ ] Confirm genuine create events still show `"Name created this document"`
- [ ] Confirm null editors on non-migration versions still show "Former member"

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0162df1-2ffc-4572-859e-509b1198ef80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0162df1-2ffc-4572-859e-509b1198ef80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

