### PR TITLE
feat: Add editable KPI descriptions

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1752,6 +1752,7 @@ export interface Kpi {
   unit: string;
   cadence: string;
   spaceId: Id;
+  description?: string | null;
   champion?: Person | null;
   latestEntry?: KpiEntry | null;
   entries?: KpiEntry[] | null;
@@ -5059,6 +5060,7 @@ export interface KpisCreateKpiInput {
   unit: string;
   cadence: string;
   championId?: Id | null;
+  description?: Json | null;
 }
 
 export interface KpisCreateKpiResult {
@@ -5079,6 +5081,7 @@ export interface KpisEditKpiInput {
   unit?: string | null;
   cadence?: string | null;
   championId?: Id | null;
+  description?: Json | null;
 }
 
 export interface KpisEditKpiResult {

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -18,6 +18,7 @@ export function parseKpiForTurboUi(paths: Paths, kpi: ApiKpi): SpaceKpisPage.Kpi
   return {
     id: kpi.id,
     name: kpi.name,
+    description: kpi.description ? JSON.parse(kpi.description) : null,
     unit: kpi.unit,
     cadence: kpi.cadence as SpaceKpisPage.Cadence,
     champion: parsePersonForTurboUi(paths, kpi.champion),

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Navigate, useNavigate } from "react-router";
 
-import { SpaceKpisPage } from "turboui";
+import { showErrorToast, SpaceKpisPage } from "turboui";
 import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/types";
 
 import * as Companies from "@/models/companies";
@@ -76,6 +76,10 @@ export function Page() {
       refresh();
       return kpiId;
     });
+
+    if (!result.success) {
+      showErrorToast("Error", "Failed to update KPI description.");
+    }
 
     return result.success;
   };

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -8,6 +8,7 @@ import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as Kpis from "@/models/kpis";
 
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { usePaths } from "@/routes/paths";
 import { useCompanyLoaderData } from "@/routes/useCompanyLoaderData";
 import { useLoadedData, useRefresh } from "./loader";
@@ -20,6 +21,7 @@ export function Page() {
   const { space, kpis, kpi } = useLoadedData();
 
   const peopleSearch = People.usePeopleSearch({ type: "space", id: space.id! });
+  const richTextHandlers = useRichEditorHandlers({ scope: { type: "space", id: space.id! } });
 
   const [createKpi] = Kpis.useCreateKpi();
   const [editKpi] = Kpis.useEditKpi();
@@ -68,6 +70,16 @@ export function Page() {
       return input.id;
     });
 
+  const onDescriptionChange = async (kpiId: string, description: Record<string, unknown>) => {
+    const result = await run(async () => {
+      await editKpi({ kpiId, description: JSON.stringify(description) });
+      refresh();
+      return kpiId;
+    });
+
+    return result.success;
+  };
+
   // Deleting the KPI whose page we are on leaves nothing to show, so we return
   // to the list instead of refreshing into a missing KPI.
   const onDeleteKpi = async (kpiId: string) =>
@@ -93,8 +105,10 @@ export function Page() {
       currentUser={null}
       canManage={space.permissions?.canEdit ?? false}
       championSearch={championSearch}
+      richTextHandlers={richTextHandlers}
       onCreateKpi={onCreateKpi}
       onEditKpi={onEditKpi}
+      onDescriptionChange={onDescriptionChange}
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
     />

--- a/app/lib/operately/kpis/kpi.ex
+++ b/app/lib/operately/kpis/kpi.ex
@@ -10,6 +10,7 @@ defmodule Operately.Kpis.Kpi do
     field(:name, :string)
     field(:unit, :string)
     field(:cadence, Ecto.Enum, values: [:weekly, :monthly])
+    field(:description, :map)
 
     # Populated by ListKpis via Kpis.load_latest_entries/1 so the list view can
     # show the most recent value without preloading the full entry history.
@@ -24,7 +25,7 @@ defmodule Operately.Kpis.Kpi do
 
   def changeset(kpi, attrs) do
     kpi
-    |> cast(attrs, [:space_id, :champion_id, :name, :unit, :cadence])
+    |> cast(attrs, [:space_id, :champion_id, :name, :unit, :cadence, :description])
     |> validate_required([:space_id, :name, :unit, :cadence])
   end
 end

--- a/app/lib/operately/operations/kpi_creation.ex
+++ b/app/lib/operately/operations/kpi_creation.ex
@@ -21,7 +21,8 @@ defmodule Operately.Operations.KpiCreation do
         champion_id: attrs[:champion_id],
         name: attrs[:name],
         unit: attrs[:unit],
-        cadence: attrs[:cadence]
+        cadence: attrs[:cadence],
+        description: attrs[:description]
       })
     )
   end

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -112,6 +112,7 @@ defmodule OperatelyWeb.Api.Kpis do
       field :unit, :string, null: false
       field :cadence, :string, null: false
       field? :champion_id, :id, null: true
