### PR TITLE
fix: Unexport unused CompanySearchState for knip

### DIFF
--- a/app/assets/js/models/search/searchResultPath.test.ts
+++ b/app/assets/js/models/search/searchResultPath.test.ts
@@ -1,0 +1,40 @@
+import type { SearchResult } from "@/api";
+import { Paths } from "@/routes/paths";
+import { searchResultPath } from "./searchResultPath";
+
+function result(type: SearchResult["type"], navigationTarget: SearchResult["navigationTarget"]): SearchResult {
+  return {
+    __typename: "result",
+    id: "result-1",
+    type,
+    title: "Result",
+    context: "Context",
+    matchedField: "title",
+    snippet: null,
+    state: null,
+    navigationTarget,
+  };
+}
+
+describe("searchResultPath", () => {
+  const paths = new Paths({ companyId: "acme" });
+
+  test.each([
+    ["resource_hub_folder", { folderId: "folder-1" }, "/acme/folders/folder-1"],
+    ["resource_hub_document", { documentId: "document-1" }, "/acme/documents/document-1"],
+    ["resource_hub_file", { fileId: "file-1" }, "/acme/files/file-1"],
+    ["resource_hub_link", { linkId: "link-1" }, "/acme/links/link-1"],
+    ["project", { projectId: "project-1" }, "/acme/projects/project-1"],
+    ["goal", { goalId: "goal-1" }, "/acme/goals/goal-1"],
+    ["discussion", { discussionId: "discussion-1" }, "/acme/discussions/discussion-1"],
+    ["project_check_in", { projectCheckInId: "check-in-1" }, "/acme/project-check-ins/check-in-1"],
+    ["goal_check_in", { goalCheckInId: "check-in-1" }, "/acme/goal-check-ins/check-in-1"],
+    ["project_retrospective", { projectId: "project-1" }, "/acme/projects/project-1/retrospective"],
+  ] as const)("maps %s to its canonical path", (type, navigationTarget, expectedPath) => {
+    expect(searchResultPath(paths, result(type, navigationTarget))).toEqual(expectedPath);
+  });
+
+  test("rejects a result without its required navigation target", () => {
+    expect(searchResultPath(paths, result("project", {}))).toBeNull();
+  });
+});

--- a/app/assets/js/models/search/searchResultPath.ts
+++ b/app/assets/js/models/search/searchResultPath.ts
@@ -1,0 +1,29 @@
+import type { SearchResult } from "@/api";
+import { Paths } from "@/routes/paths";
+
+export function searchResultPath(paths: Paths, result: SearchResult): string | null {
+  const target = result.navigationTarget;
+
+  switch (result.type) {
+    case "resource_hub_folder":
+      return target.folderId ? paths.resourceHubFolderPath(target.folderId) : null;
+    case "resource_hub_document":
+      return target.documentId ? paths.resourceHubDocumentPath(target.documentId) : null;
+    case "resource_hub_file":
+      return target.fileId ? paths.resourceHubFilePath(target.fileId) : null;
+    case "resource_hub_link":
+      return target.linkId ? paths.resourceHubLinkPath(target.linkId) : null;
+    case "project":
+      return target.projectId ? paths.projectPath(target.projectId) : null;
+    case "goal":
+      return target.goalId ? paths.goalPath(target.goalId) : null;
+    case "discussion":
+      return target.discussionId ? paths.discussionPath(target.discussionId) : null;
+    case "project_check_in":
+      return target.projectCheckInId ? paths.projectCheckInPath(target.projectCheckInId) : null;
+    case "goal_check_in":
+      return target.goalCheckInId ? paths.goalCheckInPath(target.goalCheckInId) : null;
+    case "project_retrospective":
+      return target.projectId ? paths.projectRetrospectivePath(target.projectId) : null;
+  }
+}

