### PR TITLE
fix: Don't reuse previous file upload descriptions

### DIFF
--- a/turboui/src/Forms/RichTextArea.tsx
+++ b/turboui/src/Forms/RichTextArea.tsx
@@ -15,6 +15,7 @@ const DEFAULTS = {
   fontSize: "text-base",
   fontWeight: "font-medium",
   height: "min-h-[250px]",
+  enableLocalDraft: true,
 };
 
 type ResolvedRichTextAreaProps = RichTextAreaProps & typeof DEFAULTS;
@@ -67,7 +68,7 @@ function EditableContent(props: ResolvedRichTextAreaProps & { error: boolean }) 
     placeholder: props.placeholder,
     className: contentClassName(props),
     handlers: props.richTextHandlers,
-    localDraft: { key: localDraftKey(props.field) },
+    localDraft: props.enableLocalDraft ? { key: localDraftKey(props.field) } : undefined,
     onBlur: ({ json }) => {
       skipNextContentSync.current = true;
       setValue(json);

--- a/turboui/src/Forms/index.test.tsx
+++ b/turboui/src/Forms/index.test.tsx
@@ -28,6 +28,7 @@ const richEditorMockState = {
   localDraftRestored: false,
   restoredDraft: null as unknown,
   fallbackContent: null as unknown,
+  lastLocalDraft: undefined as { key?: string; enabled?: boolean } | undefined,
   editor: {
     commands: { setContent: jest.fn() },
     getJSON: () => richEditorMockState.restoredDraft ?? richEditorMockState.fallbackContent ?? null,
@@ -38,8 +39,9 @@ jest.mock("../RichEditor", () => ({
   Editor: (props: { hideBorder?: boolean; className?: string }) => (
     <div data-testid="rich-editor" data-hide-border={props.hideBorder ? "true" : "false"} className={props.className} />
   ),
-  useEditor: (props: { content?: unknown }) => {
+  useEditor: (props: { content?: unknown; localDraft?: { key?: string; enabled?: boolean } }) => {
     richEditorMockState.fallbackContent = props.content ?? null;
+    richEditorMockState.lastLocalDraft = props.localDraft;
 
     return {
       editor: richEditorMockState.editor,
@@ -738,6 +740,46 @@ describe("Forms", () => {
 
     expect(input).toHaveValue("Roadmap");
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("disables local drafts when enableLocalDraft is false", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { body: emptyContent() },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <RichTextArea field="body" enableLocalDraft={false} richTextHandlers={createMockRichEditorHandlers()} />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(richEditorMockState.lastLocalDraft).toBeUndefined();
+  });
+
+  test("stores local drafts by field path by default", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { body: emptyContent() },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <RichTextArea field="body" richTextHandlers={createMockRichEditorHandlers()} />
+        </Form>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(richEditorMockState.lastLocalDraft).toEqual(
+      expect.objectContaining({ key: expect.stringContaining("body") }),
+    );
   });
 
   test("hides editor border when hideBorder is set", () => {

--- a/turboui/src/Forms/types.ts
+++ b/turboui/src/Forms/types.ts
@@ -208,6 +208,7 @@ export interface RichTextAreaProps {
   showToolbarTopBorder?: boolean;
   readonly?: boolean;
   hideToolbar?: boolean;
+  enableLocalDraft?: boolean;
 }
 
 export interface PasswordInputProps {

--- a/turboui/src/ResourceHub/AddFileWidget.test.tsx
+++ b/turboui/src/ResourceHub/AddFileWidget.test.tsx
@@ -6,6 +6,12 @@ import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { AddFileWidget } from "./AddFileWidget";
 import { NewFileModalsProvider, type NewFileModalsContextValue } from "./contexts/NewFileModalsContext";
 
+const PREVIOUS_DESCRIPTION = "Notes from the previous PDF";
+
+const richEditorMockState = {
+  leftoverDraft: null as unknown,
+};
+
 jest.mock("../icons", () => {
   const HiddenIcon = () => <span aria-hidden="true" />;
 
@@ -29,16 +35,54 @@ jest.mock("../icons", () => {
 });
 
 jest.mock("../RichEditor", () => ({
-  Editor: () => <div data-testid="rich-editor" />,
-  useEditor: (props: { content?: unknown }) => ({
-    editor: {
-      commands: { setContent: jest.fn() },
-      getJSON: () => props.content ?? null,
-    },
-    localDraftRestored: false,
-    clearLocalDraft: () => undefined,
-  }),
+  Editor: ({ editor }: { editor: { getJSON: () => unknown } }) => (
+    <div data-testid="rich-editor">{plainTextFromRichContent(editor.getJSON())}</div>
+  ),
+  useEditor: (props: { content?: unknown; localDraft?: { key?: string; enabled?: boolean } }) => {
+    const draftsEnabled = Boolean(props.localDraft?.key) && props.localDraft?.enabled !== false;
+    const restored = draftsEnabled ? richEditorMockState.leftoverDraft : null;
+    const content = restored ?? props.content ?? null;
+
+    return {
+      editor: {
+        commands: { setContent: jest.fn() },
+        getJSON: () => content,
+      },
+      localDraftRestored: Boolean(restored),
+      clearLocalDraft: () => {
+        richEditorMockState.leftoverDraft = null;
+      },
+    };
+  },
 }));
+
+function plainTextFromRichContent(content: unknown): string {
+  if (!content || typeof content !== "object") {
+    return "";
+  }
+
+  const node = content as { text?: string; content?: unknown[] };
+  const parts: string[] = [];
+
+  if (typeof node.text === "string") {
+    parts.push(node.text);
+  }
+
+  if (Array.isArray(node.content)) {
+    for (const child of node.content) {
+      parts.push(plainTextFromRichContent(child));
+    }
+  }
+
+  return parts.join("");
+}
+
+function descriptionDraft(text: string) {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
 
 function buildSubscriptions(): React.ComponentProps<typeof AddFileWidget>["subscriptions"] {
   return {
@@ -52,11 +96,7 @@ function buildSubscriptions(): React.ComponentProps<typeof AddFileWidget>["subsc
   };
 }
 
-function Harness({
-  onUpload,
-}: {
-  onUpload: React.ComponentProps<typeof AddFileWidget>["onUpload"];
-}) {
+function Harness({ onUpload }: { onUpload: React.ComponentProps<typeof AddFileWidget>["onUpload"] }) {
   const [files, setFiles] = React.useState<File[] | undefined>([
     new File(["hello world"], "Roadmap.pdf", { type: "application/pdf" }),
   ]);
@@ -83,11 +123,21 @@ function Harness({
         formatFileSize={(size) => `${size} bytes`}
         onUpload={onUpload}
       />
+      <button
+        type="button"
+        onClick={() => setFiles([new File(["budget"], "Budget.xlsx", { type: "application/vnd.ms-excel" })])}
+      >
+        Drop next file
+      </button>
     </NewFileModalsProvider>
   );
 }
 
 describe("AddFileWidget", () => {
+  beforeEach(() => {
+    richEditorMockState.leftoverDraft = null;
+  });
+
   test("renders selected file details and editable file names", async () => {
     render(<Harness onUpload={async () => undefined} />);
 
@@ -115,5 +165,57 @@ describe("AddFileWidget", () => {
     resolveUpload?.();
 
     await waitFor(() => expect(screen.queryByText("Uploading file")).not.toBeInTheDocument());
+  });
+
+  test("does not restore a leftover description draft for a newly selected file", async () => {
+    richEditorMockState.leftoverDraft = descriptionDraft(PREVIOUS_DESCRIPTION);
+
+    render(<Harness onUpload={async () => undefined} />);
+
+    expect(await screen.findByDisplayValue("Roadmap")).toBeInTheDocument();
+    expect(screen.queryByText(PREVIOUS_DESCRIPTION)).not.toBeInTheDocument();
+  });
+
+  test("starts a new upload with an empty description after cancel", async () => {
+    richEditorMockState.leftoverDraft = descriptionDraft(PREVIOUS_DESCRIPTION);
+
+    render(<Harness onUpload={async () => undefined} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+    fireEvent.click(screen.getByRole("button", { name: "Drop next file" }));
+
+    expect(await screen.findByDisplayValue("Budget")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Roadmap")).not.toBeInTheDocument();
+    expect(screen.queryByText(PREVIOUS_DESCRIPTION)).not.toBeInTheDocument();
+  });
+
+  test("discards the previous description when a new file is dropped onto an open upload form", async () => {
+    richEditorMockState.leftoverDraft = descriptionDraft(PREVIOUS_DESCRIPTION);
+
+    render(<Harness onUpload={async () => undefined} />);
+
+    expect(await screen.findByDisplayValue("Roadmap")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Drop next file" }));
+
+    expect(await screen.findByDisplayValue("Budget")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Roadmap")).not.toBeInTheDocument();
+    expect(screen.queryByText(PREVIOUS_DESCRIPTION)).not.toBeInTheDocument();
+  });
+
+  test("starts a new upload with an empty description after a successful upload", async () => {
+    richEditorMockState.leftoverDraft = descriptionDraft(PREVIOUS_DESCRIPTION);
+
+    render(<Harness onUpload={async () => undefined} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.queryByText("Uploading file")).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Drop next file" }));
+
+    expect(await screen.findByDisplayValue("Budget")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Roadmap")).not.toBeInTheDocument();
+    expect(screen.queryByText(PREVIOUS_DESCRIPTION)).not.toBeInTheDocument();
   });
 });

--- a/turboui/src/ResourceHub/AddFileWidget.test.tsx
+++ b/turboui/src/ResourceHub/AddFileWidget.test.tsx
@@ -35,8 +35,8 @@ jest.mock("../icons", () => {
 });
 
 jest.mock("../RichEditor", () => ({
-  Editor: ({ editor }: { editor: { getJSON: () => unknown } }) => (
-    <div data-testid="rich-editor">{plainTextFromRichContent(editor.getJSON())}</div>
+  Editor: ({ editor }: { editor: { editor?: { getJSON?: () => unknown } } }) => (
+    <div data-testid="rich-editor">{plainTextFromRichContent(editor?.editor?.getJSON?.())}</div>
   ),
   useEditor: (props: { content?: unknown; localDraft?: { key?: string; enabled?: boolean } }) => {
     const draftsEnabled = Boolean(props.localDraft?.key) && props.localDraft?.enabled !== false;

--- a/turboui/src/ResourceHub/AddFileWidget.tsx
+++ b/turboui/src/ResourceHub/AddFileWidget.tsx
@@ -52,11 +52,17 @@ export function AddFileWidget({ subscriptions, richTextHandlers, formatFileSize,
   });
 
   useEffect(() => {
-    if (form && files) {
-      const initialFileItems = files.map((file) => new PayloadItem(file));
-      form.actions.setValue("items", initialFileItems);
+    if (files) {
+      form.actions.setValue(
+        "items",
+        files.map((file) => new PayloadItem(file)),
+      );
       setProgress(0);
+      return;
     }
+
+    form.actions.reset();
+    setProgress(0);
     // Intentionally omit `form`: it is a new object each render and would reset upload progress.
   }, [files]);
 
@@ -93,8 +99,13 @@ function Files({
 
   return (
     <div>
-      {items.map((_, i) => (
-        <FileForm key={i} index={i} formatFileSize={formatFileSize} richTextHandlers={richTextHandlers} />
+      {items.map((item, i) => (
+        <FileForm
+          key={fileFormKey(item, i)}
+          index={i}
+          formatFileSize={formatFileSize}
+          richTextHandlers={richTextHandlers}
+        />
       ))}
     </div>
   );
@@ -140,6 +151,7 @@ function FileForm({
             placeholder="Leave notes here..."
             richTextHandlers={richTextHandlers}
             height="min-h-[80px]"
+            enableLocalDraft={false}
           />
           <FileDetails file={item.mainFile} formatFileSize={formatFileSize} />
         </Forms.FieldGroup>
@@ -150,6 +162,14 @@ function FileForm({
       </div>
     </div>
   );
+}
+
+function fileFormKey(item: PayloadItem, index: number) {
+  if (!item?.mainFile) {
+    return String(index);
+  }
+
+  return `${item.mainFile.name}-${item.mainFile.size}-${item.mainFile.lastModified}`;
 }
 
 function FileDetails({ file, formatFileSize }: { file: File; formatFileSize: (size: number) => string }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes https://github.com/operately/operately/issues/5058

## Problem

Uploading a file with notes, then starting another upload on the same Documents & Files page, kept the previous description. Cancel had the same leftover. The notes field is a rich-text editor that autosaves drafts by field path (`items[0].description`). Every new file on that page shared the same key, so the old notes came back even though the filename was different.

## Solution

- Turn off local drafts on the file upload notes field. Notes are about a specific file, and cancel/finish should discard them.
- Reset the upload form when the file selection is cleared so the next upload does not reuse previous titles or notes.
- Remount each file row when the selected file changes, so dropping a replacement file starts with empty notes.

## Testing

- TurboUI tests for leftover drafts after cancel, after a successful upload, and when a new file is dropped onto an open form.
- Form tests that `enableLocalDraft={false}` does not store a draft.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a67b1085-f347-4880-a256-3ca5ea0e43be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a67b1085-f347-4880-a256-3ca5ea0e43be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

