### PR TITLE
fix: Render API-created space task notes

### DIFF
--- a/app/test/features/space_kanban/task_cards_test.exs
+++ b/app/test/features/space_kanban/task_cards_test.exs
@@ -38,18 +38,32 @@ defmodule Operately.Features.SpaceKanban.TaskCardsTest do
     |> Steps.assert_description(content: "Updated description for kanban flow.")
   end
 
-  feature "task description set through external API is visible in the slide-in", ctx do
-    description = Operately.Support.RichText.rich_text("Hello world from API", :as_string)
+  feature "task description set during external API creation is visible in the slide-in", ctx do
+    ctx =
+      ctx
+      |> Factory.add_api_token(:api_token, :creator, read_only: false)
+      |> Steps.create_space_task_through_external_api(
+        name: "External API task",
+        description: api_task_description()
+      )
 
+    ctx
+    |> Steps.visit_kanban_page(task_id: ctx.external_api_task_id)
+    |> Steps.assert_description(content: "First paragraph from the API.")
+    |> Steps.assert_description(content: "Second paragraph from the API.")
+  end
+
+  feature "task description updated through external API is visible after a fresh page load", ctx do
     ctx =
       ctx
       |> Factory.add_api_token(:api_token, :creator, read_only: false)
       |> Steps.create_space_task_through_external_api(name: "External API task")
-      |> Steps.update_task_description_through_external_api(description: description)
+      |> Steps.update_task_description_through_external_api(description: api_task_description())
 
     ctx
     |> Steps.visit_kanban_page(task_id: ctx.external_api_task_id)
-    |> Steps.assert_description(content: "Hello world from API")
+    |> Steps.assert_description(content: "First paragraph from the API.")
+    |> Steps.assert_description(content: "Second paragraph from the API.")
   end
 
   feature "delete a task from the slide-in", ctx do
@@ -62,5 +76,27 @@ defmodule Operately.Features.SpaceKanban.TaskCardsTest do
     |> Steps.change_task_status(prev_status: "Not started", next_status: new_status)
     |> Steps.delete_task()
     |> Steps.assert_task_removed(task_key: :second_task, status_value: new_status)
+  end
+
+  defp api_task_description do
+    Jason.encode!(%{
+      type: "doc",
+      content: [
+        %{
+          type: "paragraph",
+          content: [
+            %{type: "text", text: ""},
+            %{type: "text", text: "First paragraph from the API."}
+          ]
+        },
+        %{
+          type: "paragraph",
+          content: [
+            %{type: "text", text: "Second paragraph from the API."},
+            %{type: "text", text: ""}
+          ]
+        }
+      ]
+    })
   end
 end

--- a/app/test/support/features/space_kanban_steps.ex
+++ b/app/test/support/features/space_kanban_steps.ex
@@ -42,16 +42,25 @@ defmodule Operately.Support.Features.SpaceKanbanSteps do
     |> UI.assert_has(testid: "task-slide-in")
   end
 
-  step :create_space_task_through_external_api, ctx, name: name do
+  step :create_space_task_through_external_api, ctx, opts do
     conn = api_conn()
+    name = Keyword.fetch!(opts, :name)
 
-    assert {200, res} = OperatelyWeb.TurboCase.external_mutation(conn, ctx.api_token, "tasks/create", %{
+    inputs = %{
       assignee_id: nil,
       due_date: nil,
       id: Paths.space_id(ctx.space),
       name: name,
       type: "space"
-    })
+    }
+
+    inputs =
+      case Keyword.fetch(opts, :description) do
+        {:ok, description} -> Map.put(inputs, :description, description)
+        :error -> inputs
+      end
+
+    assert {200, res} = OperatelyWeb.TurboCase.external_mutation(conn, ctx.api_token, "tasks/create", inputs)
 
     Map.put(ctx, :external_api_task_id, res.task.id)
   end

--- a/turboui/src/PageDescription/index.test.tsx
+++ b/turboui/src/PageDescription/index.test.tsx
@@ -3,7 +3,6 @@ import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { PageDescription } from ".";
-import { normalizeRichTextContent } from "../RichEditor/useEditor";
 
 const emptyDoc = { type: "doc", content: [{ type: "paragraph" }] };
 const descriptionDoc = {
@@ -29,24 +28,6 @@ const descriptionWithEmptyTextNodes = {
     },
   ],
 };
