### PR TITLE
fix: Make MCP refresh-token rotation atomic and persist replay revocation

### DIFF
--- a/app/lib/operately/mcp/operations/token_exchange.ex
+++ b/app/lib/operately/mcp/operations/token_exchange.ex
@@ -102,65 +102,80 @@ defmodule Operately.Mcp.Operations.TokenExchange do
     end
   end
 
+  # Reuse of a rotated refresh token revokes the grant family (RFC 9700).
+  # An expired refresh token only fails the exchange; the grant stays active.
   defp rotate_refresh_token(%RefreshToken{} = refresh_token) do
-    Repo.transaction(fn ->
-      refresh_token =
-        Repo.one!(
-          from(t in RefreshToken,
-            where: t.id == ^refresh_token.id,
-            preload: [grant: [:account, :company]]
+    result =
+      Repo.transaction(fn ->
+        refresh_token =
+          Repo.one!(
+            from(t in RefreshToken,
+              where: t.id == ^refresh_token.id,
+              preload: [grant: [:account, :company]],
+              lock: "FOR UPDATE"
+            )
           )
-        )
 
-      cond do
-        refresh_token.revoked_at ->
-          Repo.rollback(:invalid_grant)
+        cond do
+          refresh_token.revoked_at ->
+            Repo.rollback(:invalid_grant)
 
-        refresh_token.used_at ->
-          GrantOps.revoke_grant_lineage(refresh_token.grant, Token.now(), true)
-          Repo.rollback(:invalid_grant)
+          refresh_token.used_at ->
+            GrantOps.revoke_grant_lineage(refresh_token.grant, Token.now(), true)
+            {:replay, :invalid_grant}
 
-        Token.expired?(refresh_token.expires_at) ->
-          GrantOps.revoke_grant_lineage(refresh_token.grant, Token.now(), true)
-          Repo.rollback(:invalid_grant)
+          Token.expired?(refresh_token.expires_at) ->
+            Repo.rollback(:invalid_grant)
 
-        true ->
-          now = Token.now()
+          true ->
+            rotate_unused_refresh_token!(refresh_token)
+        end
+      end)
 
-          refresh_token
-          |> RefreshToken.changeset(%{used_at: now})
-          |> Repo.update!()
-
-          {access_token, raw_access_token} = build_access_token(refresh_token.grant, refresh_token.scopes, refresh_token.resource)
-
-          access_token = Repo.insert!(access_token)
-
-          {new_refresh_token, raw_refresh_token} =
-            build_refresh_token(refresh_token.grant, refresh_token.scopes, refresh_token.resource, refresh_token.id)
-
-          new_refresh_token = Repo.insert!(new_refresh_token)
-
-          refresh_token
-          |> RefreshToken.changeset(%{replaced_by_token_id: new_refresh_token.id})
-          |> Repo.update!()
-
-          %{
-            access_token: raw_access_token,
-            refresh_token: raw_refresh_token,
-            token_type: "Bearer",
-            expires_in: @access_token_ttl_seconds,
-            scope: Resources.scopes_to_string(refresh_token.scopes),
-            access_token_record: access_token,
-            refresh_token_record: new_refresh_token,
-            grant: refresh_token.grant
-          }
-      end
-    end)
-    |> case do
+    case result do
+      {:ok, {:replay, :invalid_grant}} -> {:error, :invalid_grant}
       {:ok, tokens} -> {:ok, tokens}
       {:error, reason} -> {:error, reason}
       {:error, _step, reason, _changes} -> {:error, reason}
     end
+  rescue
+    error in Ecto.ConstraintError ->
+      if error.constraint == "mcp_refresh_tokens_previous_token_id_index" do
+        {:error, :invalid_grant}
+      else
+        reraise error, __STACKTRACE__
+      end
+  end
+
+  defp rotate_unused_refresh_token!(%RefreshToken{} = refresh_token) do
+    now = Token.now()
+
+    refresh_token
+    |> RefreshToken.changeset(%{used_at: now})
+    |> Repo.update!()
+
+    {access_token, raw_access_token} = build_access_token(refresh_token.grant, refresh_token.scopes, refresh_token.resource)
+    access_token = Repo.insert!(access_token)
+
+    {new_refresh_token, raw_refresh_token} =
+      build_refresh_token(refresh_token.grant, refresh_token.scopes, refresh_token.resource, refresh_token.id)
+
+    new_refresh_token = Repo.insert!(new_refresh_token)
+
+    refresh_token
+    |> RefreshToken.changeset(%{replaced_by_token_id: new_refresh_token.id})
+    |> Repo.update!()
+
+    %{
+      access_token: raw_access_token,
+      refresh_token: raw_refresh_token,
+      token_type: "Bearer",
+      expires_in: @access_token_ttl_seconds,
+      scope: Resources.scopes_to_string(refresh_token.scopes),
+      access_token_record: access_token,
+      refresh_token_record: new_refresh_token,
+      grant: refresh_token.grant
+    }
   end
 
   defp issue_tokens!(%Grant{} = grant, scopes, resource, previous_refresh_token_id) do

--- a/app/lib/operately/mcp/refresh_token.ex
+++ b/app/lib/operately/mcp/refresh_token.ex
@@ -21,6 +21,7 @@ defmodule Operately.Mcp.RefreshToken do
     |> cast(attrs, [:grant_id, :token_hash, :resource, :scopes, :expires_at, :revoked_at, :used_at, :previous_token_id, :replaced_by_token_id])
     |> validate_required([:grant_id, :token_hash, :resource, :scopes, :expires_at])
     |> unique_constraint(:token_hash)
+    |> unique_constraint(:previous_token_id)
     |> foreign_key_constraint(:grant_id)
     |> foreign_key_constraint(:previous_token_id)
     |> foreign_key_constraint(:replaced_by_token_id)

--- a/app/priv/repo/migrations/20260814125253_unique_mcp_refresh_token_previous_token_id.exs
+++ b/app/priv/repo/migrations/20260814125253_unique_mcp_refresh_token_previous_token_id.exs
@@ -1,0 +1,11 @@
+defmodule Operately.Repo.Migrations.UniqueMcpRefreshTokenPreviousTokenId do
+  use Ecto.Migration
+
+  def change do
+    # Replace the lookup-only index with a unique one so a refresh token can have
+    # at most one successor. Postgres cannot alter that index in place, and keeping
+    # both would collide on the default name.
+    drop index(:mcp_refresh_tokens, [:previous_token_id])
+    create unique_index(:mcp_refresh_tokens, [:previous_token_id])
+  end
+end

--- a/app/test/operately/mcp/operations/token_exchange_test.exs
+++ b/app/test/operately/mcp/operations/token_exchange_test.exs
@@ -1,0 +1,61 @@
+defmodule Operately.Mcp.Operations.TokenExchangeTest do
+  use Operately.DataCase, async: true
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Mcp
+  alias Operately.Mcp.{Grant, RefreshToken, Token}
+  alias Operately.Repo
+
+  test "allows only one successor per refresh token" do
+    account = account_fixture()
+    company = company_fixture(%{company_name: "Unique Successor Co"}, account)
+    grant = insert_grant!(account, company)
+    previous = insert_refresh_token!(grant)
+
+    insert_refresh_token!(grant, previous_token_id: previous.id)
+
+    assert {:error, changeset} =
+             %RefreshToken{}
+             |> RefreshToken.changeset(%{
+               grant_id: grant.id,
+               token_hash: Token.hash("refresh-token-#{System.unique_integer()}"),
+               resource: Mcp.canonical_resource_uri(),
+               scopes: grant.scopes,
+               expires_at: DateTime.add(Token.now(), 86_400, :second),
+               previous_token_id: previous.id
+             })
+             |> Repo.insert()
+
+    assert {"has already been taken", _} = changeset.errors[:previous_token_id]
+  end
+
+  defp insert_grant!(account, company) do
+    %Grant{}
+    |> Grant.changeset(%{
+      account_id: account.id,
+      company_id: company.id,
+      client_id: "https://client.example.com/oauth/client.json",
+      client_name: "Example MCP Client",
+      redirect_uri: "https://client.example.com/callback",
+      resource: Mcp.canonical_resource_uri(),
+      scopes: ["mcp:read"]
+    })
+    |> Repo.insert!()
+  end
+
+  defp insert_refresh_token!(grant, attrs \\ []) do
+    defaults = %{
+      grant_id: grant.id,
+      token_hash: Token.hash("refresh-token-#{System.unique_integer()}"),
+      resource: Mcp.canonical_resource_uri(),
+      scopes: grant.scopes,
+      expires_at: DateTime.add(Token.now(), 86_400, :second)
+    }
+
+    %RefreshToken{}
+    |> RefreshToken.changeset(Map.merge(defaults, Map.new(attrs)))
+    |> Repo.insert!()
+  end
+end

--- a/app/test/operately_web/controllers/mcp_oauth_controller_test.exs
+++ b/app/test/operately_web/controllers/mcp_oauth_controller_test.exs
@@ -4,8 +4,11 @@ defmodule OperatelyWeb.McpOAuthControllerTest do
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
   import OperatelyWeb.Mcp.ToolConnHelper, except: [authorize_params: 2, authorize_params: 3]
+  import Ecto.Query
 
   alias Operately.Mcp
+  alias Operately.Mcp.{AccessToken, Grant, RefreshToken, Session, Token}
+  alias Operately.Repo
   alias OperatelyWeb.Mcp.ToolConnHelper
 
   setup do
@@ -256,11 +259,12 @@ defmodule OperatelyWeb.McpOAuthControllerTest do
     assert metadata.client_id == client.client_id
   end
 
-  test "rotates refresh tokens and rejects replay", %{conn: _conn, client: client} do
+  test "rotates refresh tokens and revokes the grant family on replay", %{conn: _conn, client: client} do
     account = account_fixture()
     company = company_fixture(%{company_name: "Rotations LLC"}, account)
 
-    %{refresh_token: refresh_token} = authorize_and_issue_tokens(account, company, client)
+    %{access_token: access_token, refresh_token: refresh_token} = authorize_and_issue_tokens(account, company, client)
+    {_initialize_conn, _session_id} = initialize_session(access_token)
 
     first_refresh_conn =
       post(build_conn(), "/oauth/token", %{
@@ -288,6 +292,68 @@ defmodule OperatelyWeb.McpOAuthControllerTest do
 
     assert replay_conn.status == 400
     assert replay_body["error"] == "invalid_grant"
+
+    grant = Repo.one!(from(g in Grant, where: g.account_id == ^account.id and g.company_id == ^company.id))
+    assert grant.revoked_at
+
+    assert Repo.all(from(t in AccessToken, where: t.grant_id == ^grant.id and is_nil(t.revoked_at))) == []
+    assert Repo.all(from(t in RefreshToken, where: t.grant_id == ^grant.id and is_nil(t.revoked_at))) == []
+    assert Repo.all(from(s in Session, where: s.grant_id == ^grant.id and is_nil(s.closed_at))) == []
+
+    successor_refresh_conn =
+      post(build_conn(), "/oauth/token", %{
+        "grant_type" => "refresh_token",
+        "client_id" => client.client_id,
+        "refresh_token" => first_refresh_body["refresh_token"],
+        "resource" => Mcp.canonical_resource_uri()
+      })
+
+    assert successor_refresh_conn.status == 400
+    assert Jason.decode!(successor_refresh_conn.resp_body)["error"] == "invalid_grant"
+
+    successor_mcp_conn =
+      build_conn()
+      |> put_req_header("accept", "application/json, text/event-stream")
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", "Bearer #{first_refresh_body["access_token"]}")
+      |> post("/mcp", %{
+        "jsonrpc" => "2.0",
+        "id" => "1",
+        "method" => "initialize",
+        "params" => %{
+          "protocolVersion" => Mcp.latest_protocol_version(),
+          "capabilities" => %{},
+          "clientInfo" => %{"name" => "Example Client", "version" => "1.0.0"}
+        }
+      })
+
+    assert successor_mcp_conn.status == 401
+  end
+
+  test "expired refresh tokens fail without revoking the grant", %{conn: _conn, client: client} do
+    account = account_fixture()
+    company = company_fixture(%{company_name: "Expiry LLC"}, account)
+
+    %{refresh_token: refresh_token} = authorize_and_issue_tokens(account, company, client)
+
+    RefreshToken
+    |> Repo.get_by!(token_hash: Token.hash(refresh_token))
+    |> RefreshToken.changeset(%{expires_at: DateTime.add(Token.now(), -60, :second)})
+    |> Repo.update!()
+
+    expired_conn =
+      post(build_conn(), "/oauth/token", %{
+        "grant_type" => "refresh_token",
+        "client_id" => client.client_id,
+        "refresh_token" => refresh_token,
+        "resource" => Mcp.canonical_resource_uri()
+      })
+
+    assert expired_conn.status == 400
+    assert Jason.decode!(expired_conn.resp_body)["error"] == "invalid_grant"
+
+    grant = Repo.one!(from(g in Grant, where: g.account_id == ^account.id and g.company_id == ^company.id))
+    refute grant.revoked_at
   end
 
   test "registers a dynamic oauth client", %{conn: conn} do

--- a/specs/0012-operately-mcp.md
+++ b/specs/0012-operately-mcp.md
@@ -166,6 +166,10 @@ When the authorization request omits `scope` or passes an empty value, Operately
 
 Discovery metadata advertises supported scopes and the read-only default via `scopes_supported` and `default_scopes` on Protected Resource Metadata and Authorization Server Metadata.
 
+### Refresh-token rotation
+
+Refresh tokens rotate on each successful `/oauth/token` refresh. Reuse of an already-rotated refresh token returns `invalid_grant` and **revokes the grant family** (grant, access tokens, refresh tokens, sessions), per RFC 9700. An **expired** refresh token returns `invalid_grant` only; the grant stays active so the client can reauthorize without an implicit revoke. At most one successor exists per refresh token (`previous_token_id` is unique).
+
 ### Client registration
 
 PRs 1–4 accept only pre-registered OAuth clients configured on the Operately server:


### PR DESCRIPTION
Fixes https://github.com/operately/operately/issues/4919