### PR TITLE
feat: Show KPI details in a sidebar and edit champion and cadence inline

### DIFF
--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -64,19 +64,12 @@ function KpiSidebar({
 }) {
   const [champion, setChampion] = React.useState(kpi.champion);
   const [cadence, setCadence] = React.useState(kpi.cadence);
-  const [people, setPeople] = React.useState<SpaceKpisPage.Person[]>([]);
+  const searchData = useChampionSearch(championSearch);
 
   React.useEffect(() => {
     setChampion(kpi.champion);
     setCadence(kpi.cadence);
   }, [kpi.champion, kpi.cadence]);
-
-  const onSearch = React.useCallback(
-    async (query: string) => {
-      setPeople(await championSearch(query));
-    },
-    [championSearch],
-  );
 
   const save = async (nextChampion: SpaceKpisPage.Person | null, nextCadence: SpaceKpisPage.Cadence) => {
     const previous = { champion, cadence };
@@ -104,7 +97,7 @@ function KpiSidebar({
           <PersonField
             person={champion}
             setPerson={(person) => save(person, cadence)}
-            searchData={{ people, onSearch }}
+            searchData={searchData}
             emptyStateMessage="Set champion"
             emptyStateReadOnlyMessage="No champion"
             testId="kpi-champion"
@@ -119,6 +112,33 @@ function KpiSidebar({
       </SidebarSection>
     </aside>
   );
+}
+
+// PersonField debounces keystrokes but still lets requests overlap, so a slower
+// earlier search could otherwise land last and offer people who don't match what
+// was typed. Keep only the newest request's results, and show none when a search
+// fails rather than leaving names from a previous query on screen.
+function useChampionSearch(search: (query: string) => Promise<SpaceKpisPage.Person[]>): PersonField.SearchData {
+  const [people, setPeople] = React.useState<SpaceKpisPage.Person[]>([]);
+  const newestRequest = React.useRef(0);
+
+  const onSearch = React.useCallback(
+    async (query: string) => {
+      const request = ++newestRequest.current;
+
+      let results: SpaceKpisPage.Person[] = [];
+      try {
+        results = await search(query);
+      } catch (error) {
+        console.error(error);
+      }
+
+      if (request === newestRequest.current) setPeople(results);
+    },
+    [search],
+  );
+
+  return React.useMemo(() => ({ people, onSearch }), [people, onSearch]);
 }
 
 function CadenceField({

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 
 import { Avatar } from "../Avatar";
+import { Menu, MenuActionItem } from "../Menu";
 import { PersonField } from "../PersonField";
 import { SidebarSection } from "../SidebarSection";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
-import { formatCadence, formatShortDate, formatValue, latestEntry, latestTrend } from "./utils";
+import { CADENCE_OPTIONS, formatCadence, formatShortDate, formatValue, latestEntry, latestTrend } from "./utils";
 
 interface KpiDetailProps {
   kpi: SpaceKpisPage.Kpi;
@@ -62,11 +63,13 @@ function KpiSidebar({
   onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
 }) {
   const [champion, setChampion] = React.useState(kpi.champion);
+  const [cadence, setCadence] = React.useState(kpi.cadence);
   const [people, setPeople] = React.useState<SpaceKpisPage.Person[]>([]);
 
   React.useEffect(() => {
     setChampion(kpi.champion);
-  }, [kpi.champion]);
+    setCadence(kpi.cadence);
+  }, [kpi.champion, kpi.cadence]);
 
   const onSearch = React.useCallback(
     async (query: string) => {
@@ -75,19 +78,23 @@ function KpiSidebar({
     [championSearch],
   );
 
-  const handleChampionChange = async (person: SpaceKpisPage.Person | null) => {
-    const previous = champion;
-    setChampion(person);
+  const save = async (nextChampion: SpaceKpisPage.Person | null, nextCadence: SpaceKpisPage.Cadence) => {
+    const previous = { champion, cadence };
+    setChampion(nextChampion);
+    setCadence(nextCadence);
 
     const result = await onEditKpi({
       id: kpi.id,
       name: kpi.name,
       unit: kpi.unit,
-      cadence: kpi.cadence,
-      championId: person?.id ?? null,
+      cadence: nextCadence,
+      championId: nextChampion?.id ?? null,
     });
 
-    if (!result.success) setChampion(previous);
+    if (!result.success) {
+      setChampion(previous.champion);
+      setCadence(previous.cadence);
+    }
   };
 
   return (
@@ -96,7 +103,7 @@ function KpiSidebar({
         {canManage ? (
           <PersonField
             person={champion}
-            setPerson={handleChampionChange}
+            setPerson={(person) => save(person, cadence)}
             searchData={{ people, onSearch }}
             emptyStateMessage="Set champion"
             emptyStateReadOnlyMessage="No champion"
@@ -108,9 +115,56 @@ function KpiSidebar({
       </SidebarSection>
 
       <SidebarSection title="Cadence">
-        <div className="text-sm text-content-base">{formatCadence(kpi.cadence)}</div>
+        <CadenceField cadence={cadence} readonly={!canManage} onChange={(next) => save(champion, next)} />
       </SidebarSection>
     </aside>
+  );
+}
+
+function CadenceField({
+  cadence,
+  readonly,
+  onChange,
+}: {
+  cadence: SpaceKpisPage.Cadence;
+  readonly: boolean;
+  onChange: (cadence: SpaceKpisPage.Cadence) => void;
+}) {
+  const label = formatCadence(cadence);
+
+  if (readonly) {
+    return (
+      <div className="text-sm text-content-base" data-test-id="kpi-cadence">
+        {label}
+      </div>
+    );
+  }
+
+  return (
+    <Menu
+      testId="kpi-cadence"
+      size="tiny"
+      customTrigger={
+        <button
+          type="button"
+          className="flex items-center truncate text-left text-sm font-medium text-content-base focus:outline-none focus:ring-2 focus:ring-primary-base hover:bg-surface-dimmed px-1.5 py-1 -my-1 -mx-1.5 rounded cursor-pointer"
+        >
+          {label}
+        </button>
+      }
+    >
+      {CADENCE_OPTIONS.map((option) => (
+        <MenuActionItem
+          key={option.value}
+          onClick={() => {
+            if (option.value !== cadence) onChange(option.value);
+          }}
+          testId={`kpi-cadence-${option.value}`}
+        >
+          {option.label}
+        </MenuActionItem>
+      ))}
+    </Menu>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
 import { Avatar } from "../Avatar";
+import { PersonField } from "../PersonField";
+import { SidebarSection } from "../SidebarSection";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
@@ -8,56 +10,107 @@ import { formatCadence, formatShortDate, formatValue, latestEntry, latestTrend }
 
 interface KpiDetailProps {
   kpi: SpaceKpisPage.Kpi;
+  canManage: boolean;
+  championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
+  onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
 }
 
 // The KPI name, back navigation and the "Log update" action live in the shared
-// page header (see index.tsx), so the detail body focuses on the metadata,
-// latest value, history chart and the recorded-updates log.
-export function KpiDetail({ kpi }: KpiDetailProps) {
+// page header (see index.tsx), so the detail body focuses on the latest value,
+// history chart, recorded-updates log, and supporting information sidebar.
+export function KpiDetail({ kpi, canManage, championSearch, onEditKpi }: KpiDetailProps) {
   const latest = latestEntry(kpi);
   const trend = latestTrend(kpi);
 
   return (
-    <div data-test-id="kpi-detail">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-content-dimmed">
-        <span>
-          Measured in <span className="font-medium text-content-base">{kpi.unit}</span>
-        </span>
-        <span>
-          Cadence <span className="font-medium text-content-base">{formatCadence(kpi.cadence)}</span>
-        </span>
-        <span className="flex items-center gap-1.5">
-          Champion
-          {kpi.champion ? (
-            <span className="flex items-center gap-1.5 font-medium text-content-base">
-              <Avatar person={kpi.champion} size="tiny" />
-              {kpi.champion.fullName}
-            </span>
-          ) : (
-            <span className="font-medium text-content-subtle">Unassigned</span>
+    <div className="sm:grid sm:grid-cols-12 sm:gap-8" data-test-id="kpi-detail">
+      <div className="sm:col-span-8">
+        <div className="flex items-end gap-3">
+          <div className="text-4xl font-bold text-content-accent">
+            {latest ? formatValue(latest.value, kpi.unit) : "—"}
+          </div>
+          <div className="pb-1">
+            <TrendIndicator delta={trend} />
+          </div>
+          {latest && (
+            <div className="pb-1.5 text-xs text-content-dimmed">latest · {formatShortDate(latest.recordedAt)}</div>
           )}
-        </span>
-      </div>
-
-      <div className="mt-6 flex items-end gap-3">
-        <div className="text-4xl font-bold text-content-accent">
-          {latest ? formatValue(latest.value, kpi.unit) : "—"}
         </div>
-        <div className="pb-1">
-          <TrendIndicator delta={trend} />
+
+        <div className="mt-6 rounded-lg border border-stroke-base bg-surface-base p-4">
+          <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
+          <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
         </div>
-        {latest && (
-          <div className="pb-1.5 text-xs text-content-dimmed">latest · {formatShortDate(latest.recordedAt)}</div>
-        )}
+
+        <EntriesTable entries={kpi.entries} unit={kpi.unit} />
       </div>
 
-      <div className="mt-6 rounded-lg border border-stroke-base bg-surface-base p-4">
-        <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
-        <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
-      </div>
-
-      <EntriesTable entries={kpi.entries} unit={kpi.unit} />
+      <KpiSidebar kpi={kpi} canManage={canManage} championSearch={championSearch} onEditKpi={onEditKpi} />
     </div>
+  );
+}
+
+function KpiSidebar({
+  kpi,
+  canManage,
+  championSearch,
+  onEditKpi,
+}: {
+  kpi: SpaceKpisPage.Kpi;
+  canManage: boolean;
+  championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
+  onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
+}) {
+  const [champion, setChampion] = React.useState(kpi.champion);
+  const [people, setPeople] = React.useState<SpaceKpisPage.Person[]>([]);
+
+  React.useEffect(() => {
+    setChampion(kpi.champion);
+  }, [kpi.champion]);
+
+  const onSearch = React.useCallback(
+    async (query: string) => {
+      setPeople(await championSearch(query));
+    },
+    [championSearch],
+  );
+
+  const handleChampionChange = async (person: SpaceKpisPage.Person | null) => {
+    const previous = champion;
+    setChampion(person);
+
+    const result = await onEditKpi({
+      id: kpi.id,
+      name: kpi.name,
+      unit: kpi.unit,
+      cadence: kpi.cadence,
+      championId: person?.id ?? null,
+    });
+
+    if (!result.success) setChampion(previous);
+  };
+
+  return (
+    <aside className="mt-8 space-y-6 sm:col-span-4 sm:mt-0 sm:pl-8" data-test-id="kpi-sidebar">
+      <SidebarSection title="Champion">
+        {canManage ? (
+          <PersonField
+            person={champion}
+            setPerson={handleChampionChange}
+            searchData={{ people, onSearch }}
+            emptyStateMessage="Set champion"
+            emptyStateReadOnlyMessage="No champion"
+            testId="kpi-champion"
+          />
+        ) : (
+          <PersonField person={champion} readonly emptyStateReadOnlyMessage="No champion" testId="kpi-champion" />
+        )}
+      </SidebarSection>
+
+      <SidebarSection title="Cadence">
+        <div className="text-sm text-content-base">{formatCadence(kpi.cadence)}</div>
+      </SidebarSection>
+    </aside>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/KpiFormModal.tsx
+++ b/turboui/src/SpaceKpisPage/KpiFormModal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Form, SelectBox, SelectPerson, Submit, TextInput, useForm } from "../Forms";
 import { Modal } from "../Modal";
 import type { SpaceKpisPage } from "./types";
+import { CADENCE_OPTIONS } from "./utils";
 
 interface KpiFormModalProps {
   isOpen: boolean;
@@ -16,11 +17,6 @@ interface KpiFormModalProps {
   onCreate: (input: SpaceKpisPage.NewKpiInput) => Promise<SpaceKpisPage.MutationResult>;
   onEdit: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
 }
-
-const CADENCE_OPTIONS = [
-  { label: "Weekly", value: "weekly" },
-  { label: "Monthly", value: "monthly" },
-];
 
 // Create/Edit KPI form → calls the `createKpi` / `updateKpi` mutation via the
 // onCreate / onEdit callbacks. Mirrors the goal add form: presentational form,

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -1,12 +1,20 @@
 import * as React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { MemoryRouter } from "react-router";
 
+import { createTestId } from "../TestableElement";
 import { SpaceKpisPage } from "./index";
 import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
-import { mockChampionSearch, mockCurrentUser, mockKpis, mockLongChampionSearch, mockSpace } from "./mockData";
+import {
+  mockChampionSearch,
+  mockCurrentUser,
+  mockKpis,
+  mockLongChampionSearch,
+  mockPeople,
+  mockSpace,
+} from "./mockData";
 
 // This codebase tags elements with `data-test-id` (not the default
 // `data-testid`), so we resolve them via the attribute selector, polling until
@@ -100,6 +108,69 @@ describe("SpaceKpisPage layout", () => {
     // The header action is now "Log update", not "New KPI".
     expect(container.querySelector('[data-test-id="kpi-detail-log-update"]')).toBeInTheDocument();
     expect(container.querySelector('[data-test-id="new-kpi"]')).not.toBeInTheDocument();
+  });
+
+  test("shows KPI information in a sidebar beside its value and history", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target });
+    const sidebar = container.querySelector<HTMLElement>('[data-test-id="kpi-sidebar"]')!;
+
+    expect(sidebar).toBeInTheDocument();
+    expect(within(sidebar).getByText("Champion")).toBeInTheDocument();
+    expect(within(sidebar).getByText(target.champion!.fullName)).toBeInTheDocument();
+    expect(within(sidebar).getByText("Cadence")).toBeInTheDocument();
+    expect(within(sidebar).getByText("Monthly")).toBeInTheDocument();
+    expect(within(sidebar).queryByText("Unit")).not.toBeInTheDocument();
+  });
+
+  test("editors can change the champion from the sidebar", async () => {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const onEditKpi = jest.fn().mockResolvedValue({ success: true, id: target.id });
+    const replacement = mockPeople.find((person) => person.id !== target.champion?.id)!;
+
+    renderPage({ selectedKpi: target, onEditKpi });
+
+    await user.click(await findByTestId("kpi-champion"));
+    await user.click(await findByTestId("kpi-champion-assign-another"));
+    await user.click(await findByTestId(createTestId("kpi-champion", "search-result", replacement.fullName)));
+
+    await waitFor(() =>
+      expect(onEditKpi).toHaveBeenCalledWith(expect.objectContaining({ id: target.id, championId: replacement.id })),
+    );
+  });
+
+  test("read-only viewers cannot change the champion from the sidebar", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target, canManage: false });
+
+    expect(container.querySelector('[data-test-id="kpi-champion"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-test-id="kpi-champion"]')?.tagName).toBe("A");
+  });
+
+  test("editors can change the cadence from the sidebar", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const onEditKpi = jest.fn().mockResolvedValue({ success: true, id: target.id });
+
+    renderPage({ selectedKpi: target, onEditKpi });
+
+    await user.click(await findByTestId("kpi-cadence"));
+    await user.click(await findByTestId("kpi-cadence-weekly"));
+
+    await waitFor(() =>
+      expect(onEditKpi).toHaveBeenCalledWith(expect.objectContaining({ id: target.id, cadence: "weekly" })),
+    );
+  });
+
+  test("read-only viewers cannot change the cadence from the sidebar", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target, canManage: false });
+
+    expect(container.querySelector('[data-test-id="kpi-cadence"]')?.tagName).not.toBe("BUTTON");
+    expect(container.querySelector('[data-test-id="kpi-cadence-weekly"]')).not.toBeInTheDocument();
   });
 
   test("read-only viewers see no header action", () => {

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { MemoryRouter } from "react-router";
@@ -140,6 +140,65 @@ describe("SpaceKpisPage layout", () => {
     await waitFor(() =>
       expect(onEditKpi).toHaveBeenCalledWith(expect.objectContaining({ id: target.id, championId: replacement.id })),
     );
+  });
+
+  test("a failed champion search leaves the picker usable and offers no stale names", async () => {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const championSearch = jest.fn().mockRejectedValue(new Error("network down"));
+
+    renderPage({ selectedKpi: target, championSearch });
+
+    await user.click(await findByTestId("kpi-champion"));
+    await user.click(await findByTestId("kpi-champion-assign-another"));
+
+    // The rejection has to be caught here rather than escaping as an unhandled
+    // promise, and the picker must offer nothing rather than stale names.
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+    expect(document.querySelector('[data-test-id^="kpi-champion-search-result"]')).not.toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  // A slow early search must not land last and offer people who don't match what
+  // the user has since typed.
+  test("a slow champion search does not override the results of a newer one", async () => {
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const [stale, fresh] = mockPeople.filter((person) => person.id !== target.champion?.id);
+
+    let resolveStale: (people: SpaceKpisPageNS.Person[]) => void = () => {};
+    const championSearch = jest
+      .fn()
+      .mockImplementationOnce(() => new Promise<SpaceKpisPageNS.Person[]>((resolve) => (resolveStale = resolve)))
+      .mockResolvedValue([fresh!]);
+
+    renderPage({ selectedKpi: target, championSearch });
+
+    await user.click(await findByTestId("kpi-champion"));
+    await user.click(await findByTestId("kpi-champion-assign-another"));
+
+    const search = screen.getByPlaceholderText("Search...");
+    await user.type(search, "a");
+    await waitFor(() => expect(championSearch).toHaveBeenCalledTimes(1));
+
+    await user.type(search, "b");
+    await waitFor(() => expect(championSearch).toHaveBeenCalledTimes(2));
+    await findByTestId(createTestId("kpi-champion", "search-result", fresh!.fullName));
+
+    await act(async () => {
+      resolveStale([stale!]);
+    });
+
+    expect(
+      document.querySelector(`[data-test-id="${createTestId("kpi-champion", "search-result", stale!.fullName)}"]`),
+    ).not.toBeInTheDocument();
+    expect(await findByTestId(createTestId("kpi-champion", "search-result", fresh!.fullName))).toBeInTheDocument();
   });
 
   test("read-only viewers cannot change the champion from the sidebar", () => {

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -50,7 +50,11 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   let primaryAction: HeaderAction | null = null;
   if (canManage && contentReady) {
     if (selectedKpi) {
-      primaryAction = { label: "Log update", onClick: () => setLogKpiId(selectedKpi.id), testId: "kpi-detail-log-update" };
+      primaryAction = {
+        label: "Log update",
+        onClick: () => setLogKpiId(selectedKpi.id),
+        testId: "kpi-detail-log-update",
+      };
     } else {
       primaryAction = { label: "New KPI", onClick: () => setIsNewOpen(true), testId: "new-kpi" };
     }
@@ -81,7 +85,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
       />
 
       <div className="flex-1 overflow-auto">
-        <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">
+        <div className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6">
           <KpisContent
             {...props}
             canManage={canManage}
@@ -184,9 +188,7 @@ function PageHeader(props: PageHeaderProps) {
       <div className="mt-1 flex items-center justify-between gap-4">
         <div className="flex items-center gap-2">
           <IconChartColumn size={20} className="text-content-dimmed" />
-          <h1 className="text-sm font-bold text-content-accent sm:text-base">
-            {props.selectedKpiName ?? "KPIs"}
-          </h1>
+          <h1 className="text-sm font-bold text-content-accent sm:text-base">{props.selectedKpiName ?? "KPIs"}</h1>
         </div>
 
         <div className="flex items-center gap-1.5">
@@ -233,7 +235,14 @@ function KpisContent(props: KpisContentProps) {
   }
 
   if (props.selectedKpi) {
-    return <KpiDetail kpi={props.selectedKpi} />;
+    return (
+      <KpiDetail
+        kpi={props.selectedKpi}
+        canManage={props.canManage}
+        championSearch={props.championSearch}
+        onEditKpi={props.onEditKpi}
+      />
+    );
   }
 
   return (

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -100,7 +100,8 @@ export namespace SpaceKpisPage {
     kpis: Kpi[];
     currentUser: Person | null;
 
-    // Search backing the champion picker in the "New KPI" form.
+    // Search backing the champion picker in the New/Edit KPI form and the
+    // inline champion field on a KPI's page.
     championSearch: (query: string) => Promise<Person[]>;
 
     // The KPI whose page is being viewed, with its entries loaded for the

--- a/turboui/src/SpaceKpisPage/utils.ts
+++ b/turboui/src/SpaceKpisPage/utils.ts
@@ -11,6 +11,11 @@ export function formatCadence(cadence: SpaceKpisPage.Cadence): string {
   }
 }
 
+export const CADENCE_OPTIONS: { label: string; value: SpaceKpisPage.Cadence }[] = [
+  { label: "Weekly", value: "weekly" },
+  { label: "Monthly", value: "monthly" },
+];
+
 // Compact, locale-aware number so charts/tables stay readable
 // (e.g. 1500000 -> "1.5M", 87.5 -> "87.5").
 export function formatValue(value: number, unit?: string): string {


### PR DESCRIPTION
## Summary

A KPI's page showed its unit, cadence, and champion as a dimmed strip of text above the value, unlike project and task pages which put that information in a sidebar. It was also read-only: changing the champion or cadence meant opening the Edit KPI modal.

- `KpiDetail` now uses the same 8+4 twelve-column layout as `ProjectPage/Overview` and `TaskPage`. The value, history chart, and recorded-updates table stay in the main column; Champion and Cadence move into a `SidebarSection`-based sidebar that stacks below the content on small screens.
- Champion is an inline `PersonField`, matching the assignee field on tasks. Editors can pick someone else or clear the assignment; viewers see a read-only name linking to the profile.
- Cadence is an inline `Menu` of Weekly/Monthly for editors, and plain text for viewers.
- Both fields save through the existing `onEditKpi` mutation and roll back optimistically if it fails, so no app bridge or backend change was needed — the page already passed `championSearch` and `onEditKpi`.
- The unit is no longer its own field. It already appears next to the latest value (for example `1.4M USD`), so a separate row was duplicate information.
- `CADENCE_OPTIONS` moved from `KpiFormModal` into `utils.ts` so the modal and the sidebar offer the same options from one source, now typed as `Cadence` rather than plain strings.
- The page container widened from `max-w-5xl` to `max-w-6xl` to match Project/Task/Goal pages now that there is a sidebar.

TurboUI primitives reused: `SidebarSection`, `PersonField`, `Menu`/`MenuActionItem`. The cadence trigger is a raw `<button>` because Radix's `customTrigger` clones a DOM element via `asChild`, which is the same approach `KpiList` already uses for its actions menu.

## Test plan

- [x] `turboui` KPI suites: 28 tests pass, including new coverage that the sidebar renders Champion and Cadence but not Unit, that editors can change each one, and that viewers get read-only markup for both
- [x] Champion search failure and out-of-order response cases are covered by tests that fail against the naive `setPeople(await search(query))` version (see review discussion)
- [x] Full CI: 10002 tests passed
- [x] `npx tsc --noEmit` for `turboui` and for `app` (`tsconfig.lint.json`)
- [ ] Manual check on a KPI page: change champion, clear it, switch cadence, and confirm each persists across a reload
- [ ] Manual check as a viewer without edit access: both fields read-only
- [ ] Narrow viewport: sidebar stacks below the chart

Made with [Cursor](https://cursor.com)
