### PR TITLE
fix: Show Docs & Files tab on milestone and task pages

### DIFF
--- a/turboui/src/MilestonePage/index.tsx
+++ b/turboui/src/MilestonePage/index.tsx
@@ -3,18 +3,9 @@ import { DateField } from "../DateField";
 import TaskCreationModal from "../TaskBoard/components/TaskCreationModal";
 import * as Types from "../TaskBoard/types";
 import { Timeline } from "../Timeline";
-import {
-  IconCheck,
-  IconClipboardText,
-  IconFlag,
-  IconFlagFilled,
-  IconListCheck,
-  IconLogs,
-  IconMessage,
-  IconMessages,
-} from "../icons";
+import { IconCheck, IconFlag, IconFlagFilled } from "../icons";
 import { ProjectPageLayout } from "../ProjectPageLayout";
-import { useTabs } from "../Tabs";
+import { useProjectPageTabs } from "../ProjectPageLayout/useProjectPageTabs";
 import { MilestoneSidebar } from "./components/Sidebar";
 import { DeleteModal } from "./components/DeleteModal";
 import { PersonField } from "../PersonField";
@@ -180,27 +171,12 @@ export function MilestonePage(props: MilestonePage.Props) {
     }
   };
 
-  const tabs = useTabs(
-    "tasks",
-    [
-      { id: "overview", label: "Overview", icon: <IconClipboardText size={14} /> },
-      {
-        id: "tasks",
-        label: "Tasks",
-        icon: <IconListCheck size={14} />,
-        count: childrenCount.tasksCount,
-      },
-      { id: "check-ins", label: "Check-ins", icon: <IconMessage size={14} />, count: childrenCount.checkInsCount },
-      {
-        id: "discussions",
-        label: "Discussions",
-        icon: <IconMessages size={14} />,
-        count: childrenCount.discussionsCount,
-      },
-      { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },
-    ],
-    { urlPath: projectLink },
-  );
+  const tabs = useProjectPageTabs({
+    defaultTab: "tasks",
+    childrenCount,
+    showDocsAndFiles: true,
+    urlPath: projectLink,
+  });
 
   const spaceProps =
     "space" in state ? { space: state.space, workmapLink: state.workmapLink } : { homeLink: state.homeLink };

--- a/turboui/src/ProjectPage/index.tsx
+++ b/turboui/src/ProjectPage/index.tsx
@@ -1,16 +1,15 @@
 import React from "react";
 
 import { ProjectPageLayout } from "../ProjectPageLayout";
+import { useProjectPageTabs } from "../ProjectPageLayout/useProjectPageTabs";
 
 import { PageDocsAndFilesTab, type PageDocsAndFiles } from "../DocsAndFiles/PageDocsAndFiles";
-import { IconClipboardText, IconListCheck, IconLogs, IconMessage, IconMessages } from "../icons";
 
 import { DateField } from "../DateField";
 import { MoveModal } from "../Modal/MoveModal";
 import { BadgeStatus } from "../StatusBadge/types";
 import { PersonField } from "../PersonField";
 import { PrivacyField } from "../PrivacyField";
-import { useTabs } from "../Tabs";
 import * as TaskBoardTypes from "../TaskBoard/types";
 import type { KanbanBoardProps, KanbanState } from "../TaskBoard/KanbanView/types";
 import { CheckIns } from "./CheckIns";
