### PR TITLE
feat: Give each KPI its own page

### DIFF
--- a/app/assets/js/features/SpaceTools/ToolsSection.test.tsx
+++ b/app/assets/js/features/SpaceTools/ToolsSection.test.tsx
@@ -26,7 +26,12 @@ jest.mock("./components", () => ({
 // turboui bundles its own React instance, so stub the KPI summary content.
 jest.mock("turboui", () => ({ KpiSummaryCard: () => null }));
 
-jest.mock("@/routes/paths", () => ({ usePaths: () => ({ spaceKpisPath: (id: string) => `/spaces/${id}/kpis` }) }));
+jest.mock("@/routes/paths", () => ({
+  usePaths: () => ({
+    spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+    spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+  }),
+}));
 
 const mockCompany = jest.fn();
 jest.mock("@/routes/useCompanyLoaderData", () => ({

--- a/app/assets/js/features/activities/KpiCreated/index.test.tsx
+++ b/app/assets/js/features/activities/KpiCreated/index.test.tsx
@@ -11,8 +11,15 @@ jest.mock("@/routes/paths", () => ({
   usePaths: () => ({
     spacePath: (id: string) => `/spaces/${id}`,
     spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+    spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
   }),
 }));
+
+const paths: any = {
+  homePath: () => "/acme",
+  spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+  spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+};
 
 describe("kpi_created activities", () => {
   const activity: any = {
@@ -20,6 +27,7 @@ describe("kpi_created activities", () => {
     author: { fullName: "Jo Smith" },
     content: {
       space: { id: "space-1", name: "General" },
+      kpi: { id: "kpi-1" },
       kpiName: "Weekly active users",
     },
   };
@@ -36,18 +44,21 @@ describe("kpi_created activities", () => {
       "Created KPI: Weekly active users",
     );
     expect(renderToStaticMarkup(<>{ActivityHandler.NotificationLocation({ activity })}</>)).toBe("General");
-    expect(ActivityHandler.pagePath({ spaceKpisPath: (id: string) => `/spaces/${id}/kpis` } as any, activity)).toBe(
-      "/spaces/space-1/kpis",
-    );
+  });
+
+  it("links to the KPI's own page", () => {
+    expect(ActivityHandler.pagePath(paths, activity)).toBe("/spaces/space-1/kpis/kpi-1");
+  });
+
+  it("falls back to the space's KPI list when the activity carries no KPI", () => {
+    const activityWithoutKpi = { ...activity, content: { ...activity.content, kpi: null } };
+
+    expect(ActivityHandler.pagePath(paths, activityWithoutKpi)).toBe("/spaces/space-1/kpis");
   });
 
   it("redirects to home when the activity has no space", () => {
     const activityWithoutSpace = { ...activity, content: { kpiName: "Weekly active users" } };
-    const paths = {
-      homePath: () => "/acme",
-      spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
-    };
 
-    expect(ActivityHandler.pagePath(paths as any, activityWithoutSpace)).toBe("/acme");
+    expect(ActivityHandler.pagePath(paths, activityWithoutSpace)).toBe("/acme");
   });
 });

--- a/app/assets/js/features/activities/KpiCreated/index.tsx
+++ b/app/assets/js/features/activities/KpiCreated/index.tsx
@@ -12,9 +12,14 @@ const KpiCreated: ActivityHandler = {
   },
 
   pagePath(paths, activity: Activity) {
-    const spaceId = content(activity).space?.id;
+    const data = content(activity);
+    const spaceId = data.space?.id;
+    const kpiId = data.kpi?.id;
 
-    return spaceId ? paths.spaceKpisPath(spaceId) : paths.homePath();
+    if (!spaceId) return paths.homePath();
+
+    // Activities recorded before KPIs had their own page carry no KPI id.
+    return kpiId ? paths.spaceKpiPath(spaceId, kpiId) : paths.spaceKpisPath(spaceId);
   },
 
   PageTitle(_props: { activity: Activity }) {

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -22,6 +22,7 @@ export function parseKpiForTurboUi(paths: Paths, kpi: ApiKpi): SpaceKpisPage.Kpi
     cadence: kpi.cadence as SpaceKpisPage.Cadence,
     champion: parsePersonForTurboUi(paths, kpi.champion),
     insertedAt: kpi.insertedAt ? new Date(kpi.insertedAt) : new Date(),
+    link: paths.spaceKpiPath(kpi.spaceId, kpi.id),
     latestEntry: kpi.latestEntry ? parseKpiEntryForTurboUi(paths, kpi.latestEntry) : null,
     entries: (kpi.entries ?? []).map((entry) => parseKpiEntryForTurboUi(paths, entry)),
   };

--- a/app/assets/js/pages/SpaceKpisPage/loader.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/loader.tsx
@@ -1,20 +1,25 @@
 import * as Pages from "@/components/Pages";
 import * as Spaces from "@/models/spaces";
-import { listKpis } from "@/models/kpis";
+import { getKpi, listKpis } from "@/models/kpis";
 import { Kpi } from "@/api";
 
 interface LoadedData {
   space: Spaces.Space;
   kpis: Kpi[];
+
+  // The KPI addressed by the route (/spaces/:id/kpis/:kpiId), loaded with its
+  // entries for the chart. Null on the list route.
+  kpi: Kpi | null;
 }
 
 export async function loader({ params }): Promise<LoadedData> {
-  const [space, kpis] = await Promise.all([
+  const [space, kpis, kpi] = await Promise.all([
     Spaces.getSpace({ id: params.id, includePermissions: true }),
     listKpis({ spaceId: params.id }).then((d) => d.kpis),
+    params.kpiId ? getKpi({ kpiId: params.kpiId }).then((d) => d.kpi) : null,
   ]);
 
-  return { space, kpis };
+  return { space, kpis, kpi };
 }
 
 export function useLoadedData(): LoadedData {

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Navigate } from "react-router";
+import { Navigate, useNavigate } from "react-router";
 
 import { SpaceKpisPage } from "turboui";
 import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/types";
@@ -14,9 +14,10 @@ import { useLoadedData, useRefresh } from "./loader";
 
 export function Page() {
   const paths = usePaths();
+  const navigate = useNavigate();
   const refresh = useRefresh();
   const { company } = useCompanyLoaderData();
-  const { space, kpis } = useLoadedData();
+  const { space, kpis, kpi } = useLoadedData();
 
   const peopleSearch = People.usePeopleSearch({ type: "space", id: space.id! });
 
@@ -25,7 +26,9 @@ export function Page() {
   const [deleteKpi] = Kpis.useDeleteKpi();
   const [logKpiEntry] = Kpis.useLogKpiEntry();
 
-  const parsedKpis = React.useMemo(() => kpis.map((kpi) => Kpis.parseKpiForTurboUi(paths, kpi)), [kpis, paths]);
+  const kpisLink = paths.spaceKpisPath(space.id!);
+  const parsedKpis = React.useMemo(() => kpis.map((k) => Kpis.parseKpiForTurboUi(paths, k)), [kpis, paths]);
+  const selectedKpi = React.useMemo(() => (kpi ? Kpis.parseKpiForTurboUi(paths, kpi) : null), [kpi, paths]);
 
   const championSearch = React.useCallback(
     async (query: string) => People.parsePeopleForTurboUi(paths, await peopleSearch(query)),
@@ -65,10 +68,13 @@ export function Page() {
       return input.id;
     });
 
+  // Deleting the KPI whose page we are on leaves nothing to show, so we return
+  // to the list instead of refreshing into a missing KPI.
   const onDeleteKpi = async (kpiId: string) =>
     run(async () => {
       await deleteKpi({ kpiId });
-      refresh();
+      if (kpiId === selectedKpi?.id) navigate(kpisLink);
+      else refresh();
     });
 
   const onRecordEntry = async (input: SpaceKpisPageTypes.RecordEntryInput) =>
@@ -77,17 +83,16 @@ export function Page() {
       refresh();
     });
 
-  const onLoadKpi = async (kpiId: string) => Kpis.parseKpiForTurboUi(paths, (await Kpis.getKpi({ kpiId })).kpi);
-
   return (
     <SpaceKpisPage
       space={{ id: space.id!, name: space.name!, link: paths.spacePath(space.id!) }}
       navigation={[{ to: paths.spacePath(space.id!), label: space.name! }]}
+      kpisLink={kpisLink}
       kpis={parsedKpis}
+      selectedKpi={selectedKpi}
       currentUser={null}
       canManage={space.permissions?.canEdit ?? false}
       championSearch={championSearch}
-      onLoadKpi={onLoadKpi}
       onCreateKpi={onCreateKpi}
       onEditKpi={onEditKpi}
       onDeleteKpi={onDeleteKpi}

--- a/app/assets/js/routes/index.tsx
+++ b/app/assets/js/routes/index.tsx
@@ -110,6 +110,7 @@ export function createAppRoutes(createRouter: typeof createBrowserRouter = creat
         pageRoute("spaces/:id/work-map", pages.SpaceWorkMapPage),
         pageRoute("spaces/:id/kanban", pages.SpaceKanbanPage),
         pageRoute("spaces/:id/kpis", pages.SpaceKpisPage),
+        pageRoute("spaces/:id/kpis/:kpiId", pages.SpaceKpisPage),
         pageRoute("spaces/:id/project-templates", pages.ProjectTemplatesPage),
 
         pageRoute("resource-hubs/:id", pages.ResourceHubPage),

--- a/app/assets/js/routes/paths.tsx
+++ b/app/assets/js/routes/paths.tsx
@@ -406,6 +406,10 @@ export class Paths {
     return this.createCompanyPath(["spaces", spaceId, "kpis"]);
   }
 
+  spaceKpiPath(spaceId: string, kpiId: string) {
+    return this.createCompanyPath(["spaces", spaceId, "kpis", kpiId]);
+  }
+
   projectTemplatesPath() {
     return this.createCompanyPath(["project-templates"]);
   }

--- a/turboui/src/SpaceKpisPage/DeleteKpiModal.tsx
+++ b/turboui/src/SpaceKpisPage/DeleteKpiModal.tsx
@@ -10,16 +10,12 @@ interface DeleteKpiModalProps {
   isOpen: boolean;
   onClose: () => void;
   onDelete: (kpiId: string) => Promise<SpaceKpisPage.MutationResult>;
-
-  // Called after a successful delete so the page can leave the (now missing)
-  // detail view and return to the list.
-  onDeleted?: () => void;
 }
 
 // Confirmation before deleting a KPI. Deleting removes the KPI and all of its
 // recorded entries, so we guard it behind an explicit destructive confirm —
 // mirroring the project delete flow.
-export function DeleteKpiModal({ kpi, isOpen, onClose, onDelete, onDeleted }: DeleteKpiModalProps) {
+export function DeleteKpiModal({ kpi, isOpen, onClose, onDelete }: DeleteKpiModalProps) {
   const [isDeleting, setIsDeleting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -34,7 +30,6 @@ export function DeleteKpiModal({ kpi, isOpen, onClose, onDelete, onDeleted }: De
 
       if (result.success) {
         onClose();
-        onDeleted?.();
       } else {
         setError(result.error ?? "Something went wrong. Please try again.");
       }

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -8,17 +8,12 @@ import { formatCadence, formatShortDate, formatValue, latestEntry, latestTrend }
 
 interface KpiDetailProps {
   kpi: SpaceKpisPage.Kpi;
-
-  // True while the KPI's entries are still being fetched (the list endpoint
-  // omits them). Shows a placeholder in place of the chart/history so we don't
-  // flash a misleading "No data" state.
-  loadingHistory?: boolean;
 }
 
 // The KPI name, back navigation and the "Log update" action live in the shared
 // page header (see index.tsx), so the detail body focuses on the metadata,
 // latest value, history chart and the recorded-updates log.
-export function KpiDetail({ kpi, loadingHistory = false }: KpiDetailProps) {
+export function KpiDetail({ kpi }: KpiDetailProps) {
   const latest = latestEntry(kpi);
   const trend = latestTrend(kpi);
 
@@ -44,33 +39,24 @@ export function KpiDetail({ kpi, loadingHistory = false }: KpiDetailProps) {
         </span>
       </div>
 
-      {loadingHistory ? (
-        <div className="mt-6 space-y-6" data-test-id="kpi-detail-loading">
-          <div className="h-10 w-40 animate-pulse rounded bg-surface-dimmed" />
-          <div className="h-[220px] animate-pulse rounded-lg bg-surface-dimmed" />
+      <div className="mt-6 flex items-end gap-3">
+        <div className="text-4xl font-bold text-content-accent">
+          {latest ? formatValue(latest.value, kpi.unit) : "—"}
         </div>
-      ) : (
-        <>
-          <div className="mt-6 flex items-end gap-3">
-            <div className="text-4xl font-bold text-content-accent">
-              {latest ? formatValue(latest.value, kpi.unit) : "—"}
-            </div>
-            <div className="pb-1">
-              <TrendIndicator delta={trend} />
-            </div>
-            {latest && (
-              <div className="pb-1.5 text-xs text-content-dimmed">latest · {formatShortDate(latest.recordedAt)}</div>
-            )}
-          </div>
+        <div className="pb-1">
+          <TrendIndicator delta={trend} />
+        </div>
+        {latest && (
+          <div className="pb-1.5 text-xs text-content-dimmed">latest · {formatShortDate(latest.recordedAt)}</div>
+        )}
+      </div>
 
-          <div className="mt-6 rounded-lg border border-stroke-base bg-surface-base p-4">
-            <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
-            <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
-          </div>
+      <div className="mt-6 rounded-lg border border-stroke-base bg-surface-base p-4">
+        <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
+        <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
+      </div>
 
-          <EntriesTable entries={kpi.entries} unit={kpi.unit} />
-        </>
-      )}
+      <EntriesTable entries={kpi.entries} unit={kpi.unit} />
     </div>
   );
 }

--- a/turboui/src/SpaceKpisPage/KpiList.tsx
+++ b/turboui/src/SpaceKpisPage/KpiList.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Avatar } from "../Avatar";
+import { BlackLink } from "../Link";
 import { IconChartColumn, IconDots } from "../icons";
 import { KpiActionsMenu } from "./KpiActionsMenu";
 import type { SpaceKpisPage } from "./types";
@@ -10,14 +11,13 @@ import { TrendIndicator } from "./TrendIndicator";
 interface KpiListProps {
   kpis: SpaceKpisPage.Kpi[];
   canManage: boolean;
-  onSelect: (kpiId: string) => void;
   onLogUpdate: (kpiId: string) => void;
   onNewKpi: () => void;
   onEdit: (kpiId: string) => void;
   onDelete: (kpiId: string) => void;
 }
 
-export function KpiList({ kpis, canManage, onSelect, onLogUpdate, onNewKpi, onEdit, onDelete }: KpiListProps) {
+export function KpiList({ kpis, canManage, onLogUpdate, onNewKpi, onEdit, onDelete }: KpiListProps) {
   if (kpis.length === 0) {
     return <EmptyState canManage={canManage} onNewKpi={onNewKpi} />;
   }
@@ -40,7 +40,6 @@ export function KpiList({ kpis, canManage, onSelect, onLogUpdate, onNewKpi, onEd
               key={kpi.id}
               kpi={kpi}
               canManage={canManage}
-              onSelect={() => onSelect(kpi.id)}
               onLogUpdate={() => onLogUpdate(kpi.id)}
               onEdit={() => onEdit(kpi.id)}
               onDelete={() => onDelete(kpi.id)}
@@ -55,14 +54,12 @@ export function KpiList({ kpis, canManage, onSelect, onLogUpdate, onNewKpi, onEd
 function KpiRow({
   kpi,
   canManage,
-  onSelect,
   onLogUpdate,
   onEdit,
   onDelete,
 }: {
   kpi: SpaceKpisPage.Kpi;
   canManage: boolean;
-  onSelect: () => void;
   onLogUpdate: () => void;
   onEdit: () => void;
   onDelete: () => void;
@@ -72,12 +69,18 @@ function KpiRow({
 
   return (
     <tr
-      className="group cursor-pointer border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
-      onClick={onSelect}
+      className="group border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
       data-test-id={`kpi-row-${kpi.id}`}
     >
       <td className="px-4 py-3">
-        <div className="font-semibold text-content-accent group-hover:underline">{kpi.name}</div>
+        <BlackLink
+          to={kpi.link}
+          className="font-semibold text-content-accent"
+          underline="hover"
+          testId={`kpi-link-${kpi.id}`}
+        >
+          {kpi.name}
+        </BlackLink>
         <div className="text-xs text-content-dimmed">Measured in {kpi.unit}</div>
       </td>
 
@@ -107,8 +110,7 @@ function KpiRow({
 
       <td className="px-4 py-3 text-right">
         {canManage && (
-          // Stop row-selection navigation when interacting with the actions.
-          <div className="flex items-center justify-end gap-1" onClick={(event) => event.stopPropagation()}>
+          <div className="flex items-center justify-end gap-1">
             <button
               type="button"
               className="rounded-md px-2 py-1 text-xs font-medium text-link-base opacity-0 transition-opacity hover:bg-surface-accent group-hover:opacity-100"

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
@@ -29,6 +29,7 @@ const kpi: SpaceKpisPage.Kpi = {
   cadence: "weekly",
   champion: null,
   insertedAt: new Date(),
+  link: "/spaces/space-growth/kpis/kpi-signups",
   latestEntry: null,
   entries: [],
 };

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
+import { useParams } from "react-router";
 
 import { SpaceKpisPage } from "./index";
 import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
-import { mockChampionSearch, mockCurrentUser, mockKpis, mockPeople, mockSpace } from "./mockData";
+import { mockChampionSearch, mockCurrentUser, mockKpis, mockKpisLink, mockPeople, mockSpace } from "./mockData";
 
 //
 // Space KPIs — proof of concept (frontend, Storybook only).
@@ -23,14 +24,22 @@ import { mockChampionSearch, mockCurrentUser, mockKpis, mockPeople, mockSpace } 
 // recordKpiEntry GraphQL mutations) actually update the UI, letting reviewers
 // exercise the happy path.
 //
+// Each KPI has its own page, so the harness reads the open KPI from the route
+// (`/spaces/:spaceId/kpis/:kpiId`) the way the app does. Stories that show the
+// detail view set that route through the `reactRouter` parameter.
+//
 type HarnessArgs = {
   loading?: boolean;
   error?: string | null;
   canManage?: boolean;
   emptySpace?: boolean;
   failMutations?: boolean;
-  initialSelectedKpiId?: string | null;
 };
+
+// Opens a story on a single KPI's page.
+function kpiRoute(kpiId: string) {
+  return { reactRouter: { path: `${mockKpisLink}/${kpiId}`, routePath: `${mockKpisLink}/:kpiId` } };
+}
 
 const meta = {
   title: "Pages/SpaceKpisPage",
@@ -52,6 +61,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function Harness(args: HarnessArgs) {
   const [kpis, setKpis] = React.useState<SpaceKpisPageNS.Kpi[]>(() => (args.emptySpace ? [] : clone(mockKpis)));
+  const { kpiId } = useParams();
 
   const onCreateKpi = async (input: SpaceKpisPageNS.NewKpiInput): Promise<SpaceKpisPageNS.MutationResult> => {
     console.log("createKpi", input);
@@ -62,13 +72,15 @@ function Harness(args: HarnessArgs) {
     }
 
     const champion = mockPeople.find((p) => p.id === input.championId) ?? null;
+    const id = `kpi-${crypto.randomUUID()}`;
     const newKpi: SpaceKpisPageNS.Kpi = {
-      id: `kpi-${crypto.randomUUID()}`,
+      id,
       name: input.name,
       unit: input.unit,
       cadence: input.cadence,
       champion,
       insertedAt: new Date(),
+      link: `${mockKpisLink}/${id}`,
       latestEntry: null,
       entries: [],
     };
@@ -141,7 +153,9 @@ function Harness(args: HarnessArgs) {
     <SpaceKpisPage
       space={mockSpace}
       navigation={[{ to: mockSpace.link, label: mockSpace.name }]}
+      kpisLink={mockKpisLink}
       kpis={kpis}
+      selectedKpi={kpis.find((kpi) => kpi.id === kpiId) ?? null}
       currentUser={mockCurrentUser}
       championSearch={mockChampionSearch}
       onCreateKpi={onCreateKpi}
@@ -151,7 +165,6 @@ function Harness(args: HarnessArgs) {
       loading={args.loading}
       error={args.error}
       canManage={args.canManage}
-      initialSelectedKpiId={args.initialSelectedKpiId}
     />
   );
 }
@@ -161,27 +174,21 @@ export const Default: Story = {
   args: {},
 };
 
-// Detail view opened on a KPI with lots of history — shows the line chart,
-// trend, champion + cadence, and the recorded-updates log.
+// A single KPI's page, opened on one with lots of history — shows the line
+// chart, trend, champion + cadence, and the recorded-updates log.
 export const DetailView: Story = {
-  args: {
-    initialSelectedKpiId: "kpi-mrr",
-  },
+  parameters: kpiRoute("kpi-mrr"),
 };
 
-// Edge case: a KPI with a single entry can't plot a trend line yet, so the
-// detail view shows a single-value card prompting for another update.
+// Edge case: a KPI with a single entry can't plot a trend line yet, so its page
+// shows a single-value card prompting for another update.
 export const SingleEntry: Story = {
-  args: {
-    initialSelectedKpiId: "kpi-signups",
-  },
+  parameters: kpiRoute("kpi-signups"),
 };
 
 // Edge case: a brand-new KPI with no entries — empty chart and "No data" states.
 export const NoDataYet: Story = {
-  args: {
-    initialSelectedKpiId: "kpi-churn",
-  },
+  parameters: kpiRoute("kpi-churn"),
 };
 
 // First-run experience: a space that has not created any KPIs yet.

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -19,13 +19,16 @@ async function findByTestId(testId: string): Promise<HTMLElement> {
   });
 }
 
+const kpisLink = `/spaces/${mockSpace.id}/kpis`;
+
 // These tests guard the unified space-tool layout: the KPIs page should present
 // the same page chrome (breadcrumb navigation + tool title + header action) as
 // the other space tools rather than an in-page tab bar.
-function renderPage(overrides: Partial<SpaceKpisPageNS.Props> = {}) {
-  const props: SpaceKpisPageNS.Props = {
+function pageProps(overrides: Partial<SpaceKpisPageNS.Props> = {}): SpaceKpisPageNS.Props {
+  return {
     space: mockSpace,
     navigation: [{ to: `/spaces/${mockSpace.id}`, label: mockSpace.name }],
+    kpisLink,
     kpis: mockKpis,
     currentUser: mockCurrentUser,
     championSearch: mockChampionSearch,
@@ -35,10 +38,12 @@ function renderPage(overrides: Partial<SpaceKpisPageNS.Props> = {}) {
     onRecordEntry: async () => ({ success: true }),
     ...overrides,
   };
+}
 
+function renderPage(overrides: Partial<SpaceKpisPageNS.Props> = {}) {
   return render(
     <MemoryRouter>
-      <SpaceKpisPage {...props} />
+      <SpaceKpisPage {...pageProps(overrides)} />
     </MemoryRouter>,
   );
 }
@@ -70,25 +75,31 @@ describe("SpaceKpisPage layout", () => {
     expect(container.querySelector('[data-test-id="new-kpi"]')).toBeInTheDocument();
   });
 
+  // Every KPI has its own page, so the list links to it instead of swapping the
+  // content in place. That makes a KPI shareable: the link can be copied,
+  // bookmarked, and opened in a new tab.
+  test("each KPI in the list links to its own page", () => {
+    renderPage();
+
+    mockKpis.forEach((kpi) => {
+      expect(screen.getByText(kpi.name).closest("a")).toHaveAttribute("href", kpi.link);
+    });
+  });
+
   test("opening a KPI moves its name into the header and swaps the primary action to 'Log update'", () => {
     const target = mockKpis[0]!;
-    const { container } = renderPage({ initialSelectedKpiId: target.id });
+    const { container } = renderPage({ selectedKpi: target });
 
     // KPI name becomes the header title...
     expect(screen.getByRole("heading", { name: target.name })).toBeInTheDocument();
 
-    // ...and "KPIs" becomes a breadcrumb back to the list.
+    // ...and "KPIs" becomes a breadcrumb linking back to the list.
     const backCrumb = container.querySelector('[data-test-id="kpis-breadcrumb"]');
-    expect(backCrumb).toBeInTheDocument();
+    expect(backCrumb).toHaveAttribute("href", kpisLink);
 
     // The header action is now "Log update", not "New KPI".
     expect(container.querySelector('[data-test-id="kpi-detail-log-update"]')).toBeInTheDocument();
     expect(container.querySelector('[data-test-id="new-kpi"]')).not.toBeInTheDocument();
-
-    // Clicking the breadcrumb returns to the list.
-    fireEvent.click(backCrumb!);
-    expect(screen.getByRole("heading", { name: "KPIs" })).toBeInTheDocument();
-    expect(container.querySelector('[data-test-id="new-kpi"]')).toBeInTheDocument();
   });
 
   test("read-only viewers see no header action", () => {
@@ -112,6 +123,7 @@ describe("SpaceKpisPage list latest value", () => {
       cadence: "weekly",
       champion: null,
       insertedAt: new Date(),
+      link: `${kpisLink}/kpi-throughput`,
       latestEntry: { id: "e1", value: 123, recordedAt: new Date(), recordedBy: null },
       entries: [],
     };
@@ -171,7 +183,7 @@ describe("SpaceKpisPage edit & delete", () => {
   test("the detail header exposes the same manage menu for the open KPI", async () => {
     const user = userEvent.setup();
     const target = mockKpis[0]!;
-    const { container } = renderPage({ initialSelectedKpiId: target.id });
+    const { container } = renderPage({ selectedKpi: target });
 
     await user.click(container.querySelector(`[data-test-id="kpi-actions-${target.id}"]`)!);
 
@@ -188,7 +200,7 @@ describe("SpaceKpisPage edit & delete", () => {
     expect(list.container.querySelector(`[data-test-id="kpi-actions-${target.id}"]`)).not.toBeInTheDocument();
     list.unmount();
 
-    const detail = renderPage({ canManage: false, initialSelectedKpiId: target.id });
+    const detail = renderPage({ canManage: false, selectedKpi: target });
     expect(detail.container.querySelector(`[data-test-id="kpi-actions-${target.id}"]`)).not.toBeInTheDocument();
   });
 });
@@ -262,21 +274,34 @@ describe("SpaceKpisPage create & log", () => {
     );
   });
 
-  test("logging an entry reloads the detail so the chart reflects the new value", async () => {
+  // The open KPI comes from the route loader, so a logged entry reaches the
+  // chart when the page re-renders with refreshed route data. This harness
+  // stands in for that refresh.
+  test("logging an entry from the detail view updates the chart once the route data refreshes", async () => {
     const user = userEvent.setup();
 
     // Start from a KPI with a single entry (single-point card), then log a
     // second one so the history becomes a multi-point line chart.
     const base = mockKpis.find((kpi) => kpi.id === "kpi-signups")!;
-    let entries = base.entries;
 
-    const onLoadKpi = jest.fn(async () => ({ ...base, entries: [...entries] }));
-    const onRecordEntry = jest.fn(async () => {
-      entries = [...entries, { id: "new-entry", value: 500, recordedAt: new Date(), recordedBy: null }];
-      return { success: true };
-    });
+    function Harness() {
+      const [kpi, setKpi] = React.useState(base);
 
-    const { container } = renderPage({ initialSelectedKpiId: base.id, onLoadKpi, onRecordEntry });
+      const onRecordEntry = async (input: SpaceKpisPageNS.RecordEntryInput) => {
+        const entry = { id: "new-entry", value: input.value, recordedAt: new Date(), recordedBy: null };
+        setKpi((current) => ({ ...current, entries: [...current.entries, entry] }));
+
+        return { success: true };
+      };
+
+      return <SpaceKpisPage {...pageProps({ selectedKpi: kpi, onRecordEntry })} />;
+    }
+
+    const { container } = render(
+      <MemoryRouter>
+        <Harness />
+      </MemoryRouter>,
+    );
 
     // Single entry → single-value card, no trend line yet.
     await findByTestId("kpi-line-chart-single");
@@ -287,8 +312,7 @@ describe("SpaceKpisPage create & log", () => {
     fireEvent.change(await findByTestId("log-update-period"), { target: { value: "2026-07-30" } });
     await user.click(await findByTestId("submit"));
 
-    // After logging, the detail reloads and the chart now plots a line.
+    // With the refreshed KPI there are two entries, so the chart plots a line.
     await findByTestId("kpi-line-chart");
-    expect(onLoadKpi).toHaveBeenCalledTimes(2);
   });
 });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -20,57 +20,28 @@ import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
 export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   const canManage = props.canManage ?? true;
 
-  const [selectedKpiId, setSelectedKpiId] = React.useState<string | null>(props.initialSelectedKpiId ?? null);
   const [isNewOpen, setIsNewOpen] = React.useState(false);
   const [logKpiId, setLogKpiId] = React.useState<string | null>(null);
   const [editKpiId, setEditKpiId] = React.useState<string | null>(null);
   const [deleteKpiId, setDeleteKpiId] = React.useState<string | null>(null);
 
-  // The list endpoint omits entries, so the detail view lazily loads the full
-  // KPI (with entries) via `onLoadKpi`. Until it resolves we fall back to the
-  // list row so the header/metadata render immediately.
-  const { onLoadKpi } = props;
-  const [detailKpi, setDetailKpi] = React.useState<SpaceKpisPageNS.Kpi | null>(null);
-  const [detailLoading, setDetailLoading] = React.useState(false);
+  // The KPI on display is decided by the route, not by page state: each KPI has
+  // its own page, so opening one is a navigation and its data (including the
+  // entries the list omits) arrives with the route.
+  const selectedKpi = props.selectedKpi ?? null;
 
-  const loadDetail = React.useCallback(
-    async (kpiId: string) => {
-      if (!onLoadKpi) return;
-      setDetailLoading(true);
-      try {
-        const full = await onLoadKpi(kpiId);
-        setDetailKpi((current) => (full && full.id === kpiId ? full : current));
-      } finally {
-        setDetailLoading(false);
-      }
-    },
-    [onLoadKpi],
-  );
+  // Modals act on KPIs from the list, or on the open KPI when its page is shown
+  // directly (its permalink may be opened before the list is browsed).
+  const findKpi = (kpiId: string | null) => {
+    if (!kpiId) return null;
+    if (selectedKpi?.id === kpiId) return selectedKpi;
 
-  React.useEffect(() => {
-    setDetailKpi(null);
-    if (selectedKpiId && onLoadKpi) loadDetail(selectedKpiId);
-  }, [selectedKpiId, onLoadKpi, loadDetail]);
-
-  const listKpi = props.kpis.find((kpi) => kpi.id === selectedKpiId) ?? null;
-  const selectedKpi = detailKpi && detailKpi.id === selectedKpiId ? detailKpi : listKpi;
-  const logKpi = props.kpis.find((kpi) => kpi.id === logKpiId) ?? null;
-  const editKpi = props.kpis.find((kpi) => kpi.id === editKpiId) ?? null;
-  const deleteKpi = props.kpis.find((kpi) => kpi.id === deleteKpiId) ?? null;
-
-  // After mutating the open KPI, reload its detail so the chart/log reflect the
-  // change without needing a full page reload.
-  const handleRecordEntry = async (input: SpaceKpisPageNS.RecordEntryInput) => {
-    const result = await props.onRecordEntry(input);
-    if (result.success && input.kpiId === selectedKpiId) await loadDetail(input.kpiId);
-    return result;
+    return props.kpis.find((kpi) => kpi.id === kpiId) ?? null;
   };
 
-  const handleEditKpi = async (input: SpaceKpisPageNS.EditKpiInput) => {
-    const result = await props.onEditKpi(input);
-    if (result.success && input.id === selectedKpiId) await loadDetail(input.id);
-    return result;
-  };
+  const logKpi = findKpi(logKpiId);
+  const editKpi = findKpi(editKpiId);
+  const deleteKpi = findKpi(deleteKpiId);
 
   const contentReady = !props.loading && !props.error;
 
@@ -96,14 +67,17 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         }
       : null;
 
+  // A KPI's own page is bookmarkable, so name it after the KPI.
+  const title = selectedKpi ? [selectedKpi.name, props.space.name] : [props.space.name, "KPIs"];
+
   return (
-    <PageNew title={[props.space.name, "KPIs"]} size="fullwidth" testId="space-kpis-page">
+    <PageNew title={title} size="fullwidth" testId="space-kpis-page">
       <PageHeader
         navigation={props.navigation}
+        kpisLink={props.kpisLink}
         selectedKpiName={selectedKpi?.name ?? null}
         primaryAction={primaryAction}
         kpiActions={headerKpiActions}
-        onBackToList={() => setSelectedKpiId(null)}
       />
 
       <div className="flex-1 overflow-auto">
@@ -112,8 +86,6 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
             {...props}
             canManage={canManage}
             selectedKpi={selectedKpi}
-            detailLoading={detailLoading && detailKpi === null}
-            onSelectKpi={setSelectedKpiId}
             onOpenNew={() => setIsNewOpen(true)}
             onOpenLog={setLogKpiId}
             onOpenEdit={setEditKpiId}
@@ -128,7 +100,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         onClose={() => setIsNewOpen(false)}
         championSearch={props.championSearch}
         onCreate={props.onCreateKpi}
-        onEdit={handleEditKpi}
+        onEdit={props.onEditKpi}
       />
 
       {/* Edit KPI — keyed by id so the form re-initialises for each KPI. */}
@@ -139,7 +111,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         championSearch={props.championSearch}
         kpi={editKpi}
         onCreate={props.onCreateKpi}
-        onEdit={handleEditKpi}
+        onEdit={props.onEditKpi}
       />
 
       <DeleteKpiModal
@@ -147,18 +119,13 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         isOpen={deleteKpiId !== null}
         onClose={() => setDeleteKpiId(null)}
         onDelete={props.onDeleteKpi}
-        onDeleted={() => {
-          // If we deleted the KPI currently open in the detail view, fall back
-          // to the list since the detail can no longer be shown.
-          if (selectedKpiId === deleteKpiId) setSelectedKpiId(null);
-        }}
       />
 
       <LogUpdateForm
         kpi={logKpi}
         isOpen={logKpiId !== null}
         onClose={() => setLogKpiId(null)}
-        onRecord={handleRecordEntry}
+        onRecord={props.onRecordEntry}
       />
     </PageNew>
   );
@@ -178,10 +145,10 @@ interface HeaderKpiActions {
 
 interface PageHeaderProps {
   navigation: Navigation.Item[];
+  kpisLink: string;
   selectedKpiName: string | null;
   primaryAction: HeaderAction | null;
   kpiActions: HeaderKpiActions | null;
-  onBackToList: () => void;
 }
 
 // Breadcrumb + title header shared visual language with the Work Map / Tasks
@@ -201,14 +168,14 @@ function PageHeader(props: PageHeaderProps) {
         ))}
 
         {props.selectedKpiName ? (
-          <button
-            type="button"
-            className="text-xs leading-snug text-content-dimmed hover:underline"
-            onClick={props.onBackToList}
-            data-test-id="kpis-breadcrumb"
+          <BlackLink
+            to={props.kpisLink}
+            className="text-xs leading-snug text-content-dimmed"
+            underline="hover"
+            testId="kpis-breadcrumb"
           >
             KPIs
-          </button>
+          </BlackLink>
         ) : (
           <span className="text-xs leading-snug text-content-dimmed">KPIs</span>
         )}
@@ -250,8 +217,6 @@ function PageHeader(props: PageHeaderProps) {
 interface KpisContentProps extends SpaceKpisPageNS.Props {
   canManage: boolean;
   selectedKpi: SpaceKpisPageNS.Kpi | null;
-  detailLoading: boolean;
-  onSelectKpi: (id: string) => void;
   onOpenNew: () => void;
   onOpenLog: (id: string) => void;
   onOpenEdit: (id: string) => void;
@@ -268,14 +233,13 @@ function KpisContent(props: KpisContentProps) {
   }
 
   if (props.selectedKpi) {
-    return <KpiDetail kpi={props.selectedKpi} loadingHistory={props.detailLoading} />;
+    return <KpiDetail kpi={props.selectedKpi} />;
   }
 
   return (
     <KpiList
       kpis={props.kpis}
       canManage={props.canManage}
-      onSelect={props.onSelectKpi}
       onLogUpdate={props.onOpenLog}
       onNewKpi={props.onOpenNew}
       onEdit={props.onOpenEdit}

--- a/turboui/src/SpaceKpisPage/mockData.tsx
+++ b/turboui/src/SpaceKpisPage/mockData.tsx
@@ -54,12 +54,16 @@ function makeEntries(
 
 // Mirrors the backend: the list endpoint provides `latestEntry` alongside the
 // (here fully-populated) history, so stories render latest values consistently.
-function withLatestEntry(kpi: Omit<SpaceKpisPage.Kpi, "latestEntry">): SpaceKpisPage.Kpi {
+// The permalink matches the app's route: /spaces/:spaceId/kpis/:kpiId.
+function withLatestEntryAndLink(kpi: Omit<SpaceKpisPage.Kpi, "latestEntry" | "link">): SpaceKpisPage.Kpi {
   return {
     ...kpi,
+    link: `${mockKpisLink}/${kpi.id}`,
     latestEntry: kpi.entries.length > 0 ? kpi.entries[kpi.entries.length - 1]! : null,
   };
 }
+
+export const mockKpisLink = `/spaces/${mockSpace.id}/kpis`;
 
 export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
@@ -127,7 +131,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
     // No entries yet — exercises the empty chart / "No data" states.
     entries: [],
   },
-] as Omit<SpaceKpisPage.Kpi, "latestEntry">[]).map(withLatestEntry);
+] as Omit<SpaceKpisPage.Kpi, "latestEntry" | "link">[]).map(withLatestEntryAndLink);
 
 // A trimmed set of KPIs used by the KpiSummaryCard stories to show a mix of
 // trends within a single space: rising (MRR), volatile (NPS), and a brand-new

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -44,6 +44,9 @@ export namespace SpaceKpisPage {
     champion: Person | null;
     insertedAt: Date;
 
+    // Permalink to this KPI's own page, so lists can link to it.
+    link: string;
+
     // The most recent entry, provided by the list endpoint so the list view can
     // show the latest value without loading the full history. Null when the KPI
     // has no entries yet.
@@ -91,18 +94,18 @@ export namespace SpaceKpisPage {
     // (Work Map, Tasks). Typically a single crumb linking back to the space.
     navigation: Navigation.Item[];
 
+    // Link to the KPI list itself, used by the breadcrumb when a KPI is open.
+    kpisLink: string;
+
     kpis: Kpi[];
     currentUser: Person | null;
 
     // Search backing the champion picker in the "New KPI" form.
     championSearch: (query: string) => Promise<Person[]>;
 
-    // Optional lazy-loader for a single KPI's full record (including its
-    // entries) used by the detail view. The list endpoint omits entries for
-    // performance, so the page fetches them on demand when a KPI is opened.
-    // When omitted (e.g. stories with fully-populated mock data), the KPI from
-    // `kpis` is used as-is.
-    onLoadKpi?: (kpiId: string) => Promise<Kpi | null>;
+    // The KPI whose page is being viewed, with its entries loaded for the
+    // chart. Comes from the route (`.../kpis/:kpiId`); null renders the list.
+    selectedKpi?: Kpi | null;
 
     // Callbacks that stand in for the GraphQL mutations. Resolvers call the
     // Operately.Operations.{KpiCreating,KpiUpdating,KpiDeleting,KpiEntryRecording}
@@ -119,8 +122,5 @@ export namespace SpaceKpisPage {
 
     // In the POC any space member can read & write, so this defaults to true.
     canManage?: boolean;
-
-    // Optional: pre-select a KPI to open straight into the detail view (used by stories).
-    initialSelectedKpiId?: string | null;
   }
 }


### PR DESCRIPTION
## Summary

Individual KPIs had no URL. Opening one from the space KPIs list swapped the list for a detail view held in React state, so a KPI could not be copied as a link, bookmarked, or opened in a new tab — and the `kpi_created` activity could only link to the space's KPI list even though it carries the KPI.

Each KPI now has its own page at `/:companyId/spaces/:spaceId/kpis/:kpiId`, reusing the existing `SpaceKpisPage` bridge so the page chrome, modals, and permission gating are unchanged.

- The route loader fetches the KPI named in the URL (via the `get_kpi` query that already existed for lazy-loading) alongside the list, and passes it to TurboUI as `selectedKpi`.
- Since the open KPI arrives with the route, the TurboUI page dropped its `selectedKpiId` state, the `onLoadKpi` lazy-loader, and the detail-loading skeleton. That also fixes a latent refetch loop: the old load effect depended on `onLoadKpi`, which the bridge re-created on every render.
- KPI names in the list are `BlackLink`s to `kpi.link`, following the Work Map `ItemNameCell` pattern, and the "KPIs" breadcrumb is a link back to the list instead of a button that reset state.
- The browser tab is now named after the KPI when viewing its page.
- `kpi_created` activities link to the KPI, falling back to the space list for older activities recorded before the KPI id was in their content.

Two intentional behavior changes:

- Clicking anywhere in a list row no longer opens the KPI — only the name link does, matching the Work Map table.
- Deleting the KPI you are viewing navigates back to the list instead of swapping content in place.

TurboUI primitives reused: `BlackLink`, plus the existing `PageNew`, `KpiDetail`, `KpiFormModal`, `DeleteKpiModal`, `LogUpdateForm`, and `KpiActionsMenu`. The `New KPI` / `Log update` header buttons are still raw `<button>`s; that is pre-existing markup in this page that I left untouched.

## Test plan

- [x] `turboui` suite: 711 tests pass, including new coverage that every list row links to its KPI's page and that the breadcrumb links back to the list
- [x] App Jest: `KpiCreated` handler links to the KPI and falls back to the list when the activity carries no KPI
- [x] `npx tsc --noEmit` for both `turboui` and `app` (`tsconfig.lint.json`)
- [ ] Manual click-through: open a KPI from the list, reload the page directly on its URL, copy the link into a new tab, log an update, then delete it and confirm the return to the list
- [ ] Storybook detail stories (`DetailView`, `SingleEntry`, `NoDataYet`) now open on a KPI route

Made with [Cursor](https://cursor.com)