### PR TITLE
feat: Match word prefixes in resource hub search

### DIFF
--- a/app/lib/operately/search/resource_hub_query.ex
+++ b/app/lib/operately/search/resource_hub_query.ex
@@ -31,6 +31,7 @@ defmodule Operately.Search.ResourceHubQuery do
   defp candidate_query(hub_id, query) do
     normalized_title = Text.normalize_title(query)
     title_prefix = title_prefix_pattern(normalized_title)
+    {use_prefix?, tsquery_expr, websearch_expr} = tsquery_args(query)
     eligible_items = eligible_items_query(hub_id)
     visible_nodes = visible_nodes_query(hub_id)
 
@@ -42,9 +43,11 @@ defmodule Operately.Search.ResourceHubQuery do
       where: entry.resource_hub_id == ^hub_id,
       where:
         fragment(
-          "? @@ websearch_to_tsquery('public.operately'::regconfig, ?)",
+          "? @@ (CASE WHEN ? THEN to_tsquery('public.operately'::regconfig, ?) ELSE websearch_to_tsquery('public.operately'::regconfig, ?) END)",
           field(entry, :search_vector),
-          ^query
+          ^use_prefix?,
+          ^tsquery_expr,
+          ^websearch_expr
         ) or fragment("? LIKE ? ESCAPE '!'", entry.normalized_title, ^title_prefix),
       select: item.node_id,
       order_by: [
@@ -52,15 +55,19 @@ defmodule Operately.Search.ResourceHubQuery do
         desc: fragment("? LIKE ? ESCAPE '!'", entry.normalized_title, ^title_prefix),
         desc:
           fragment(
-            "ts_rank_cd(to_tsvector('public.operately'::regconfig, coalesce(?, '')), websearch_to_tsquery('public.operately'::regconfig, ?))",
+            "ts_rank_cd(to_tsvector('public.operately'::regconfig, coalesce(?, '')), CASE WHEN ? THEN to_tsquery('public.operately'::regconfig, ?) ELSE websearch_to_tsquery('public.operately'::regconfig, ?) END)",
             entry.title,
-            ^query
+            ^use_prefix?,
+            ^tsquery_expr,
+            ^websearch_expr
           ),
         desc:
           fragment(
-            "ts_rank_cd(to_tsvector('public.operately'::regconfig, coalesce(?, '')), websearch_to_tsquery('public.operately'::regconfig, ?))",
+            "ts_rank_cd(to_tsvector('public.operately'::regconfig, coalesce(?, '')), CASE WHEN ? THEN to_tsquery('public.operately'::regconfig, ?) ELSE websearch_to_tsquery('public.operately'::regconfig, ?) END)",
             entry.body,
-            ^query
+            ^use_prefix?,
+            ^tsquery_expr,
+            ^websearch_expr
           ),
         asc: entry.source_id
       ],
@@ -68,6 +75,13 @@ defmodule Operately.Search.ResourceHubQuery do
     )
     |> recursive_ctes(true)
     |> with_cte("visible_search_nodes", as: ^visible_nodes)
+  end
+
+  defp tsquery_args(query) do
+    case Text.search_tsquery(query) do
+      {:prefix, tsquery} -> {true, tsquery, query}
+      {:websearch, websearch_query} -> {false, "", websearch_query}
+    end
   end
 
   defp title_prefix_pattern(title) do