-const validRichDescription = {
-  type: "doc",
-  content: [
-    { type: "paragraph" },
-    {
-      type: "paragraph",
-      content: [
-        { type: "text", text: "Hello ", marks: [{ type: "bold" }] },
-        {
-          type: "mention",
-          attrs: { id: "jane-doe-abc123", label: "Jane Doe" },
-          marks: [{ type: "bold" }],
-        },
-      ],
-    },
-  ],
-};
-
 const richTextHandlers = {
   mentionedPersonLookup: jest.fn(),
   mentionSearchScope: { type: "none" as const },
@@ -54,23 +35,6 @@ const richTextHandlers = {
 };
 
 describe("PageDescription", () => {
-  it("removes empty text nodes without mutating the source document", () => {
-    expect(normalizeRichTextContent(descriptionWithEmptyTextNodes)).toEqual({
-      type: "doc",
-      content: [
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "First paragraph from the API." }],
-        },
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "Second paragraph from the API." }],
-        },
-      ],
-    });
-    expect(descriptionWithEmptyTextNodes.content[0].content[0]).toEqual({ type: "text", text: "" });
-  });
-
   it("renders meaningful content alongside empty text nodes", async () => {
     const { container } = render(
       <PageDescription
@@ -155,10 +119,6 @@ describe("PageDescription", () => {
         "Second paragraph from the API.",
       );
     });
-  });
-
-  it("leaves valid rich text, empty paragraphs, mentions, attributes, and marks unchanged", () => {
-    expect(normalizeRichTextContent(validRichDescription)).toBe(validRichDescription);
   });
 
   it.each([null, { type: "doc", content: [] }, emptyDoc])(

--- a/turboui/src/PageDescription/index.test.tsx
+++ b/turboui/src/PageDescription/index.test.tsx
@@ -1,13 +1,50 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { PageDescription } from ".";
+import { normalizeRichTextContent } from "../RichEditor/useEditor";
 
 const emptyDoc = { type: "doc", content: [{ type: "paragraph" }] };
 const descriptionDoc = {
   type: "doc",
   content: [{ type: "paragraph", content: [{ type: "text", text: "Hello world" }] }],
+};
+const descriptionWithEmptyTextNodes = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "" },
+        { type: "text", text: "First paragraph from the API." },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Second paragraph from the API." },
+        { type: "text", text: "" },
+      ],
+    },
+  ],
+};
+const validRichDescription = {
+  type: "doc",
+  content: [
+    { type: "paragraph" },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello ", marks: [{ type: "bold" }] },
+        {
+          type: "mention",
+          attrs: { id: "jane-doe-abc123", label: "Jane Doe" },
+          marks: [{ type: "bold" }],
+        },
+      ],
+    },
+  ],
 };
 
 const richTextHandlers = {
@@ -17,6 +54,46 @@ const richTextHandlers = {
 };
 
 describe("PageDescription", () => {
+  it("removes empty text nodes without mutating the source document", () => {
+    expect(normalizeRichTextContent(descriptionWithEmptyTextNodes)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "First paragraph from the API." }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Second paragraph from the API." }],
+        },
+      ],
+    });
+    expect(descriptionWithEmptyTextNodes.content[0].content[0]).toEqual({ type: "text", text: "" });
+  });
+
+  it("renders meaningful content alongside empty text nodes", async () => {
+    const { container } = render(
+      <PageDescription
+        description={descriptionWithEmptyTextNodes}
+        onDescriptionChange={jest.fn()}
+        richTextHandlers={richTextHandlers}
+        label="Notes"
+        testId="description"
+        emptyTestId="empty-description"
+        canEdit
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-test-id="description"]')).toHaveTextContent(
+        "First paragraph from the API.",
+      );
+      expect(container.querySelector('[data-test-id="description"]')).toHaveTextContent(
+        "Second paragraph from the API.",
+      );
+    });
+  });
+
   it("renders a description that arrives after the component mounted empty", () => {
     const { container, rerender } = render(
       <PageDescription
@@ -46,4 +123,61 @@ describe("PageDescription", () => {
 
     expect(container.querySelector('[data-test-id="description"]')).toHaveTextContent("Hello world");
   });
+
+  it("renders meaningful content when an existing description is replaced", async () => {
+    const { container, rerender } = render(
+      <PageDescription
+        description={descriptionDoc}
+        onDescriptionChange={jest.fn()}
+        richTextHandlers={richTextHandlers}
+        label="Notes"
+        testId="description"
+        canEdit
+      />,
+    );
+
+    rerender(
+      <PageDescription
+        description={descriptionWithEmptyTextNodes}
+        onDescriptionChange={jest.fn()}
+        richTextHandlers={richTextHandlers}
+        label="Notes"
+        testId="description"
+        canEdit
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-test-id="description"]')).toHaveTextContent(
+        "First paragraph from the API.",
+      );
+      expect(container.querySelector('[data-test-id="description"]')).toHaveTextContent(
+        "Second paragraph from the API.",
+      );
+    });
+  });
+
+  it("leaves valid rich text, empty paragraphs, mentions, attributes, and marks unchanged", () => {
+    expect(normalizeRichTextContent(validRichDescription)).toBe(validRichDescription);
+  });
+
+  it.each([null, { type: "doc", content: [] }, emptyDoc])(
+    "uses the zero state for an empty description",
+    (description) => {
+      const { container } = render(
+        <PageDescription
+          description={description}
+          onDescriptionChange={jest.fn()}
+          richTextHandlers={richTextHandlers}
+          label="Notes"
+          testId="description"
+          emptyTestId="empty-description"
+          canEdit
+        />,
+      );
+
+      expect(container.querySelector('[data-test-id="empty-description"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-test-id="description"]')).not.toBeInTheDocument();
+    },
+  );
 });