@@ -228,29 +227,11 @@ export function ProjectPage(props: ProjectPage.Props) {
   const state = useProjectPageState(props);
   const taskCompletion = React.useMemo(() => getTaskCompletionStats(state.tasks), [state.tasks]);
 
-  const tabs = useTabs("overview", [
-    { id: "overview", label: "Overview", icon: <IconClipboardText size={14} /> },
-    {
-      id: "tasks",
-      label: "Tasks",
-      icon: <IconListCheck size={14} />,
-      count: state.childrenCount.tasksCount,
-    },
-    { id: "check-ins", label: "Check-ins", icon: <IconMessage size={14} />, count: state.childrenCount.checkInsCount },
-    {
-      id: "discussions",
-      label: "Discussions",
-      icon: <IconMessages size={14} />,
-      count: state.childrenCount.discussionsCount,
-    },
-    {
-      id: "docs-and-files",
-      label: "Docs & Files",
-      icon: <IconClipboardText size={14} />,
-      hidden: !state.docsAndFiles,
-    },
-    { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },
-  ]);
+  const tabs = useProjectPageTabs({
+    defaultTab: "overview",
+    childrenCount: state.childrenCount,
+    showDocsAndFiles: Boolean(state.docsAndFiles),
+  });
   const activeTab = !state.docsAndFiles && tabs.active === "docs-and-files" ? "overview" : tabs.active;
 
   return (
@@ -267,7 +248,9 @@ export function ProjectPage(props: ProjectPage.Props) {
         {activeTab === "tasks" && <TasksSection state={state} />}
         {activeTab === "check-ins" && <CheckIns {...state} />}
         {activeTab === "discussions" && <Discussions {...state} />}
-        {activeTab === "docs-and-files" && state.docsAndFiles && <PageDocsAndFilesTab docsAndFiles={state.docsAndFiles} />}
+        {activeTab === "docs-and-files" && state.docsAndFiles && (
+          <PageDocsAndFilesTab docsAndFiles={state.docsAndFiles} />
+        )}
         {activeTab === "activity" && <Activity {...state} />}
       </div>
 

--- a/turboui/src/ProjectPageLayout/useProjectPageTabs.test.tsx
+++ b/turboui/src/ProjectPageLayout/useProjectPageTabs.test.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router";
+
+import { Tabs } from "../Tabs";
+import { useProjectPageTabs } from "./useProjectPageTabs";
+
+jest.mock("../icons", () => {
+  const HiddenIcon = () => <span aria-hidden="true" />;
+
+  return {
+    IconClipboardText: HiddenIcon,
+    IconListCheck: HiddenIcon,
+    IconLogs: HiddenIcon,
+    IconMessage: HiddenIcon,
+    IconMessages: HiddenIcon,
+  };
+});
+
+const childrenCount = {
+  tasksCount: 4,
+  discussionsCount: 2,
+  checkInsCount: 1,
+};
+
+function ProjectTabs() {
+  const tabs = useProjectPageTabs({
+    defaultTab: "overview",
+    childrenCount,
+    showDocsAndFiles: true,
+  });
+
+  return <Tabs tabs={tabs} />;
+}
+
+function HiddenDocsTabs() {
+  const tabs = useProjectPageTabs({
+    defaultTab: "overview",
+    childrenCount,
+    showDocsAndFiles: false,
+  });
+
+  return <Tabs tabs={tabs} />;
+}
+
+function ChildPageTabs() {
+  const tabs = useProjectPageTabs({
+    defaultTab: "overview",
+    childrenCount,
+    showDocsAndFiles: true,
+    urlPath: "/projects/project-1",
+  });
+
+  return <Tabs tabs={tabs} />;
+}
+
+describe("useProjectPageTabs", () => {
+  test("includes the docs and files tab when showDocsAndFiles is true", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/project-1"]}>
+        <ProjectTabs />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Docs & Files" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Overview" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Activity" })).toBeInTheDocument();
+  });
+
+  test("hides the docs and files tab when showDocsAndFiles is false", () => {
+    render(
+      <MemoryRouter initialEntries={["/projects/project-1"]}>
+        <HiddenDocsTabs />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "Docs & Files" })).not.toBeInTheDocument();
+  });
+
+  test("uses urlPath for child pages so docs and files navigates to the project", () => {
+    render(
+      <MemoryRouter initialEntries={["/milestones/m-1"]}>
+        <ChildPageTabs />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Docs & Files" })).toHaveAttribute(
+      "href",
+      "/projects/project-1?tab=docs-and-files",
+    );
+  });
+});