+      field? :description, :json, null: true
     end
 
     outputs do
@@ -129,7 +130,8 @@ defmodule OperatelyWeb.Api.Kpis do
           name: inputs.name,
           unit: inputs.unit,
           cadence: inputs.cadence,
-          champion_id: inputs[:champion_id]
+          champion_id: inputs[:champion_id],
+          description: inputs[:description]
         })
       end)
       |> run(:serialized, fn ctx -> {:ok, %{kpi: Serializer.serialize(Repo.preload(ctx.operation, :champion), level: :essential)}} end)
@@ -159,6 +161,7 @@ defmodule OperatelyWeb.Api.Kpis do
       field? :unit, :string, null: true
       field? :cadence, :string, null: true
       field? :champion_id, :id, null: true
+      field? :description, :json, null: true
     end
 
     outputs do
@@ -184,7 +187,7 @@ defmodule OperatelyWeb.Api.Kpis do
     end
 
     defp edit_attrs(inputs) do
-      [:name, :unit, :cadence, :champion_id]
+      [:name, :unit, :cadence, :champion_id, :description]
       |> Enum.filter(&Map.has_key?(inputs, &1))
       |> Map.new(fn key -> {key, inputs[key]} end)
     end

--- a/app/lib/operately_web/api/serializers/kpi.ex
+++ b/app/lib/operately_web/api/serializers/kpi.ex
@@ -7,6 +7,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.Kpi do
       name: kpi.name,
       unit: kpi.unit,
       cadence: Atom.to_string(kpi.cadence),
+      description: kpi.description && Jason.encode!(kpi.description),
       space_id: Operately.ShortUuid.encode!(kpi.space_id),
       champion: Serializer.serialize(kpi.champion),
       latest_entry: serialize_latest_entry(kpi),

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1051,6 +1051,7 @@ defmodule OperatelyWeb.Api.Types do
     field :unit, :string, null: false
     field :cadence, :string, null: false
     field :space_id, :id, null: false
+    field? :description, :string, null: true
     field? :champion, :person, null: true
     field? :latest_entry, :kpi_entry, null: true
     field? :entries, list_of(:kpi_entry), null: true

--- a/app/priv/repo/migrations/20260824124317_add_description_to_kpis.exs
+++ b/app/priv/repo/migrations/20260824124317_add_description_to_kpis.exs
@@ -1,0 +1,9 @@
+defmodule Operately.Repo.Migrations.AddDescriptionToKpis do
+  use Ecto.Migration
+
+  def change do
+    alter table(:kpis) do
+      add :description, :map
+    end
+  end
+end

--- a/app/test/operately/operations/kpi_creation_test.exs
+++ b/app/test/operately/operations/kpi_creation_test.exs
@@ -19,6 +19,7 @@ defmodule Operately.Operations.KpiCreationTest do
       space_id: space.id,
       champion_id: champion.id,
       name: "Customer satisfaction",
+      description: %{"type" => "doc", "content" => [%{"type" => "paragraph"}]},
       unit: "%",
       cadence: :monthly
     }
@@ -32,6 +33,7 @@ defmodule Operately.Operations.KpiCreationTest do
     assert kpi.space_id == ctx.space.id
     assert kpi.champion_id == ctx.champion.id
     assert kpi.name == "Customer satisfaction"
+    assert kpi.description == ctx.attrs.description
     assert kpi.unit == "%"
     assert kpi.cadence == :monthly
 

