### PR TITLE
chore: Show Docs & Files counts on project and goal tabs

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1632,6 +1632,12 @@ export interface GoalCheckUpdate {
   index: number;
 }
 
+export interface GoalChildrenCount {
+  discussionsCount: number;
+  checkInsCount: number;
+  docsAndFilesCount: number;
+}
+
 export interface GoalDiscussion {
   __typename: "goal_discussion";
   id: Id;
@@ -1898,6 +1904,7 @@ export interface ProjectChildrenCount {
   tasksCount: number;
   discussionsCount: number;
   checkInsCount: number;
+  docsAndFilesCount: number;
 }
 
 export interface ProjectContributor {
@@ -2578,9 +2585,7 @@ export type ActivityContent =
   | ActivityContentTaskUpdate;
 
 export type ActivityDataUnion =
-  | ActivityEventDataProjectCreate
-  | ActivityEventDataMilestoneCreate
-  | ActivityEventDataCommentPost;
+  ActivityEventDataProjectCreate | ActivityEventDataMilestoneCreate | ActivityEventDataCommentPost;
 
 export type ActivityResourceUnion = Project | Update | Milestone | Comment;
 
@@ -2604,13 +2609,7 @@ export type UpdateContent =
   | UpdateContentMessage;
 
 export type AccessOptions =
-  | "no_access"
-  | "minimal_access"
-  | "view_access"
-  | "comment_access"
-  | "edit_access"
-  | "admin_access"
-  | "full_access";
+  "no_access" | "minimal_access" | "view_access" | "comment_access" | "edit_access" | "admin_access" | "full_access";
 
 export type AccountTheme = "dark" | "light" | "system";
 
@@ -2655,14 +2654,7 @@ export type GoalCheckInStatus = "on_track" | "caution" | "off_track";
 export type GoalPrivacyValues = "public" | "internal" | "confidential" | "secret";
 
 export type GoalStatus =
-  | "on_track"
-  | "achieved"
-  | "missed"
-  | "paused"
-  | "caution"
-  | "off_track"
-  | "pending"
-  | "outdated";
+  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
 
 export type MilestoneCommentAction = "none" | "complete" | "reopen";
 
@@ -2703,15 +2695,7 @@ export type ReactionParentType =
 export type ResourceAccessTypes = "space" | "goal" | "project";
 
 export type ResourceHubLinkType =
-  | "airtable"
-  | "dropbox"
-  | "figma"
-  | "google"
-  | "google_doc"
-  | "google_sheet"
-  | "google_slides"
-  | "notion"
-  | "other";
+  "airtable" | "dropbox" | "figma" | "google" | "google_doc" | "google_sheet" | "google_slides" | "notion" | "other";
 
 export type ReviewAssignmentDueStatus = "overdue" | "due_today" | "due_soon" | "upcoming" | "none";
 
@@ -2731,10 +2715,7 @@ export type ReviewAssignmentTypes =
 export type SearchMatchedField = "title" | "name" | "content" | "description";
 
 export type SearchResultType =
-  | "resource_hub_folder"
-  | "resource_hub_document"
-  | "resource_hub_file"
-  | "resource_hub_link";
+  "resource_hub_folder" | "resource_hub_document" | "resource_hub_file" | "resource_hub_link";
 
 export type SearchScopeOptions = "company" | "project" | "space" | "goal" | "resource_hub" | "none";
 
@@ -2765,14 +2746,7 @@ export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secre
 export type WorkMapItemState = "active" | "paused" | "closed";
 
 export type WorkMapItemStatus =
-  | "on_track"
-  | "achieved"
-  | "missed"
-  | "paused"
-  | "caution"
-  | "off_track"
-  | "pending"
-  | "outdated";
+  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
 
 export type WorkMapItemType = "project" | "goal";
 
@@ -3013,6 +2987,14 @@ export interface GetThemeInput {}
 
 export interface GetThemeResult {
   theme: AccountTheme;
+}
+
+export interface GoalsCountChildrenInput {
+  id: Id;
+}
+
+export interface GoalsCountChildrenResult {
+  childrenCount: GoalChildrenCount;
 }
 
 export interface GoalsGetInput {
@@ -6518,6 +6500,10 @@ class ApiNamespaceProjects {
 class ApiNamespaceGoals {
   constructor(private client: ApiClient) {}
 
+  async countChildren(input: GoalsCountChildrenInput): Promise<GoalsCountChildrenResult> {
+    return this.client.get("/goals/count_children", input);
+  }
+
   async get(input: GoalsGetInput): Promise<GoalsGetResult> {
     return this.client.get("/goals/get", input);
   }
@@ -8285,6 +8271,10 @@ export default {
     listDiscussions: (input: GoalsListDiscussionsInput) => defaultApiClient.apiNamespaceGoals.listDiscussions(input),
     useListDiscussions: (input: GoalsListDiscussionsInput) =>
       useQuery<GoalsListDiscussionsResult>(() => defaultApiClient.apiNamespaceGoals.listDiscussions(input)),
+
+    countChildren: (input: GoalsCountChildrenInput) => defaultApiClient.apiNamespaceGoals.countChildren(input),
+    useCountChildren: (input: GoalsCountChildrenInput) =>
+      useQuery<GoalsCountChildrenResult>(() => defaultApiClient.apiNamespaceGoals.countChildren(input)),
 
     updateName: (input: GoalsUpdateNameInput) => defaultApiClient.apiNamespaceGoals.updateName(input),
     useUpdateName: () =>

--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -2585,7 +2585,9 @@ export type ActivityContent =
   | ActivityContentTaskUpdate;
 
 export type ActivityDataUnion =
-  ActivityEventDataProjectCreate | ActivityEventDataMilestoneCreate | ActivityEventDataCommentPost;
+  | ActivityEventDataProjectCreate
+  | ActivityEventDataMilestoneCreate
+  | ActivityEventDataCommentPost;
 
 export type ActivityResourceUnion = Project | Update | Milestone | Comment;
 
@@ -2609,7 +2611,13 @@ export type UpdateContent =
   | UpdateContentMessage;
 
 export type AccessOptions =
-  "no_access" | "minimal_access" | "view_access" | "comment_access" | "edit_access" | "admin_access" | "full_access";
+  | "no_access"
+  | "minimal_access"
+  | "view_access"
+  | "comment_access"
+  | "edit_access"
+  | "admin_access"
+  | "full_access";
 
 export type AccountTheme = "dark" | "light" | "system";
 
@@ -2654,7 +2662,14 @@ export type GoalCheckInStatus = "on_track" | "caution" | "off_track";
 export type GoalPrivacyValues = "public" | "internal" | "confidential" | "secret";
 
 export type GoalStatus =
-  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
+  | "on_track"
+  | "achieved"
+  | "missed"
+  | "paused"
+  | "caution"
+  | "off_track"
+  | "pending"
+  | "outdated";
 
 export type MilestoneCommentAction = "none" | "complete" | "reopen";
 
@@ -2695,7 +2710,15 @@ export type ReactionParentType =
 export type ResourceAccessTypes = "space" | "goal" | "project";
 
 export type ResourceHubLinkType =
-  "airtable" | "dropbox" | "figma" | "google" | "google_doc" | "google_sheet" | "google_slides" | "notion" | "other";
+  | "airtable"
+  | "dropbox"
+  | "figma"
+  | "google"
+  | "google_doc"
+  | "google_sheet"
+  | "google_slides"
+  | "notion"
+  | "other";
 
 export type ReviewAssignmentDueStatus = "overdue" | "due_today" | "due_soon" | "upcoming" | "none";
 
@@ -2715,7 +2738,10 @@ export type ReviewAssignmentTypes =
 export type SearchMatchedField = "title" | "name" | "content" | "description";
 
 export type SearchResultType =
-  "resource_hub_folder" | "resource_hub_document" | "resource_hub_file" | "resource_hub_link";
+  | "resource_hub_folder"
+  | "resource_hub_document"
+  | "resource_hub_file"
+  | "resource_hub_link";
 
 export type SearchScopeOptions = "company" | "project" | "space" | "goal" | "resource_hub" | "none";
 
@@ -2746,7 +2772,14 @@ export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secre
 export type WorkMapItemState = "active" | "paused" | "closed";
 
 export type WorkMapItemStatus =
-  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
+  | "on_track"
+  | "achieved"
+  | "missed"
+  | "paused"
+  | "caution"
+  | "off_track"
+  | "pending"
+  | "outdated";
 
 export type WorkMapItemType = "project" | "goal";
 

--- a/app/assets/js/pages/GoalPage/index.tsx
+++ b/app/assets/js/pages/GoalPage/index.tsx
@@ -1,4 +1,4 @@
-import Api, { GoalDiscussion, GoalProgressUpdate, GoalRetrospective } from "@/api";
+import Api, { GoalChildrenCount, GoalDiscussion, GoalProgressUpdate, GoalRetrospective } from "@/api";
 import * as Companies from "@/models/companies";
 import * as Goals from "@/models/goals";
 import { PageModule } from "@/routes/types";
@@ -42,7 +42,7 @@ import { useChecklists } from "./useChecklists";
 export default { name: "GoalPage", loader, Page } as PageModule;
 
 export function pageCacheKey(id: string): string {
-  return `v32-GoalPage.goal-${id}`;
+  return `v33-GoalPage.goal-${id}`;
 }
 
 type GoalDocsAndFilesData = {
@@ -58,6 +58,7 @@ type LoaderResult = {
     checkIns: GoalProgressUpdate[];
     checklist: Goals.Check[];
     discussions: GoalDiscussion[];
+    childrenCount: GoalChildrenCount;
     docsAndFiles: GoalDocsAndFilesData | null;
   };
 
@@ -87,6 +88,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
         workMap: getWorkMap({ parentGoalId: params.id, includeAssignees: true }).then((d) => d.workMap),
         checkIns: Api.goals.listCheckIns({ goalId: params.id }).then((d) => d.checkIns),
         discussions: Api.goals.listDiscussions({ goalId: params.id }).then((d) => d.discussions),
+        childrenCount: Api.goals.countChildren({ id: params.id }).then((d) => d.childrenCount),
       });
 
       return {
@@ -137,7 +139,7 @@ function Page() {
   const navigate = useNavigate();
   const { company } = useCompanyLoaderData();
   const { data, refresh } = PageCache.useData(loader);
-  const { goal, workMap, checkIns, discussions, docsAndFiles } = data;
+  const { goal, workMap, checkIns, discussions, childrenCount, docsAndFiles } = data;
   const currentUser = useMe();
 
   assertPresent(goal.privacy);
@@ -327,6 +329,7 @@ function Page() {
     targets,
     checkIns: prepareCheckIns(paths, checkIns),
     discussions: prepareDiscussions(paths, discussions),
+    childrenCount,
     docsAndFiles: goalDocsAndFilesProps,
     contributors: [],
     relatedWorkItems: prepareWorkMapData(workMap),

--- a/app/assets/js/pages/MilestonePage/index.tsx
+++ b/app/assets/js/pages/MilestonePage/index.tsx
@@ -72,7 +72,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
 }
 
 function pageCacheKey(id: string): string {
-  return `v12-MilestoneV2Page.task-${id}`;
+  return `v13-MilestoneV2Page.task-${id}`;
 }
 
 function Page() {

--- a/app/assets/js/pages/ProjectPage/index.tsx
+++ b/app/assets/js/pages/ProjectPage/index.tsx
@@ -39,7 +39,7 @@ export default { name: "ProjectPage", loader, Page } as PageModule;
 export { pageCacheKey as projectPageCacheKey };
 
 function pageCacheKey(id: string): string {
-  return `v7-ProjectV2Page.project-${id}`;
+  return `v8-ProjectV2Page.project-${id}`;
 }
 
 type ProjectDocsAndFilesData = {

--- a/app/assets/js/pages/TaskPage/index.tsx
+++ b/app/assets/js/pages/TaskPage/index.tsx
@@ -76,7 +76,7 @@ async function loader({ params, refreshCache = false }): Promise<LoaderResult> {
 export default { name: "TaskPage", loader, Page } as PageModule;
 
 function pageCacheKey(id: string): string {
-  return `v8-TaskV2Page.task-${id}`;
+  return `v9-TaskV2Page.task-${id}`;
 }
 
 function Page() {
@@ -303,7 +303,7 @@ interface usePageFieldProps<T> {
   pageData: { data: any; cacheVersion: number };
   value: (data: {
     task: Tasks.Task;
-    childrenCount: { tasksCount: number; discussionsCount: number };
+    childrenCount: { tasksCount: number; discussionsCount: number; checkInsCount: number; docsAndFilesCount: number };
     activities: Activities.Activity[];
   }) => T;
   update: (newValue: T) => Promise<any>;

--- a/app/lib/operately/resource_hubs.ex
+++ b/app/lib/operately/resource_hubs.ex
@@ -166,6 +166,39 @@ defmodule Operately.ResourceHubs do
     |> Repo.aggregate(:count, :id)
   end
 
+  @doc """
+  Counts documents, files, and links in the parent's resource hub that are
+  visible to the viewer. Folders are excluded. Draft documents are counted
+  only for their author, matching list visibility.
+  """
+  def count_visible_docs_and_files(%Project{id: project_id}, viewer) do
+    visible_docs_and_files_query()
+    |> where([_n, hub], hub.project_id == ^project_id)
+    |> where_visible_to(viewer.id)
+    |> Repo.aggregate(:count)
+  end
+
+  def count_visible_docs_and_files(%Goal{id: goal_id}, viewer) do
+    visible_docs_and_files_query()
+    |> where([_n, hub], hub.goal_id == ^goal_id)
+    |> where_visible_to(viewer.id)
+    |> Repo.aggregate(:count)
+  end
+
+  defp visible_docs_and_files_query do
+    from(n in Node,
+      join: hub in assoc(n, :resource_hub),
+      left_join: document in assoc(n, :document),
+      where: n.type != :folder
+    )
+  end
+
+  defp where_visible_to(query, viewer_id) do
+    from([n, _hub, document] in query,
+      where: n.type != :document or document.state == :published or document.author_id == ^viewer_id
+    )
+  end
+
   def create_node(attrs \\ %{}) do
     %Node{}
     |> Node.changeset(attrs)

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -15,6 +15,7 @@ defmodule OperatelyWeb.Api do
         query(:search_parent_goal, OperatelyWeb.Api.Goals.SearchParentGoal)
         query(:get_check_in, OperatelyWeb.Api.Goals.GetCheckIn)
         query(:list_discussions, OperatelyWeb.Api.Goals.ListDiscussions)
+        query(:count_children, OperatelyWeb.Api.Goals.CountChildren)
 
         mutation(:create, OperatelyWeb.Api.Goals.Create)
         mutation(:change_parent, OperatelyWeb.Api.Goals.ChangeParent)

--- a/app/lib/operately_web/api/goals.ex
+++ b/app/lib/operately_web/api/goals.ex
@@ -675,8 +675,46 @@ defmodule OperatelyWeb.Api.Goals do
     end
   end
 
+  defmodule CountChildren do
+    @moduledoc """
+    Counts discussions, check-ins, and docs & files for a goal.
+    """
+
+    use TurboConnect.Query
+
+    inputs do
+      field :id, :id, null: false
+    end
+
+    outputs do
+      field :children_count, :goal_children_count, null: false
+    end
+
+    def call(conn, inputs) do
+      conn
+      |> Steps.start_transaction()
+      |> Steps.find_goal(inputs.id)
+      |> Steps.check_permissions(:can_view)
+      |> Steps.count_discussions()
+      |> Steps.count_check_ins()
+      |> Steps.count_docs_and_files()
+      |> Steps.commit()
+      |> Steps.respond(fn changes ->
+        %{
+          children_count: %{
+            discussions_count: changes.discussions_count,
+            check_ins_count: changes.check_ins_count,
+            docs_and_files_count: changes.docs_and_files_count
+          }
+        }
+      end)
+    end
+  end
+
   defmodule SharedMultiSteps do
     require Logger
+    import Ecto.Query, only: [from: 2]
+    alias Operately.Repo
 
     def start_transaction(conn) do
       Ecto.Multi.new()
@@ -699,6 +737,42 @@ defmodule OperatelyWeb.Api.Goals do
     def check_permissions(multi, permission) do
       Ecto.Multi.run(multi, :permissions, fn _repo, %{goal: goal, company_read_only: company_read_only} ->
         Operately.Goals.Permissions.check(goal.request_info.access_level, permission, company_read_only: company_read_only)
+      end)
+    end
+
+    def count_discussions(multi) do
+      Ecto.Multi.run(multi, :discussions_count, fn _repo, %{goal: goal} ->
+        count =
+          from(activity in Operately.Activities.Activity,
+            where: activity.action == "goal_discussion_creation",
+            where: activity.content["goal_id"] == ^goal.id
+          )
+          |> Repo.aggregate(:count)
+
+        {:ok, count}
+      end)
+    end
+
+    def count_check_ins(multi) do
+      Ecto.Multi.run(multi, :check_ins_count, fn _repo, %{goal: goal} ->
+        count =
+          from(u in Operately.Goals.Update, where: u.goal_id == ^goal.id)
+          |> Repo.aggregate(:count)
+
+        {:ok, count}
+      end)
+    end
+
+    def count_docs_and_files(multi) do
+      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{goal: goal} ->
+        count =
+          from(n in Operately.ResourceHubs.Node,
+            join: hub in assoc(n, :resource_hub),
+            where: hub.goal_id == ^goal.id and n.type != :folder
+          )
+          |> Repo.aggregate(:count)
+
+        {:ok, count}
       end)
     end
 

--- a/app/lib/operately_web/api/goals.ex
+++ b/app/lib/operately_web/api/goals.ex
@@ -764,15 +764,8 @@ defmodule OperatelyWeb.Api.Goals do
     end
 
     def count_docs_and_files(multi) do
-      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{goal: goal} ->
-        count =
-          from(n in Operately.ResourceHubs.Node,
-            join: hub in assoc(n, :resource_hub),
-            where: hub.goal_id == ^goal.id and n.type != :folder
-          )
-          |> Repo.aggregate(:count)
-
-        {:ok, count}
+      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{goal: goal, me: me} ->
+        {:ok, Operately.ResourceHubs.count_visible_docs_and_files(goal, me)}
       end)
     end
 

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -718,15 +718,8 @@ defmodule OperatelyWeb.Api.Projects do
     end
 
     def count_docs_and_files(multi) do
-      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{project: project} ->
-        count =
-          from(n in Operately.ResourceHubs.Node,
-            join: hub in assoc(n, :resource_hub),
-            where: hub.project_id == ^project.id and n.type != :folder
-          )
-          |> Repo.aggregate(:count)
-
-        {:ok, count}
+      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{project: project, me: me} ->
+        {:ok, Operately.ResourceHubs.count_visible_docs_and_files(project, me)}
       end)
     end
 

--- a/app/lib/operately_web/api/projects.ex
+++ b/app/lib/operately_web/api/projects.ex
@@ -512,7 +512,7 @@ defmodule OperatelyWeb.Api.Projects do
 
   defmodule CountChildren do
     @moduledoc """
-    Counts discussions, tasks, and check-ins for a project.
+    Counts discussions, tasks, check-ins, and docs & files for a project.
     """
 
     use TurboConnect.Query
@@ -535,13 +535,15 @@ defmodule OperatelyWeb.Api.Projects do
       |> Steps.count_discussions()
       |> Steps.count_open_tasks()
       |> Steps.count_check_ins()
+      |> Steps.count_docs_and_files()
       |> Steps.commit()
       |> Steps.respond(fn changes ->
         %{
           children_count: %{
             discussions_count: changes.discussions_count,
             tasks_count: changes.open_tasks_count,
-            check_ins_count: changes.check_ins_count
+            check_ins_count: changes.check_ins_count,
+            docs_and_files_count: changes.docs_and_files_count
           },
         }
       end)
@@ -709,6 +711,19 @@ defmodule OperatelyWeb.Api.Projects do
       Ecto.Multi.run(multi, :check_ins_count, fn _repo, %{project: project} ->
         count =
           from(c in Operately.Projects.CheckIn, where: c.project_id == ^project.id)
+          |> Repo.aggregate(:count)
+
+        {:ok, count}
+      end)
+    end
+
+    def count_docs_and_files(multi) do
+      Ecto.Multi.run(multi, :docs_and_files_count, fn _repo, %{project: project} ->
+        count =
+          from(n in Operately.ResourceHubs.Node,
+            join: hub in assoc(n, :resource_hub),
+            where: hub.project_id == ^project.id and n.type != :folder
+          )
           |> Repo.aggregate(:count)
 
         {:ok, count}

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -727,6 +727,13 @@ defmodule OperatelyWeb.Api.Types do
     field :tasks_count, :integer
     field :discussions_count, :integer
     field :check_ins_count, :integer
+    field :docs_and_files_count, :integer
+  end
+
+  object :goal_children_count do
+    field :discussions_count, :integer
+    field :check_ins_count, :integer
+    field :docs_and_files_count, :integer
   end
 
   object :project_retrospective, for: Operately.Projects.Retrospective do

--- a/app/test/operately/resource_hubs_test.exs
+++ b/app/test/operately/resource_hubs_test.exs
@@ -1,0 +1,73 @@
+defmodule Operately.ResourceHubsTest do
+  use Operately.DataCase
+
+  alias Operately.ResourceHubs
+
+  describe "count_visible_docs_and_files/2" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_space_member(:other_member, :space)
+      |> Factory.add_project(:project, :space)
+      |> Factory.add_goal(:goal, :space)
+      |> Factory.fetch_default_project_resource_hub(:project_hub, :project)
+      |> Factory.fetch_default_goal_resource_hub(:goal_hub, :goal)
+      |> then(&{:ok, &1})
+    end
+
+    test "counts published docs, files, and links and excludes folders for a project", ctx do
+      ctx =
+        ctx
+        |> Factory.add_folder(:folder, :project_hub)
+        |> Factory.add_document(:doc, :project_hub)
+        |> Factory.add_file(:file, :project_hub)
+        |> Factory.add_link(:link, :project_hub)
+        |> Factory.add_document(:nested_doc, :project_hub, folder: :folder)
+
+      assert ResourceHubs.count_visible_docs_and_files(ctx.project, ctx.creator) == 4
+    end
+
+    test "counts published docs, files, and links and excludes folders for a goal", ctx do
+      ctx =
+        ctx
+        |> Factory.add_folder(:folder, :goal_hub)
+        |> Factory.add_document(:doc, :goal_hub)
+        |> Factory.add_file(:file, :goal_hub)
+        |> Factory.add_link(:link, :goal_hub)
+        |> Factory.add_document(:nested_doc, :goal_hub, folder: :folder)
+
+      assert ResourceHubs.count_visible_docs_and_files(ctx.goal, ctx.creator) == 4
+    end
+
+    test "includes the viewer's own draft documents", ctx do
+      ctx =
+        ctx
+        |> Factory.add_document(:published, :project_hub)
+        |> Factory.add_document(:own_draft, :project_hub, state: :draft)
+
+      assert ResourceHubs.count_visible_docs_and_files(ctx.project, ctx.creator) == 2
+    end
+
+    test "excludes draft documents authored by someone else", ctx do
+      ctx =
+        ctx
+        |> Factory.add_document(:published, :project_hub)
+        |> Factory.add_document(:own_draft, :project_hub, state: :draft)
+        |> Factory.add_document(:other_draft, :project_hub, author: :other_member, state: :draft)
+
+      assert ResourceHubs.count_visible_docs_and_files(ctx.project, ctx.creator) == 2
+      assert ResourceHubs.count_visible_docs_and_files(ctx.project, ctx.other_member) == 2
+    end
+
+    test "excludes all drafts when the viewer has none", ctx do
+      ctx =
+        ctx
+        |> Factory.add_document(:published, :goal_hub)
+        |> Factory.add_document(:creator_draft, :goal_hub, state: :draft)
+        |> Factory.add_file(:file, :goal_hub)
+
+      assert ResourceHubs.count_visible_docs_and_files(ctx.goal, ctx.other_member) == 2
+    end
+  end
+end

--- a/app/test/operately_web/api/external_queries/queries.ex
+++ b/app/test/operately_web/api/external_queries/queries.ex
@@ -20,6 +20,7 @@ defmodule OperatelyWeb.Api.ExternalQueries.Queries do
       Queries.Goals.List,
       Queries.Goals.GetCheckIn,
       Queries.Goals.ListDiscussions,
+      Queries.Goals.CountChildren,
       Queries.People.GetMe,
       Queries.Projects.GetMilestone,
       Queries.Notifications.List,

--- a/app/test/operately_web/api/external_queries/queries/goals/count_children.ex
+++ b/app/test/operately_web/api/external_queries/queries/goals/count_children.ex
@@ -1,27 +1,26 @@
-defmodule OperatelyWeb.Api.ExternalQueries.Queries.Projects.CountChildren do
+defmodule OperatelyWeb.Api.ExternalQueries.Queries.Goals.CountChildren do
   use Operately.Support.ExternalApi.QuerySpec
 
   alias Operately.Support.Factory
   alias OperatelyWeb.Paths
 
-  def query_name, do: "projects/count_children"
+  def query_name, do: "goals/count_children"
 
   @impl true
   def setup(ctx) do
     ctx
     |> Factory.setup()
     |> Factory.add_space(:space)
-    |> Factory.add_project(:project, :space)
+    |> Factory.add_goal(:goal, :space)
   end
 
   @impl true
   def inputs(ctx) do
-    %{id: Paths.project_id(ctx.project)}
+    %{id: Paths.goal_id(ctx.goal)}
   end
 
   @impl true
   def assert(res, _ctx) do
-    assert res.children_count.tasks_count == 0
     assert res.children_count.discussions_count == 0
     assert res.children_count.check_ins_count == 0
     assert res.children_count.docs_and_files_count == 0

--- a/app/test/operately_web/api/goals_test.exs
+++ b/app/test/operately_web/api/goals_test.exs
@@ -48,6 +48,62 @@ defmodule OperatelyWeb.Api.GoalsTest do
     |> Factory.add_goal(:goal, :marketing)
   end
 
+  describe "count children" do
+    test "it requires authentication", ctx do
+      assert {401, _} = query(ctx.conn, [:goals, :count_children], %{})
+    end
+
+    test "it requires an id", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {400, res} = query(ctx.conn, [:goals, :count_children], %{})
+      assert res.message == "Missing required fields: id"
+    end
+
+    test "it returns 404 if the goal does not exist", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {404, _} = query(ctx.conn, [:goals, :count_children], %{
+        id: Ecto.UUID.generate()
+      })
+    end
+
+    test "it returns counts for goal", ctx do
+      ctx =
+        ctx
+        |> Factory.add_goal_discussion(:discussion1, :goal)
+        |> Factory.add_goal_discussion(:discussion2, :goal)
+        |> Factory.add_goal_update(:check_in1, :goal, :creator)
+        |> Factory.fetch_default_goal_resource_hub(:hub, :goal)
+        |> Factory.add_folder(:folder, :hub)
+        |> Factory.add_document(:doc1, :hub)
+        |> Factory.add_file(:file1, :hub)
+        |> Factory.add_link(:link1, :hub)
+        |> Factory.add_document(:nested_doc, :hub, folder: :folder)
+        |> Factory.log_in_person(:creator)
+
+      assert {200, res} = query(ctx.conn, [:goals, :count_children], %{
+        id: Paths.goal_id(ctx.goal)
+      })
+
+      assert res.children_count.discussions_count == 2
+      assert res.children_count.check_ins_count == 1
+      assert res.children_count.docs_and_files_count == 4
+    end
+
+    test "it returns 0 counts when goal has no children", ctx do
+      ctx = Factory.log_in_person(ctx, :creator)
+
+      assert {200, res} = query(ctx.conn, [:goals, :count_children], %{
+        id: Paths.goal_id(ctx.goal)
+      })
+
+      assert res.children_count.discussions_count == 0
+      assert res.children_count.check_ins_count == 0
+      assert res.children_count.docs_and_files_count == 0
+    end
+  end
+
   describe "update access levels" do
     test "it requires authentication", ctx do
       assert {401, _} = mutation(ctx.conn, [:goals, :update_access_levels], %{})

--- a/app/test/operately_web/api/goals_test.exs
+++ b/app/test/operately_web/api/goals_test.exs
@@ -102,6 +102,31 @@ defmodule OperatelyWeb.Api.GoalsTest do
       assert res.children_count.check_ins_count == 0
       assert res.children_count.docs_and_files_count == 0
     end
+
+    test "it counts own drafts but excludes other people's drafts", ctx do
+      ctx =
+        ctx
+        |> Factory.add_space_member(:other_member, :marketing)
+        |> Factory.fetch_default_goal_resource_hub(:hub, :goal)
+        |> Factory.add_document(:published, :hub)
+        |> Factory.add_document(:own_draft, :hub, state: :draft)
+        |> Factory.add_document(:other_draft, :hub, author: :other_member, state: :draft)
+        |> Factory.log_in_person(:creator)
+
+      assert {200, res} = query(ctx.conn, [:goals, :count_children], %{
+        id: Paths.goal_id(ctx.goal)
+      })
+
+      assert res.children_count.docs_and_files_count == 2
+
+      ctx = Factory.log_in_person(ctx, :other_member)
+
+      assert {200, other_res} = query(ctx.conn, [:goals, :count_children], %{
+        id: Paths.goal_id(ctx.goal)
+      })
+
+      assert other_res.children_count.docs_and_files_count == 2
+    end
   end
 
   describe "update access levels" do

--- a/app/test/operately_web/api/projects_test.exs
+++ b/app/test/operately_web/api/projects_test.exs
@@ -534,6 +534,7 @@ defmodule OperatelyWeb.Api.ProjectsTest do
       assert res.children_count.discussions_count == 2
       assert res.children_count.tasks_count == 2
       assert res.children_count.check_ins_count == 0
+      assert res.children_count.docs_and_files_count == 0
     end
 
     test "it returns 0 counts when project has no children", ctx do
@@ -546,6 +547,7 @@ defmodule OperatelyWeb.Api.ProjectsTest do
       assert res.children_count.discussions_count == 0
       assert res.children_count.tasks_count == 0
       assert res.children_count.check_ins_count == 0
+      assert res.children_count.docs_and_files_count == 0
     end
 
     test "it finds project by task_id when use_task_id is true", ctx do
@@ -564,6 +566,7 @@ defmodule OperatelyWeb.Api.ProjectsTest do
       assert res.children_count.discussions_count == 1
       assert res.children_count.tasks_count == 1
       assert res.children_count.check_ins_count == 1
+      assert res.children_count.docs_and_files_count == 0
     end
 
     test "it finds project by milestone_id when use_milestone_id is true", ctx do
@@ -582,6 +585,7 @@ defmodule OperatelyWeb.Api.ProjectsTest do
       assert res.children_count.discussions_count == 1
       assert res.children_count.tasks_count == 1
       assert res.children_count.check_ins_count == 1
+      assert res.children_count.docs_and_files_count == 0
     end
 
     test "it returns 404 when task does not exist with use_task_id", ctx do
@@ -626,6 +630,25 @@ defmodule OperatelyWeb.Api.ProjectsTest do
       assert res.children_count.tasks_count == 2
       assert res.children_count.discussions_count == 0
       assert res.children_count.check_ins_count == 0
+      assert res.children_count.docs_and_files_count == 0
+    end
+
+    test "it counts docs and files and excludes folders", ctx do
+      ctx =
+        ctx
+        |> Factory.fetch_default_project_resource_hub(:hub, :project)
+        |> Factory.add_folder(:folder, :hub)
+        |> Factory.add_document(:doc1, :hub)
+        |> Factory.add_file(:file1, :hub)
+        |> Factory.add_link(:link1, :hub)
+        |> Factory.add_document(:nested_doc, :hub, folder: :folder)
+        |> Factory.log_in_person(:creator)
+
+      assert {200, res} = query(ctx.conn, [:projects, :count_children], %{
+        id: Paths.project_id(ctx.project)
+      })
+
+      assert res.children_count.docs_and_files_count == 4
     end
    end
 

--- a/app/test/operately_web/api/projects_test.exs
+++ b/app/test/operately_web/api/projects_test.exs
@@ -650,6 +650,31 @@ defmodule OperatelyWeb.Api.ProjectsTest do
 
       assert res.children_count.docs_and_files_count == 4
     end
+
+    test "it counts own drafts but excludes other people's drafts", ctx do
+      ctx =
+        ctx
+        |> Factory.add_space_member(:other_member, :engineering)
+        |> Factory.fetch_default_project_resource_hub(:hub, :project)
+        |> Factory.add_document(:published, :hub)
+        |> Factory.add_document(:own_draft, :hub, state: :draft)
+        |> Factory.add_document(:other_draft, :hub, author: :other_member, state: :draft)
+        |> Factory.log_in_person(:creator)
+
+      assert {200, res} = query(ctx.conn, [:projects, :count_children], %{
+        id: Paths.project_id(ctx.project)
+      })
+
+      assert res.children_count.docs_and_files_count == 2
+
+      ctx = Factory.log_in_person(ctx, :other_member)
+
+      assert {200, other_res} = query(ctx.conn, [:projects, :count_children], %{
+        id: Paths.project_id(ctx.project)
+      })
+
+      assert other_res.children_count.docs_and_files_count == 2
+    end
    end
 
   describe "update due date" do

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -60,6 +60,43 @@
           }
         ]
       },
+      "goal_children_count": {
+        "fields": [
+          {
+            "default": null,
+            "name": "discussions_count",
+            "type": {
+              "name": "integer",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
+          },
+          {
+            "default": null,
+            "name": "check_ins_count",
+            "type": {
+              "name": "integer",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
+          },
+          {
+            "default": null,
+            "name": "docs_and_files_count",
+            "type": {
+              "name": "integer",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
+          }
+        ]
+      },
       "blob_creation_input": {
         "fields": [
           {
@@ -14762,6 +14799,17 @@
             "optional": false,
             "has_default": false,
             "nullable": false
+          },
+          {
+            "default": null,
+            "name": "docs_and_files_count",
+            "type": {
+              "name": "integer",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
           }
         ]
       },
@@ -19887,8 +19935,8 @@
       ]
     }
   },
-  "endpoint_count": 199,
-  "query_count": 64,
+  "endpoint_count": 200,
+  "query_count": 65,
   "mutation_count": 135,
   "endpoints": [
     {
@@ -23290,6 +23338,42 @@
       "docstring": "Closes a goal with success status and retrospective.",
       "full_name": "goals/close",
       "method": "POST"
+    },
+    {
+      "name": "count_children",
+      "type": "query",
+      "path": "/api/external/v1/goals/count_children",
+      "handler": "OperatelyWeb.Api.Goals.CountChildren",
+      "outputs": [
+        {
+          "default": null,
+          "name": "children_count",
+          "type": {
+            "name": "goal_children_count",
+            "kind": "named"
+          },
+          "optional": false,
+          "has_default": false,
+          "nullable": false
+        }
+      ],
+      "namespace": "goals",
+      "inputs": [
+        {
+          "default": null,
+          "name": "id",
+          "type": {
+            "name": "id",
+            "kind": "named"
+          },
+          "optional": false,
+          "has_default": false,
+          "nullable": false
+        }
+      ],
+      "docstring": "Counts discussions, check-ins, and docs & files for a goal.",
+      "full_name": "goals/count_children",
+      "method": "GET"
     },
     {
       "name": "create",
@@ -27100,7 +27184,7 @@
           "nullable": false
         }
       ],
-      "docstring": "Counts discussions, tasks, and check-ins for a project.",
+      "docstring": "Counts discussions, tasks, check-ins, and docs & files for a project.",
       "full_name": "projects/count_children",
       "method": "GET"
     },

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -1512,6 +1512,12 @@ export interface GoalCheckUpdate {
   index: number;
 }
 
+export interface GoalChildrenCount {
+  discussionsCount: number;
+  checkInsCount: number;
+  docsAndFilesCount: number;
+}
+
 export interface GoalDiscussion {
   __typename: "goal_discussion";
   id: Id;
@@ -1778,6 +1784,7 @@ export interface ProjectChildrenCount {
   tasksCount: number;
   discussionsCount: number;
   checkInsCount: number;
+  docsAndFilesCount: number;
 }
 
 export interface ProjectContributor {
@@ -2458,9 +2465,7 @@ export type ActivityContent =
   | ActivityContentTaskUpdate;
 
 export type ActivityDataUnion =
-  | ActivityEventDataProjectCreate
-  | ActivityEventDataMilestoneCreate
-  | ActivityEventDataCommentPost;
+  ActivityEventDataProjectCreate | ActivityEventDataMilestoneCreate | ActivityEventDataCommentPost;
 
 export type ActivityResourceUnion = Project | Update | Milestone | Comment;
 
@@ -2484,13 +2489,7 @@ export type UpdateContent =
   | UpdateContentMessage;
 
 export type AccessOptions =
-  | "no_access"
-  | "minimal_access"
-  | "view_access"
-  | "comment_access"
-  | "edit_access"
-  | "admin_access"
-  | "full_access";
+  "no_access" | "minimal_access" | "view_access" | "comment_access" | "edit_access" | "admin_access" | "full_access";
 
 export type AccountTheme = "dark" | "light" | "system";
 
@@ -2535,14 +2534,7 @@ export type GoalCheckInStatus = "on_track" | "caution" | "off_track";
 export type GoalPrivacyValues = "public" | "internal" | "confidential" | "secret";
 
 export type GoalStatus =
-  | "on_track"
-  | "achieved"
-  | "missed"
-  | "paused"
-  | "caution"
-  | "off_track"
-  | "pending"
-  | "outdated";
+  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
 
 export type MilestoneCommentAction = "none" | "complete" | "reopen";
 
@@ -2583,15 +2575,7 @@ export type ReactionParentType =
 export type ResourceAccessTypes = "space" | "goal" | "project";
 
 export type ResourceHubLinkType =
-  | "airtable"
-  | "dropbox"
-  | "figma"
-  | "google"
-  | "google_doc"
-  | "google_sheet"
-  | "google_slides"
-  | "notion"
-  | "other";
+  "airtable" | "dropbox" | "figma" | "google" | "google_doc" | "google_sheet" | "google_slides" | "notion" | "other";
 
 export type ReviewAssignmentDueStatus = "overdue" | "due_today" | "due_soon" | "upcoming" | "none";
 
@@ -2611,10 +2595,7 @@ export type ReviewAssignmentTypes =
 export type SearchMatchedField = "title" | "name" | "content" | "description";
 
 export type SearchResultType =
-  | "resource_hub_folder"
-  | "resource_hub_document"
-  | "resource_hub_file"
-  | "resource_hub_link";
+  "resource_hub_folder" | "resource_hub_document" | "resource_hub_file" | "resource_hub_link";
 
 export type SearchScopeOptions = "company" | "project" | "space" | "goal" | "resource_hub" | "none";
 
@@ -2645,14 +2626,7 @@ export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secre
 export type WorkMapItemState = "active" | "paused" | "closed";
 
 export type WorkMapItemStatus =
-  | "on_track"
-  | "achieved"
-  | "missed"
-  | "paused"
-  | "caution"
-  | "off_track"
-  | "pending"
-  | "outdated";
+  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
 
 export type WorkMapItemType = "project" | "goal";
 

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -2465,7 +2465,9 @@ export type ActivityContent =
   | ActivityContentTaskUpdate;
 
 export type ActivityDataUnion =
-  ActivityEventDataProjectCreate | ActivityEventDataMilestoneCreate | ActivityEventDataCommentPost;
+  | ActivityEventDataProjectCreate
+  | ActivityEventDataMilestoneCreate
+  | ActivityEventDataCommentPost;
 
 export type ActivityResourceUnion = Project | Update | Milestone | Comment;
 
@@ -2489,7 +2491,13 @@ export type UpdateContent =
   | UpdateContentMessage;
 
 export type AccessOptions =
-  "no_access" | "minimal_access" | "view_access" | "comment_access" | "edit_access" | "admin_access" | "full_access";
+  | "no_access"
+  | "minimal_access"
+  | "view_access"
+  | "comment_access"
+  | "edit_access"
+  | "admin_access"
+  | "full_access";
 
 export type AccountTheme = "dark" | "light" | "system";
 
@@ -2534,7 +2542,14 @@ export type GoalCheckInStatus = "on_track" | "caution" | "off_track";
 export type GoalPrivacyValues = "public" | "internal" | "confidential" | "secret";
 
 export type GoalStatus =
-  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
+  | "on_track"
+  | "achieved"
+  | "missed"
+  | "paused"
+  | "caution"
+  | "off_track"
+  | "pending"
+  | "outdated";
 
 export type MilestoneCommentAction = "none" | "complete" | "reopen";
 
@@ -2575,7 +2590,15 @@ export type ReactionParentType =
 export type ResourceAccessTypes = "space" | "goal" | "project";
 
 export type ResourceHubLinkType =
-  "airtable" | "dropbox" | "figma" | "google" | "google_doc" | "google_sheet" | "google_slides" | "notion" | "other";
+  | "airtable"
+  | "dropbox"
+  | "figma"
+  | "google"
+  | "google_doc"
+  | "google_sheet"
+  | "google_slides"
+  | "notion"
+  | "other";
 
 export type ReviewAssignmentDueStatus = "overdue" | "due_today" | "due_soon" | "upcoming" | "none";
 
@@ -2595,7 +2618,10 @@ export type ReviewAssignmentTypes =
 export type SearchMatchedField = "title" | "name" | "content" | "description";
 
 export type SearchResultType =
-  "resource_hub_folder" | "resource_hub_document" | "resource_hub_file" | "resource_hub_link";
+  | "resource_hub_folder"
+  | "resource_hub_document"
+  | "resource_hub_file"
+  | "resource_hub_link";
 
 export type SearchScopeOptions = "company" | "project" | "space" | "goal" | "resource_hub" | "none";
 
@@ -2626,7 +2652,14 @@ export type WorkMapItemPrivacy = "public" | "internal" | "confidential" | "secre
 export type WorkMapItemState = "active" | "paused" | "closed";
 
 export type WorkMapItemStatus =
-  "on_track" | "achieved" | "missed" | "paused" | "caution" | "off_track" | "pending" | "outdated";
+  | "on_track"
+  | "achieved"
+  | "missed"
+  | "paused"
+  | "caution"
+  | "off_track"
+  | "pending"
+  | "outdated";
 
 export type WorkMapItemType = "project" | "goal";
 

--- a/turboui/src/GoalPage/index.stories.tsx
+++ b/turboui/src/GoalPage/index.stories.tsx
@@ -139,10 +139,21 @@ function Component(props: GoalPageStoryArgs) {
     retrospective: null,
   };
 
+  const checkIns = props.checkIns ?? defaults.checkIns;
+  const discussions = props.discussions ?? defaults.discussions;
+  const childrenCount = props.childrenCount ?? {
+    checkInsCount: checkIns.length,
+    discussionsCount: discussions.length,
+    docsAndFilesCount: 0,
+  };
+
   return (
     <GoalPage
       {...defaults}
       {...props}
+      checkIns={checkIns}
+      discussions={discussions}
+      childrenCount={childrenCount}
       checklistItems={checklistItems}
       goalName={goalName}
       setGoalName={setGoalName}
@@ -519,6 +530,8 @@ const description: any = {
 
 function GoalPageDocsAndFilesStory({ includeDrafts = true }: { includeDrafts?: boolean }) {
   const docsAndFiles = useMockGoalDocsAndFiles("goal-1", "Launch AI Platform", { includeDrafts });
+  const docsAndFilesCount =
+    docsAndFiles.previewNodes.length + (docsAndFiles.drafts?.nodes.length ?? 0);
 
   return (
     <Component
@@ -532,6 +545,11 @@ function GoalPageDocsAndFilesStory({ includeDrafts = true }: { includeDrafts?: b
       contributors={contributors}
       relatedWorkItems={mockRelatedWorkItems}
       docsAndFiles={docsAndFiles}
+      childrenCount={{
+        checkInsCount: mockCheckIns.length,
+        discussionsCount: mockDiscussions.length,
+        docsAndFilesCount,
+      }}
     />
   );
 }

--- a/turboui/src/GoalPage/index.test.tsx
+++ b/turboui/src/GoalPage/index.test.tsx
@@ -225,6 +225,11 @@ function GoalPageHarness({
         relatedWorkItems={[]}
         checkIns={[]}
         discussions={[]}
+        childrenCount={{
+          checkInsCount: 0,
+          discussionsCount: 0,
+          docsAndFilesCount: includeDocsAndFiles ? 1 : 0,
+        }}
         docsAndFiles={docsAndFiles}
         status="on_track"
         state="active"
@@ -255,14 +260,14 @@ describe("GoalPage", () => {
   test("hides the docs and files tab when goal docs are unavailable", () => {
     render(<GoalPageHarness />);
 
-    expect(screen.queryByRole("link", { name: "Docs & Files" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Docs & Files/ })).not.toBeInTheDocument();
     expect(screen.queryByText("Quarterly Plan")).not.toBeInTheDocument();
   });
 
   test("shows the docs and files tab and overview preview when goal docs are available", () => {
     render(<GoalPageHarness includeDocsAndFiles />);
 
-    expect(screen.getByRole("link", { name: "Docs & Files" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Docs & Files 1" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Show 1 more" })).toHaveAttribute("href", "/goals/goal-1?tab=docs-and-files");
     expect(screen.getByText("Quarterly Plan")).toBeInTheDocument();
   });

--- a/turboui/src/GoalPage/index.tsx
+++ b/turboui/src/GoalPage/index.tsx
@@ -130,6 +130,11 @@ export namespace GoalPage {
     relatedWorkItems: MiniWorkMap.WorkItem[];
     checkIns: CheckIn[];
     discussions: Discussion[];
+    childrenCount: {
+      checkInsCount: number;
+      discussionsCount: number;
+      docsAndFilesCount: number;
+    };
     docsAndFiles?: PageDocsAndFiles;
     currentUser?: Person | null;
     status: BadgeStatus;
@@ -212,9 +217,15 @@ export function GoalPage(props: GoalPage.Props) {
 
   const tabs = useTabs("overview", [
     { id: "overview", label: "Overview", icon: <IconClipboardText size={14} /> },
-    { id: "check-ins", label: "Check-Ins", icon: <IconMessage size={14} />, count: props.checkIns.length },
-    { id: "discussions", label: "Discussions", icon: <IconMessages size={14} />, count: props.discussions.length },
-    { id: "docs-and-files", label: "Docs & Files", icon: <IconClipboardText size={14} />, hidden: !state.docsAndFiles },
+    { id: "check-ins", label: "Check-Ins", icon: <IconMessage size={14} />, count: props.childrenCount.checkInsCount },
+    { id: "discussions", label: "Discussions", icon: <IconMessages size={14} />, count: props.childrenCount.discussionsCount },
+    {
+      id: "docs-and-files",
+      label: "Docs & Files",
+      icon: <IconClipboardText size={14} />,
+      count: props.childrenCount.docsAndFilesCount,
+      hidden: !state.docsAndFiles,
+    },
     { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },
   ]);
   const activeTab = !state.docsAndFiles && tabs.active === "docs-and-files" ? "overview" : tabs.active;

--- a/turboui/src/MilestonePage/MilestonePage.stories.tsx
+++ b/turboui/src/MilestonePage/MilestonePage.stories.tsx
@@ -237,6 +237,7 @@ export const Default: Story = {
           tasksCount: tasks.length,
           discussionsCount: 2,
           checkInsCount: 1,
+          docsAndFilesCount: 0,
         }}
         space={{
           id: "1",
@@ -344,6 +345,7 @@ export const EmptyMilestone: Story = {
           tasksCount: 0,
           discussionsCount: 0,
           checkInsCount: 0,
+          docsAndFilesCount: 0,
         }}
         space={{
           id: "1",
@@ -565,6 +567,7 @@ export const CompletedMilestone: Story = {
           tasksCount: tasks.length,
           discussionsCount: 3,
           checkInsCount: 2,
+          docsAndFilesCount: 0,
         }}
         space={{
           id: "1",

--- a/turboui/src/ProjectPage/OverviewSidebar.test.tsx
+++ b/turboui/src/ProjectPage/OverviewSidebar.test.tsx
@@ -42,7 +42,7 @@ function SidebarHarness({
     project: { id: "project-1", name: "Secret project" },
     newCheckInLink: "#",
     newDiscussionLink: "#",
-    childrenCount: { tasksCount: 0, discussionsCount: 0, checkInsCount: 0 },
+    childrenCount: { tasksCount: 0, discussionsCount: 0, checkInsCount: 0, docsAndFilesCount: 0 },
     permissions: { canView: true, canComment: true, canEdit: true, hasFullAccess: true },
     champion: null,
     reviewer: null,

--- a/turboui/src/ProjectPage/ProjectPageWithDocsAndFilesStory.tsx
+++ b/turboui/src/ProjectPage/ProjectPageWithDocsAndFilesStory.tsx
@@ -154,6 +154,7 @@ export function ProjectPageWithDocsAndFilesStory({
         tasksCount: tasks.length,
         discussionsCount: storyData.mockDiscussions.length,
         checkInsCount: storyData.mockCheckIns.length,
+        docsAndFilesCount: docsAndFiles.previewNodes.length + (docsAndFiles.drafts?.nodes.length ?? 0),
       }}
       description={
         asRichText(

--- a/turboui/src/ProjectPage/index.stories.tsx
+++ b/turboui/src/ProjectPage/index.stories.tsx
@@ -347,6 +347,7 @@ export const Default: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={
           asRichText(
@@ -462,6 +463,7 @@ export const OverdueCheckIn: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockOverdueCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={
           asRichText(
@@ -569,6 +571,7 @@ export const ReadOnly: Story = {
           tasksCount: mockTasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={mobileAppDescription}
         space={space}
@@ -692,6 +695,7 @@ export const EmptyTasks: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={mobileAppDescription}
         space={space}
@@ -812,6 +816,7 @@ export const EmptyProject: Story = {
           tasksCount: 0,
           discussionsCount: 0,
           checkInsCount: 0,
+          docsAndFilesCount: 0,
         }}
         description={asRichText("")}
         space={space}
@@ -910,6 +915,7 @@ export const EmptyProjectReadOnly: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={asRichText("")}
         space={space}
@@ -1049,6 +1055,7 @@ export const PausedProject: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={aiAssistantDescription}
         space={space}
@@ -1161,6 +1168,7 @@ export const ClosedProject: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={workMapsRolloutDescription}
         space={space}
@@ -1331,6 +1339,7 @@ export const ProjectWithoutSpace: Story = {
           tasksCount: tasks.length,
           discussionsCount: mockDiscussions.length,
           checkInsCount: mockCheckIns.length,
+          docsAndFilesCount: 0,
         }}
         description={
           asRichText(

--- a/turboui/src/ProjectPage/index.test.tsx
+++ b/turboui/src/ProjectPage/index.test.tsx
@@ -240,7 +240,7 @@ function ProjectPageHarness({
         project={{ id: "project-1", name: "Apollo" }}
         newCheckInLink="#"
         newDiscussionLink="#"
-        childrenCount={{ tasksCount: 0, checkInsCount: 0, discussionsCount: 0 }}
+        childrenCount={{ tasksCount: 0, checkInsCount: 0, discussionsCount: 0, docsAndFilesCount: 0 }}
         permissions={{ canView: true, canComment: false, canEdit: false, hasFullAccess: false }}
         champion={null}
         reviewer={null}

--- a/turboui/src/ProjectPageLayout/index.tsx
+++ b/turboui/src/ProjectPageLayout/index.tsx
@@ -27,6 +27,7 @@ export namespace ProjectPageLayout {
     tasksCount: number;
     discussionsCount: number;
     checkInsCount: number;
+    docsAndFilesCount: number;
   }
 
   export interface TaskCompletionStats {

--- a/turboui/src/ProjectPageLayout/useProjectPageTabs.test.tsx
+++ b/turboui/src/ProjectPageLayout/useProjectPageTabs.test.tsx
@@ -22,6 +22,7 @@ const childrenCount = {
   tasksCount: 4,
   discussionsCount: 2,
   checkInsCount: 1,
+  docsAndFilesCount: 3,
 };
 
 function ProjectTabs() {
@@ -63,7 +64,7 @@ describe("useProjectPageTabs", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("link", { name: "Docs & Files" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Docs & Files/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Overview" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Activity" })).toBeInTheDocument();
   });
@@ -75,7 +76,7 @@ describe("useProjectPageTabs", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.queryByRole("link", { name: "Docs & Files" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Docs & Files/ })).not.toBeInTheDocument();
   });
 
   test("uses urlPath for child pages so docs and files navigates to the project", () => {
@@ -85,7 +86,7 @@ describe("useProjectPageTabs", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByRole("link", { name: "Docs & Files" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Docs & Files/ })).toHaveAttribute(
       "href",
       "/projects/project-1?tab=docs-and-files",
     );

--- a/turboui/src/ProjectPageLayout/useProjectPageTabs.tsx
+++ b/turboui/src/ProjectPageLayout/useProjectPageTabs.tsx
@@ -48,6 +48,7 @@ export function useProjectPageTabs({
         id: "docs-and-files",
         label: "Docs & Files",
         icon: <IconClipboardText size={14} />,
+        count: childrenCount.docsAndFilesCount,
         hidden: !showDocsAndFiles,
       },
       { id: "activity", label: "Activity", icon: <IconLogs size={14} /> },

--- a/turboui/src/TaskPage/InProjectContextStory.tsx
+++ b/turboui/src/TaskPage/InProjectContextStory.tsx
@@ -60,6 +60,7 @@ export function InProjectContextStory() {
         tasksCount: 8,
         discussionsCount: 3,
         checkInsCount: 2,
+        docsAndFilesCount: 0,
       }}
       space={{
         id: "space-123",

--- a/turboui/src/TaskPage/index.stories.tsx
+++ b/turboui/src/TaskPage/index.stories.tsx
@@ -102,6 +102,7 @@ function Component(props: Partial<TaskPage.Props>) {
       tasksCount: 5,
       discussionsCount: 3,
       checkInsCount: 2,
+      docsAndFilesCount: 0,
     },
 
     closedAt: null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4923

## Summary
- Extended `projects.countChildren` with `docs_and_files_count`, counting resource hub documents/files/links and excluding folders.
- Added `goals.countChildren` returning discussions, check-ins, and docs & files counts.
- Wired project and goal tabs to use these API counts (goal tabs no longer rely on `.length` of loaded lists).

## Test plan
- [x] API tests for project/goal `count_children` (including folder exclusion)
- [x] External API auth specs
- [x] TurboUI tab/count unit tests
- [x] Semaphore CI: 8341 tests passed

## Notes
Docs & Files tab badges now show presence the same way Tasks/Check-ins/Discussions already do.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31205880-6696-4295-9062-5c917280e5b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31205880-6696-4295-9062-5c917280e5b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