--- a/turboui/src/ProjectPageLayout/useProjectPageTabs.tsx
+++ b/turboui/src/ProjectPageLayout/useProjectPageTabs.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { IconClipboardText, IconListCheck, IconLogs, IconMessage, IconMessages } from "../icons";
+import { useTabs, type TabsState } from "../Tabs";
+import type { ProjectPageLayout } from "./index";
+
+export type ProjectPageTabId = "overview" | "tasks" | "check-ins" | "discussions" | "docs-and-files" | "activity";
+
+export interface UseProjectPageTabsOptions {
+  defaultTab: ProjectPageTabId;
+  childrenCount: ProjectPageLayout.ChildrenCount;
+  showDocsAndFiles: boolean;
+  urlPath?: string;
+}
+
+/**
+ * Single source of truth for project-context page tabs (Project, Milestone, Task).
+ * Child pages pass urlPath so tabs navigate to the project page.
+ */
+export function useProjectPageTabs({
+  defaultTab,
+  childrenCount,
+  showDocsAndFiles,
+  urlPath,
+}: UseProjectPageTabsOptions): TabsState {
+  return useTabs(
+    defaultTab,
+    [
+      { id: "overview", label: "Overview", icon: <IconClipboardText size={14} /> },
+      {
+        id: "tasks",
+        label: "Tasks",
+        icon: <IconListCheck size={14} />,
+        count: childrenCount.tasksCount,
+      },
+      {
+        id: "check-ins",
+        label: "Check-ins",
+        icon: <IconMessage size={14} />,
+        count: childrenCount.checkInsCount,
+      },
+      {
+        id: "discussions",
+        label: "Discussions",
+        icon: <IconMessages size={14} />,
+        count: childrenCount.discussionsCount,
+      },
+      {
+        id: "docs-and-files",
+        label: "Docs & Files",
+        icon: <IconClipboardText size={14} />,
+        hidden: !showDocsAndFiles,
+      },
+      { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },
+    ],
+    urlPath ? { urlPath } : undefined,
+  );
+}

--- a/turboui/src/TaskPage/index.tsx
+++ b/turboui/src/TaskPage/index.tsx
@@ -6,8 +6,7 @@ import { TimelineItem, TimelineFilters } from "../Timeline/types";
 import { Person as TimelinePerson } from "../CommentSection/types";
 import { DateField } from "../DateField";
 import { ProjectPageLayout } from "../ProjectPageLayout";
-import { useTabs } from "../Tabs";
-import { IconClipboardText, IconListCheck, IconLogs, IconMessage, IconMessages } from "../icons";
+import { useProjectPageTabs } from "../ProjectPageLayout/useProjectPageTabs";
 import { SidebarNotificationSection } from "../SidebarSection";
 
 import { PageHeader } from "./PageHeader";
@@ -275,32 +274,12 @@ function useTaskPageState(props: TaskPage.Props): TaskPage.ContentState {
 export function TaskPage(props: TaskPage.Props) {
   const contentState = useTaskPageState(props);
 
-  const tabs = useTabs(
-    "tasks",
-    [
-      { id: "overview", label: "Overview", icon: <IconClipboardText size={14} /> },
-      {
-        id: "tasks",
-        label: "Tasks",
-        icon: <IconListCheck size={14} />,
-        count: props.childrenCount.tasksCount,
-      },
-      {
-        id: "check-ins",
-        label: "Check-ins",
-        icon: <IconMessage size={14} />,
-        count: props.childrenCount.checkInsCount,
-      },
-      {
-        id: "discussions",
-        label: "Discussions",
-        icon: <IconMessages size={14} />,
-        count: props.childrenCount.discussionsCount,
-      },
-      { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },
-    ],
-    { urlPath: props.projectLink },
-  );
+  const tabs = useProjectPageTabs({
+    defaultTab: "tasks",
+    childrenCount: props.childrenCount,
+    showDocsAndFiles: true,
+    urlPath: props.projectLink,
+  });
 
   return (
     <ProjectPageLayout


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4916

## Problem

The Docs & Files tab was missing from the project milestone page (and the same bug on the task page). Project, Milestone, and Task each maintained their own hardcoded tab lists; when Docs & Files was added to `ProjectPage`, the child pages were never updated.

## Solution

Introduce `useProjectPageTabs` as the single source of truth for project-context tabs, and use it from:

- `ProjectPage`
- `MilestonePage`
- `TaskPage`

On Milestone/Task pages, the tab links to the project Docs & Files tab via the existing `urlPath` behavior (same as Overview, Check-ins, etc.).

## Tests

- Added unit coverage for `useProjectPageTabs` (show/hide Docs & Files, `urlPath` navigation)
- Existing `ProjectPage` Docs & Files tests still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb629430-8377-4ac9-a140-54f188ea11f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb629430-8377-4ac9-a140-54f188ea11f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