--- a/app/assets/js/models/search/useCompanySearch.ts
+++ b/app/assets/js/models/search/useCompanySearch.ts
@@ -1,0 +1,124 @@
+import * as React from "react";
+import { useSearchParams } from "react-router";
+
+import Api, { CompaniesSearchInput, CompaniesSearchResult, SearchResult } from "@/api";
+import { SearchPage } from "turboui";
+
+type Search = (input: CompaniesSearchInput) => Promise<CompaniesSearchResult>;
+
+export interface CompanySearchState {
+  query: string;
+  status: SearchPage.Status;
+  results: SearchResult[];
+  onQueryChange: (query: string) => void;
+}
+
+const SEARCH_DELAY = 300;
+const RESULT_LIMIT = 30;
+
+class SearchRequest {
+  private version = 0;
+
+  begin(): number {
+    this.version += 1;
+    return this.version;
+  }
+
+  invalidate(): void {
+    this.version += 1;
+  }
+
+  isCurrent(version: number): boolean {
+    return this.version === version;
+  }
+}
+
+export function useCompanySearch(search: Search = Api.companies.search): CompanySearchState {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlQuery = searchParams.get("q") ?? "";
+  const [query, setQuery] = React.useState(urlQuery);
+  const editedQuery = React.useRef<string>();
+  const pendingUrlQuery = React.useRef<string>();
+  const requests = React.useRef(new SearchRequest());
+  const [status, setStatus] = React.useState<SearchPage.Status>("initial");
+  const [results, setResults] = React.useState<SearchResult[]>([]);
+
+  React.useEffect(() => {
+    const version = requests.current.begin();
+    const normalizedQuery = query.trim();
+    const wasEdited = editedQuery.current === query;
+    editedQuery.current = undefined;
+
+    setResults([]);
+
+    if (normalizedQuery.length < 2) {
+      setStatus("initial");
+      return;
+    }
+
+    setStatus("loading");
+
+    const runSearch = async () => {
+      try {
+        const response = await search({ query: normalizedQuery });
+        if (!requests.current.isCurrent(version)) return;
+
+        setResults(response.results.slice(0, RESULT_LIMIT));
+        setStatus("success");
+      } catch {
+        if (!requests.current.isCurrent(version)) return;
+
+        setStatus("error");
+      }
+    };
+
+    if (!wasEdited) {
+      runSearch();
+      return;
+    }
+
+    const timer = window.setTimeout(runSearch, SEARCH_DELAY);
+    return () => window.clearTimeout(timer);
+  }, [query, search]);
+
+  // Sync browser-driven URL changes without replaying local edits.
+  React.useEffect(() => {
+    if (pendingUrlQuery.current !== undefined) {
+      if (pendingUrlQuery.current === urlQuery) {
+        pendingUrlQuery.current = undefined;
+      }
+      return;
+    }
+
+    if (urlQuery !== query) {
+      setQuery(urlQuery);
+    }
+  }, [query, urlQuery]);
+
+  // Ignore in-flight responses after the page unmounts.
+  React.useEffect(() => {
+    return () => {
+      requests.current.invalidate();
+    };
+  }, []);
+
+  const onQueryChange = React.useCallback(
+    (nextQuery: string) => {
+      editedQuery.current = nextQuery;
+      pendingUrlQuery.current = nextQuery;
+      setQuery(nextQuery);
+
+      const nextParams = new URLSearchParams(searchParams);
+      if (nextQuery.length === 0) {
+        nextParams.delete("q");
+      } else {
+        nextParams.set("q", nextQuery);
+      }
+
+      setSearchParams(nextParams, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return { query, status, results, onQueryChange };
+}

--- a/app/assets/js/models/search/useCompanySearch.ts
+++ b/app/assets/js/models/search/useCompanySearch.ts
@@ -6,7 +6,7 @@ import { SearchPage } from "turboui";
 
 type Search = (input: CompaniesSearchInput) => Promise<CompaniesSearchResult>;
 
-export interface CompanySearchState {
+interface CompanySearchState {
   query: string;
   status: SearchPage.Status;
   results: SearchResult[];

--- a/app/assets/js/pages/SearchPage/index.tsx
+++ b/app/assets/js/pages/SearchPage/index.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 
-import * as Pages from "@/components/Pages";
 import { searchResultPath } from "@/models/search/searchResultPath";
 import { useCompanySearch } from "@/models/search/useCompanySearch";
 import { usePaths } from "@/routes/paths";
 import { PageModule } from "@/routes/types";
 import { SearchPage as SearchPageView } from "turboui";
+import { loader } from "./loader";
 
-export default { name: "SearchPage", loader: Pages.emptyLoader, Page } as PageModule;
+export default { name: "SearchPage", loader, Page } as PageModule;
 
 function Page() {
   const paths = usePaths();

--- a/app/assets/js/pages/SearchPage/index.tsx
+++ b/app/assets/js/pages/SearchPage/index.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import * as Pages from "@/components/Pages";
+import { searchResultPath } from "@/models/search/searchResultPath";
+import { useCompanySearch } from "@/models/search/useCompanySearch";
+import { usePaths } from "@/routes/paths";
+import { PageModule } from "@/routes/types";
+import { SearchPage as SearchPageView } from "turboui";
+
+export default { name: "SearchPage", loader: Pages.emptyLoader, Page } as PageModule;
+
+function Page() {
+  const paths = usePaths();
+  const search = useCompanySearch();
+
+  const results = React.useMemo<SearchPageView.Result[]>(
+    () =>
+      search.results.flatMap((result) => {
+        const link = searchResultPath(paths, result);
+        return link ? [{ ...result, link }] : [];
+      }),
+    [paths, search.results],
+  );
+
+  return (
+    <SearchPageView
+      query={search.query}
+      status={search.status}
+      results={results}
+      onQueryChange={search.onQueryChange}
+    />
+  );
+}

--- a/app/assets/js/pages/SearchPage/loader.ts
+++ b/app/assets/js/pages/SearchPage/loader.ts
@@ -1,0 +1,12 @@
+import { Paths } from "@/routes/paths";
+import { redirectIfFeatureNotEnabled } from "@/routes/redirectUtils";
+import type { Loader } from "@/routes/types";
+
+export const loader: Loader = async ({ params }) => {
+  await redirectIfFeatureNotEnabled(params, {
+    feature: "full_text_search",
+    path: Paths.companyHomePath(params.companyId),
+  });
+
+  return null;
+};

--- a/app/assets/js/pages/index.tsx
+++ b/app/assets/js/pages/index.tsx
@@ -96,6 +96,7 @@ import ResourceHubNewDocumentPage from "./ResourceHubNewDocumentPage";
 import ResourceHubNewLinkPage from "./ResourceHubNewLinkPage";
 import ResourceHubPage from "./ResourceHubPage";
 import ReviewPage from "./ReviewPage";
+import SearchPage from "./SearchPage";
 import SetupPage from "./SetupPage";
 import SignUpPage from "./SignUpPage";
 import SignUpWithEmailPage from "./SignUpWithEmailPage";
@@ -209,6 +210,7 @@ export default {
   ResourceHubNewLinkPage,
   ResourceHubPage,
   ReviewPage,
+  SearchPage,
   SetupPage,
   SignUpPage,
   SignUpWithEmailPage,

--- a/app/assets/js/routes/index.tsx
+++ b/app/assets/js/routes/index.tsx
@@ -61,6 +61,7 @@ export function createAppRoutes(createRouter: typeof createBrowserRouter = creat
       shouldRevalidate: companyShouldRevalidate,
       children: [
         pageRoute("", pages.HomePage),
+        pageRoute("search", pages.SearchPage),
         pageRoute("invite-team", pages.InviteTeamPage),
         pageRoute("invite-people", pages.MemberTypeSelectionPage),
         pageRoute("review", pages.ReviewPage),

--- a/app/assets/js/routes/paths.test.tsx
+++ b/app/assets/js/routes/paths.test.tsx
@@ -6,4 +6,13 @@ describe("Paths", () => {
 
     expect(paths.feedPath()).toEqual("/nexus-dynamics");
   });
+
+  test("builds a company search path with an encoded optional query", () => {
+    const paths = new Paths({ companyId: "nexus-dynamics" });
+
+    expect(paths.searchPath()).toEqual("/nexus-dynamics/search");
+    expect(paths.searchPath("customer evidence & plans")).toEqual(
+      "/nexus-dynamics/search?q=customer+evidence+%26+plans",
+    );
+  });
 });

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -70,6 +70,14 @@ export class Paths {
     return this.createCompanyPath([]);
   }
 
+  searchPath(query?: string) {
+    const path = this.createCompanyPath(["search"]);
+    if (!query) return path;
+
+    const searchParams = new URLSearchParams({ q: query });
+    return `${path}?${searchParams.toString()}`;
+  }
+
   setupPath() {
     return this.createCompanyPath(["setup"]);
   }

--- a/app/lib/operately_web/paths.ex
+++ b/app/lib/operately_web/paths.ex
@@ -60,6 +60,16 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company)])
   end
 
+  def search_path(company, query \\ nil)
+
+  def search_path(company = %Company{}, nil) do
+    create_path([company_id(company), "search"])
+  end
+
+  def search_path(company = %Company{}, query) when is_binary(query) do
+    search_path(company) <> "?" <> URI.encode_query(%{q: query})
+  end
+
   def people_path(company = %Company{}) do
     create_path([company_id(company), "people"])
   end

--- a/app/test/features/company_search_test.exs
+++ b/app/test/features/company_search_test.exs
@@ -1,0 +1,26 @@
+defmodule Operately.Features.CompanySearchTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.CompanySearchSteps, as: Steps
+
+  setup ctx, do: Steps.setup(ctx)
+
+  feature "opens a shared body search and navigates to its result", ctx do
+    ctx
+    |> Steps.visit_search_page("approval workflow")
+    |> Steps.assert_search_query("approval workflow")
+    |> Steps.assert_project_result("Website redesign")
+    |> Steps.assert_body_match_metadata()
+    |> Steps.open_project_result()
+    |> Steps.assert_project_page()
+  end
+
+  feature "searches again from the dedicated page", ctx do
+    ctx
+    |> Steps.visit_search_page()
+    |> Steps.assert_initial_state()
+    |> Steps.search_for("renewal evidence")
+    |> Steps.assert_search_location("renewal evidence")
+    |> Steps.assert_project_result("Customer portal")
+  end
+end

--- a/app/test/support/features/company_search_steps.ex
+++ b/app/test/support/features/company_search_steps.ex
@@ -1,0 +1,94 @@
+defmodule Operately.Support.Features.CompanySearchSteps do
+  use Operately.FeatureCase
+
+  alias Operately.Projects.Project
+  alias Operately.Search.SourceIndexer
+  alias Operately.Support.RichText
+  alias OperatelyWeb.Paths
+
+  step :setup, ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space, name: "Product")
+    |> Factory.add_project(:website, :space, name: "Website redesign")
+    |> Factory.add_project(:portal, :space, name: "Customer portal")
+    |> set_project_description(:website, "Customer interviews show that the approval workflow needs to be simpler.")
+    |> set_project_description(:portal, "Renewal evidence supports a clearer customer portal.")
+    |> index_project(:website)
+    |> index_project(:portal)
+    |> Factory.log_in_person(:creator)
+  end
+
+  step :visit_search_page, ctx do
+    UI.visit(ctx, Paths.search_path(ctx.company))
+  end
+
+  step :visit_search_page, ctx, query do
+    UI.visit(ctx, Paths.search_path(ctx.company, query))
+  end
+
+  step :assert_search_query, ctx, query do
+    UI.assert_has(ctx, testid: "company-search-input", value: query)
+  end
+
+  step :assert_initial_state, ctx do
+    UI.assert_text(ctx, "Search across projects, goals, discussions, documents, and more.")
+  end
+
+  step :search_for, ctx, query do
+    ctx
+    |> UI.fill(testid: "company-search-input", with: query)
+    |> UI.sleep(500)
+  end
+
+  step :assert_search_location, ctx, query do
+    UI.assert_location(ctx, Paths.search_path(ctx.company, query))
+  end
+
+  step :assert_project_result, ctx, project_name do
+    ctx
+    |> UI.wait_until_text(project_name)
+    |> UI.assert_has(testid: "company-search-result")
+  end
+
+  step :assert_body_match_metadata, ctx do
+    ctx
+    |> UI.assert_text("Project · Product")
+    |> UI.assert_text("Matched in description")
+    |> UI.assert_text("approval workflow")
+  end
+
+  step :open_project_result, ctx do
+    UI.click(ctx, testid: "company-search-result")
+  end
+
+  step :assert_project_page, ctx do
+    project_path =
+      Paths.create_path([
+        Paths.company_id(ctx.company),
+        "projects",
+        Operately.ShortUuid.encode!(ctx.website.id)
+      ])
+
+    ctx
+    |> UI.assert_page(project_path)
+    |> UI.wait_until_has(testid: "project-page")
+    |> UI.wait_until_text(ctx.website.name, testid: "project-page")
+  end
+
+  defp set_project_description(ctx, project_name, description) do
+    project =
+      ctx
+      |> Map.fetch!(project_name)
+      |> Project.changeset(%{description: RichText.rich_text(description)})
+      |> Repo.update!()
+
+    Map.put(ctx, project_name, project)
+  end
+
+  defp index_project(ctx, project_name) do
+    project = Map.fetch!(ctx, project_name)
+    assert {:ok, _summary} = SourceIndexer.sync("project", project.id)
+    ctx
+  end
+end

--- a/app/test/support/features/company_search_steps.ex
+++ b/app/test/support/features/company_search_steps.ex
@@ -9,6 +9,7 @@ defmodule Operately.Support.Features.CompanySearchSteps do
   step :setup, ctx do
     ctx
     |> Factory.setup()
+    |> Factory.enable_feature("full_text_search")
     |> Factory.add_space(:space, name: "Product")
     |> Factory.add_project(:website, :space, name: "Website redesign")
     |> Factory.add_project(:portal, :space, name: "Customer portal")
@@ -53,7 +54,8 @@ defmodule Operately.Support.Features.CompanySearchSteps do
 
   step :assert_body_match_metadata, ctx do
     ctx
-    |> UI.assert_text("Project · Product")
+    |> UI.assert_text("PROJECT")
+    |> UI.assert_text("In Product")
     |> UI.assert_text("Matched in description")
     |> UI.assert_text("approval workflow")
   end

--- a/specs/0015-full-text-search.md
+++ b/specs/0015-full-text-search.md
@@ -802,6 +802,7 @@ PRs 3.1 through 3.4 are complete and remain unchanged as the indexing, permissio
 #### PR 3.8 — `chore: Add company Search page`
 
 - [x] Add the company Search route and page, using URL parameter `q` as the shareable and reload-safe query.
+- [x] Gate the Search page behind the `full_text_search` experimental feature and redirect disabled companies to Home.
 - [x] Seed the search field from `q`, immediately search valid initial queries, debounce edits by 300 ms, update the URL without one history entry per keystroke, and handle browser back/forward.
 - [x] Ignore stale responses and render distinct initial, loading, populated, empty, and error states while keeping focus in the search field.
 - [x] Render at most 30 mixed full-text results with resource type, title/name, context, optional historical state, strongest matched field, safe body snippet, and canonical navigation.

--- a/specs/0015-full-text-search.md
+++ b/specs/0015-full-text-search.md
@@ -801,12 +801,12 @@ PRs 3.1 through 3.4 are complete and remain unchanged as the indexing, permissio
 
 #### PR 3.8 — `chore: Add company Search page`
 
-- [ ] Add the company Search route and page, using URL parameter `q` as the shareable and reload-safe query.
-- [ ] Seed the search field from `q`, immediately search valid initial queries, debounce edits by 300 ms, update the URL without one history entry per keystroke, and handle browser back/forward.
-- [ ] Ignore stale responses and render distinct initial, loading, populated, empty, and error states while keeping focus in the search field.
-- [ ] Render at most 30 mixed full-text results with resource type, title/name, context, optional historical state, strongest matched field, safe body snippet, and canonical navigation.
-- [ ] Keep quick-navigation groups off this page and do not add pagination in the first release.
-- [ ] Add focused page/component stories and company feature coverage for carried queries, direct links, subsequent searches, stale responses, all request states, result navigation, accessibility, and the 30-result cap.
+- [x] Add the company Search route and page, using URL parameter `q` as the shareable and reload-safe query.
+- [x] Seed the search field from `q`, immediately search valid initial queries, debounce edits by 300 ms, update the URL without one history entry per keystroke, and handle browser back/forward.
+- [x] Ignore stale responses and render distinct initial, loading, populated, empty, and error states while keeping focus in the search field.
+- [x] Render at most 30 mixed full-text results with resource type, title/name, context, optional historical state, strongest matched field, safe body snippet, and canonical navigation.
+- [x] Keep quick-navigation groups off this page and do not add pagination in the first release.
+- [x] Add focused page/component stories and company feature coverage for carried queries, direct links, subsequent searches, stale responses, all request states, result navigation, accessibility, and the 30-result cap.
 
 #### PR 3.9 — `chore: Connect quick search to full-text search`
 

--- a/turboui/src/ResourceHub/NodeIcon.tsx
+++ b/turboui/src/ResourceHub/NodeIcon.tsx
@@ -3,7 +3,7 @@ import { calculateImageRatio, ImageWithPlaceholder } from "../ImageWithPlacehold
 import classNames from "../utils/classnames";
 import { IconAlignJustified, IconChartColumn, IconFolderFilled, IconLink, IconLogs, IconVideo } from "../icons";
 import { getNodeLinkType, getNodeThumbnail, getNodeType, hasNodeContentType, isNodeMovFile, isNodeVideoFile } from "./selectors";
-import type { ResourceHubNode } from "./types";
+import type { ResourceHubNode, ResourceHubNodeType } from "./types";
 import { LinkIcon } from "./LinkIcon";
 
 export function NodeIcon({ node, size }: { node: ResourceHubNode; size: number }) {
@@ -11,27 +11,30 @@ export function NodeIcon({ node, size }: { node: ResourceHubNode; size: number }
   const linkType = getNodeLinkType(node);
   const thumbnail = getNodeThumbnail(node);
 
-  if (nodeType === "folder") return <FolderIcon size={size} />;
+  if (nodeType === "folder") return <ResourceHubTypeIcon type="folder" size={size} />;
 
   if (nodeType === "link") {
     if (linkType && linkType !== "other") return <LinkIcon type={linkType} size={size} />;
-    return <FileIcon size={size} icon={IconLink} />;
+    return <ResourceHubTypeIcon type="link" size={size} />;
   }
 
   if (thumbnail) return <Thumbnail url={thumbnail.url} alt={thumbnail.alt} width={thumbnail.width} height={thumbnail.height} size={size} />;
 
-  if (nodeType === "document") return <FileIcon size={size} icon={IconAlignJustified} color="bg-sky-500" />;
+  if (nodeType === "document") return <ResourceHubTypeIcon type="document" size={size} />;
   if (hasNodeContentType(node, "pdf")) return <FileIcon size={size} filetype="pdf" color="bg-red-500" icon={IconAlignJustified} />;
   if (isNodeMovFile(node)) return <FileIcon size={size} filetype="mov" icon={IconVideo} />;
   if (isNodeVideoFile(node)) return <FileIcon size={size} icon={IconVideo} />;
   if (hasNodeContentType(node, "audio")) return <FileIcon size={size} filetype="audio" />;
   if (hasNodeContentType(node, "zip")) return <FileIcon size={size} filetype="zip" icon={IconChartColumn} />;
 
-  return <FileIcon size={size} icon={IconAlignJustified} />;
+  return <ResourceHubTypeIcon type="file" size={size} />;
 }
 
-function FolderIcon({ size }: { size: number }) {
-  return <IconFolderFilled size={size} className="text-sky-500" />;
+export function ResourceHubTypeIcon({ type, size }: { type: ResourceHubNodeType; size: number }) {
+  if (type === "folder") return <IconFolderFilled size={size} className="text-sky-500" />;
+  if (type === "link") return <FileIcon size={size} icon={IconLink} />;
+
+  return <FileIcon size={size} icon={IconAlignJustified} />;
 }
 
 interface FileIconProps {

--- a/turboui/src/ResourceHub/NodePresentation.test.tsx
+++ b/turboui/src/ResourceHub/NodePresentation.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from "react-router";
 
 import { ResourceHubNodesListProvider, type ResourceHubNodesListContextValue } from "./contexts/NodesListContext";
 import { NodeDescription } from "./NodeDescription";
-import { NodeIcon } from "./NodeIcon";
+import { NodeIcon, ResourceHubTypeIcon } from "./NodeIcon";
 import { NodeMenu } from "./NodeMenu";
 import type { ResourceHubNode } from "./types";
 
@@ -113,6 +113,21 @@ const listContext: ResourceHubNodesListContextValue = {
 };
 
 describe("resource hub node presentation", () => {
+  test("renders the canonical icon for each basic resource type", () => {
+    render(
+      <>
+        <ResourceHubTypeIcon type="folder" size={48} />
+        <ResourceHubTypeIcon type="document" size={48} />
+        <ResourceHubTypeIcon type="file" size={48} />
+        <ResourceHubTypeIcon type="link" size={48} />
+      </>,
+    );
+
+    expect(screen.getByText("folder-icon")).toBeInTheDocument();
+    expect(screen.getAllByText("doc-icon")).toHaveLength(2);
+    expect(screen.getByText("link-icon")).toBeInTheDocument();
+  });
+
   test("renders description details from a raw document node", () => {
     render(<NodeDescription node={documentNode} />);
 

--- a/turboui/src/ResourceHub/index.tsx
+++ b/turboui/src/ResourceHub/index.tsx
@@ -6,7 +6,7 @@ export type { AddFolderModalProps } from "./AddFolderModal";
 export { ContinueEditingDrafts } from "./ContinueEditingDrafts";
 export { DraftNodesList } from "./DraftNodesList";
 export { FileDragAndDropArea } from "./FileDragAndDropArea";
-export { FileIcon, NodeIcon } from "./NodeIcon";
+export { FileIcon, NodeIcon, ResourceHubTypeIcon } from "./NodeIcon";
 export { LinkIcon } from "./LinkIcon";
 export { Header } from "./Header";
 export { NodeMenu } from "./NodeMenu";

--- a/turboui/src/SearchPage/index.stories.tsx
+++ b/turboui/src/SearchPage/index.stories.tsx
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import * as React from "react";
+
+import type { SearchResult } from "../ApiTypes";
+import { SearchPage } from "./index";
+
+const meta = {
+  title: "Pages/SearchPage",
+  component: SearchPage,
+  parameters: {
+    layout: "fullscreen",
+    reactRouter: {
+      path: "/acme/search",
+      routePath: "/:companyId/search",
+    },
+  },
+} satisfies Meta<typeof SearchPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function result(overrides: Partial<SearchResult & { link: string }> = {}): SearchPage.Result {
+  return {
+    __typename: "result",
+    id: "project-1",
+    type: "project",
+    title: "Website redesign",
+    context: "Marketing",
+    matchedField: "description",
+    snippet:
+      "Customer research supports simplifying the information architecture and making the approval workflow easier to understand.",
+    state: "closed",
+    navigationTarget: { projectId: "project-1" },
+    link: "/acme/projects/project-1",
+    ...overrides,
+  };
+}
+
+function InteractivePage(props: Omit<SearchPage.Props, "query" | "onQueryChange"> & { initialQuery?: string }) {
+  const [query, setQuery] = React.useState(props.initialQuery ?? "");
+  return <SearchPage {...props} query={query} onQueryChange={setQuery} />;
+}
+
+export const Initial: Story = {
+  args: { query: "", status: "initial", results: [], onQueryChange: () => undefined },
+  render: () => <InteractivePage status="initial" results={[]} />,
+};
+
+export const Loading: Story = {
+  args: { query: "customer evidence", status: "loading", results: [], onQueryChange: () => undefined },
+  render: () => <InteractivePage initialQuery="customer evidence" status="loading" results={[]} />,
+};
+
+export const Populated: Story = {
+  args: { query: "customer evidence", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => (
+    <InteractivePage
+      initialQuery="customer evidence"
+      status="success"
+      results={[
+        result(),
+        result({
+          id: "document-1",
+          type: "resource_hub_document",
+          title: "Customer research synthesis",
+          context: "Product",
+          matchedField: "content",
+          state: null,
+          navigationTarget: { documentId: "document-1" },
+          link: "/acme/documents/document-1",
+        }),
+        result({
+          id: "check-in-1",
+          type: "goal_check_in",
+          title: "Check-in on 2026-07-28",
+          context: "Improve customer onboarding",
+          matchedField: "message",
+          state: "paused",
+          navigationTarget: { goalCheckInId: "check-in-1" },
+          link: "/acme/goal-check-ins/check-in-1",
+        }),
+      ]}
+    />
+  ),
+};
+
+export const HighlightedMatches: Story = {
+  args: { query: "improve", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => (
+    <InteractivePage
+      initialQuery="improve"
+      status="success"
+      results={[
+        result({
+          id: "runway-review",
+          type: "resource_hub_document",
+          title: "Runway and Revenue Review",
+          context: "Extend runway from Series A",
+          matchedField: "content",
+          snippet:
+            "Paid acquisition efficiency improved week over week. Tighten discretionary marketing spend until CAC stabilizes.",
+          state: null,
+          navigationTarget: { documentId: "runway-review" },
+          link: "/acme/documents/runway-review",
+        }),
+        result({
+          id: "customer-feedback",
+          type: "resource_hub_document",
+          title: "Improve beta customer feedback",
+          context: "Ship collaborative docs beta",
+          matchedField: "content",
+          snippet: "Real-time presence is the most requested improvement. Comment resolution needs clearer status.",
+          state: null,
+          navigationTarget: { documentId: "customer-feedback" },
+          link: "/acme/documents/customer-feedback",
+        }),
+      ]}
+    />
+  ),
+};
+
+export const Empty: Story = {
+  args: { query: "missing content", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => <InteractivePage initialQuery="missing content" status="success" results={[]} />,
+};
+
+export const Error: Story = {
+  args: { query: "customer evidence", status: "error", results: [], onQueryChange: () => undefined },
+  render: () => <InteractivePage initialQuery="customer evidence" status="error" results={[]} />,
+};
+
+export const LongContent: Story = {
+  args: { query: "strategy", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => (
+    <InteractivePage
+      initialQuery="strategy"
+      status="success"
+      results={[
+        result({
+          title:
+            "A deliberately long project title that demonstrates how search results behave when names need to wrap across several lines",
+          context: "A space with a deliberately long name used to verify responsive wrapping",
+          snippet: Array(8)
+            .fill(
+              "This long plain-text snippet demonstrates predictable wrapping and truncation without changing the layout.",
+            )
+            .join(" "),
+        }),
+      ]}
+    />
+  ),
+};
+
+export const HistoricalStates: Story = {
+  args: { query: "review", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => (
+    <InteractivePage
+      initialQuery="review"
+      status="success"
+      results={[
+        result({ id: "closed", title: "Closed project", state: "closed", link: "/closed" }),
+        result({ id: "completed", title: "Completed goal", type: "goal", state: "completed", link: "/completed" }),
+        result({
+          id: "archived",
+          title: "Archived discussion",
+          type: "discussion",
+          state: "archived",
+          link: "/archived",
+        }),
+        result({ id: "paused", title: "Paused check-in", type: "project_check_in", state: "paused", link: "/paused" }),
+      ]}
+    />
+  ),
+};
+
+export const ThirtyResults: Story = {
+  args: { query: "planning", status: "success", results: [], onQueryChange: () => undefined },
+  render: () => (
+    <InteractivePage
+      initialQuery="planning"
+      status="success"
+      results={Array.from({ length: 30 }, (_, index) =>
+        result({
+          id: `result-${index}`,
+          title: `Planning result ${index + 1}`,
+          state: null,
+          link: `/acme/results/${index + 1}`,
+        }),
+      )}
+    />
+  ),
+};

--- a/turboui/src/SearchPage/index.test.tsx
+++ b/turboui/src/SearchPage/index.test.tsx
@@ -1,0 +1,174 @@
+import * as React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router";
+
+import type { SearchResult } from "../ApiTypes";
+import { SearchPage } from "./index";
+
+function result(overrides: Partial<SearchResult & { link: string }> = {}): SearchResult & { link: string } {
+  return {
+    __typename: "result",
+    id: "result-1",
+    type: "project",
+    title: "Website redesign",
+    context: "Marketing",
+    matchedField: "description",
+    snippet: "Customer research supports the new information architecture.",
+    state: "closed",
+    navigationTarget: { projectId: "project-1" },
+    link: "/acme/projects/project-1",
+    ...overrides,
+  };
+}
+
+function renderPage(props: Partial<React.ComponentProps<typeof SearchPage>> = {}) {
+  const defaultProps: React.ComponentProps<typeof SearchPage> = {
+    query: "",
+    status: "initial",
+    results: [],
+    onQueryChange: jest.fn(),
+  };
+
+  return render(
+    <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <SearchPage {...defaultProps} {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SearchPage", () => {
+  test("renders the initial state and keeps the search field focused", () => {
+    renderPage();
+
+    expect(screen.getByRole("heading", { level: 1, name: "Search" })).toBeInTheDocument();
+    const input = screen.getByRole("searchbox", { name: "Search titles and content…" });
+    expect(input).toHaveFocus();
+    expect(screen.getByText("Search across projects, goals, discussions, documents, and more.")).toBeInTheDocument();
+  });
+
+  test("reports query changes without managing the request", () => {
+    const onQueryChange = jest.fn();
+    renderPage({ onQueryChange });
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "customer evidence" } });
+
+    expect(onQueryChange).toHaveBeenCalledWith("customer evidence");
+  });
+
+  test("renders loading, empty, and error states accessibly", () => {
+    const { rerender } = renderPage({ query: "evidence", status: "loading" });
+    expect(screen.getByRole("status")).toHaveTextContent("Searching…");
+
+    rerender(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <SearchPage query="evidence" status="success" results={[]} onQueryChange={jest.fn()} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("No content found for “evidence”. Try different keywords.");
+
+    rerender(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <SearchPage query="evidence" status="error" results={[]} onQueryChange={jest.fn()} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Search is unavailable. Try again.");
+    expect(screen.getByRole("searchbox")).toHaveFocus();
+  });
+
+  test("renders result metadata, state, snippet, and navigation", () => {
+    renderPage({ query: "research", status: "success", results: [result()] });
+
+    expect(screen.getByRole("status")).toHaveTextContent("1 result found.");
+    expect(screen.getByRole("link", { name: /Website redesign/ })).toHaveAttribute("href", "/acme/projects/project-1");
+    expect(screen.getByText("Project")).toBeInTheDocument();
+    expect(screen.getByText("In Marketing")).toBeInTheDocument();
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+    expect(screen.getByText("Matched in description")).toBeInTheDocument();
+    expect(screen.getByTestId("search-result-snippet")).toHaveTextContent(
+      "Customer research supports the new information architecture.",
+    );
+  });
+
+  test("uses the Resource Hub document icon and makes the resource hierarchy explicit", () => {
+    renderPage({
+      query: "runway",
+      status: "success",
+      results: [
+        result({
+          type: "resource_hub_document",
+          title: "Runway and Revenue Review",
+          context: "Extend runway from Series A",
+        }),
+      ],
+    });
+
+    expect(screen.getByText("Document")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Runway and Revenue Review" })).toBeInTheDocument();
+    expect(screen.getByText("In Extend runway from Series A")).toBeInTheDocument();
+    expect(screen.queryByText("Document · Extend runway from Series A")).not.toBeInTheDocument();
+
+    const icon = screen.getByTestId("search-result-icon");
+    expect(icon).toHaveClass("h-12", "w-12", "self-start");
+    expect(icon.querySelector(".border-stroke-base")).toBeInTheDocument();
+  });
+
+  test("highlights matching query terms in titles and snippets without rendering HTML", () => {
+    const { container } = renderPage({
+      query: "improve",
+      status: "success",
+      results: [
+        result({
+          title: "Improve customer onboarding",
+          snippet: "The team improved <strong>activation</strong> this quarter.",
+        }),
+      ],
+    });
+
+    expect(Array.from(container.querySelectorAll("mark")).map((mark) => mark.textContent)).toEqual([
+      "Improve",
+      "improve",
+    ]);
+    expect(screen.getByTestId("search-result-snippet")).toHaveTextContent(
+      "The team improved <strong>activation</strong> this quarter.",
+    );
+    expect(container.querySelector("strong")).not.toBeInTheDocument();
+  });
+
+  test("renders all indexed resource labels and caps the visible list at 30 results", () => {
+    const types: SearchResult["type"][] = [
+      "resource_hub_folder",
+      "resource_hub_document",
+      "resource_hub_file",
+      "resource_hub_link",
+      "project",
+      "goal",
+      "discussion",
+      "project_check_in",
+      "goal_check_in",
+      "project_retrospective",
+    ];
+    const typeResults = types.map((type, index) =>
+      result({ id: `type-${index}`, type, title: `Result ${index}`, link: `/result-${index}`, state: null }),
+    );
+    const extraResults = Array.from({ length: 25 }, (_, index) =>
+      result({ id: `extra-${index}`, title: `Extra ${index}`, link: `/extra-${index}`, state: null }),
+    );
+
+    const { container } = renderPage({
+      query: "result",
+      status: "success",
+      results: [...typeResults, ...extraResults],
+    });
+
+    expect(container.querySelectorAll('[data-test-id="company-search-result"]')).toHaveLength(30);
+    expect(screen.getByText("Folder")).toBeInTheDocument();
+    expect(screen.getByText("Document")).toBeInTheDocument();
+    expect(screen.getByText("File")).toBeInTheDocument();
+    expect(screen.getByText("Link")).toBeInTheDocument();
+    expect(screen.getByText("Project check-in")).toBeInTheDocument();
+    expect(screen.getByText("Goal check-in")).toBeInTheDocument();
+    expect(screen.getByText("Project retrospective")).toBeInTheDocument();
+    expect(screen.getAllByText("In Marketing")).toHaveLength(30);
+  });
+});

--- a/turboui/src/SearchPage/index.tsx
+++ b/turboui/src/SearchPage/index.tsx
@@ -1,0 +1,249 @@
+import * as React from "react";
+
+import type { SearchResult, SearchResultState, SearchResultType } from "../ApiTypes";
+import { Input } from "../Forms/Input";
+import {
+  IconCalendar,
+  IconGoal,
+  IconHistory,
+  IconMessage,
+  IconProject,
+  IconSearch,
+} from "../icons";
+import { DivLink } from "../Link";
+import { Page } from "../Page";
+import { ResourceHubTypeIcon } from "../ResourceHub";
+
+export namespace SearchPage {
+  export type Status = "initial" | "loading" | "success" | "error";
+  export type Result = SearchResult & { link: string };
+
+  export interface Props {
+    query: string;
+    status: Status;
+    results: Result[];
+    onQueryChange: (query: string) => void;
+  }
+}
+
+const RESULT_LIMIT = 30;
+
+export function SearchPage({ query, status, results, onQueryChange }: SearchPage.Props) {
+  const visibleResults = results.slice(0, RESULT_LIMIT);
+
+  return (
+    <Page title="Search" size="large" testId="company-search-page">
+      <main className="min-h-[75vh] px-4 py-8 sm:px-12 sm:py-10">
+        <h1 className="sr-only">Search</h1>
+        <SearchField query={query} onQueryChange={onQueryChange} />
+        <div className="mt-8">
+          <SearchContent query={query} status={status} results={visibleResults} />
+        </div>
+      </main>
+    </Page>
+  );
+}
+
+function SearchField({ query, onQueryChange }: Pick<SearchPage.Props, "query" | "onQueryChange">) {
+  return (
+    <div className="relative">
+      <label className="sr-only" htmlFor="company-search-input">
+        Search titles and content…
+      </label>
+      <IconSearch
+        aria-hidden="true"
+        size={22}
+        className="pointer-events-none absolute left-4 top-1/2 z-10 -translate-y-1/2 text-content-subtle"
+      />
+      <Input
+        id="company-search-input"
+        testId="company-search-input"
+        type="search"
+        autoFocus
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        placeholder="Search titles and content…"
+        className="py-3 pl-12 pr-4 text-base sm:text-lg"
+      />
+    </div>
+  );
+}
+
+function SearchContent({ query, status, results }: Pick<SearchPage.Props, "query" | "status" | "results">) {
+  if (status === "loading") {
+    return <SearchMessage role="status">Searching…</SearchMessage>;
+  }
+
+  if (status === "error") {
+    return <SearchMessage role="alert">Search is unavailable. Try again.</SearchMessage>;
+  }
+
+  if (status === "initial") {
+    return (
+      <SearchMessage role="status">Search across projects, goals, discussions, documents, and more.</SearchMessage>
+    );
+  }
+
+  if (results.length === 0) {
+    return <SearchMessage role="status">No content found for “{query}”. Try different keywords.</SearchMessage>;
+  }
+
+  return (
+    <>
+      <p role="status" className="sr-only">
+        {resultCountLabel(results.length)}
+      </p>
+      <ol aria-label="Search results" className="divide-y divide-surface-outline">
+        {results.map((result) => (
+          <li key={`${result.type}-${result.id}`}>
+            <SearchResultRow query={query} result={result} />
+          </li>
+        ))}
+      </ol>
+    </>
+  );
+}
+
+function SearchMessage({ role, children }: { role: "status" | "alert"; children: React.ReactNode }) {
+  return (
+    <p role={role} className="py-16 text-center text-sm text-content-dimmed sm:text-base">
+      {children}
+    </p>
+  );
+}
+
+function SearchResultRow({ query, result }: { query: string; result: SearchPage.Result }) {
+  const metadata = RESULT_TYPE_METADATA[result.type];
+  const highlightTerms = getHighlightTerms(query);
+
+  return (
+    <DivLink
+      to={result.link}
+      testId="company-search-result"
+      className="group flex items-start gap-3 rounded-lg px-2 py-5 transition-colors hover:bg-surface-highlight sm:gap-4 sm:px-3"
+    >
+      <div
+        aria-hidden="true"
+        data-testid="search-result-icon"
+        className="mt-0.5 flex h-12 w-12 shrink-0 self-start items-center justify-center"
+      >
+        <SearchResultIcon type={result.type} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs font-semibold uppercase tracking-wide text-content-dimmed">{metadata.label}</span>
+          {result.state ? <StateBadge state={result.state} /> : null}
+        </div>
+        <h2 className="mt-1 min-w-0 break-words text-base font-semibold text-content-accent">
+          <HighlightedText text={result.title} terms={highlightTerms} />
+        </h2>
+        <p className="mt-1 break-words text-sm text-content-dimmed">In {result.context}</p>
+        <p className="mt-2 text-xs font-medium text-content-subtle">Matched in {result.matchedField}</p>
+        {result.snippet ? (
+          <p
+            data-testid="search-result-snippet"
+            className="mt-1 line-clamp-3 break-words text-sm leading-6 text-content-base"
+          >
+            <HighlightedText text={result.snippet} terms={highlightTerms} />
+          </p>
+        ) : null}
+      </div>
+    </DivLink>
+  );
+}
+
+function SearchResultIcon({ type }: { type: SearchResultType }) {
+  switch (type) {
+    case "resource_hub_folder":
+      return <ResourceHubTypeIcon type="folder" size={48} />;
+    case "resource_hub_document":
+      return <ResourceHubTypeIcon type="document" size={48} />;
+    case "resource_hub_file":
+      return <ResourceHubTypeIcon type="file" size={48} />;
+    case "resource_hub_link":
+      return <ResourceHubTypeIcon type="link" size={48} />;
+    case "project":
+      return <IconProject size={32} />;
+    case "goal":
+      return <IconGoal size={32} />;
+    case "discussion":
+      return <IconMessage size={28} className="text-content-dimmed" />;
+    case "project_check_in":
+    case "goal_check_in":
+      return <IconCalendar size={28} className="text-content-dimmed" />;
+    case "project_retrospective":
+      return <IconHistory size={28} className="text-content-dimmed" />;
+  }
+}
+
+function HighlightedText({ text, terms }: { text: string; terms: string[] }) {
+  if (terms.length === 0) return <>{text}</>;
+
+  const alternatives = terms.map(escapeRegExp).join("|");
+  const segments = text.split(new RegExp(`(${alternatives})`, "giu"));
+  const exactMatch = new RegExp(`^(?:${alternatives})$`, "iu");
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        exactMatch.test(segment) ? (
+          <mark
+            key={`${segment}-${index}`}
+            className="rounded-sm bg-yellow-200/80 px-0.5 text-inherit dark:bg-yellow-700/60"
+          >
+            {segment}
+          </mark>
+        ) : (
+          segment
+        ),
+      )}
+    </>
+  );
+}
+
+function getHighlightTerms(query: string) {
+  const words = query.split(/[^\p{L}\p{N}]+/u);
+  const uniqueWords = new Map<string, string>();
+
+  words.forEach((word) => {
+    if (word.length > 1) uniqueWords.set(word.toLowerCase(), word);
+  });
+
+  return Array.from(uniqueWords.values()).sort((left, right) => right.length - left.length);
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function StateBadge({ state }: { state: SearchResultState }) {
+  return (
+    <span className="rounded-full border border-surface-outline bg-surface-dimmed px-2 py-0.5 text-xs font-medium text-content-dimmed">
+      {STATE_LABELS[state]}
+    </span>
+  );
+}
+
+function resultCountLabel(count: number) {
+  return count === 1 ? "1 result found." : `${count} results found.`;
+}
+
+const RESULT_TYPE_METADATA: Record<SearchResultType, { label: string }> = {
+  resource_hub_folder: { label: "Folder" },
+  resource_hub_document: { label: "Document" },
+  resource_hub_file: { label: "File" },
+  resource_hub_link: { label: "Link" },
+  project: { label: "Project" },
+  goal: { label: "Goal" },
+  discussion: { label: "Discussion" },
+  project_check_in: { label: "Project check-in" },
+  goal_check_in: { label: "Goal check-in" },
+  project_retrospective: { label: "Project retrospective" },
+};
+
+const STATE_LABELS: Record<SearchResultState, string> = {
+  closed: "Closed",
+  completed: "Completed",
+  archived: "Archived",
+  paused: "Paused",
+};

--- a/turboui/src/index.tsx
+++ b/turboui/src/index.tsx
@@ -28,6 +28,7 @@ export * from "./PieChart";
 export * from "./ProgressBar";
 export * from "./RichContent";
 export * from "./ResourceHub";
+export * from "./SearchPage";
 export * from "./Spacer";
 export * from "./StatusBadge";
 export * from "./SmallStatusIndicator";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Lint CI failure on #4956 (`make test.js.dead.code` / knip).

Knip reported `CompanySearchState` as an unused exported type in `useCompanySearch.ts`. The interface is only used as the hook’s return type, so the export was removed.

This commit was also pushed to `full-text-search-page` so #4956 picks up the fix.

## Test plan

- [x] `npm --prefix app run knip`
- [x] `npx tsc --noEmit -p tsconfig.lint.json` (in `app/`)
- [ ] Confirm Lint job passes on CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2764e268-acf6-4877-93a7-3bf39a19b2c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2764e268-acf6-4877-93a7-3bf39a19b2c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