--- a/app/test/operately/operations/kpi_editing_test.exs
+++ b/app/test/operately/operations/kpi_editing_test.exs
@@ -19,11 +19,14 @@ defmodule Operately.Operations.KpiEditingTest do
   end
 
   test "updates the KPI and records an activity", ctx do
-    {:ok, kpi} = Kpis.edit_kpi(ctx.creator, ctx.kpi, %{name: "New name", unit: "points"})
+    description = %{"type" => "doc", "content" => [%{"type" => "paragraph"}]}
+    {:ok, kpi} = Kpis.edit_kpi(ctx.creator, ctx.kpi, %{name: "New name", unit: "points", description: description})
 
     assert kpi.name == "New name"
     assert kpi.unit == "points"
+    assert kpi.description == description
     assert Kpis.get_kpi(ctx.kpi.id).name == "New name"
+    assert Kpis.get_kpi(ctx.kpi.id).description == description
 
     activity =
       from(a in Activity, where: a.action == "kpi_edited" and a.content["kpi_id"] == ^kpi.id)

--- a/app/test/operately_web/api/external_mutations/mutations/kpis/create_kpi.ex
+++ b/app/test/operately_web/api/external_mutations/mutations/kpis/create_kpi.ex
@@ -18,7 +18,8 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.CreateKpi do
       space_id: Paths.space_id(ctx.space),
       name: "Revenue",
       unit: "$",
-      cadence: "monthly"
+      cadence: "monthly",
+      description: Jason.encode!(%{"type" => "doc", "content" => [%{"type" => "paragraph"}]})
     }
   end
 
@@ -26,6 +27,7 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.CreateKpi do
   def assert(response, _ctx) do
     assert response.kpi.id
     assert response.kpi.name == "Revenue"
+    assert response.kpi.description
     refute Map.has_key?(response, :error)
   end
 end

--- a/app/test/operately_web/api/external_mutations/mutations/kpis/edit_kpi.ex
+++ b/app/test/operately_web/api/external_mutations/mutations/kpis/edit_kpi.ex
@@ -24,7 +24,8 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.EditKpi do
     %{
       kpi_id: Paths.kpi_id(ctx.kpi),
       name: "Renamed",
-      unit: "%"
+      unit: "%",
+      description: Jason.encode!(%{"type" => "doc", "content" => [%{"type" => "paragraph"}]})
     }
   end
 
@@ -32,6 +33,7 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.EditKpi do
   def assert(response, _ctx) do
     assert response.kpi.name == "Renamed"
     assert response.kpi.unit == "%"
+    assert response.kpi.description
     refute Map.has_key?(response, :error)
   end
 end

--- a/app/test/operately_web/api/kpis/create_kpi_test.exs
+++ b/app/test/operately_web/api/kpis/create_kpi_test.exs
@@ -21,21 +21,25 @@ defmodule OperatelyWeb.Api.Kpis.CreateKpiTest do
 
     test "any space member (not only the champion) can create a KPI", ctx do
       ctx = Factory.log_in_person(ctx, :member)
+      description = %{"type" => "doc", "content" => [%{"type" => "paragraph"}]}
 
       inputs = %{
         space_id: Paths.space_id(ctx.space),
         name: "Revenue",
         unit: "$",
         cadence: "monthly",
-        champion_id: Paths.person_id(ctx.champion)
+        champion_id: Paths.person_id(ctx.champion),
+        description: Jason.encode!(description)
       }
 
       assert {200, res} = mutation(ctx.conn, [:kpis, :create_kpi], inputs)
       assert res.kpi.name == "Revenue"
+      assert Jason.decode!(res.kpi.description) == description
 
       assert [kpi] = Kpis.list_kpis(ctx.space.id)
       assert kpi.name == "Revenue"
       assert kpi.champion_id == ctx.champion.id
+      assert kpi.description == description
     end
 
     test "a non-space-member cannot create a KPI", ctx do

--- a/app/test/operately_web/api/kpis/edit_kpi_test.exs
+++ b/app/test/operately_web/api/kpis/edit_kpi_test.exs
@@ -28,12 +28,15 @@ defmodule OperatelyWeb.Api.Kpis.EditKpiTest do
     test "any space member (not only the champion) can edit a KPI", ctx do
       ctx = Factory.log_in_person(ctx, :member)
 
