### PR TITLE
fix: Backfill editor_id on migration baseline document versions

### DIFF
--- a/app/lib/operately/data/change_111_backfill_migration_version_editors.ex
+++ b/app/lib/operately/data/change_111_backfill_migration_version_editors.ex
@@ -1,0 +1,41 @@
+defmodule Operately.Data.Change111BackfillMigrationVersionEditors do
+  @moduledoc """
+  Sets editor_id on migration-baseline document versions from the document author.
+
+  Idempotent: only updates versions where origin is migration, editor_id is null,
+  and the document still has an author_id.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Operately.Repo
+  alias __MODULE__.{Document, DocumentVersion}
+
+  def run do
+    from(v in DocumentVersion,
+      join: d in Document,
+      on: v.document_id == d.id,
+      where: v.origin == "migration" and is_nil(v.editor_id) and not is_nil(d.author_id),
+      update: [set: [editor_id: d.author_id]]
+    )
+    |> Repo.update_all([])
+  end
+
+  defmodule Document do
+    use Operately.Schema
+
+    schema "resource_documents" do
+      field :author_id, :binary_id
+    end
+  end
+
+  defmodule DocumentVersion do
+    use Operately.Schema
+
+    schema "resource_document_versions" do
+      field :document_id, :binary_id
+      field :editor_id, :binary_id
+      field :origin, :string
+    end
+  end
+end

--- a/app/priv/repo/migrations/20260723132842_backfill_migration_version_editors.exs
+++ b/app/priv/repo/migrations/20260723132842_backfill_migration_version_editors.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.BackfillMigrationVersionEditors do
+  use Ecto.Migration
+
+  def up do
+    Operately.Data.Change111BackfillMigrationVersionEditors.run()
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/app/test/operately/data/change_111_backfill_migration_version_editors_test.exs
+++ b/app/test/operately/data/change_111_backfill_migration_version_editors_test.exs
@@ -1,0 +1,133 @@
+defmodule Operately.Data.Change111BackfillMigrationVersionEditorsTest do
+  use Operately.DataCase
+
+  alias Operately.Data.Change111BackfillMigrationVersionEditors, as: Change
+  alias Operately.Data.Change111BackfillMigrationVersionEditors.{Document, DocumentVersion}
+  alias Operately.Support.Factory
+
+  # Minimal seed schemas so this test stays independent of live ResourceHubs modules.
+  defmodule SeedDocument do
+    use Operately.Schema
+
+    schema "resource_documents" do
+      field :author_id, :binary_id
+      field :name, :string
+      field :content, :map
+      field :current_version, :integer
+
+      timestamps()
+    end
+  end
+
+  defmodule SeedDocumentVersion do
+    use Operately.Schema
+
+    schema "resource_document_versions" do
+      field :document_id, :binary_id
+      field :version_number, :integer
+      field :title, :string
+      field :content, :map
+      field :editor_id, :binary_id
+      field :origin, :string
+      field :inserted_at, :naive_datetime
+    end
+  end
+
+  setup ctx do
+    ctx = Factory.setup(ctx)
+    {:ok, ctx}
+  end
+
+  test "sets editor_id from document author on migration baselines", ctx do
+    document = insert_document!(ctx.creator.id, "Migrated doc")
+    version = insert_version!(document.id, origin: "migration", editor_id: nil)
+
+    Change.run()
+
+    assert Repo.get!(DocumentVersion, version.id).editor_id == ctx.creator.id
+  end
+
+  test "is idempotent", ctx do
+    document = insert_document!(ctx.creator.id, "Idempotent doc")
+    version = insert_version!(document.id, origin: "migration", editor_id: nil)
+
+    Change.run()
+    Change.run()
+
+    assert Repo.get!(DocumentVersion, version.id).editor_id == ctx.creator.id
+  end
+
+  test "skips non-migration versions", ctx do
+    document = insert_document!(ctx.creator.id, "Created doc")
+    version = insert_version!(document.id, origin: "created", editor_id: nil)
+
+    Change.run()
+
+    assert Repo.get!(DocumentVersion, version.id).editor_id == nil
+  end
+
+  test "skips migration versions that already have an editor", ctx do
+    other =
+      ctx
+      |> Factory.add_company_member(:other)
+      |> then(& &1.other)
+
+    document = insert_document!(ctx.creator.id, "Already attributed")
+    version = insert_version!(document.id, origin: "migration", editor_id: other.id)
+
+    Change.run()
+
+    assert Repo.get!(DocumentVersion, version.id).editor_id == other.id
+  end
+
+  test "skips documents without an author", _ctx do
+    document = insert_document!(nil, "No author")
+    version = insert_version!(document.id, origin: "migration", editor_id: nil)
+
+    Change.run()
+
+    assert Repo.get!(DocumentVersion, version.id).editor_id == nil
+    assert Repo.get!(Document, document.id).author_id == nil
+  end
+
+  #
+  # Helpers
+  #
+
+  defp insert_document!(author_id, name) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    {:ok, document} =
+      %SeedDocument{}
+      |> Ecto.Changeset.change(%{
+        author_id: author_id,
+        name: name,
+        content: %{"type" => "doc", "content" => []},
+        current_version: 1,
+        inserted_at: now,
+        updated_at: now
+      })
+      |> Repo.insert()
+
+    document
+  end
+
+  defp insert_version!(document_id, opts) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    {:ok, version} =
+      %SeedDocumentVersion{}
+      |> Ecto.Changeset.change(%{
+        document_id: document_id,
+        version_number: 1,
+        title: "Version",
+        content: %{"type" => "doc", "content" => []},
+        editor_id: opts[:editor_id],
+        origin: opts[:origin],
+        inserted_at: now
+      })
+      |> Repo.insert()
+
+    version
+  end
+end

--- a/specs/0016-document-version-history.md
+++ b/specs/0016-document-version-history.md
@@ -277,7 +277,7 @@ Create:
 | `version_number` | integer | not null, check `> 0` | Monotonic per-document version |
 | `title` | text | not null | Document title (`resource_documents.name`) at this revision |
 | `content` | map/JSONB | not null | Complete TipTap JSON snapshot |
-| `editor_id` | binary UUID | nullable FK to `people`, `on_delete: :nilify_all` | Person who produced the version; null for migration baselines or removed editors |
+| `editor_id` | binary UUID | nullable FK to `people`, `on_delete: :nilify_all` | Person who produced the version; null only for removed editors |
 | `origin` | enum/string | not null | `created`, `edited`, `restored`, or `migration` |
 | `restored_from_version_number` | integer | nullable, check `> 0` | Source version for a restoration |
 | `inserted_at` | UTC datetime | not null | Version creation time |
@@ -299,14 +299,14 @@ Use an idempotent data migration under `app/lib/operately/data` to create versio
 
 - `title`: current `resource_documents.name`
 - `content`: current document content
-- `editor_id`: null
+- `editor_id`: null (filled later from the document author)
 - `origin`: `migration`
 - `inserted_at`: document `updated_at`
 - `resource_documents.current_version`: `1`
 
 The baseline reads title and body from the document row only; it does not join `resource_nodes`.
 
-The history UI labels this row `History Begins Here` and explains `This is the earliest saved version available.` It does not attribute the row to the original author or imply that it is the original document body.
+A follow-up data migration sets `editor_id` from `resource_documents.author_id` on migration baselines. The history UI then attributes the baseline to the document author using the same create copy as a normal first version (`"{name} created this document"`).
 
 Per the repository's data-migration rules, the migration must define minimal inline schemas or use direct SQL. It must not depend on the current application `Document`, `Node`, or `DocumentVersion` modules.
 
@@ -963,7 +963,7 @@ This phase proves comparison quality before persistence/API work commits the pro
 - Drafts have no version history until first publish; draft title/body saves do not create versions.
 - Every title/body save on a published document creates exactly one immutable version in the same transaction.
 - Subscription-only and publication-state-only changes do not create content versions.
-- Existing documents have a clearly labeled migration baseline.
+- Existing documents have a migration baseline attributed to the document author.
 - Anyone who can view a document can list versions and compare each version with its predecessor.
 - The diff detects text, formatting, link, mention, blob, and block-structure changes.
 - Diff rendering is accessible and responsive, with no color-only meaning.

--- a/turboui/src/DocumentVersionHistoryPage/__tests__/types.test.ts
+++ b/turboui/src/DocumentVersionHistoryPage/__tests__/types.test.ts
@@ -141,8 +141,11 @@ describe("event copy", () => {
     expect(eventDescription(edited, created)).toBe("Ada Lovelace updated this document");
     expect(editorLabel(version({ versionNumber: 1, editor: null }))).toBe("Former member");
 
-    const migrated = version({ versionNumber: 1, origin: "migration", editor: null });
+    const migrated = version({ versionNumber: 1, origin: "migration", editor: person });
     expect(eventActionText(migrated, null)).toBe("created this document");
-    expect(eventDescription(migrated, null)).toBe("Former member created this document");
+    expect(eventDescription(migrated, null)).toBe("Ada Lovelace created this document");
+
+    const migratedWithoutEditor = version({ versionNumber: 1, origin: "migration", editor: null });
+    expect(eventDescription(migratedWithoutEditor, null)).toBe("Former member created this document");
   });
 });


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/4892.