--- a/turboui/src/RichEditor/richTextContent.test.ts
+++ b/turboui/src/RichEditor/richTextContent.test.ts
@@ -1,0 +1,62 @@
+import { normalizeRichTextContent } from "./richTextContent";
+
+const descriptionWithEmptyTextNodes = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "" },
+        { type: "text", text: "First paragraph from the API." },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Second paragraph from the API." },
+        { type: "text", text: "" },
+      ],
+    },
+  ],
+};
+
+const validRichDescription = {
+  type: "doc",
+  content: [
+    { type: "paragraph" },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Hello ", marks: [{ type: "bold" }] },
+        {
+          type: "mention",
+          attrs: { id: "jane-doe-abc123", label: "Jane Doe" },
+          marks: [{ type: "bold" }],
+        },
+      ],
+    },
+  ],
+};
+
+describe("normalizeRichTextContent", () => {
+  it("removes empty text nodes without mutating the source document", () => {
+    expect(normalizeRichTextContent(descriptionWithEmptyTextNodes)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "First paragraph from the API." }],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Second paragraph from the API." }],
+        },
+      ],
+    });
+    expect(descriptionWithEmptyTextNodes.content[0].content[0]).toEqual({ type: "text", text: "" });
+  });
+
+  it("leaves valid rich text, empty paragraphs, mentions, attributes, and marks unchanged", () => {
+    expect(normalizeRichTextContent(validRichDescription)).toBe(validRichDescription);
+  });
+});

--- a/turboui/src/RichEditor/richTextContent.ts
+++ b/turboui/src/RichEditor/richTextContent.ts
@@ -1,0 +1,32 @@
+export interface RichTextNode {
+  type: string;
+  text?: string;
+  content?: RichTextNode[];
+  [key: string]: unknown;
+}
+
+export type RichTextContent = RichTextNode | RichTextNode[] | string | null | undefined;
+
+export function normalizeRichTextContent(content: RichTextContent): RichTextContent {
+  if (!isRichTextNode(content)) return content;
+
+  return normalizeRichTextNode(content);
+}
+
+function isRichTextNode(content: RichTextContent): content is RichTextNode {
+  return typeof content === "object" && content !== null && !Array.isArray(content);
+}
+
+function normalizeRichTextNode(node: RichTextNode): RichTextNode {
+  if (!Array.isArray(node.content)) return node;
+
+  const children = node.content;
+  const normalizedChildren = children
+    .filter((child) => child.type !== "text" || child.text !== "")
+    .map(normalizeRichTextNode);
+  const contentChanged =
+    normalizedChildren.length !== children.length ||
+    normalizedChildren.some((child, index) => child !== children[index]);
+
+  return contentChanged ? { ...node, content: normalizedChildren } : node;
+}

