### PR TITLE
feat: Add notification subscriptions to KPIs

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -1756,6 +1756,7 @@ export interface Kpi {
   champion?: Person | null;
   latestEntry?: KpiEntry | null;
   entries?: KpiEntry[] | null;
+  subscriptionList?: SubscriptionList | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
 }
@@ -3069,7 +3070,8 @@ export type SubscriptionParentType =
   | "project"
   | "milestone"
   | "project_task"
-  | "space_task";
+  | "space_task"
+  | "kpi";
 
 export type SuccessStatus = "achieved" | "missed";
 

--- a/app/assets/js/models/subscriptions/useSubscription.tsx
+++ b/app/assets/js/models/subscriptions/useSubscription.tsx
@@ -7,7 +7,7 @@ import { PageCache } from "@/routes/PageCache";
 interface UseSubscriptionOptions {
   subscriptionList?: SubscriptionList | null;
   entityId: string;
-  entityType: "project" | "milestone" | "project_task" | "space_task";
+  entityType: "project" | "milestone" | "project_task" | "space_task" | "kpi";
   cacheKey: string;
   onRefresh?: () => Promise<void>;
 }

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -7,6 +7,7 @@ import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as Kpis from "@/models/kpis";
+import { useSubscription } from "@/models/subscriptions";
 
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { usePaths } from "@/routes/paths";
@@ -31,6 +32,13 @@ export function Page() {
   const kpisLink = paths.spaceKpisPath(space.id!);
   const parsedKpis = React.useMemo(() => kpis.map((k) => Kpis.parseKpiForTurboUi(paths, k)), [kpis, paths]);
   const selectedKpi = React.useMemo(() => (kpi ? Kpis.parseKpiForTurboUi(paths, kpi) : null), [kpi, paths]);
+  const subscriptions = useSubscription({
+    subscriptionList: kpi?.subscriptionList,
+    entityId: kpi?.id ?? "",
+    entityType: "kpi",
+    cacheKey: `v1-SpaceKpisPage-${space.id}-${kpi?.id ?? "list"}`,
+    onRefresh: refresh,
+  });
 
   const championSearch = React.useCallback(
     async (query: string) => People.parsePeopleForTurboUi(paths, await peopleSearch(query)),
@@ -108,6 +116,7 @@ export function Page() {
       selectedKpi={selectedKpi}
       currentUser={null}
       canManage={space.permissions?.canEdit ?? false}
+      subscriptions={subscriptions}
       championSearch={championSearch}
       richTextHandlers={richTextHandlers}
       onCreateKpi={onCreateKpi}

--- a/app/lib/operately/activities/notifications/kpi_edited.ex
+++ b/app/lib/operately/activities/notifications/kpi_edited.ex
@@ -1,5 +1,5 @@
 defmodule Operately.Activities.Notifications.KpiEdited do
   def dispatch(activity) do
-    Operately.Kpis.Notifications.notify_space_members(activity)
+    Operately.Kpis.Notifications.notify_subscribers(activity)
   end
 end

--- a/app/lib/operately/activities/notifications/kpi_entry_logged.ex
+++ b/app/lib/operately/activities/notifications/kpi_entry_logged.ex
@@ -1,13 +1,5 @@
 defmodule Operately.Activities.Notifications.KpiEntryLogged do
   def dispatch(activity) do
-    kpi = Operately.Kpis.get_kpi(activity.content["kpi_id"])
-
-    [kpi && kpi.champion_id]
-    |> Enum.filter(fn id -> id != nil and id != activity.author_id end)
-    |> Enum.uniq()
-    |> Enum.map(fn id ->
-      %{person_id: id, activity_id: activity.id, should_send_email: false}
-    end)
-    |> Operately.Notifications.bulk_create()
+    Operately.Kpis.Notifications.notify_subscribers(activity)
   end
 end

--- a/app/lib/operately/data/change_113_create_subscription_lists_for_kpis.ex
+++ b/app/lib/operately/data/change_113_create_subscription_lists_for_kpis.ex
@@ -1,0 +1,119 @@
+defmodule Operately.Data.Change113CreateSubscriptionListsForKpis do
+  alias Operately.Repo
+  alias __MODULE__.{Kpi, Subscription, SubscriptionList}
+
+  def run do
+    Repo.transaction(fn ->
+      Kpi
+      |> Repo.all()
+      |> Enum.each(&ensure_subscription_list/1)
+    end)
+  end
+
+  defp ensure_subscription_list(kpi) do
+    subscription_list =
+      case SubscriptionList.get(:system, parent_id: kpi.id) do
+        {:ok, subscription_list} ->
+          subscription_list
+
+        {:error, :not_found} ->
+          {:ok, subscription_list} =
+            SubscriptionList.create(%{
+              parent_id: kpi.id,
+              parent_type: :kpi
+            })
+
+          subscription_list
+      end
+
+    update_kpi(subscription_list, kpi)
+    subscribe_champion(subscription_list, kpi)
+  end
+
+  defp update_kpi(subscription_list, kpi) do
+    if subscription_list.id != kpi.subscription_list_id do
+      {:ok, _} = Kpi.update(kpi, %{subscription_list_id: subscription_list.id})
+    end
+
+    subscription_list
+  end
+
+  defp subscribe_champion(_subscription_list, %{champion_id: nil}), do: :ok
+
+  defp subscribe_champion(subscription_list, kpi) do
+    case Subscription.get(:system, subscription_list_id: subscription_list.id, person_id: kpi.champion_id) do
+      {:ok, _} ->
+        :ok
+
+      {:error, :not_found} ->
+        {:ok, _} =
+          Subscription.create(%{
+            subscription_list_id: subscription_list.id,
+            person_id: kpi.champion_id,
+            type: :invited
+          })
+
+        :ok
+    end
+  end
+
+  defmodule Kpi do
+    use Operately.Schema
+
+    schema "kpis" do
+      belongs_to :subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id
+      field :champion_id, Ecto.UUID
+
+      timestamps()
+    end
+
+    def changeset(kpi, attrs) do
+      kpi
+      |> cast(attrs, [:subscription_list_id])
+    end
+
+    def update(kpi, attrs), do: changeset(kpi, attrs) |> Repo.update()
+  end
+
+  defmodule SubscriptionList do
+    use Operately.Schema
+    use Operately.Repo.Getter
+
+    schema "subscription_lists" do
+      field :parent_id, Ecto.UUID
+      field :parent_type, Ecto.Enum, values: [:kpi]
+      field :send_to_everyone, :boolean, default: false
+
+      timestamps()
+    end
+
+    def changeset(attrs) do
+      %__MODULE__{}
+      |> cast(attrs, [:parent_id, :parent_type, :send_to_everyone])
+    end
+
+    def create(attrs), do: changeset(attrs) |> Repo.insert()
+  end
+
+  defmodule Subscription do
+    use Operately.Schema
+    use Operately.Repo.Getter
+
+    schema "subscriptions" do
+      field :subscription_list_id, Ecto.UUID
+      field :person_id, Ecto.UUID
+      field :type, Ecto.Enum, values: [:invited, :joined, :mentioned]
+      field :canceled, :boolean, default: false
+
+      timestamps()
+      request_info()
+    end
+
+    def changeset(attrs) do
+      %__MODULE__{}
+      |> cast(attrs, [:subscription_list_id, :person_id, :type, :canceled])
+    end
+
+    def create(attrs), do: changeset(attrs) |> Repo.insert()
+  end
+end

--- a/app/lib/operately/kpis/kpi.ex
+++ b/app/lib/operately/kpis/kpi.ex
@@ -1,10 +1,13 @@
 defmodule Operately.Kpis.Kpi do
   use Operately.Schema
+  use Operately.Repo.Getter
 
   schema "kpis" do
     belongs_to(:space, Operately.Groups.Group, foreign_key: :space_id)
     belongs_to(:champion, Operately.People.Person, foreign_key: :champion_id)
+    belongs_to(:subscription_list, Operately.Notifications.SubscriptionList, foreign_key: :subscription_list_id)
 
+    has_one(:access_context, through: [:space, :access_context])
     has_many(:entries, Operately.Kpis.KpiEntry)
 
     field(:name, :string)
@@ -17,6 +20,8 @@ defmodule Operately.Kpis.Kpi do
     field(:latest_entry, :any, virtual: true)
 
     timestamps()
+    request_info()
+    requester_access_level()
   end
 
   def changeset(attrs = %{}) do
@@ -25,7 +30,7 @@ defmodule Operately.Kpis.Kpi do
 
   def changeset(kpi, attrs) do
     kpi
-    |> cast(attrs, [:space_id, :champion_id, :name, :unit, :cadence, :description])
-    |> validate_required([:space_id, :name, :unit, :cadence])
+    |> cast(attrs, [:space_id, :champion_id, :subscription_list_id, :name, :unit, :cadence, :description])
+    |> validate_required([:space_id, :name, :unit, :cadence, :subscription_list_id])
   end
 end

--- a/app/lib/operately/kpis/notifications.ex
+++ b/app/lib/operately/kpis/notifications.ex
@@ -3,8 +3,11 @@ defmodule Operately.Kpis.Notifications do
   Notification fan-out helpers for KPI activities.
   """
 
+  alias Operately.Access
   alias Operately.Groups
   alias Operately.Groups.Group
+  alias Operately.Notifications.SubscribersLoader
+  alias Operately.Notifications.Subscription
 
   def notify_space_members(activity) do
     space = Groups.get_group(activity.content["space_id"])
@@ -23,5 +26,48 @@ defmodule Operately.Kpis.Notifications do
       %{person_id: id, activity_id: activity.id, should_send_email: false}
     end)
     |> Operately.Notifications.bulk_create()
+  end
+
+  def notify_subscribers(activity) do
+    kpi = Operately.Kpis.get_kpi(activity.content["kpi_id"])
+
+    case kpi do
+      nil ->
+        {:ok, []}
+
+      kpi ->
+        kpi
+        |> get_subscribers(ignore: [activity.author_id])
+        |> Enum.map(fn id ->
+          %{person_id: id, activity_id: activity.id, should_send_email: false}
+        end)
+        |> Operately.Notifications.bulk_create()
+    end
+  end
+
+  def get_subscribers(kpi, opts \\ []) do
+    ignore = Keyword.get(opts, :ignore, [])
+    access_context = Access.get_context!(group_id: kpi.space_id)
+
+    kpi
+    |> Map.put(:access_context, access_context)
+    |> SubscribersLoader.load_for_notifications([], ignore)
+  end
+
+  def ensure_subscription(nil, _person_id, _type), do: {:ok, nil}
+  def ensure_subscription(_subscription_list_id, nil, _type), do: {:ok, nil}
+
+  def ensure_subscription(subscription_list_id, person_id, type) do
+    case Subscription.get(:system, subscription_list_id: subscription_list_id, person_id: person_id) do
+      {:error, :not_found} ->
+        Operately.Notifications.create_subscription(%{
+          subscription_list_id: subscription_list_id,
+          person_id: person_id,
+          type: type
+        })
+
+      {:ok, subscription} ->
+        Operately.Notifications.update_subscription(subscription, %{canceled: false})
+    end
   end
 end

--- a/app/lib/operately/notifications.ex
+++ b/app/lib/operately/notifications.ex
@@ -172,6 +172,12 @@ defmodule Operately.Notifications do
           join: s in assoc(c, :subscription_list), as: :subscription_list,
           where: s.id == ^id
         )
+      :kpi ->
+        from(k in Operately.Kpis.Kpi,
+          join: g in assoc(k, :space), as: :resource,
+          join: s in assoc(k, :subscription_list), as: :subscription_list,
+          where: s.id == ^id
+        )
     end
     |> Fetch.get_resource_with_access_level(person_id, selected_resource: :subscription_list)
   end
@@ -243,6 +249,12 @@ defmodule Operately.Notifications do
         from(a in Operately.Activities.Activity, as: :resource,
           join: c in assoc(a, :comment_thread),
           join: s in assoc(c, :subscription_list),
+          where: s.id == ^id
+        )
+      :kpi ->
+        from(k in Operately.Kpis.Kpi,
+          join: g in assoc(k, :space), as: :resource,
+          join: s in assoc(k, :subscription_list),
           where: s.id == ^id
         )
     end

--- a/app/lib/operately/notifications/subscription_list.ex
+++ b/app/lib/operately/notifications/subscription_list.ex
@@ -17,6 +17,7 @@ defmodule Operately.Notifications.SubscriptionList do
       :space_task,
       :project_milestone,
       :project,
+      :kpi,
     ]
     field :send_to_everyone, :boolean, default: false
 

--- a/app/lib/operately/operations/kpi_creation.ex
+++ b/app/lib/operately/operations/kpi_creation.ex
@@ -2,29 +2,43 @@ defmodule Operately.Operations.KpiCreation do
   alias Ecto.Multi
   alias Operately.Repo
   alias Operately.Kpis.Kpi
+  alias Operately.Kpis.Notifications
   alias Operately.Activities
+  alias Operately.Operations.Notifications.SubscriptionList, as: SubscriptionListOps
 
   def run(creator, attrs) do
     Multi.new()
+    |> SubscriptionListOps.insert(%{send_to_everyone: false, subscription_parent_type: :kpi})
     |> insert_kpi(attrs)
+    |> SubscriptionListOps.update(:kpi)
+    |> subscribe_people(creator)
     |> insert_activity(creator)
     |> Repo.transaction()
     |> Repo.extract_result(:kpi)
   end
 
   defp insert_kpi(multi, attrs) do
-    Multi.insert(
-      multi,
-      :kpi,
+    Multi.insert(multi, :kpi, fn %{subscription_list: subscription_list} ->
       Kpi.changeset(%{
         space_id: attrs[:space_id],
         champion_id: attrs[:champion_id],
+        subscription_list_id: subscription_list.id,
         name: attrs[:name],
         unit: attrs[:unit],
         cadence: attrs[:cadence],
         description: attrs[:description]
       })
-    )
+    end)
+  end
+
+  defp subscribe_people(multi, creator) do
+    multi
+    |> Multi.run(:creator_subscription, fn _repo, %{subscription_list: subscription_list} ->
+      Notifications.ensure_subscription(subscription_list.id, creator.id, :joined)
+    end)
+    |> Multi.run(:champion_subscription, fn _repo, %{subscription_list: subscription_list, kpi: kpi} ->
+      Notifications.ensure_subscription(subscription_list.id, kpi.champion_id, :invited)
+    end)
   end
 
   defp insert_activity(multi, creator) do

--- a/app/lib/operately/operations/kpi_editing.ex
+++ b/app/lib/operately/operations/kpi_editing.ex
@@ -2,14 +2,22 @@ defmodule Operately.Operations.KpiEditing do
   alias Ecto.Multi
   alias Operately.Repo
   alias Operately.Kpis.Kpi
+  alias Operately.Kpis.Notifications
   alias Operately.Activities
 
   def run(author, %Kpi{} = kpi, attrs) do
     Multi.new()
     |> Multi.update(:kpi, Kpi.changeset(kpi, attrs))
+    |> subscribe_champion()
     |> insert_activity(author, kpi)
     |> Repo.transaction()
     |> Repo.extract_result(:kpi)
+  end
+
+  defp subscribe_champion(multi) do
+    Multi.run(multi, :champion_subscription, fn _repo, %{kpi: kpi} ->
+      Notifications.ensure_subscription(kpi.subscription_list_id, kpi.champion_id, :invited)
+    end)
   end
 
   defp insert_activity(multi, author, kpi) do

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -85,7 +85,7 @@ defmodule OperatelyWeb.Api.Kpis do
         kpi ->
           # Entries are ordered by period so the chart renders history in order.
           entries = Kpis.list_entries(kpi_id) |> Repo.preload(:recorded_by)
-          {:ok, %{Repo.preload(kpi, :champion) | entries: entries}}
+          {:ok, %{Repo.preload(kpi, [:champion, subscription_list: [subscriptions: :person]]) | entries: entries}}
       end
     end
 

--- a/app/lib/operately_web/api/notifications/is_subscribed.ex
+++ b/app/lib/operately_web/api/notifications/is_subscribed.ex
@@ -77,6 +77,9 @@ defmodule OperatelyWeb.Api.Notifications.IsSubscribed do
       :space_task ->
         Operately.Tasks.Task.get(ctx.me, id: resource_id)
 
+      :kpi ->
+        Operately.Kpis.Kpi.get(ctx.me, id: resource_id)
+
       _ ->
         {:error, :invalid_resource_type}
     end

--- a/app/lib/operately_web/api/notifications/subscribe.ex
+++ b/app/lib/operately_web/api/notifications/subscribe.ex
@@ -47,6 +47,7 @@ defmodule OperatelyWeb.Api.Notifications.Subscribe do
       :project_task -> Projects.Permissions.check(access_level, :can_view, company_read_only: company_read_only)
       :space_task -> Groups.Permissions.check(access_level, :can_view, company_read_only: company_read_only)
       :milestone -> Projects.Permissions.check(access_level, :can_view, company_read_only: company_read_only)
+      :kpi -> Groups.Permissions.check(access_level, :can_view, company_read_only: company_read_only)
     end
   end
 end

--- a/app/lib/operately_web/api/serializers/kpi.ex
+++ b/app/lib/operately_web/api/serializers/kpi.ex
@@ -11,6 +11,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.Kpi do
       space_id: Operately.ShortUuid.encode!(kpi.space_id),
       champion: Serializer.serialize(kpi.champion),
       latest_entry: serialize_latest_entry(kpi),
+      subscription_list: serialize_subscription_list(kpi),
       inserted_at: Serializer.serialize(kpi.inserted_at),
       updated_at: Serializer.serialize(kpi.updated_at)
     }
@@ -28,4 +29,12 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.Kpi do
   end
 
   defp serialize_latest_entry(_kpi), do: nil
+
+  defp serialize_subscription_list(kpi) do
+    if Ecto.assoc_loaded?(kpi.subscription_list) do
+      Serializer.serialize(kpi.subscription_list)
+    else
+      nil
+    end
+  end
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -1055,6 +1055,7 @@ defmodule OperatelyWeb.Api.Types do
     field? :champion, :person, null: true
     field? :latest_entry, :kpi_entry, null: true
     field? :entries, list_of(:kpi_entry), null: true
+    field? :subscription_list, :subscription_list, null: true
     field? :inserted_at, :datetime, null: true
     field? :updated_at, :datetime, null: true
   end
@@ -2699,7 +2700,8 @@ defmodule OperatelyWeb.Api.Types do
       :project,
       :milestone,
       :project_task,
-      :space_task
+      :space_task,
+      :kpi
     ]
   )
 

--- a/app/priv/repo/migrations/20260824151433_add_subscription_list_to_kpis.exs
+++ b/app/priv/repo/migrations/20260824151433_add_subscription_list_to_kpis.exs
@@ -1,0 +1,23 @@
+defmodule Operately.Repo.Migrations.AddSubscriptionListToKpis do
+  use Ecto.Migration
+
+  def up do
+    alter table(:kpis) do
+      add :subscription_list_id, references(:subscription_lists, on_delete: :delete_all, type: :binary_id), null: true
+    end
+
+    create index(:kpis, [:subscription_list_id])
+
+    flush()
+
+    Operately.Data.Change113CreateSubscriptionListsForKpis.run()
+  end
+
+  def down do
+    drop index(:kpis, [:subscription_list_id])
+
+    alter table(:kpis) do
+      remove :subscription_list_id
+    end
+  end
+end

--- a/app/test/operately/data/change_113_create_subscription_lists_for_kpis_test.exs
+++ b/app/test/operately/data/change_113_create_subscription_lists_for_kpis_test.exs
@@ -1,0 +1,80 @@
+defmodule Operately.Data.Change113CreateSubscriptionListsForKpisTest do
+  use Operately.DataCase
+
+  import Operately.KpisFixtures
+
+  alias Operately.Notifications.{Subscription, SubscriptionList}
+
+  setup ctx do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_space_member(:champion, :space)
+
+    Enum.reduce(1..3, ctx, fn num, ctx ->
+      kpi_name = String.to_atom("kpi_#{num}")
+      kpi = kpi_fixture(ctx.creator, %{space_id: ctx.space.id, champion_id: ctx.champion.id, name: "KPI #{num}"})
+
+      ctx
+      |> Map.put(kpi_name, kpi)
+      |> reset_kpi_subscription_list(kpi_name)
+    end)
+  end
+
+  test "creates subscriptions lists for existing KPIs and subscribes the champion", ctx do
+    kpis = [ctx.kpi_1, ctx.kpi_2, ctx.kpi_3]
+
+    Enum.each(kpis, fn kpi ->
+      assert kpi.subscription_list_id == nil
+    end)
+
+    Operately.Data.Change113CreateSubscriptionListsForKpis.run()
+
+    Enum.each(kpis, fn kpi ->
+      kpi = Repo.reload(kpi)
+
+      assert kpi.subscription_list_id != nil
+      assert {:ok, subscription_list} = SubscriptionList.get(:system, id: kpi.subscription_list_id)
+      assert subscription_list.parent_id == kpi.id
+      assert subscription_list.parent_type == :kpi
+
+      assert {:ok, subscription} =
+               Subscription.get(:system, subscription_list_id: kpi.subscription_list_id, person_id: ctx.champion.id)
+
+      assert subscription.type == :invited
+    end)
+  end
+
+  test "does not create duplicate subscription lists for KPIs that already have them", ctx do
+    kpi = kpi_fixture(ctx.creator, %{space_id: ctx.space.id, name: "Already subscribed"})
+    {:ok, subscription_list} = SubscriptionList.get(:system, id: kpi.subscription_list_id)
+
+    Operately.Data.Change113CreateSubscriptionListsForKpis.run()
+
+    kpi = Repo.reload(kpi)
+    assert kpi.subscription_list_id == subscription_list.id
+
+    subscription_lists = Repo.all(from(sl in SubscriptionList, where: sl.parent_id == ^kpi.id))
+    assert length(subscription_lists) == 1
+  end
+
+  defp reset_kpi_subscription_list(ctx, kpi_name) do
+    kpi = ctx[kpi_name]
+    subscription_list_id = kpi.subscription_list_id
+
+    {1, nil} =
+      Repo.update_all(
+        from(k in Operately.Kpis.Kpi, where: k.id == ^kpi.id),
+        set: [subscription_list_id: nil]
+      )
+
+    from(s in Subscription, where: s.subscription_list_id == ^subscription_list_id)
+    |> Repo.delete_all()
+
+    from(sl in SubscriptionList, where: sl.id == ^subscription_list_id)
+    |> Repo.delete_all()
+
+    Map.put(ctx, kpi_name, Repo.reload(kpi))
+  end
+end

--- a/app/test/operately/operations/kpi_creation_test.exs
+++ b/app/test/operately/operations/kpi_creation_test.exs
@@ -36,8 +36,37 @@ defmodule Operately.Operations.KpiCreationTest do
     assert kpi.description == ctx.attrs.description
     assert kpi.unit == "%"
     assert kpi.cadence == :monthly
+    assert kpi.subscription_list_id
 
     assert Enum.map(Kpis.list_kpis(ctx.space.id), & &1.id) == [kpi.id]
+  end
+
+  test "subscribes the creator and champion", ctx do
+    {:ok, kpi} = Kpis.create_kpi(ctx.creator, ctx.attrs)
+
+    assert {:ok, subscription_list} =
+             Operately.Notifications.SubscriptionList.get(:system, id: kpi.subscription_list_id)
+
+    assert subscription_list.parent_id == kpi.id
+    assert subscription_list.parent_type == :kpi
+
+    assert {:ok, creator_subscription} =
+             Operately.Notifications.Subscription.get(:system,
+               subscription_list_id: kpi.subscription_list_id,
+               person_id: ctx.creator.id
+             )
+
+    assert creator_subscription.type == :joined
+    refute creator_subscription.canceled
+
+    assert {:ok, champion_subscription} =
+             Operately.Notifications.Subscription.get(:system,
+               subscription_list_id: kpi.subscription_list_id,
+               person_id: ctx.champion.id
+             )
+
+    assert champion_subscription.type == :invited
+    refute champion_subscription.canceled
   end
 
   test "records a kpi_created activity", ctx do

--- a/app/test/operately/operations/kpi_editing_test.exs
+++ b/app/test/operately/operations/kpi_editing_test.exs
@@ -1,5 +1,6 @@
 defmodule Operately.Operations.KpiEditingTest do
   use Operately.DataCase
+  use Operately.Support.Notifications
 
   import Operately.CompaniesFixtures
   import Operately.PeopleFixtures
@@ -8,14 +9,17 @@ defmodule Operately.Operations.KpiEditingTest do
 
   alias Operately.Kpis
   alias Operately.Activities.Activity
+  alias Operately.Notifications
 
   setup do
     company = company_fixture()
     creator = person_fixture_with_account(%{company_id: company.id})
+    champion = person_fixture_with_account(%{company_id: company.id})
     space = group_fixture(creator)
-    kpi = kpi_fixture(creator, %{space_id: space.id, name: "Old name"})
+    {:ok, _} = Operately.Groups.add_members(creator, space.id, [%{id: champion.id, access_level: 70}])
+    kpi = kpi_fixture(creator, %{space_id: space.id, champion_id: champion.id, name: "Old name"})
 
-    {:ok, creator: creator, space: space, kpi: kpi}
+    {:ok, company: company, creator: creator, champion: champion, space: space, kpi: kpi}
   end
 
   test "updates the KPI and records an activity", ctx do
@@ -34,5 +38,38 @@ defmodule Operately.Operations.KpiEditingTest do
 
     assert activity.content["old_name"] == "Old name"
     assert activity.content["new_name"] == "New name"
+  end
+
+  test "subscribes a newly assigned champion", ctx do
+    new_champion = person_fixture_with_account(%{company_id: ctx.company.id})
+    {:ok, _} = Operately.Groups.add_members(ctx.creator, ctx.space.id, [%{id: new_champion.id, access_level: 70}])
+
+    {:ok, kpi} = Kpis.edit_kpi(ctx.creator, ctx.kpi, %{champion_id: new_champion.id})
+
+    assert {:ok, subscription} =
+             Notifications.Subscription.get(:system,
+               subscription_list_id: kpi.subscription_list_id,
+               person_id: new_champion.id
+             )
+
+    refute subscription.canceled
+  end
+
+  test "notifies subscribers other than the author", ctx do
+    {:ok, kpi} =
+      Oban.Testing.with_testing_mode(:manual, fn ->
+        Kpis.edit_kpi(ctx.creator, ctx.kpi, %{name: "New name"})
+      end)
+
+    activity =
+      from(a in Activity, where: a.action == "kpi_edited" and a.content["kpi_id"] == ^kpi.id)
+      |> Repo.one()
+
+    perform_job(activity.id)
+
+    notified_ids = activity.id |> fetch_notifications() |> Enum.map(& &1.person_id)
+
+    assert ctx.champion.id in notified_ids
+    refute ctx.creator.id in notified_ids
   end
 end

--- a/app/test/operately/operations/kpi_entry_logging_test.exs
+++ b/app/test/operately/operations/kpi_entry_logging_test.exs
@@ -15,6 +15,7 @@ defmodule Operately.Operations.KpiEntryLoggingTest do
     creator = person_fixture_with_account(%{company_id: company.id})
     champion = person_fixture_with_account(%{company_id: company.id})
     space = group_fixture(creator)
+    {:ok, _} = Operately.Groups.add_members(creator, space.id, [%{id: champion.id, access_level: 70}])
     kpi = kpi_fixture(creator, %{space_id: space.id, champion_id: champion.id})
 
     {:ok, company: company, creator: creator, champion: champion, space: space, kpi: kpi}

--- a/app/test/operately_web/api/kpis/get_kpi_test.exs
+++ b/app/test/operately_web/api/kpis/get_kpi_test.exs
@@ -39,6 +39,8 @@ defmodule OperatelyWeb.Api.Kpis.GetKpiTest do
       assert Jason.decode!(res.kpi.description) == description
       periods = Enum.map(res.kpi.entries, & &1.period)
       assert periods == ["2026-01-01", "2026-02-01", "2026-03-01"]
+      assert res.kpi.subscription_list
+      assert res.kpi.subscription_list.parent_type == "kpi"
     end
 
     test "a non-space-member cannot get a KPI", ctx do

--- a/app/test/operately_web/api/notifications/is_subscribed_test.exs
+++ b/app/test/operately_web/api/notifications/is_subscribed_test.exs
@@ -2,6 +2,7 @@ defmodule OperatelyWeb.Api.Notifications.IsSubscribedTest do
   use OperatelyWeb.TurboCase
 
   alias Operately.Access.Binding
+  import Operately.KpisFixtures
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -50,6 +51,9 @@ defmodule OperatelyWeb.Api.Notifications.IsSubscribedTest do
       |> Factory.add_messages_board(:board1, :default_space)
       |> Factory.add_message(:message1, :board1)
       |> Factory.create_space_task(:space_task1, :default_space)
+      |> then(fn ctx ->
+        Map.put(ctx, :kpi1, kpi_fixture(ctx.creator, %{space_id: ctx.default_space.id}))
+      end)
       |> Factory.add_space_member(:person, :default_space)
       |> Factory.log_in_person(:person)
     end
@@ -131,6 +135,17 @@ defmodule OperatelyWeb.Api.Notifications.IsSubscribedTest do
       assert {200, res} = query(ctx.conn, [:notifications, :is_subscribed], %{
         resource_id: Paths.task_id(ctx.space_task1),
         resource_type: "space_task"
+      })
+
+      assert res.subscribed == true
+    end
+
+    test "returns true when user is subscribed to a kpi", ctx do
+      Factory.add_subscription(ctx, :sub1, :kpi1, person: ctx.person, type: :joined)
+
+      assert {200, res} = query(ctx.conn, [:notifications, :is_subscribed], %{
+        resource_id: Paths.kpi_id(ctx.kpi1),
+        resource_type: "kpi"
       })
 
       assert res.subscribed == true

--- a/app/test/operately_web/api/notifications/subscribe_test.exs
+++ b/app/test/operately_web/api/notifications/subscribe_test.exs
@@ -200,6 +200,30 @@ defmodule OperatelyWeb.Api.Notifications.SubscribeTest do
     end
   end
 
+  describe "kpi subscriptions" do
+    setup ctx do
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+      |> Factory.add_space_member(:person, :space)
+      |> Factory.log_in_person(:person)
+    end
+
+    test "subscribes to kpi notifications", ctx do
+      kpi = Operately.KpisFixtures.kpi_fixture(ctx.creator, %{space_id: ctx.space.id})
+
+      refute Notifications.is_subscriber?(ctx.person.id, kpi.subscription_list_id)
+
+      assert {200, _} =
+               mutation(ctx.conn, [:notifications, :subscribe], %{
+                 subscription_list_id: Paths.subscription_list_id(%{id: kpi.subscription_list_id}),
+                 type: "kpi"
+               })
+
+      assert Notifications.is_subscriber?(ctx.person.id, kpi.subscription_list_id)
+    end
+  end
+
   #
   # Helpers
   #

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -1636,6 +1636,7 @@ export interface Kpi {
   champion?: Person | null;
   latestEntry?: KpiEntry | null;
   entries?: KpiEntry[] | null;
+  subscriptionList?: SubscriptionList | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
 }
@@ -2949,7 +2950,8 @@ export type SubscriptionParentType =
   | "project"
   | "milestone"
   | "project_task"
-  | "space_task";
+  | "space_task"
+  | "kpi";
 
 export type SuccessStatus = "achieved" | "missed";
 

--- a/turboui/src/NotificationToggle/index.tsx
+++ b/turboui/src/NotificationToggle/index.tsx
@@ -7,13 +7,14 @@ const ENTITY_LABEL_BY_TYPE: Record<NotificationToggle.Props["entityType"], strin
   space_task: "task",
   project: "project",
   milestone: "milestone",
+  kpi: "KPI",
 };
 
 export namespace NotificationToggle {
   export interface Props {
     isSubscribed: boolean;
     onToggle: (subscribed: boolean) => void;
-    entityType: "project_task" | "space_task" | "project" | "milestone";
+    entityType: "project_task" | "space_task" | "project" | "milestone" | "kpi";
   }
 }
 

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -5,7 +5,7 @@ import { Menu, MenuActionItem } from "../Menu";
 import { PageDescription } from "../PageDescription";
 import { PersonField } from "../PersonField";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
-import { SidebarSection } from "../SidebarSection";
+import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
@@ -18,6 +18,7 @@ interface KpiDetailProps {
   onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
   onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
   richTextHandlers: RichEditorHandlers;
+  subscriptions?: SpaceKpisPage.Props["subscriptions"];
 }
 
 // The KPI name, back navigation and the "Log update" action live in the shared
@@ -30,6 +31,7 @@ export function KpiDetail({
   onEditKpi,
   onDescriptionChange,
   richTextHandlers,
+  subscriptions,
 }: KpiDetailProps) {
   const [description, setDescription] = React.useState(kpi.description);
 
@@ -69,7 +71,13 @@ export function KpiDetail({
         </div>
       </div>
 
-      <KpiSidebar kpi={kpi} canManage={canManage} championSearch={championSearch} onEditKpi={onEditKpi} />
+      <KpiSidebar
+        kpi={kpi}
+        canManage={canManage}
+        championSearch={championSearch}
+        onEditKpi={onEditKpi}
+        subscriptions={subscriptions}
+      />
     </div>
   );
 }
@@ -79,11 +87,13 @@ function KpiSidebar({
   canManage,
   championSearch,
   onEditKpi,
+  subscriptions,
 }: {
   kpi: SpaceKpisPage.Kpi;
   canManage: boolean;
   championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
   onEditKpi: (input: SpaceKpisPage.EditKpiInput) => Promise<SpaceKpisPage.MutationResult>;
+  subscriptions?: SpaceKpisPage.Props["subscriptions"];
 }) {
   const [champion, setChampion] = React.useState(kpi.champion);
   const [cadence, setCadence] = React.useState(kpi.cadence);
@@ -135,6 +145,8 @@ function KpiSidebar({
       <SidebarSection title="Cadence">
         <CadenceField cadence={cadence} readonly={!canManage} onChange={(next) => save(champion, next)} />
       </SidebarSection>
+
+      {subscriptions && <SidebarNotificationSection {...subscriptions} />}
     </aside>
   );
 }

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useParams } from "react-router";
 
 import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
+import { useMockSubscriptions } from "../utils/storybook/subscriptions";
 import { SpaceKpisPage } from "./index";
 import type { SpaceKpisPage as SpaceKpisPageNS } from "./types";
 import { mockChampionSearch, mockCurrentUser, mockKpis, mockKpisLink, mockPeople, mockSpace } from "./mockData";
@@ -63,6 +64,7 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 function Harness(args: HarnessArgs) {
   const [kpis, setKpis] = React.useState<SpaceKpisPageNS.Kpi[]>(() => (args.emptySpace ? [] : clone(mockKpis)));
   const { kpiId } = useParams();
+  const subscriptions = useMockSubscriptions({ entityType: "kpi", initial: true });
 
   const onCreateKpi = async (input: SpaceKpisPageNS.NewKpiInput): Promise<SpaceKpisPageNS.MutationResult> => {
     console.log("createKpi", input);
@@ -178,6 +180,7 @@ function Harness(args: HarnessArgs) {
       loading={args.loading}
       error={args.error}
       canManage={args.canManage}
+      subscriptions={subscriptions}
     />
   );
 }

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -128,6 +128,22 @@ describe("SpaceKpisPage layout", () => {
     expect(within(sidebar).queryByText("Unit")).not.toBeInTheDocument();
   });
 
+  test("shows a subscribe control in the sidebar on a KPI page", () => {
+    const target = mockKpis[0]!;
+    renderPage({
+      selectedKpi: target,
+      subscriptions: {
+        isSubscribed: false,
+        onToggle: () => {},
+        hidden: false,
+        entityType: "kpi",
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Subscribe" })).toBeInTheDocument();
+    expect(screen.getByText("You're not receiving notifications from this KPI.")).toBeInTheDocument();
+  });
+
   test("shows the KPI description above its history", () => {
     const target = mockKpis[0]!;
     const { container } = renderPage({ selectedKpi: target });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -243,6 +243,7 @@ function KpisContent(props: KpisContentProps) {
         onEditKpi={props.onEditKpi}
         onDescriptionChange={props.onDescriptionChange}
         richTextHandlers={props.richTextHandlers}
+        subscriptions={props.subscriptions}
       />
     );
   }

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -10,6 +10,7 @@
 //
 import type { Navigation } from "../Page/Navigation";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
+import { SidebarNotificationSection } from "../SidebarSection";
 
 export namespace SpaceKpisPage {
   // Ecto.Enum :weekly | :monthly on the backend.
@@ -127,5 +128,8 @@ export namespace SpaceKpisPage {
 
     // In the POC any space member can read & write, so this defaults to true.
     canManage?: boolean;
+
+    // Subscribe/unsubscribe for the open KPI, matching tasks and projects.
+    subscriptions?: SidebarNotificationSection.Props;
   }
 }


### PR DESCRIPTION
## Summary

KPIs had no way to follow changes — you only heard about a KPI if you happened to be its champion. This gives each KPI a subscription list, the same mechanism tasks use.

- **Subscribe/unsubscribe from the KPI sidebar.** Reuses the existing `SidebarNotificationSection` / `NotificationToggle` TurboUI components, so it looks and behaves exactly like the control on tasks and projects.
- **Sensible defaults.** Creating a KPI subscribes the creator and the champion; assigning a new champion subscribes them too.
- **Notifications now go to subscribers.** Editing a KPI or logging a value notifies everyone subscribed rather than only the champion. Creating a KPI still notifies the whole space, so people can discover it and subscribe.
- **Existing KPIs are backfilled** with a subscription list, and their champions are subscribed.

## Migration notes

`20260824151433_add_subscription_list_to_kpis` adds a nullable `subscription_list_id` to `kpis` (plus an index), then runs `Operately.Data.Change113CreateSubscriptionListsForKpis` to backfill lists and champion subscriptions. The backfill is idempotent and safe to re-run.

## Test plan

- [x] `make test FILE=app/test/operately/operations/kpi_creation_test.exs` — creator and champion get subscribed
- [x] `make test FILE=app/test/operately/operations/kpi_editing_test.exs` — new champion subscribed; subscribers notified, author excluded
- [x] `make test FILE=app/test/operately/operations/kpi_entry_logging_test.exs`
- [x] `make test FILE=app/test/operately/data/change_113_create_subscription_lists_for_kpis_test.exs` — backfill, no duplicates
- [x] `make test FILE=app/test/operately_web/api/kpis/get_kpi_test.exs` — subscription list is serialized
- [x] `make test FILE=app/test/operately_web/api/notifications/subscribe_test.exs` — subscribing to a KPI
- [x] `make test FILE=app/test/operately_web/api/notifications/is_subscribed_test.exs`
- [x] Space KPIs Jest suite, including the new sidebar subscribe control
- [ ] Manual click-through in a browser


Made with [Cursor](https://cursor.com)