-      inputs = %{kpi_id: Paths.kpi_id(ctx.kpi), name: "Renamed", unit: "%"}
+      description = %{"type" => "doc", "content" => [%{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Weekly active users"}]}]}
+      inputs = %{kpi_id: Paths.kpi_id(ctx.kpi), name: "Renamed", unit: "%", description: Jason.encode!(description)}
       assert {200, res} = mutation(ctx.conn, [:kpis, :edit_kpi], inputs)
 
       assert res.kpi.name == "Renamed"
+      assert Jason.decode!(res.kpi.description) == description
       assert Kpis.get_kpi(ctx.kpi.id).name == "Renamed"
       assert Kpis.get_kpi(ctx.kpi.id).unit == "%"
+      assert Kpis.get_kpi(ctx.kpi.id).description == description
     end
 
     test "a non-space-member cannot edit a KPI", ctx do

--- a/app/test/operately_web/api/kpis/get_kpi_test.exs
+++ b/app/test/operately_web/api/kpis/get_kpi_test.exs
@@ -24,15 +24,19 @@ defmodule OperatelyWeb.Api.Kpis.GetKpiTest do
     end
 
     test "a space member can get a KPI with its entries ordered by period for charting", ctx do
+      description = %{"type" => "doc", "content" => [%{"type" => "paragraph", "content" => [%{"type" => "text", "text" => "Revenue retained each month"}]}]}
+      {:ok, kpi} = Operately.Kpis.edit_kpi(ctx.creator, ctx.kpi, %{description: description})
+
       # Log entries out of order to prove the API returns them sorted.
-      kpi_entry_fixture(ctx.member, ctx.kpi, value: 3.0, period: ~D[2026-03-01])
-      kpi_entry_fixture(ctx.member, ctx.kpi, value: 1.0, period: ~D[2026-01-01])
-      kpi_entry_fixture(ctx.member, ctx.kpi, value: 2.0, period: ~D[2026-02-01])
+      kpi_entry_fixture(ctx.member, kpi, value: 3.0, period: ~D[2026-03-01])
+      kpi_entry_fixture(ctx.member, kpi, value: 1.0, period: ~D[2026-01-01])
+      kpi_entry_fixture(ctx.member, kpi, value: 2.0, period: ~D[2026-02-01])
 
       ctx = Factory.log_in_person(ctx, :member)
-      assert {200, res} = query(ctx.conn, [:kpis, :get_kpi], %{kpi_id: Paths.kpi_id(ctx.kpi)})
+      assert {200, res} = query(ctx.conn, [:kpis, :get_kpi], %{kpi_id: Paths.kpi_id(kpi)})
 
-      assert res.kpi.id == Paths.kpi_id(ctx.kpi)
+      assert res.kpi.id == Paths.kpi_id(kpi)
+      assert Jason.decode!(res.kpi.description) == description
       periods = Enum.map(res.kpi.entries, & &1.period)
       assert periods == ["2026-01-01", "2026-02-01", "2026-03-01"]
     end

--- a/app/test/operately_web/api/kpis/list_kpis_test.exs
+++ b/app/test/operately_web/api/kpis/list_kpis_test.exs
@@ -20,7 +20,8 @@ defmodule OperatelyWeb.Api.Kpis.ListKpisTest do
     end
 
     test "a space member can list the KPIs of the space", ctx do
-      k1 = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "Revenue")
+      description = %{"type" => "doc", "content" => [%{"type" => "paragraph"}]}
+      k1 = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "Revenue", description: description)
       k2 = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "Churn")
 
       ctx = Factory.log_in_person(ctx, :member)
@@ -29,6 +30,9 @@ defmodule OperatelyWeb.Api.Kpis.ListKpisTest do
       ids = Enum.map(res.kpis, & &1.id)
       assert Paths.kpi_id(k1) in ids
       assert Paths.kpi_id(k2) in ids
+
+      listed = Enum.find(res.kpis, &(&1.id == Paths.kpi_id(k1)))
+      assert Jason.decode!(listed.description) == description
     end
 
     test "each KPI carries its latest entry (value + period) without full history", ctx do

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -28782,6 +28782,17 @@
           "optional": true,
           "has_default": false,
           "nullable": true
