### PR TITLE
chore: Remove Log update from the KPI list table

### DIFF
--- a/turboui/src/SpaceKpisPage/KpiList.tsx
+++ b/turboui/src/SpaceKpisPage/KpiList.tsx
@@ -10,14 +10,10 @@ import { TrendIndicator } from "./TrendIndicator";
 interface KpiListProps {
   kpis: SpaceKpisPage.Kpi[];
   canManage: boolean;
-  onLogUpdate: (kpiId: string) => void;
   onNewKpi: () => void;
 }
 
-// Logging an update is the one action a row offers, since it is the only thing
-// worth doing to several KPIs in a row. Renaming, retuning and deleting a KPI
-// happen on its own page, where its history is there to judge them by.
-export function KpiList({ kpis, canManage, onLogUpdate, onNewKpi }: KpiListProps) {
+export function KpiList({ kpis, canManage, onNewKpi }: KpiListProps) {
   if (kpis.length === 0) {
     return <EmptyState canManage={canManage} onNewKpi={onNewKpi} />;
   }
@@ -31,12 +27,11 @@ export function KpiList({ kpis, canManage, onLogUpdate, onNewKpi }: KpiListProps
             <th className="px-4 py-2 font-medium">Cadence</th>
             <th className="px-4 py-2 font-medium">Champion</th>
             <th className="px-4 py-2 text-right font-medium">Latest value</th>
-            <th className="px-4 py-2" />
           </tr>
         </thead>
         <tbody>
           {kpis.map((kpi) => (
-            <KpiRow key={kpi.id} kpi={kpi} canManage={canManage} onLogUpdate={() => onLogUpdate(kpi.id)} />
+            <KpiRow key={kpi.id} kpi={kpi} />
           ))}
         </tbody>
       </table>
@@ -44,21 +39,13 @@ export function KpiList({ kpis, canManage, onLogUpdate, onNewKpi }: KpiListProps
   );
 }
 
-function KpiRow({
-  kpi,
-  canManage,
-  onLogUpdate,
-}: {
-  kpi: SpaceKpisPage.Kpi;
-  canManage: boolean;
-  onLogUpdate: () => void;
-}) {
+function KpiRow({ kpi }: { kpi: SpaceKpisPage.Kpi }) {
   const latest = latestEntry(kpi);
   const trend = latestTrend(kpi);
 
   return (
     <tr
-      className="group border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
+      className="border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
       data-test-id={`kpi-row-${kpi.id}`}
     >
       <td className="px-4 py-3">
@@ -94,19 +81,6 @@ function KpiRow({
           </div>
         ) : (
           <span className="text-content-subtle">No data</span>
-        )}
-      </td>
-
-      <td className="px-4 py-3 text-right">
-        {canManage && (
-          <button
-            type="button"
-            className="rounded-md px-2 py-1 text-xs font-medium text-link-base opacity-0 transition-opacity hover:bg-surface-accent group-hover:opacity-100"
-            onClick={onLogUpdate}
-            data-test-id={`log-update-${kpi.id}`}
-          >
-            Log update
-          </button>
         )}
       </td>
     </tr>

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -462,14 +462,13 @@ describe("SpaceKpisPage edit & delete", () => {
     expect(container.querySelector('[data-test-id="delete-kpi"]')).not.toBeInTheDocument();
   });
 
-  // Managing a KPI belongs on its own page, where its history is on screen to
-  // judge the change by, so rows carry no manage menu of their own.
-  test("KPI rows offer only 'Log update', with no overflow menu", () => {
+  // Managing a KPI belongs on its own page, so list rows carry no actions.
+  test("KPI rows have no 'Log update' action and no overflow menu", () => {
     const target = mockKpis[0]!;
     const { container } = renderPage();
     const row = container.querySelector<HTMLElement>(`[data-test-id="kpi-row-${target.id}"]`)!;
 
-    expect(within(row).getByText("Log update")).toBeInTheDocument();
+    expect(within(row).queryByText("Log update")).not.toBeInTheDocument();
     expect(within(row).queryByLabelText("KPI actions")).not.toBeInTheDocument();
   });
 });
@@ -528,9 +527,9 @@ describe("SpaceKpisPage create & log", () => {
     const user = userEvent.setup();
     const onRecordEntry = jest.fn().mockResolvedValue({ success: true });
     const target = mockKpis[0]!;
-    const { container } = renderPage({ onRecordEntry });
+    const { container } = renderPage({ selectedKpi: target, onRecordEntry });
 
-    await user.click(container.querySelector(`[data-test-id="log-update-${target.id}"]`)!);
+    await user.click(container.querySelector('[data-test-id="kpi-detail-log-update"]')!);
     await findByTestId("log-update-modal");
 
     fireEvent.change(await findByTestId("value"), { target: { value: "123" } });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -34,8 +34,8 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   // sidebar — so they are held here and shared by both.
   const openKpi = useKpiFields(selectedKpi, props.onEditKpi);
 
-  // An update can be logged from a list row, or on the open KPI when its page is
-  // shown directly (its permalink may be opened before the list is browsed).
+  // An update is logged from the open KPI's page, whose permalink may be opened
+  // before the list is browsed.
   const logKpi = (() => {
     if (!logKpiId) return null;
     if (selectedKpi?.id === logKpiId) return selectedKpi;
@@ -81,7 +81,6 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
             selectedKpi={selectedKpi}
             openKpi={openKpi}
             onOpenNew={() => setIsNewOpen(true)}
-            onOpenLog={setLogKpiId}
             onOpenDelete={() => setIsDeleteOpen(true)}
           />
         </div>
@@ -207,7 +206,6 @@ interface KpisContentProps extends SpaceKpisPageNS.Props {
   selectedKpi: SpaceKpisPageNS.Kpi | null;
   openKpi: KpiFields | null;
   onOpenNew: () => void;
-  onOpenLog: (id: string) => void;
   onOpenDelete: () => void;
 }
 
@@ -238,7 +236,7 @@ function KpisContent(props: KpisContentProps) {
   }
 
   return (
-    <KpiList kpis={props.kpis} canManage={props.canManage} onLogUpdate={props.onOpenLog} onNewKpi={props.onOpenNew} />
+    <KpiList kpis={props.kpis} canManage={props.canManage} onNewKpi={props.onOpenNew} />
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove the per-row **Log update** action from the space KPIs table.
- Logging an update remains on the KPI page via the header action.

## Test plan
- [ ] Open a space KPIs list and confirm rows show no Log update link.
- [ ] Open a KPI and confirm Log update still works from the header.


Made with [Cursor](https://cursor.com)