### PR TITLE
chore: Restyle the dev bar and let it collapse out of the way

### DIFF
--- a/app/assets/js/features/DevBar/DevPill.tsx
+++ b/app/assets/js/features/DevBar/DevPill.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+import classNames from "classnames";
+
+interface Props {
+  children: React.ReactNode;
+  onClick: () => void;
+  active?: boolean;
+  title?: string;
+}
+
+export function DevPill({ children, onClick, active, title }: Props) {
+  const className = classNames(
+    "inline-flex items-center gap-1 rounded px-1.5 py-1",
+    "border text-xxs uppercase tracking-wide leading-none transition-colors",
+    active
+      ? "border-[rgba(52,211,153,0.4)] bg-[rgba(52,211,153,0.14)] text-emerald-300"
+      : "border-shade-2 bg-shade-1 text-white-2 hover:bg-shade-2 hover:text-white-1",
+  );
+
+  return (
+    <button type="button" className={className} onClick={onClick} title={title}>
+      {children}
+    </button>
+  );
+}
+
+export function DevIconButton({ children, onClick, title }: Omit<Props, "active">) {
+  const className = classNames(
+    "inline-flex items-center justify-center rounded p-1",
+    "text-white-2 transition-colors hover:bg-shade-2 hover:text-white-1",
+  );
+
+  return (
+    <button type="button" className={className} onClick={onClick} title={title}>
+      {children}
+    </button>
+  );
+}

--- a/app/assets/js/features/DevBar/ToggleTestIds.tsx
+++ b/app/assets/js/features/DevBar/ToggleTestIds.tsx
@@ -1,15 +1,10 @@
 import React from "react";
 
+import { IconHash } from "turboui";
+import { DevPill } from "./DevPill";
+
 export function ToggleTestIds() {
   const [show, setShow] = React.useState(false);
-  const status = show ? "ON" : "OFF";
-  const color = show ? "text-green-500" : "text-white-1";
-
-  const toggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setShow(!show);
-  };
-  const className = color + " cursor-pointer";
 
   React.useEffect(() => {
     if (!show) return;
@@ -29,19 +24,19 @@ export function ToggleTestIds() {
   }, [show]);
 
   return (
-    <div className="">
-      TestIDs [
-      <span className={className} onClick={toggle}>
-        {status}
-      </span>
-      ]
+    <>
+      <DevPill active={show} onClick={() => setShow(!show)} title="Outline elements that have a data-test-id">
+        <IconHash size={12} />
+        test ids
+      </DevPill>
+
       {show && (
         <style>
           {`
           [data-test-id]:not([data-test-id-annotation]) {
-            outline: ${show ? "1px solid red" : "none"};
+            outline: 1px solid red;
           }
-          
+
           [data-test-id]::before {
             content: attr(data-test-id);
             position: absolute;
@@ -57,6 +52,6 @@ export function ToggleTestIds() {
         `}
         </style>
       )}
-    </div>
+    </>
   );
 }

--- a/app/assets/js/features/DevBar/ToggleTheme.tsx
+++ b/app/assets/js/features/DevBar/ToggleTheme.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 
+import { IconDeviceLaptop, IconMoon, IconSun } from "turboui";
 import { DevThemeOverride } from "@/utils/devThemeOverride";
+import { DevPill } from "./DevPill";
 
 interface Props {
   override: DevThemeOverride | null;
@@ -8,34 +10,38 @@ interface Props {
   setOverride: (mode: DevThemeOverride | null) => void;
 }
 
-export function ToggleTheme({ override, colorMode, setOverride }: Props) {
-  const statusColor = override ? "text-green-500" : "text-white-1";
+type Mode = DevThemeOverride | "auto";
 
-  const toggle = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setOverride(colorMode === "dark" ? "light" : "dark");
-  };
+const ICONS = {
+  auto: IconDeviceLaptop,
+  light: IconSun,
+  dark: IconMoon,
+};
 
-  const reset = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    setOverride(null);
-  };
+export function ToggleTheme({ override, setOverride }: Props) {
+  const mode: Mode = override ?? "auto";
+  const next = nextMode(mode);
+  const Icon = ICONS[mode];
 
   return (
-    <div>
-      Theme [
-      <span className={`${statusColor} cursor-pointer`} onClick={toggle}>
-        {colorMode}
-      </span>
-      ]
-      {override && (
-        <>
-          {" "}
-          <span className="cursor-pointer text-white-2" onClick={reset}>
-            reset
-          </span>
-        </>
-      )}
-    </div>
+    <DevPill
+      active={Boolean(override)}
+      onClick={() => setOverride(next === "auto" ? null : next)}
+      title={`Theme: ${mode === "auto" ? "following the account setting" : "overridden"} — click for ${next}`}
+    >
+      <Icon size={12} />
+      {mode}
+    </DevPill>
   );
+}
+
+function nextMode(mode: Mode): Mode {
+  switch (mode) {
+    case "auto":
+      return "light";
+    case "light":
+      return "dark";
+    case "dark":
+      return "auto";
+  }
 }

--- a/app/assets/js/features/DevBar/index.tsx
+++ b/app/assets/js/features/DevBar/index.tsx
@@ -1,11 +1,16 @@
 import React from "react";
 
 import classNames from "classnames";
+import { IconChevronDown } from "turboui";
 import { useStateWithLocalStorage } from "@/hooks/useStateWithLocalStorage";
+import { DevIconButton } from "./DevPill";
 import { ToggleTestIds } from "./ToggleTestIds";
 import { ToggleTheme } from "./ToggleTheme";
 import { useDevBarData } from "./useDevBarData";
 import { useDevThemeOverride } from "./useDevThemeOverride";