+        },
+        {
+          "default": null,
+          "name": "description",
+          "type": {
+            "name": "string",
+            "kind": "named"
+          },
+          "optional": true,
+          "has_default": false,
+          "nullable": true
         }
       ],
       "docstring": "Creates a KPI in a space. Any space member with edit access may create one.",
@@ -28893,6 +28904,17 @@
           "name": "champion_id",
           "type": {
             "name": "id",
+            "kind": "named"
+          },
+          "optional": true,
+          "has_default": false,
+          "nullable": true
+        },
+        {
+          "default": null,
+          "name": "description",
+          "type": {
+            "name": "string",
             "kind": "named"
           },
           "optional": true,

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -1632,6 +1632,7 @@ export interface Kpi {
   unit: string;
   cadence: string;
   spaceId: Id;
+  description?: string | null;
   champion?: Person | null;
   latestEntry?: KpiEntry | null;
   entries?: KpiEntry[] | null;

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -31,12 +31,24 @@ export function KpiDetail({
   onDescriptionChange,
   richTextHandlers,
 }: KpiDetailProps) {
+  const [description, setDescription] = React.useState(kpi.description);
+
+  React.useEffect(() => {
+    setDescription(kpi.description);
+  }, [kpi.id, kpi.description]);
+
+  const saveDescription = async (nextDescription: Record<string, unknown>) => {
+    const success = await onDescriptionChange(kpi.id, nextDescription);
+    if (success) setDescription(nextDescription);
+    return success;
+  };
+
   return (
     <div className="sm:grid sm:grid-cols-12 sm:gap-8" data-test-id="kpi-detail">
       <div className="space-y-12 sm:col-span-8">
         <PageDescription
-          description={kpi.description}
-          onDescriptionChange={(description) => onDescriptionChange(kpi.id, description)}
+          description={description}
+          onDescriptionChange={saveDescription}
           richTextHandlers={richTextHandlers}
           label="Description"
           placeholder="Describe this KPI..."

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -2,7 +2,9 @@ import React from "react";
 
 import { Avatar } from "../Avatar";
 import { Menu, MenuActionItem } from "../Menu";
+import { PageDescription } from "../PageDescription";
 import { PersonField } from "../PersonField";
+import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import { SidebarSection } from "../SidebarSection";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
@@ -14,21 +16,45 @@ interface KpiDetailProps {
   canManage: boolean;
   championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
   onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
+  onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
+  richTextHandlers: RichEditorHandlers;
 }
 
 // The KPI name, back navigation and the "Log update" action live in the shared
 // page header (see index.tsx). The latest value is in the sidebar last-update
 // card, so the main column is the history chart and the recorded-updates log.
-export function KpiDetail({ kpi, canManage, championSearch, onEditKpi }: KpiDetailProps) {
+export function KpiDetail({
+  kpi,
+  canManage,
+  championSearch,
+  onEditKpi,
+  onDescriptionChange,
+  richTextHandlers,
+}: KpiDetailProps) {
   return (
     <div className="sm:grid sm:grid-cols-12 sm:gap-8" data-test-id="kpi-detail">
-      <div className="sm:col-span-8">
-        <div className="rounded-lg border border-stroke-base bg-surface-base p-4">
-          <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
-          <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
-        </div>
+      <div className="space-y-12 sm:col-span-8">
+        <PageDescription
+          description={kpi.description}
+          onDescriptionChange={(description) => onDescriptionChange(kpi.id, description)}
+          richTextHandlers={richTextHandlers}
+          label="Description"
+          placeholder="Describe this KPI..."
+          zeroStatePlaceholder="Add a description..."
+          testId="kpi-description"
+          emptyTestId="kpi-description-empty"
+          localDraftKey={`kpi:${kpi.id}:description`}
+          canEdit={canManage}
+        />
 
-        <EntriesTable entries={kpi.entries} unit={kpi.unit} />
+        <div>
+          <div className="rounded-lg border border-stroke-base bg-surface-base p-4">
+            <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
+            <KpiLineChart entries={kpi.entries} unit={kpi.unit} />
+          </div>
+
+          <EntriesTable entries={kpi.entries} unit={kpi.unit} />
+        </div>
       </div>
 
       <KpiSidebar kpi={kpi} canManage={canManage} championSearch={championSearch} onEditKpi={onEditKpi} />

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
@@ -25,6 +25,7 @@ function today(): string {
 const kpi: SpaceKpisPage.Kpi = {
   id: "kpi-signups",
   name: "Weekly Sign-ups",
+  description: null,
   unit: "users",
   cadence: "weekly",
   champion: null,

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { useParams } from "react-router";
 
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { SpaceKpisPage } from "./index";
 import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
 import { mockChampionSearch, mockCurrentUser, mockKpis, mockKpisLink, mockPeople, mockSpace } from "./mockData";
@@ -76,6 +77,7 @@ function Harness(args: HarnessArgs) {
     const newKpi: SpaceKpisPageNS.Kpi = {
       id,
       name: input.name,
+      description: null,
       unit: input.unit,
       cadence: input.cadence,
       champion,
@@ -108,6 +110,15 @@ function Harness(args: HarnessArgs) {
     );
 
     return { success: true, id: input.id };
+  };
+
+  const onDescriptionChange = async (kpiId: string, description: Record<string, unknown>) => {
+    await delay(400);
+
+    if (args.failMutations) return false;
+
+    setKpis((prev) => prev.map((kpi) => (kpi.id === kpiId ? { ...kpi, description } : kpi)));
+    return true;
   };
 
   const onDeleteKpi = async (kpiId: string): Promise<SpaceKpisPageNS.MutationResult> => {
@@ -158,8 +169,10 @@ function Harness(args: HarnessArgs) {
       selectedKpi={kpis.find((kpi) => kpi.id === kpiId) ?? null}
       currentUser={mockCurrentUser}
       championSearch={mockChampionSearch}
+      richTextHandlers={createMockRichEditorHandlers()}
       onCreateKpi={onCreateKpi}
       onEditKpi={onEditKpi}
+      onDescriptionChange={onDescriptionChange}
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
       loading={args.loading}

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -5,6 +5,7 @@ import "@testing-library/jest-dom";
 import { MemoryRouter } from "react-router";
 
 import { createTestId } from "../TestableElement";
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { SpaceKpisPage } from "./index";
 import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
 import {
@@ -43,8 +44,10 @@ function pageProps(overrides: Partial<SpaceKpisPageNS.Props> = {}): SpaceKpisPag
     championSearch: mockChampionSearch,
     onCreateKpi: async () => ({ success: true }),
     onEditKpi: async () => ({ success: true }),
+    onDescriptionChange: async () => true,
     onDeleteKpi: async () => ({ success: true }),
     onRecordEntry: async () => ({ success: true }),
+    richTextHandlers: createMockRichEditorHandlers(),
     ...overrides,
   };
 }
@@ -123,6 +126,34 @@ describe("SpaceKpisPage layout", () => {
     expect(within(sidebar).getByText("Cadence")).toBeInTheDocument();
     expect(within(sidebar).getByText("Monthly")).toBeInTheDocument();
     expect(within(sidebar).queryByText("Unit")).not.toBeInTheDocument();
+  });
+
+  test("shows the KPI description above its history", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target });
+
+    expect(container.querySelector('[data-test-id="kpi-description"]')).toHaveTextContent(
+      "Tracks recurring revenue from active subscriptions at the end of each month.",
+    );
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+  });
+
+  test("lets editors add a missing description in place", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis.find((kpi) => kpi.description === null)!;
+    const { container } = renderPage({ selectedKpi: target });
+
+    await user.click(within(container).getByText("Add a description..."));
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  test("does not offer description editing to read-only viewers", () => {
+    const target = mockKpis.find((kpi) => kpi.description === null)!;
+    renderPage({ selectedKpi: target, canManage: false });
+
+    expect(screen.queryByText("Add a description...")).not.toBeInTheDocument();
   });
 
   // Mirrors a project's last check-in: the sidebar answers what was recorded,
@@ -307,6 +338,7 @@ describe("SpaceKpisPage list latest value", () => {
     const kpi: SpaceKpisPageNS.Kpi = {
       id: "kpi-throughput",
       name: "PR Throughput",
+      description: null,
       unit: "USD",
       cadence: "weekly",
       champion: null,

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -241,6 +241,8 @@ function KpisContent(props: KpisContentProps) {
         canManage={props.canManage}
         championSearch={props.championSearch}
         onEditKpi={props.onEditKpi}
+        onDescriptionChange={props.onDescriptionChange}
+        richTextHandlers={props.richTextHandlers}
       />
     );
   }

--- a/turboui/src/SpaceKpisPage/mockData.tsx
+++ b/turboui/src/SpaceKpisPage/mockData.tsx
@@ -1,4 +1,5 @@
 import { genPeople } from "../utils/storybook/genPeople";
+import { asRichText } from "../utils/storybook/richContent";
 import type { SpaceKpisPage } from "./types";
 
 const people = genPeople(6);
@@ -69,6 +70,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
     id: "kpi-mrr",
     name: "Monthly Recurring Revenue",
+    description: asRichText("Tracks recurring revenue from active subscriptions at the end of each month."),
     unit: "USD",
     cadence: "monthly",
     champion: bob!,
@@ -85,6 +87,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
     id: "kpi-nps",
     name: "Net Promoter Score",
+    description: null,
     unit: "NPS",
     cadence: "monthly",
     champion: carol!,
@@ -99,6 +102,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
     id: "kpi-uptime",
     name: "Service Uptime",
+    description: null,
     unit: "%",
     cadence: "weekly",
     champion: dave!,
@@ -114,6 +118,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
     id: "kpi-signups",
     name: "Weekly Sign-ups",
+    description: null,
     unit: "users",
     cadence: "weekly",
     champion: null,
@@ -124,6 +129,7 @@ export const mockKpis: SpaceKpisPage.Kpi[] = ([
   {
     id: "kpi-churn",
     name: "Logo Churn",
+    description: null,
     unit: "%",
     cadence: "monthly",
     champion: alice!,

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -9,6 +9,7 @@
 // target/threshold fields.
 //
 import type { Navigation } from "../Page/Navigation";
+import type { RichEditorHandlers } from "../RichEditor/useEditor";
 
 export namespace SpaceKpisPage {
   // Ecto.Enum :weekly | :monthly on the backend.
@@ -39,6 +40,7 @@ export namespace SpaceKpisPage {
   export interface Kpi {
     id: string;
     name: string;
+    description: Record<string, unknown> | null;
     unit: string;
     cadence: Cadence;
     champion: Person | null;
@@ -114,8 +116,10 @@ export namespace SpaceKpisPage {
     // (see models/gql convention).
     onCreateKpi: (input: NewKpiInput) => Promise<MutationResult>;
     onEditKpi: (input: EditKpiInput) => Promise<MutationResult>;
+    onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
     onDeleteKpi: (kpiId: string) => Promise<MutationResult>;
     onRecordEntry: (input: RecordEntryInput) => Promise<MutationResult>;
+    richTextHandlers: RichEditorHandlers;
 
     // Route-loader driven data states.
     loading?: boolean;


### PR DESCRIPTION
## Summary
- persist rich-text descriptions on KPIs and expose them through create, edit, get, and list API responses
- show the description above KPI history using the same in-place `PageDescription` editor as tasks
- preserve read-only permissions, local drafts, mentions, and file uploads through the existing space-scoped rich-text handlers
- regenerate TypeScript clients and the CLI API catalog

## Migration
- adds a nullable `description` JSONB column to `kpis`; existing KPIs start with an empty description state

## TurboUI reuse
- `PageDescription` for view, empty, and in-place edit states
- existing `RichEditor`, `RichContent`, `PrimaryButton`, and `SecondaryButton` through `PageDescription`
- no new raw interactive controls

## Test plan
- [x] KPI creation/edit/get operation and API tests
- [x] external mutation authorization suite
- [x] SpaceKpisPage and LogUpdateForm Jest suites (34 tests)
- [x] app and TurboUI TypeScript lint checks
- [x] TurboUI build
- [x] CLI build and catalog sync

Made with [Cursor](https://cursor.com)