--- a/app/lib/operately/search/text.ex
+++ b/app/lib/operately/search/text.ex
@@ -3,6 +3,10 @@ defmodule Operately.Search.Text do
   Normalizes user-visible text consistently when indexing and querying search titles.
   """
 
+  @websearch_or ~r/(?:^|\s)OR(?:\s|$)/
+  @websearch_exclusion ~r/(?:^|\s)-/
+  @token_splitter ~r/[^\p{L}\p{N}]+/u
+
   def normalize_title(title) when is_binary(title) do
     title
     |> String.normalize(:nfkd)
@@ -21,4 +25,55 @@ defmodule Operately.Search.Text do
   end
 
   def normalize_query(_), do: ""
+
+  @doc """
+  Builds the PostgreSQL tsquery used for resource-hub full-text matching.
+
+  Ordinary typed input becomes a `to_tsquery` expression that requires every
+  complete token and treats the last token as a prefix (`:*`). Quoted phrases,
+  `OR`, and `-exclusions` stay on `websearch_to_tsquery` so their syntax is
+  preserved without producing invalid `to_tsquery` input.
+  """
+  def search_tsquery(query) when is_binary(query) do
+    normalized_query = normalize_query(query)
+
+    cond do
+      websearch_syntax?(normalized_query) ->
+        {:websearch, normalized_query}
+
+      prefix_tsquery = build_prefix_tsquery(normalized_query) ->
+        {:prefix, prefix_tsquery}
+
+      true ->
+        {:websearch, normalized_query}
+    end
+  end
+
+  def search_tsquery(_), do: {:websearch, ""}
+
+  defp websearch_syntax?(query) do
+    String.contains?(query, "\"") or Regex.match?(@websearch_or, query) or Regex.match?(@websearch_exclusion, query)
+  end
+
+  defp build_prefix_tsquery(query) do
+    tokens =
+      query
+      |> normalize_title()
+      |> String.split(@token_splitter, trim: true)
+
+    case tokens do
+      [] ->
+        nil
+
+      tokens ->
+        {leading, [last]} = Enum.split(tokens, -1)
+
+        (Enum.map(leading, &quote_lexeme/1) ++ [quote_lexeme(last) <> ":*"])
+        |> Enum.join(" & ")
+    end
+  end
+
+  defp quote_lexeme(lexeme) do
+    "'" <> String.replace(lexeme, "'", "''") <> "'"
+  end
 end

--- a/app/lib/operately/search/text.ex
+++ b/app/lib/operately/search/text.ex
@@ -5,7 +5,7 @@ defmodule Operately.Search.Text do
 
   @websearch_or ~r/(?:^|\s)OR(?:\s|$)/
   @websearch_exclusion ~r/(?:^|\s)-/
-  @token_splitter ~r/[^\p{L}\p{N}]+/u
+  @ordinary_word_query ~r/^[\p{L}\p{N}]+(?:\s+[\p{L}\p{N}]+)*$/u
 
   def normalize_title(title) when is_binary(title) do
     title
@@ -41,8 +41,8 @@ defmodule Operately.Search.Text do
       websearch_syntax?(normalized_query) ->
         {:websearch, normalized_query}
 
-      prefix_tsquery = build_prefix_tsquery(normalized_query) ->
-        {:prefix, prefix_tsquery}
+      ordinary_word_query?(normalized_query) ->
+        {:prefix, build_prefix_tsquery(normalized_query)}
 
       true ->
         {:websearch, normalized_query}
@@ -55,22 +55,20 @@ defmodule Operately.Search.Text do
     String.contains?(query, "\"") or Regex.match?(@websearch_or, query) or Regex.match?(@websearch_exclusion, query)
   end
 
+  defp ordinary_word_query?(query) do
+    Regex.match?(@ordinary_word_query, normalize_title(query))
+  end
+
   defp build_prefix_tsquery(query) do
     tokens =
       query
       |> normalize_title()
-      |> String.split(@token_splitter, trim: true)
+      |> String.split()
 
-    case tokens do
-      [] ->
-        nil
+    {leading, [last]} = Enum.split(tokens, -1)
 
-      tokens ->
-        {leading, [last]} = Enum.split(tokens, -1)
-
-        (Enum.map(leading, &quote_lexeme/1) ++ [quote_lexeme(last) <> ":*"])
-        |> Enum.join(" & ")
-    end
+    (Enum.map(leading, &quote_lexeme/1) ++ [quote_lexeme(last) <> ":*"])
+    |> Enum.join(" & ")
   end
 
   defp quote_lexeme(lexeme) do

--- a/app/lib/operately/search/text.ex
+++ b/app/lib/operately/search/text.ex
@@ -39,13 +39,13 @@ defmodule Operately.Search.Text do
 
     cond do
       websearch_syntax?(normalized_query) ->
-        {:websearch, normalized_query}
+        {:websearch, normalize_websearch_query(normalized_query)}
 
       ordinary_word_query?(normalized_query) ->
         {:prefix, build_prefix_tsquery(normalized_query)}
 
       true ->
-        {:websearch, normalized_query}
+        {:websearch, normalize_websearch_query(normalized_query)}
     end
   end
 
@@ -57,6 +57,10 @@ defmodule Operately.Search.Text do
 
   defp ordinary_word_query?(query) do
     Regex.match?(@ordinary_word_query, normalize_title(query))
+  end
+
+  defp normalize_websearch_query(query) do
+    String.replace(query, ~r/\bhttps?:\/\//iu, "")
   end
 
   defp build_prefix_tsquery(query) do

--- a/app/test/operately/search/resource_hub_query_test.exs
+++ b/app/test/operately/search/resource_hub_query_test.exs
@@ -107,14 +107,61 @@ defmodule Operately.Search.ResourceHubQueryTest do
     ctx =
       Factory.add_document(ctx, :structured_lexemes, :hub,
         name: "Contact directory",
-        content: RichText.rich_text("Email support@operately.com, visit example.com, or use version 3.14")
+        content:
+          RichText.rich_text(
+            "Contact support@operately.com at example.com about version v1.2.3 or 3.14 on 2026-07-27 at 14:30. Read /docs/start or https://operately.com/docs/search about alpha-beta."
+          )
       )
 
     sync(:document, ctx.structured_lexemes.id)
 
-    for query <- ["support@operately.com", "example.com", "3.14"] do
+    for query <- [
+          "support@operately.com",
+          "example.com",
+          "3.14",
+          "2026-07-27",
+          "14:30",
+          "v1.2.3",
+          "/docs/start",
+          "alpha-beta",
+          "contact support@operately.com",
+          "https://operately.com/docs/search"
+        ] do
       assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, query)
       assert id == ctx.structured_lexemes.id
+    end
+  end
+
+  test "preserves OR semantics with structured lexemes", ctx do
+    ctx =
+      Factory.add_document(ctx, :support, :hub,
+        name: "Support directory",
+        content: RichText.rich_text("Contact support@operately.com")
+      )
+
+    sync(:document, ctx.support.id)
+
+    result_ids =
+      ctx.hub
+      |> Search.search_resource_hub("navigation OR support@operately.com")
+      |> Enum.map(& &1.document.id)
+      |> MapSet.new()
+
+    assert result_ids == MapSet.new([ctx.document.id, ctx.support.id])
+  end
+
+  test "matches non-Latin word prefixes", ctx do
+    ctx =
+      Factory.add_document(ctx, :international, :hub,
+        name: "International notes",
+        content: RichText.rich_text("Навигационные заметки 東京計画")
+      )
+
+    sync(:document, ctx.international.id)
+
+    for query <- ["Навигац", "東京"] do
+      assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, query)
+      assert id == ctx.international.id
     end
   end
 

--- a/app/test/operately/search/resource_hub_query_test.exs
+++ b/app/test/operately/search/resource_hub_query_test.exs
@@ -84,6 +84,25 @@ defmodule Operately.Search.ResourceHubQueryTest do
     assert id == ctx.document.id
   end
 
+  test "matches word prefixes in titles and bodies while typing", ctx do
+    ctx =
+      Factory.add_document(ctx, :sentence, :hub,
+        name: "Typing notes",
+        content: RichText.rich_text("This is just a test")
+      )
+
+    sync(:document, ctx.sentence.id)
+
+    assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, "just a t")
+    assert id == ctx.sentence.id
+
+    assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, "navig")
+    assert id == ctx.document.id
+
+    assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, "Enterpri")
+    assert id == ctx.document.id
+  end
+
   test "searches space-, project-, and goal-owned resource hubs", ctx do
     ctx =
       ctx

--- a/app/test/operately/search/resource_hub_query_test.exs
+++ b/app/test/operately/search/resource_hub_query_test.exs
@@ -103,6 +103,21 @@ defmodule Operately.Search.ResourceHubQueryTest do
     assert id == ctx.document.id
   end
 
+  test "matches structured lexemes in document bodies", ctx do
+    ctx =
+      Factory.add_document(ctx, :structured_lexemes, :hub,
+        name: "Contact directory",
+        content: RichText.rich_text("Email support@operately.com, visit example.com, or use version 3.14")
+      )
+
+    sync(:document, ctx.structured_lexemes.id)
+
+    for query <- ["support@operately.com", "example.com", "3.14"] do
+      assert [%{document: %{id: id}}] = Search.search_resource_hub(ctx.hub, query)
+      assert id == ctx.structured_lexemes.id
+    end
+  end
+
   test "searches space-, project-, and goal-owned resource hubs", ctx do
     ctx =
       ctx

--- a/app/test/operately/search/text_test.exs
+++ b/app/test/operately/search/text_test.exs
@@ -14,6 +14,11 @@ defmodule Operately.Search.TextTest do
       assert Text.search_tsquery("CAFÉ handb") == {:prefix, "'cafe' & 'handb':*"}
     end
 
+    test "builds prefix tsqueries for non-Latin words" do
+      assert Text.search_tsquery("Навигац") == {:prefix, "'навигац':*"}
+      assert Text.search_tsquery("東京") == {:prefix, "'東京':*"}
+    end
+
     test "keeps websearch syntax on the websearch path" do
       assert Text.search_tsquery(~s("customer research")) == {:websearch, ~s("customer research")}
       assert Text.search_tsquery("customer -archive") == {:websearch, "customer -archive"}
@@ -21,9 +26,36 @@ defmodule Operately.Search.TextTest do
     end
 
     test "keeps structured lexemes on the websearch path" do
-      assert Text.search_tsquery("support@operately.com") == {:websearch, "support@operately.com"}
-      assert Text.search_tsquery("example.com") == {:websearch, "example.com"}
-      assert Text.search_tsquery("3.14") == {:websearch, "3.14"}
+      for query <- [
+            "support@operately.com",
+            "example.com",
+            "3.14",
+            "2026-07-27",
+            "14:30",
+            "v1.2.3",
+            "/docs/start",
+            "alpha-beta"
+          ] do
+        assert Text.search_tsquery(query) == {:websearch, query}
+      end
+    end
+
+    test "keeps mixed plain and structured terms on the websearch path" do
+      query = "contact support@operately.com"
+
+      assert Text.search_tsquery(query) == {:websearch, query}
+    end
+
+    test "does not add prefix operators inside punctuation-bearing terms" do
+      assert Text.search_tsquery("alpha-be") == {:websearch, "alpha-be"}
+    end
+
+    test "removes URL schemes to match PostgreSQL's indexed URL lexemes" do
+      assert Text.search_tsquery("https://operately.com/docs/search") ==
+               {:websearch, "operately.com/docs/search"}
+
+      assert Text.search_tsquery("visit HTTP://operately.com/docs/search") ==
+               {:websearch, "visit operately.com/docs/search"}
     end
 
     test "falls back to websearch when no searchable tokens remain" do

--- a/app/test/operately/search/text_test.exs
+++ b/app/test/operately/search/text_test.exs
@@ -1,0 +1,28 @@
+defmodule Operately.Search.TextTest do
+  use ExUnit.Case, async: true
+
+  alias Operately.Search.Text
+
+  describe "search_tsquery/1" do
+    test "builds a prefix tsquery for the last typed token" do
+      assert Text.search_tsquery("just a t") == {:prefix, "'just' & 'a' & 't':*"}
+      assert Text.search_tsquery("navig") == {:prefix, "'navig':*"}
+      assert Text.search_tsquery("Enterprise research") == {:prefix, "'enterprise' & 'research':*"}
+    end
+
+    test "folds accents and case before building the prefix tsquery" do
+      assert Text.search_tsquery("CAFÉ handb") == {:prefix, "'cafe' & 'handb':*"}
+    end
+
+    test "keeps websearch syntax on the websearch path" do
+      assert Text.search_tsquery(~s("customer research")) == {:websearch, ~s("customer research")}
+      assert Text.search_tsquery("customer -archive") == {:websearch, "customer -archive"}
+      assert Text.search_tsquery("customer OR archive") == {:websearch, "customer OR archive"}
+    end
+
+    test "falls back to websearch when no searchable tokens remain" do
+      assert Text.search_tsquery("!!!") == {:websearch, "!!!"}
+      assert Text.search_tsquery("   ") == {:websearch, ""}
+    end
+  end
+end

--- a/app/test/operately/search/text_test.exs
+++ b/app/test/operately/search/text_test.exs
@@ -20,6 +20,12 @@ defmodule Operately.Search.TextTest do
       assert Text.search_tsquery("customer OR archive") == {:websearch, "customer OR archive"}
     end
 
+    test "keeps structured lexemes on the websearch path" do
+      assert Text.search_tsquery("support@operately.com") == {:websearch, "support@operately.com"}
+      assert Text.search_tsquery("example.com") == {:websearch, "example.com"}
+      assert Text.search_tsquery("3.14") == {:websearch, "3.14"}
+    end
+
     test "falls back to websearch when no searchable tokens remain" do
       assert Text.search_tsquery("!!!") == {:websearch, "!!!"}
       assert Text.search_tsquery("   ") == {:websearch, ""}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resource hub full-text search previously matched only whole tokens via `websearch_to_tsquery`, so typing a partial word (e.g. `navig` or `just a t`) returned no results even when `navigation` / `just a test` was indexed.

This change builds a `to_tsquery` expression for ordinary typed input that:

- requires every complete token
- treats the **last** token as a prefix (`:*`)

Quoted phrases, `OR`, and `-exclusions` still use `websearch_to_tsquery` so existing web-search syntax keeps working. No reindex or schema changes are required.

## Test plan

- [x] `make test FILE=app/test/operately/search/text_test.exs`
- [x] `make test FILE=app/test/operately/search/resource_hub_query_test.exs`
- [x] `make test FILE=app/test/operately_web/api/resource_hubs/search_test.exs`
- [x] CI green (`ci/semaphoreci/pr: Operately — Build & Test`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a8f-79c8-73bf-b38e-4f8570565b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a8f-79c8-73bf-b38e-4f8570565b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

