### PR TITLE
chore: Migrate account and company admin pages to TurboUI Page

### DIFF
--- a/app/assets/js/pages/AccountAppearancePage/index.tsx
+++ b/app/assets/js/pages/AccountAppearancePage/index.tsx
@@ -18,7 +18,7 @@ function Page() {
 
   return (
     <TurboUIPage
-      title={["Apperance", "Account"]}
+      title={["Appearance", "Account"]}
       size="small"
       navigation={[
         { to: paths.homePath(), label: "Home" },

--- a/app/assets/js/pages/AccountAppearancePage/index.tsx
+++ b/app/assets/js/pages/AccountAppearancePage/index.tsx
@@ -1,9 +1,8 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as People from "@/models/people";
 import * as React from "react";
 
-import { IconSun, IconMoon, IconDeviceLaptop, Forms, showErrorToast } from "turboui";
+import { IconSun, IconMoon, IconDeviceLaptop, Forms, showErrorToast, Page as TurboUIPage } from "turboui";
 
 import classnames from "classnames";
 
@@ -15,28 +14,21 @@ import { usePaths } from "@/routes/paths";
 export default { name: "AccountAppearancePage", loader: Pages.emptyLoader, Page } as PageModule;
 
 function Page() {
-  return (
-    <Pages.Page title={["Apperance", "Account"]}>
-      <Paper.Root size="small">
-        <Navigation />
-        <Paper.Body>
-          <Form />
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
-  );
-}
-
-function Navigation() {
   const paths = usePaths();
 
   return (
-    <Paper.Navigation
-      items={[
+    <TurboUIPage
+      title={["Apperance", "Account"]}
+      size="small"
+      navigation={[
         { to: paths.homePath(), label: "Home" },
         { to: paths.accountSettingsPath(), label: "Settings" },
       ]}
-    />
+    >
+      <div className="px-10 py-8">
+        <Form />
+      </div>
+    </TurboUIPage>
   );
 }
 

--- a/app/assets/js/pages/AccountChangePasswordPage/index.tsx
+++ b/app/assets/js/pages/AccountChangePasswordPage/index.tsx
@@ -1,11 +1,10 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as Accounts from "@/models/accounts";
 import * as React from "react";
 
 import { PageModule } from "@/routes/types";
 import { useNavigate } from "react-router";
-import { Forms, showSuccessToast, showErrorToast } from "turboui";
+import { Forms, showSuccessToast, showErrorToast, Page as TurboUIPage } from "turboui";
 
 import { usePaths } from "@/routes/paths";
 export default { name: "AccountChangePasswordPage", loader: Pages.emptyLoader, Page } as PageModule;
@@ -43,51 +42,44 @@ function Page() {
   });
 
   return (
-    <Pages.Page title={"Change Password"} testId="change-password-page">
-      <Paper.Root size="small">
-        <Navigation />
-
-        <Paper.Body>
-          <Paper.Header title="Change Password" />
-
-          <Forms.Form form={form}>
-            <Forms.FieldGroup>
-              <Forms.PasswordInput
-                field={"currentPassword"}
-                label="Current Password"
-                placeholder="Enter your current password"
-              />
-              <Forms.PasswordInput
-                field={"newPassword"}
-                label="New Password"
-                minLength={12}
-                placeholder="At least 12 characters"
-              />
-              <Forms.PasswordInput
-                field={"confirmPassword"}
-                label="Confirm New Password"
-                minLength={12}
-                placeholder="At least 12 characters"
-              />
-            </Forms.FieldGroup>
-
-            <Forms.Submit saveText="Change Password" cancelText="Cancel" />
-          </Forms.Form>
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
-  );
-}
-
-function Navigation() {
-  const paths = usePaths();
-
-  return (
-    <Paper.Navigation
-      items={[
+    <TurboUIPage
+      title={"Change Password"}
+      size="small"
+      testId="change-password-page"
+      navigation={[
         { to: paths.homePath(), label: "Home" },
         { to: paths.accountSecurityPath(), label: "Password & Security" },
       ]}
-    />
+    >
+      <div className="px-10 py-8">
+        <div className="mb-6">
+          <div className="text-content-accent text-lg md:text-2xl font-extrabold">Change Password</div>
+        </div>
+
+        <Forms.Form form={form}>
+          <Forms.FieldGroup>
+            <Forms.PasswordInput
+              field={"currentPassword"}
+              label="Current Password"
+              placeholder="Enter your current password"
+            />
+            <Forms.PasswordInput
+              field={"newPassword"}
+              label="New Password"
+              minLength={12}
+              placeholder="At least 12 characters"
+            />
+            <Forms.PasswordInput
+              field={"confirmPassword"}
+              label="Confirm New Password"
+              minLength={12}
+              placeholder="At least 12 characters"
+            />
+          </Forms.FieldGroup>
+
+          <Forms.Submit saveText="Change Password" cancelText="Cancel" />
+        </Forms.Form>
+      </div>
+    </TurboUIPage>
   );
 }

--- a/app/assets/js/pages/CompanyAdminManageAdminsPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminManageAdminsPage/page.tsx
@@ -1,5 +1,4 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as React from "react";
@@ -12,7 +11,8 @@ import { useFrom } from "./useForm";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { createTestId } from "@/utils/testid";
-import { Avatar, BlackLink, SecondaryButton } from "turboui";
+import { Avatar, BlackLink, SecondaryButton, Page as TurboUIPage } from "turboui";
+import classNames from "classnames";
 
 import { usePaths } from "@/routes/paths";
 export function Page() {
@@ -22,32 +22,66 @@ export function Page() {
   const { admins, owners } = useLoadedData();
 
   return (
-    <Pages.Page title={"Manage admins and owners"} testId="manage-admins-page">
-      <Paper.Root>
-        <Paper.Navigation items={[{ to: paths.companyAdminPath(), label: "Company Administration" }]} />
+    <TurboUIPage
+      title={"Manage admins and owners"}
+      testId="manage-admins-page"
+      navigation={[{ to: paths.companyAdminPath(), label: "Company Administration" }]}
+    >
+      <div className="px-12 py-10">
+        <div className="mb-6">
+          <div className="text-content-accent text-lg md:text-2xl font-extrabold">Manage admins and owners</div>
+          <div className="mt-2">Add/Remove people who are in charge of the company and its operations</div>
+        </div>
 
-        <Paper.Body>
-          <Paper.Header
-            title="Manage admins and owners"
-            subtitle="Add/Remove people who are in charge of the company and its operations"
-          />
+        <Section
+          title="Administrators"
+          subtitle="Company administrators can add/remove people from the company, manage their profiles, update company settings, and more."
+          actions={<AddAdminsModal form={form} />}
+        >
+          <PeopleList type="admins" people={admins} />
+        </Section>
 
-          <Paper.Section
-            title="Administrators"
-            subtitle="Company administrators can add/remove people from the company, manage their profiles, update company settings, and more."
-            actions={<AddAdminsModal form={form} />}
-            children={<PeopleList type="admins" people={admins} />}
-          />
+        <Section
+          title="Account Owners"
+          subtitle="Owners have the highest level of access and can manage all aspects of the company, including billing, and have access to all resources."
+          actions={<AddOwnersModal form={form} />}
+        >
+          <PeopleList type="owners" people={owners} />
+        </Section>
+      </div>
+    </TurboUIPage>
+  );
+}
 
-          <Paper.Section
-            title="Account Owners"
-            subtitle="Owners have the highest level of access and can manage all aspects of the company, including billing, and have access to all resources."
-            actions={<AddOwnersModal form={form} />}
-            children={<PeopleList type="owners" people={owners} />}
-          />
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
+function Section({
+  title,
+  subtitle,
+  actions,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  actions?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  const className = classNames("flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0", {
+    "mb-6": subtitle,
+    "mb-2": !subtitle,
+  });
+
+  return (
+    <div className="mt-10" data-test-id={createTestId(title, "section")}>
+      <div className={className}>
+        <div>
+          <h2 className="font-bold">{title}</h2>
+          {subtitle && <p className="text-sm max-w-xl">{subtitle}</p>}
+        </div>
+
+        {actions && <div className="w-full sm:w-auto">{actions}</div>}
+      </div>
+
+      {children}
+    </div>
   );
 }
 

--- a/app/assets/js/pages/CompanyAdminPage/CompanyAdmins.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/CompanyAdmins.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import * as People from "@/models/people";
-import * as Paper from "@/components/PaperContainer";
 
 import { Avatar } from "turboui";
 
 import { useLoadedData } from "./loader";
+import { Section } from "./Section";
 
 export function CompanyAdmins() {
   const { company } = useLoadedData();
@@ -13,9 +13,9 @@ export function CompanyAdmins() {
   if (company.admins.length === 0) return null;
 
   return (
-    <Paper.Section title="Administrators">
+    <Section title="Administrators">
       <PeopleList people={company.admins || []} />
-    </Paper.Section>
+    </Section>
   );
 }
 
@@ -26,9 +26,9 @@ export function CompanyOwners() {
   if (company.owners.length === 0) return null;
 
   return (
-    <Paper.Section title="Account Owners">
+    <Section title="Account Owners">
       <PeopleList people={company.owners || []} />
-    </Paper.Section>
+    </Section>
   );
 }
 

--- a/app/assets/js/pages/CompanyAdminPage/DangerZone.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/DangerZone.tsx
@@ -13,7 +13,7 @@ import {
   Modal,
 } from "turboui";
 
-import * as Paper from "@/components/PaperContainer";
+import { Section } from "./Section";
 
 export function DangerZone() {
   const { company, ownerIds } = useLoadedData();
@@ -23,11 +23,11 @@ export function DangerZone() {
   if (!amIOwner) return null;
 
   return (
-    <Paper.Section title="Danger Zone:">
+    <Section title="Danger Zone:">
       <div className="bg-surface-base">
         <DeleteCompanyItem companyName={company.name!} />
       </div>
-    </Paper.Section>
+    </Section>
   );
 }
 

--- a/app/assets/js/pages/CompanyAdminPage/NavigationBackToLobby.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/NavigationBackToLobby.tsx
@@ -1,8 +1,0 @@
-import * as Paper from "@/components/PaperContainer";
-import * as React from "react";
-
-import { usePaths } from "@/routes/paths";
-export function NavigationBackToLobby() {
-  const paths = usePaths();
-  return <Paper.Navigation items={[{ to: paths.homePath(), label: "Home" }]} />;
-}

--- a/app/assets/js/pages/CompanyAdminPage/Section.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/Section.tsx
@@ -1,0 +1,32 @@
+import classNames from "classnames";
+import React from "react";
+import { createTestId } from "@/utils/testid";
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export function Section({ title, subtitle, actions, children }: Props) {
+  const className = classNames("flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0", {
+    "mb-6": subtitle,
+    "mb-2": !subtitle,
+  });
+
+  return (
+    <div className="mt-10" data-test-id={createTestId(title, "section")}>
+      <div className={className}>
+        <div>
+          <h2 className="font-bold">{title}</h2>
+          {subtitle && <p className="text-sm max-w-xl">{subtitle}</p>}
+        </div>
+
+        {actions && <div className="w-full sm:w-auto">{actions}</div>}
+      </div>
+
+      {children}
+    </div>
+  );
+}

--- a/app/assets/js/pages/CompanyAdminPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/page.tsx
@@ -38,9 +38,9 @@ export function Page() {
 
         <Section title="What's this?">
           <p>
-            This is the company administration page where owners and admins can manage the company's settings. They
-            have special permissions to add or remove team members, change who can access the application, and more. If
-            you need something done, contact one of them.
+            This is the company administration page where owners and admins can manage the company's settings. They have
+            special permissions to add or remove team members, change who can access the application, and more. If you
+            need something done, contact one of them.
           </p>
 
           <p className="mt-2">

--- a/app/assets/js/pages/CompanyAdminPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminPage/page.tsx
@@ -1,15 +1,23 @@
-import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as React from "react";
-import { IconFileExport, IconFileText, IconLetterCase, IconLock, IconShieldLock, IconUser, IconUsers, OptionsMenuItem } from "turboui";
+import {
+  IconFileExport,
+  IconFileText,
+  IconLetterCase,
+  IconLock,
+  IconShieldLock,
+  IconUser,
+  IconUsers,
+  OptionsMenuItem,
+  Link,
+  Page as TurboUIPage,
+} from "turboui";
 
 import { useMe } from "@/contexts/CurrentCompanyContext";
 import { includesId } from "@/routes/paths";
-import { Link } from "turboui";
 import { CompanyAdmins, CompanyOwners } from "./CompanyAdmins";
 import { useLoadedData } from "./loader";
-import { NavigationBackToLobby } from "./NavigationBackToLobby";
 import { DangerZone } from "./DangerZone";
+import { Section } from "./Section";
 
 import { usePaths } from "@/routes/paths";
 
@@ -18,35 +26,36 @@ export function Page() {
   const { company } = useLoadedData();
 
   return (
-    <Pages.Page title={[company.name!, "Administration"]} testId="company-admin-page">
-      <Paper.Root size="small">
-        <NavigationBackToLobby />
+    <TurboUIPage
+      title={[company.name!, "Administration"]}
+      size="small"
+      testId="company-admin-page"
+      navigation={[{ to: paths.homePath(), label: "Home" }]}
+    >
+      <div className="px-10 py-8">
+        <div className="uppercase text-sm tracking-wide">Company Administration</div>
+        <div className="text-content-accent text-3xl font-extrabold">{company.name}</div>
 
-        <Paper.Body minHeight="none">
-          <div className="uppercase text-sm tracking-wide">Company Administration</div>
-          <div className="text-content-accent text-3xl font-extrabold">{company.name}</div>
+        <Section title="What's this?">
+          <p>
+            This is the company administration page where owners and admins can manage the company's settings. They
+            have special permissions to add or remove team members, change who can access the application, and more. If
+            you need something done, contact one of them.
+          </p>
 
-          <Paper.Section title="What's this?">
-            <p>
-              This is the company administration page where owners and admins can manage the company's settings. They
-              have special permissions to add or remove team members, change who can access the application, and more. If
-              you need something done, contact one of them.
-            </p>
+          <p className="mt-2">
+            <Link to={paths.companyPermissionsPath()}>View permission breakdown</Link>
+          </p>
+        </Section>
 
-            <p className="mt-2">
-              <Link to={paths.companyPermissionsPath()}>View permission breakdown</Link>
-            </p>
-          </Paper.Section>
+        <CompanyAdmins />
+        <CompanyOwners />
 
-          <CompanyAdmins />
-          <CompanyOwners />
-
-          <AdminsMenu />
-          <OwnersMenu />
-          <DangerZone />
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
+        <AdminsMenu />
+        <OwnersMenu />
+        <DangerZone />
+      </div>
+    </TurboUIPage>
   );
 }
 
@@ -69,15 +78,25 @@ function AdminsMenu() {
   const restorePath = paths.companyAdminRestoreSuspendedPeoplePath();
 
   return (
-    <Paper.Section title="As an admin or owner, you can:">
+    <Section title="As an admin or owner, you can:">
       <div>
         <OptionsMenuItem linkTo={managePeople} icon={IconUsers} title="Manage team members" />
 
         <OptionsMenuItem linkTo={restorePath} icon={IconUser} title="Restore access for deactivated team members" />
-        <OptionsMenuItem hidden={!window.appConfig.billingEnabled || !company.permissions?.canManageBilling} linkTo={manageBilling} icon={IconFileText} title="Manage plan" />
-        <OptionsMenuItem hidden={!company.permissions?.canEditDetails} linkTo={renameCompanyPath} icon={IconLetterCase} title="Rename the company" />
+        <OptionsMenuItem
+          hidden={!window.appConfig.billingEnabled || !company.permissions?.canManageBilling}
+          linkTo={manageBilling}
+          icon={IconFileText}
+          title="Manage plan"
+        />
+        <OptionsMenuItem
+          hidden={!company.permissions?.canEditDetails}
+          linkTo={renameCompanyPath}
+          icon={IconLetterCase}
+          title="Rename the company"
+        />
       </div>
-    </Paper.Section>
+    </Section>
   );
 }
 
@@ -98,12 +117,17 @@ function OwnersMenu() {
   const exportCompany = paths.companyExportPath();
 
   return (
-    <Paper.Section title="As an owner, you can:">
+    <Section title="As an owner, you can:">
       <div>
         <OptionsMenuItem linkTo={manageAdmins} icon={IconShieldLock} title="Manage administrators and owners" />
-        <OptionsMenuItem hidden={!company.permissions?.canEditTrustedEmailDomains} linkTo={manageTrustedDomains} icon={IconLock} title="Manage trusted email domains" />
+        <OptionsMenuItem
+          hidden={!company.permissions?.canEditTrustedEmailDomains}
+          linkTo={manageTrustedDomains}
+          icon={IconLock}
+          title="Manage trusted email domains"
+        />
         <OptionsMenuItem linkTo={exportCompany} icon={IconFileExport} title="Export company data" />
       </div>
-    </Paper.Section>
+    </Section>
   );
 }

--- a/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
@@ -1,11 +1,10 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as Billing from "@/models/billing";
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as React from "react";
 
-import { BillingLimitGuidanceNotice, BlackLink, InfoCallout, Link, SecondaryButton, showErrorToast } from "turboui";
+import { BillingLimitGuidanceNotice, BlackLink, InfoCallout, Link, SecondaryButton, showErrorToast, Page as TurboUIPage } from "turboui";
 import { PageModule } from "@/routes/types";
 import { includesId } from "@/routes/paths";
 import { createTestId } from "@/utils/testid";
@@ -40,31 +39,31 @@ function Page() {
   const [limitGuidance, setLimitGuidance] = React.useState<Billing.BillingLimitGuidance | null>(null);
 
   return (
-    <Pages.Page title={["Restore Deactivated Team Members", company.name!]} testId="restore-suspended-people-page">
-      <>
-        <Paper.Root size="medium">
-          <Navigation />
+    <>
+      <TurboUIPage
+        title={["Restore Deactivated Team Members", company.name!]}
+        size="medium"
+        testId="restore-suspended-people-page"
+        navigation={[{ to: paths.companyAdminPath(), label: "Company Administration" }]}
+      >
+        <div className="px-12 py-10">
+          <div className="mb-6">
+            <div className="text-content-accent text-lg md:text-2xl font-extrabold">Restore Deactivated Team Members</div>
+          </div>
 
-          <Paper.Body>
-            <Paper.Header title="Restore Deactivated Team Members" />
+          {suspendedPeople.length === 0 ? (
+            <NoSuspenedPeopleMessage />
+          ) : (
+            <SuspendedPeopleList onLimitError={setLimitGuidance} viewerRole={viewerRole} paths={paths} />
+          )}
+        </div>
+      </TurboUIPage>
 
-            {suspendedPeople.length === 0 ? (
-              <NoSuspenedPeopleMessage />
-            ) : (
-              <SuspendedPeopleList onLimitError={setLimitGuidance} viewerRole={viewerRole} paths={paths} />
-            )}
-          </Paper.Body>
-        </Paper.Root>
-
-        {limitGuidance && <BillingLimitGuidanceNotice isOpen={true} onClose={() => setLimitGuidance(null)} guidance={limitGuidance} />}
-      </>
-    </Pages.Page>
+      {limitGuidance && (
+        <BillingLimitGuidanceNotice isOpen={true} onClose={() => setLimitGuidance(null)} guidance={limitGuidance} />
+      )}
+    </>
   );
-}
-
-function Navigation() {
-  const paths = usePaths();
-  return <Paper.Navigation items={[{ to: paths.companyAdminPath(), label: "Company Administration" }]} />;
 }
 
 function NoSuspenedPeopleMessage() {

--- a/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
+++ b/app/assets/js/pages/CompanyAdminRestoreSuspendedPeoplePage/index.tsx
@@ -4,7 +4,15 @@ import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as React from "react";
 
-import { BillingLimitGuidanceNotice, BlackLink, InfoCallout, Link, SecondaryButton, showErrorToast, Page as TurboUIPage } from "turboui";
+import {
+  BillingLimitGuidanceNotice,
+  BlackLink,
+  InfoCallout,
+  Link,
+  SecondaryButton,
+  showErrorToast,
+  Page as TurboUIPage,
+} from "turboui";
 import { PageModule } from "@/routes/types";
 import { includesId } from "@/routes/paths";
 import { createTestId } from "@/utils/testid";
@@ -48,7 +56,9 @@ function Page() {
       >
         <div className="px-12 py-10">
           <div className="mb-6">
-            <div className="text-content-accent text-lg md:text-2xl font-extrabold">Restore Deactivated Team Members</div>
+            <div className="text-content-accent text-lg md:text-2xl font-extrabold">
+              Restore Deactivated Team Members
+            </div>
           </div>
 
           {suspendedPeople.length === 0 ? (
@@ -76,8 +86,8 @@ function NoSuspenedPeopleMessage() {
         message={`No deactivated team members`}
         description={
           <p>
-            There are no deactivated team members in {company.name}. To remove access for departing team members, visit the{" "}
-            <Link to={paths.companyManagePeoplePath()}>Manage Team Members</Link> page.
+            There are no deactivated team members in {company.name}. To remove access for departing team members, visit
+            the <Link to={paths.companyManagePeoplePath()}>Manage Team Members</Link> page.
           </p>
         }
       />

--- a/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
+++ b/app/assets/js/pages/CompanyAdminTrustedEmailDomainsPage/page.tsx
@@ -1,8 +1,6 @@
-import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as React from "react";
 
-import { Forms, GhostButton, IconTrash } from "turboui";
+import { Forms, GhostButton, IconTrash, Page as TurboUIPage } from "turboui";
 
 import { createTestId } from "@/utils/testid";
 import { useLoadedData } from "./loader";
@@ -15,25 +13,25 @@ export function Page() {
   const form = useForm({ company });
 
   return (
-    <Pages.Page title={["Trusted Email Domains", company.name!]}>
-      <Paper.Root size="small">
-        <Paper.Navigation items={[{ to: paths.companyAdminPath(), label: "Company Administration" }]} />
+    <TurboUIPage
+      title={["Trusted Email Domains", company.name!]}
+      size="small"
+      navigation={[{ to: paths.companyAdminPath(), label: "Company Administration" }]}
+    >
+      <div className="px-10 py-8">
+        <div className="text-content-accent text-3xl font-extrabold">Trusted Email Domains</div>
 
-        <Paper.Body minHeight="none">
-          <div className="text-content-accent text-3xl font-extrabold">Trusted Email Domains</div>
+        <div className="text-content-accent font-bold mt-8 text-lg">What's this?</div>
+        <p>
+          Trusted email domains are email domains that are allowed to sign up for an account in this company. If a user
+          signs up with an email address that is not from a trusted domain, and she wasn't manually added by an admin,
+          they will be denied access.
+        </p>
 
-          <div className="text-content-accent font-bold mt-8 text-lg">What's this?</div>
-          <p>
-            Trusted email domains are email domains that are allowed to sign up for an account in this company. If a
-            user signs up with an email address that is not from a trusted domain, and she wasn't manually added by an
-            admin, they will be denied access.
-          </p>
-
-          <div className="text-content-accent font-bold mt-8 text-lg mb-2">Trusted Email Domains</div>
-          <TrustedEmailDomainsList form={form} />
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
+        <div className="text-content-accent font-bold mt-8 text-lg mb-2">Trusted Email Domains</div>
+        <TrustedEmailDomainsList form={form} />
+      </div>
+    </TurboUIPage>
   );
 }
 

--- a/app/assets/js/pages/CompanyPermissionsPage/index.tsx
+++ b/app/assets/js/pages/CompanyPermissionsPage/index.tsx
@@ -1,7 +1,6 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import { PageModule } from "@/routes/types";
-import { IconCheck, IconX } from "turboui";
+import { IconCheck, IconX, Page as TurboUIPage } from "turboui";
 import * as React from "react";
 
 import { usePaths } from "@/routes/paths";
@@ -10,28 +9,30 @@ export default { name: "CompanyPermissionsPage", loader: Pages.emptyLoader, Page
 function Page() {
   const paths = usePaths();
   return (
-    <Pages.Page title="Permissions">
-      <Paper.Root size="small">
-        <Paper.NavigateBack to={paths.companyAdminPath()} title="Back to Company Admin" />
+    <TurboUIPage
+      title="Permissions"
+      size="small"
+      navigation={[{ to: paths.companyAdminPath(), label: "Company Administration" }]}
+    >
+      <div className="px-10 py-8">
         <div className="font-extrabold text-2xl mb-4 text-center">Permission Breakdown</div>
-        <Paper.Body>
-          <Header />
 
-          <Row permission="Add spaces" members={true} admins={true} owners={true} />
-          <Row permission="Add goals" members={true} admins={true} owners={true} />
-          <Row permission="Add projects" members={true} admins={true} owners={true} />
+        <Header />
 
-          <Row permission="Invite people" members={false} admins={true} owners={true} />
-          <Row permission="Remove people" members={false} admins={true} owners={true} />
-          <Row permission="Update profiles" members={false} admins={true} owners={true} />
+        <Row permission="Add spaces" members={true} admins={true} owners={true} />
+        <Row permission="Add goals" members={true} admins={true} owners={true} />
+        <Row permission="Add projects" members={true} admins={true} owners={true} />
 
-          <Row permission="Add/Remove admins" members={false} admins={false} owners={true} />
-          <Row permission="Add/Remove owners" members={false} admins={false} owners={true} />
-          <Row permission="Manage trusted email domains" members={false} admins={false} owners={true} />
-          <Row permission="Access any resource" members={false} admins={false} owners={true} />
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
+        <Row permission="Invite people" members={false} admins={true} owners={true} />
+        <Row permission="Remove people" members={false} admins={true} owners={true} />
+        <Row permission="Update profiles" members={false} admins={true} owners={true} />
+
+        <Row permission="Add/Remove admins" members={false} admins={false} owners={true} />
+        <Row permission="Add/Remove owners" members={false} admins={false} owners={true} />
+        <Row permission="Manage trusted email domains" members={false} admins={false} owners={true} />
+        <Row permission="Access any resource" members={false} admins={false} owners={true} />
+      </div>
+    </TurboUIPage>
   );
 }
 

--- a/app/assets/js/pages/CompanyRenamePage/index.tsx
+++ b/app/assets/js/pages/CompanyRenamePage/index.tsx
@@ -1,9 +1,8 @@
 import * as Pages from "@/components/Pages";
-import * as Paper from "@/components/PaperContainer";
 import * as Companies from "@/models/companies";
 import * as React from "react";
 
-import { Forms } from "turboui";
+import { Forms, Page as TurboUIPage } from "turboui";
 import { PageModule } from "@/routes/types";
 import { useNavigate, useRevalidator } from "react-router";
 
@@ -41,22 +40,23 @@ function Page() {
   });
 
   return (
-    <Pages.Page title={"Rename Company"} testId="company-rename-page">
-      <Paper.Root size="small">
-        <Paper.NavigateBack to={paths.companyAdminPath()} title="Back to Company Admin" />
+    <TurboUIPage
+      title={"Rename Company"}
+      size="small"
+      testId="company-rename-page"
+      navigation={[{ to: paths.companyAdminPath(), label: "Company Administration" }]}
+    >
+      <div className="px-10 py-8">
+        <Forms.Form form={form}>
+          <div className="mb-6 text-content-accent text-2xl font-extrabold">Editing Company Name</div>
 
-        <Paper.Body>
-          <Forms.Form form={form}>
-            <div className="mb-6 text-content-accent text-2xl font-extrabold">Editing Company Name</div>
+          <Forms.FieldGroup>
+            <Forms.TextInput label="Company Name" field={"name"} minLength={2} maxLength={100} />
+          </Forms.FieldGroup>
 
-            <Forms.FieldGroup>
-              <Forms.TextInput label="Company Name" field={"name"} minLength={2} maxLength={100} />
-            </Forms.FieldGroup>
-
-            <Forms.Submit saveText="Save" />
-          </Forms.Form>
-        </Paper.Body>
-      </Paper.Root>
-    </Pages.Page>
+          <Forms.Submit saveText="Save" />
+        </Forms.Form>
+      </div>
+    </TurboUIPage>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the Account / company admin batch of legacy page shells (`Pages.Page` + `PaperContainer`) to TurboUI `Page` (Pattern B), per the Page Shell → TurboUI migration plan.

### Pages migrated

- `AccountAppearancePage`
- `AccountChangePasswordPage`
- `CompanyAdminPage` (local `Section` helper; inlined `NavigationBackToLobby`)
- `CompanyAdminManageAdminsPage`
- `CompanyAdminRestoreSuspendedPeoplePage`
- `CompanyAdminTrustedEmailDomainsPage`
- `CompanyPermissionsPage`
- `CompanyRenamePage`

### Approach

- Replace `Pages.Page` + `Paper.Root` / `Paper.Body` with `<Page title size navigation testId>` from `turboui`
- Pass `{ to, label }[]` navigation from `usePaths()`
- Preserve body spacing with padded content wrappers (`px-10 py-8` for small, `px-12 py-10` for medium)
- Keep loader hooks via `@/components/Pages` where needed (`emptyLoader`, `useLoadedData`, `useRefresh`)
- Replace `Paper.Section` with local section markup matching existing styles/test ids

## Test plan

- [x] Local `npx tsc --noEmit -p tsconfig.lint.json` (passes)
- [x] Prettier check on changed files
- [ ] CI build & test
- [ ] Smoke account appearance + change password pages
- [ ] Smoke company admin flows (manage admins, restore people, trusted domains, permissions, rename)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9680e719-409d-4dc0-a23a-76979f5bb36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9680e719-409d-4dc0-a23a-76979f5bb36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

