### PR TITLE
chore: Allow conventional commit scopes in PR titles

### DIFF
--- a/scripts/pr-name-check
+++ b/scripts/pr-name-check
@@ -1,5 +1,10 @@
 #!/usr/local/bin ruby
 
+TYPES = %w[feat fix chore docs].freeze
+
+# Conventional commit format: type, an optional scope like (deps), then ": ".
+PR_NAME_FORMAT = /\A(#{TYPES.join("|")})(\([^()]+\))?: \S/.freeze
+
 pr_name = ENV["SEMAPHORE_GIT_PR_NAME"]
 
 if pr_name.nil?
@@ -7,23 +12,8 @@ if pr_name.nil?
   exit 0
 end
 
-if pr_name.start_with?("feat: ") 
-  puts "This is a feature PR. Everything is fine."
-  exit 0
-end
-
-if pr_name.start_with?("fix: ") 
-  puts "This is a fix PR. Everything is fine."
-  exit 0
-end
-
-if pr_name.start_with?("chore: ") 
-  puts "This is a chore PR. Everything is fine."
-  exit 0
-end
-
-if pr_name.start_with?("docs: ")
-  puts "This is a docs PR. Everything is fine."
+if PR_NAME_FORMAT.match?(pr_name)
+  puts "PR name is in the correct format. Everything is fine."
   exit 0
 end
 
@@ -33,6 +23,8 @@ puts " - feat: Description of the feature or enhancement that is being added"
 puts " - fix: Description of the bug that is being fixed"
 puts " - chore: Description of the chore that is being done"
 puts " - docs: Description of the documentation that is being added"
+puts ""
+puts "An optional scope is allowed, for example: chore(deps): bump vite from 5.4.0 to 5.4.1"
 puts ""
 
 exit 1


### PR DESCRIPTION
## Summary
- `make test.pr.name` now accepts conventional-commit scopes such as `chore(deps): bump ...`, so Dependabot PRs no longer fail the title check.
- Bare `feat:` / `fix:` / `chore:` / `docs:` titles still work; a type with no description is rejected.

## Test plan
- [ ] Confirm `SEMAPHORE_GIT_PR_NAME='chore(deps): bump vite from 5.4.0 to 5.4.1' ruby scripts/pr-name-check` exits 0
- [ ] Confirm existing titles like `feat: add goal editor` still pass
- [ ] Confirm invalid titles (`random title`, `chore:no space`) still fail
- [ ] Confirm this PR's own `test.pr.name` CI job is green


Made with [Cursor](https://cursor.com)