--- a/turboui/src/RichEditor/useEditor.tsx
+++ b/turboui/src/RichEditor/useEditor.tsx
@@ -79,6 +79,19 @@ const DEFAULT_EDITOR_PROPS: Partial<UseEditorProps> = {
   tabindex: "",
 };
 
+export function normalizeRichTextContent(content: any): any {
+  if (!content || typeof content !== "object" || !Array.isArray(content.content)) return content;
+
+  const normalizedChildren = content.content
+    .filter((child: any) => child?.type !== "text" || child.text !== "")
+    .map(normalizeRichTextContent);
+  const contentChanged =
+    normalizedChildren.length !== content.content.length ||
+    normalizedChildren.some((child: any, index: number) => child !== content.content[index]);
+
+  return contentChanged ? { ...content, content: normalizedChildren } : content;
+}
+
 export function useEditor(props: UseEditorProps): EditorState {
   props = { ...DEFAULT_EDITOR_PROPS, ...props };
 
@@ -86,9 +99,9 @@ export function useEditor(props: UseEditorProps): EditorState {
   const [submittable, setSubmittable] = React.useState(true);
   const [focused, setFocused] = React.useState(false);
   const [uploading, setUploading] = React.useState(false);
-  const baseContent = React.useRef(props.content);
+  const baseContent = React.useRef(normalizeRichTextContent(props.content));
   const [restoredDraft] = React.useState(() => readLocalDraft(props.localDraft, baseContent.current));
-  const initialContent = restoredDraft ?? props.content;
+  const initialContent = normalizeRichTextContent(restoredDraft ?? baseContent.current);
   const [empty, setEmpty] = React.useState(isRichTextEmpty(initialContent));
 
   const extensions = React.useMemo(
@@ -167,7 +180,7 @@ export function useEditor(props: UseEditorProps): EditorState {
   const setContent = React.useCallback(
     (content: any) => {
       if (!editor) return;
-      editor.commands.setContent(content, { emitUpdate: false });
+      editor.commands.setContent(normalizeRichTextContent(content), { emitUpdate: false });
     },
     [editor],
   );

--- a/turboui/src/RichEditor/useEditor.tsx
+++ b/turboui/src/RichEditor/useEditor.tsx
@@ -12,6 +12,7 @@ import {
   writeLocalDraft,
 } from "./localDrafts";
 import { SearchFn } from "./extensions/MentionPeople";
+import { normalizeRichTextContent } from "./richTextContent";
 
 export interface Person {
   id: string;
@@ -78,19 +79,6 @@ const DEFAULT_EDITOR_PROPS: Partial<UseEditorProps> = {
   autoFocus: false,
   tabindex: "",
 };
-
-export function normalizeRichTextContent(content: any): any {
-  if (!content || typeof content !== "object" || !Array.isArray(content.content)) return content;
-
-  const normalizedChildren = content.content
-    .filter((child: any) => child?.type !== "text" || child.text !== "")
-    .map(normalizeRichTextContent);
-  const contentChanged =
-    normalizedChildren.length !== content.content.length ||
-    normalizedChildren.some((child: any, index: number) => child !== content.content[index]);
-
-  return contentChanged ? { ...content, content: normalizedChildren } : content;
-}
 
 export function useEditor(props: UseEditorProps): EditorState {
   props = { ...DEFAULT_EDITOR_PROPS, ...props };


### PR DESCRIPTION
Normalize rich-text documents at the shared `useEditor` boundary before both initial TipTap construction and later `setContent` updates, removing zero-length text nodes while preserving meaningful text, marks, mentions, and empty paragraph structure. Space tasks created or updated through the external API can persist a non-empty ProseMirror description that appears blank in the task slide-in.

A `PageDescription` whose document mixes meaningful paragraphs with zero-length text nodes renders all meaningful text instead of an empty editor; A valid rich-text document remains unchanged by normalization, while empty paragraphs remain valid empty blocks and non-text nodes such as mentions retain their attributes and marks.

Fixes #4976