+
+const FAST_LOAD_MS = 500;
+const SLOW_LOAD_MS = 1500;
 
 export function DevBar() {
   if (!window.appConfig.showDevBar) return null;
@@ -20,43 +25,72 @@ function DevBarContent() {
   const [isExpanded, setIsExpanded] = useStateWithLocalStorage<boolean>("devBar", "isExpanded", true);
 
   if (!isVisible) return null;
+  if (!isExpanded) return <CollapsedHandle onClick={() => setIsExpanded(true)} />;
+
+  const loadTimeStyles = styleForLoadTime(loadTime);
 
   const className = classNames(
-    "fixed",
-    "bottom-0 left-0",
-    "bg-black text-white-1 text-xs font-mono z-50",
+    "fixed bottom-3 left-3 z-50",
     "hidden lg:block", // hidden on mobile, start showing on large screens
-    "cursor-pointer",
+    "min-w-[190px] max-w-[280px] rounded-lg border border-shade-2",
+    "bg-[rgba(24,24,27,0.92)] backdrop-blur-md shadow-2xl",
+    "font-mono text-white-1 select-none",
   );
 
-  const pageLoadColor = loadTime < 500 ? "text-green-500" : "text-content-error";
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-2 px-2.5 pt-2">
+        <span className={classNames("h-1.5 w-1.5 shrink-0 rounded-full", loadTimeStyles.dot)} />
+        <span className="min-w-0 truncate text-xs font-medium">{pageName || "unknown page"}</span>
 
-  const handleToggle = () => {
-    setIsExpanded((prev) => !prev);
-  };
+        <div className="ml-auto -mr-1 shrink-0">
+          <DevIconButton onClick={() => setIsExpanded(false)} title="Collapse dev bar">
+            <IconChevronDown size={12} />
+          </DevIconButton>
+        </div>
+      </div>
+
+      <div className="flex items-baseline gap-1 px-2.5 pb-2">
+        <span className={classNames("text-sm font-semibold tabular-nums", loadTimeStyles.text)}>
+          {loadTime.toFixed(0)}
+        </span>
+        <span className="text-xxs uppercase tracking-wide text-white-2">ms load</span>
+      </div>
+
+      <div className="flex items-center gap-1.5 border-t border-shade-2 px-2.5 py-2">
+        <ToggleTheme {...themeOverride} />
+        <ToggleTestIds />
+      </div>
+    </div>
+  );
+}
+
+function styleForLoadTime(loadTime: number) {
+  if (loadTime < FAST_LOAD_MS) return { dot: "bg-emerald-400", text: "text-emerald-400" };
+  if (loadTime < SLOW_LOAD_MS) return { dot: "bg-amber-400", text: "text-amber-400" };
+  return { dot: "bg-rose-400", text: "text-rose-400" };
+}
+
+function CollapsedHandle({ onClick }: { onClick: () => void }) {
+  // The wrapper is a larger invisible hit area, so hovering near the tiny
+  // triangle is enough to grow it into an easier click target.
+  const className = classNames(
+    "fixed bottom-0 left-0 z-50",
+    "hidden lg:flex items-end justify-start",
+    "w-10 h-10 cursor-pointer group",
+  );
+
+  const triangleClassName = classNames(
+    "w-0 h-0",
+    "border-r-transparent border-b-stone-400/70",
+    "border-r-[5px] border-b-[5px]",
+    "transition-all duration-150",
+    "group-hover:border-r-[16px] group-hover:border-b-[16px] group-hover:border-b-stone-500",
+  );
 
   return (
-    <div className={className} onClick={handleToggle}>
-      {isExpanded ? (
-        <div className="p-1">
-          <div className="flex justify-between mb-1">
-            <div className="w-20">Page Name:</div>
-            <div>{pageName}</div>
-          </div>
-
-          <div className="flex justify-between mb-1">
-            <div className="w-20">Load Time:</div>
-            <div className={pageLoadColor}>{loadTime.toFixed(0)}ms</div>
-          </div>
-
-          <ToggleTheme {...themeOverride} />
-          <ToggleTestIds />
-        </div>
-      ) : (
-        <div className="flex items-center justify-center px-2 py-2 h-10">
-          <div className="w-0 h-0 border-t-4 border-b-4 border-l-4 border-t-transparent border-b-transparent border-l-white-1 transform scale-125" />
-        </div>
-      )}
+    <div className={className} onClick={onClick} title="Show dev bar">
+      <div className={triangleClassName} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Restyled the dev bar as a compact floating card (rounded, translucent, blurred, inset from the corner) instead of a plain black box flush against the viewport edge. The page name gets a status dot and the load time is the prominent number, colored green/amber/red by threshold.
- Replaced the `Theme [light] reset` and `TestIDs [OFF]` bracket text with pill toggles. The theme pill now cycles `auto -> light -> dark` so the unlabelled reset link is gone and the current state is always visible; it highlights green while an override is active.
- Collapsing now hides the bar down to a 5px triangle in the bottom-left corner. A transparent 40x40 hover area around it grows the triangle so it stays easy to click without occupying screen space.
- Collapse is an explicit chevron button rather than a click anywhere on the panel, which removes the `stopPropagation` calls the toggles needed.

Dev-only UI: everything here renders behind `window.appConfig.showDevBar`, so there is no production surface area.

## Test plan

- [ ] With `showDevBar` enabled, load a page at >= `lg` width and confirm the card shows page name, load time, and both pills.
- [ ] Click the chevron to collapse; confirm only the tiny triangle remains and that it grows on hover, and that the collapsed state survives a reload.
- [ ] Cycle the theme pill through auto/light/dark and confirm `auto` hands control back to the account theme.
- [ ] Toggle test ids and confirm elements with `data-test-id` are still outlined and annotated.

Made with [Cursor](https://cursor.com)