### PR TITLE
feat: Show an inline sparkline on the KPI list

### DIFF
--- a/app/lib/operately/kpis.ex
+++ b/app/lib/operately/kpis.ex
@@ -26,27 +26,46 @@ defmodule Operately.Kpis do
     |> Repo.all()
   end
 
+  # How much history the list view carries per KPI: enough to plot a trend
+  # inline, without the cost of loading the whole series for every KPI.
+  @recent_entries_limit 12
+
   @doc """
-  Populates the virtual `:latest_entry` field of each KPI with its most recent
-  entry (by period). Uses a single `DISTINCT ON` query for the whole list so the
-  list view can render latest values without preloading full entry history.
+  Loads the most recent entries of each KPI (oldest -> newest) into its `:entries`
+  association, and its latest one into the virtual `:latest_entry` field. Uses a
+  single query for the whole list, capped at #{@recent_entries_limit} entries per
+  KPI, so the list view can render latest values and inline trends cheaply.
   """
-  def load_latest_entries(kpis) when is_list(kpis) do
-    latest = latest_entries_by_kpi_id(Enum.map(kpis, & &1.id))
-    Enum.map(kpis, fn kpi -> %{kpi | latest_entry: Map.get(latest, kpi.id)} end)
+  def load_recent_entries(kpis, limit \\ @recent_entries_limit) when is_list(kpis) do
+    recent = recent_entries_by_kpi_id(Enum.map(kpis, & &1.id), limit)
+
+    Enum.map(kpis, fn kpi ->
+      entries = Map.get(recent, kpi.id, [])
+      %{kpi | entries: entries, latest_entry: List.last(entries)}
+    end)
   end
 
-  defp latest_entries_by_kpi_id([]), do: %{}
+  defp recent_entries_by_kpi_id([], _limit), do: %{}
 
-  defp latest_entries_by_kpi_id(kpi_ids) do
+  defp recent_entries_by_kpi_id(kpi_ids, limit) do
+    ranked =
+      from(e in KpiEntry,
+        where: e.kpi_id in ^kpi_ids,
+        select: %{
+          id: e.id,
+          rank: row_number() |> over(partition_by: e.kpi_id, order_by: [desc: e.period, desc: e.inserted_at])
+        }
+      )
+
     from(e in KpiEntry,
-      where: e.kpi_id in ^kpi_ids,
-      distinct: e.kpi_id,
-      order_by: [asc: e.kpi_id, desc: e.period, desc: e.inserted_at]
+      join: r in subquery(ranked),
+      on: r.id == e.id,
+      where: r.rank <= ^limit,
+      order_by: [asc: e.kpi_id, asc: e.period, asc: e.inserted_at]
     )
     |> Repo.all()
     |> Repo.preload(:recorded_by)
-    |> Map.new(fn entry -> {entry.kpi_id, entry} end)
+    |> Enum.group_by(& &1.kpi_id)
   end
 
   defdelegate create_kpi(creator, attrs), to: Operately.Operations.KpiCreation, as: :run

--- a/app/lib/operately/kpis/kpi.ex
+++ b/app/lib/operately/kpis/kpi.ex
@@ -15,7 +15,7 @@ defmodule Operately.Kpis.Kpi do
     field(:cadence, Ecto.Enum, values: [:weekly, :monthly])
     field(:description, :map)
 
-    # Populated by ListKpis via Kpis.load_latest_entries/1 so the list view can
+    # Populated by ListKpis via Kpis.load_recent_entries/2 so the list view can
     # show the most recent value without preloading the full entry history.
     field(:latest_entry, :any, virtual: true)
 

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -35,7 +35,7 @@ defmodule OperatelyWeb.Api.Kpis do
         kpis =
           Kpis.list_kpis(ctx.space.id)
           |> Repo.preload(:champion)
-          |> Kpis.load_latest_entries()
+          |> Kpis.load_recent_entries()
 
         {:ok, kpis}
       end)

--- a/app/lib/operately_web/api/serializers/kpi.ex
+++ b/app/lib/operately_web/api/serializers/kpi.ex
@@ -11,19 +11,26 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.Kpi do
       space_id: Operately.ShortUuid.encode!(kpi.space_id),
       champion: Serializer.serialize(kpi.champion),
       latest_entry: serialize_latest_entry(kpi),
+      entries: serialize_entries(kpi),
       subscription_list: serialize_subscription_list(kpi),
       inserted_at: Serializer.serialize(kpi.inserted_at),
       updated_at: Serializer.serialize(kpi.updated_at)
     }
   end
 
-  def serialize(kpi, level: :full) do
-    serialize(kpi, level: :essential)
-    |> Map.put(:entries, Serializer.serialize(kpi.entries, level: :essential))
+  def serialize(kpi, level: :full), do: serialize(kpi, level: :essential)
+
+  # Entries are included whenever the caller loaded them: a KPI's own page loads
+  # its full history, while the list loads a bounded recent window for the
+  # inline trend line.
+  defp serialize_entries(kpi) do
+    if Ecto.assoc_loaded?(kpi.entries) do
+      Serializer.serialize(kpi.entries, level: :essential)
+    end
   end
 
-  # The list view carries only the most recent entry (value + period) so it can
-  # show the latest value without the cost of preloading the full history.
+  # The most recent entry (value + period), so a list can show the latest value
+  # without depending on how much history was loaded.
   defp serialize_latest_entry(%{latest_entry: %Operately.Kpis.KpiEntry{} = entry}) do
     Serializer.serialize(entry, level: :essential)
   end

--- a/app/test/operately/kpis/kpis_test.exs
+++ b/app/test/operately/kpis/kpis_test.exs
@@ -43,4 +43,38 @@ defmodule Operately.KpisTest do
 
     assert periods == [~D[2026-01-01], ~D[2026-02-01], ~D[2026-03-01]]
   end
+
+  test "load_recent_entries/2 loads each KPI's recent history and its latest entry", ctx do
+    kpi = kpi_fixture(ctx.creator, %{space_id: ctx.space.id})
+    other = kpi_fixture(ctx.creator, %{space_id: ctx.space.id, name: "Other KPI"})
+    empty = kpi_fixture(ctx.creator, %{space_id: ctx.space.id, name: "Fresh KPI"})
+
+    kpi_entry_fixture(ctx.creator, kpi, %{period: ~D[2026-02-01], value: 2.0})
+    kpi_entry_fixture(ctx.creator, kpi, %{period: ~D[2026-01-01], value: 1.0})
+    kpi_entry_fixture(ctx.creator, other, %{period: ~D[2026-01-01], value: 9.0})
+
+    [loaded, loaded_other, loaded_empty] = Kpis.load_recent_entries([kpi, other, empty])
+
+    assert Enum.map(loaded.entries, & &1.value) == [1.0, 2.0]
+    assert loaded.latest_entry.value == 2.0
+
+    assert Enum.map(loaded_other.entries, & &1.value) == [9.0]
+    assert loaded_other.latest_entry.value == 9.0
+
+    assert loaded_empty.entries == []
+    assert loaded_empty.latest_entry == nil
+  end
+
+  test "load_recent_entries/2 keeps only the most recent entries within the limit", ctx do
+    kpi = kpi_fixture(ctx.creator, %{space_id: ctx.space.id})
+
+    Enum.each(1..5, fn day ->
+      kpi_entry_fixture(ctx.creator, kpi, %{period: Date.add(~D[2026-01-01], day), value: day * 1.0})
+    end)
+
+    [loaded] = Kpis.load_recent_entries([kpi], 3)
+
+    assert Enum.map(loaded.entries, & &1.value) == [3.0, 4.0, 5.0]
+    assert loaded.latest_entry.value == 5.0
+  end
 end

--- a/app/test/operately_web/api/kpis/list_kpis_test.exs
+++ b/app/test/operately_web/api/kpis/list_kpis_test.exs
@@ -35,10 +35,11 @@ defmodule OperatelyWeb.Api.Kpis.ListKpisTest do
       assert Jason.decode!(listed.description) == description
     end
 
-    test "each KPI carries its latest entry (value + period) without full history", ctx do
+    test "each KPI carries its latest entry (value + period) and its recent history", ctx do
       kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "PR Throughput", unit: "USD")
 
-      # Log entries out of order to prove the latest (by period) is returned.
+      # Log entries out of order to prove the latest (by period) is returned, and
+      # that the history is ordered oldest -> newest for the inline trend line.
       kpi_entry_fixture(ctx.member, kpi, value: 100.0, period: ~D[2026-01-01])
       kpi_entry_fixture(ctx.member, kpi, value: 123.0, period: ~D[2026-03-01])
       kpi_entry_fixture(ctx.member, kpi, value: 110.0, period: ~D[2026-02-01])
@@ -50,11 +51,29 @@ defmodule OperatelyWeb.Api.Kpis.ListKpisTest do
       assert listed.latest_entry.value == 123.0
       assert listed.latest_entry.period == "2026-03-01"
 
-      # The list must not carry the full entry history for performance.
-      refute Map.has_key?(listed, :entries) && listed.entries
+      assert Enum.map(listed.entries, & &1.period) == ["2026-01-01", "2026-02-01", "2026-03-01"]
+      assert Enum.map(listed.entries, & &1.value) == [100.0, 110.0, 123.0]
     end
 
-    test "a KPI with no entries has a nil latest entry", ctx do
+    test "the history of each KPI is capped so the list stays cheap", ctx do
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "Sign-ups")
+
+      Enum.each(1..15, fn day ->
+        kpi_entry_fixture(ctx.member, kpi, value: day * 1.0, period: Date.add(~D[2026-01-01], day))
+      end)
+
+      ctx = Factory.log_in_person(ctx, :member)
+      assert {200, res} = query(ctx.conn, [:kpis, :list_kpis], %{space_id: Paths.space_id(ctx.space)})
+
+      listed = Enum.find(res.kpis, &(&1.id == Paths.kpi_id(kpi)))
+
+      # The 12 most recent periods, oldest -> newest.
+      assert length(listed.entries) == 12
+      assert Enum.map(listed.entries, & &1.value) == Enum.map(4..15, &(&1 * 1.0))
+      assert listed.latest_entry.value == 15.0
+    end
+
+    test "a KPI with no entries has a nil latest entry and no history", ctx do
       kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, name: "Fresh KPI")
 
       ctx = Factory.log_in_person(ctx, :member)
@@ -62,6 +81,7 @@ defmodule OperatelyWeb.Api.Kpis.ListKpisTest do
 
       listed = Enum.find(res.kpis, &(&1.id == Paths.kpi_id(kpi)))
       assert listed.latest_entry == nil
+      assert listed.entries == []
     end
 
     test "a non-space-member cannot list the KPIs", ctx do

--- a/turboui/src/SpaceKpisPage/KpiList.tsx
+++ b/turboui/src/SpaceKpisPage/KpiList.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 
 import { Avatar } from "../Avatar";
-import { BlackLink } from "../Link";
+import { DivLink } from "../Link";
 import { IconChartColumn } from "../icons";
+import { KpiSparkline } from "./KpiSparkline";
 import type { SpaceKpisPage } from "./types";
-import { formatCadence, formatValue, latestEntry, latestTrend } from "./utils";
+import { formatNumber, formatValue, latestEntry, latestTrend } from "./utils";
 import { TrendIndicator } from "./TrendIndicator";
 
 interface KpiListProps {
@@ -13,28 +14,31 @@ interface KpiListProps {
   onNewKpi: () => void;
 }
 
+// Shared by the header and every row so columns stay aligned without a <table>
+// (a table row cannot be an <a>, and we want the whole line to be the link).
+const ROW_GRID = "grid grid-cols-[minmax(0,1fr)_14rem_8rem_11rem] items-center";
+
 export function KpiList({ kpis, canManage, onNewKpi }: KpiListProps) {
   if (kpis.length === 0) {
     return <EmptyState canManage={canManage} onNewKpi={onNewKpi} />;
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-stroke-base" data-test-id="kpi-list">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-stroke-base bg-surface-dimmed text-left text-xs uppercase tracking-wide text-content-dimmed">
-            <th className="px-4 py-2 font-medium">KPI</th>
-            <th className="px-4 py-2 font-medium">Cadence</th>
-            <th className="px-4 py-2 font-medium">Champion</th>
-            <th className="px-4 py-2 text-right font-medium">Latest value</th>
-          </tr>
-        </thead>
-        <tbody>
-          {kpis.map((kpi) => (
-            <KpiRow key={kpi.id} kpi={kpi} />
-          ))}
-        </tbody>
-      </table>
+    <div className="mx-auto max-w-3xl overflow-hidden rounded-lg border border-stroke-base" data-test-id="kpi-list">
+      <div className="text-sm">
+        <div
+          className={`${ROW_GRID} border-b border-stroke-base bg-surface-dimmed text-left text-xs uppercase tracking-wide text-content-dimmed`}
+        >
+          <div className="px-4 py-2 font-medium">KPI</div>
+          <div className="px-4 py-2 font-medium">Champion</div>
+          <div className="px-4 py-2 font-medium">History</div>
+          <div className="px-4 py-2 text-right font-medium">Latest value</div>
+        </div>
+
+        {kpis.map((kpi) => (
+          <KpiRow key={kpi.id} kpi={kpi} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -44,46 +48,43 @@ function KpiRow({ kpi }: { kpi: SpaceKpisPage.Kpi }) {
   const trend = latestTrend(kpi);
 
   return (
-    <tr
-      className="border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
-      data-test-id={`kpi-row-${kpi.id}`}
+    <DivLink
+      to={kpi.link}
+      testId={`kpi-row-${kpi.id}`}
+      className={`${ROW_GRID} cursor-pointer border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight`}
     >
-      <td className="px-4 py-3">
-        <BlackLink
-          to={kpi.link}
-          className="font-semibold text-content-accent"
-          underline="hover"
-          testId={`kpi-link-${kpi.id}`}
-        >
-          {kpi.name}
-        </BlackLink>
-        <div className="text-xs text-content-dimmed">Measured in {kpi.unit}</div>
-      </td>
+      <div className="truncate px-4 py-3 text-content-accent" data-test-id={`kpi-link-${kpi.id}`}>
+        {kpi.name}
+      </div>
 
-      <td className="px-4 py-3 text-content-base">{formatCadence(kpi.cadence)}</td>
-
-      <td className="px-4 py-3">
+      <div className="truncate whitespace-nowrap px-4 py-3">
         {kpi.champion ? (
           <div className="flex items-center gap-2">
             <Avatar person={kpi.champion} size="tiny" />
-            <span className="text-content-base">{kpi.champion.fullName}</span>
+            <span className="truncate text-content-base">{kpi.champion.fullName}</span>
           </div>
         ) : (
           <span className="text-content-subtle">Unassigned</span>
         )}
-      </td>
+      </div>
 
-      <td className="px-4 py-3 text-right">
+      <div className="px-4 py-3">
+        <KpiSparkline entries={kpi.entries} width={112} testId={`kpi-sparkline-${kpi.id}`} />
+      </div>
+
+      <div className="whitespace-nowrap px-4 py-3 text-right">
         {latest ? (
           <div className="flex items-center justify-end gap-2">
-            <span className="font-semibold text-content-accent">{formatValue(latest.value, kpi.unit)}</span>
+            <span className="text-content-accent">
+              {kpi.unit === "%" ? formatValue(latest.value, "%") : formatNumber(latest.value)}
+            </span>
             <TrendIndicator delta={trend} />
           </div>
         ) : (
           <span className="text-content-subtle">No data</span>
         )}
-      </td>
-    </tr>
+      </div>
+    </DivLink>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/KpiSparkline.tsx
+++ b/turboui/src/SpaceKpisPage/KpiSparkline.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+
+import classNames from "../utils/classnames";
+import type { SpaceKpisPage } from "./types";
+
+interface KpiSparklineProps {
+  // Entries ordered oldest -> newest, as stored on a KPI.
+  entries: SpaceKpisPage.KpiEntry[];
+  width?: number;
+  height?: number;
+  testId?: string;
+}
+
+// Minimal, dependency-free sparkline — the same SVG plotting approach as
+// KpiLineChart, stripped down to a trend line over a gradient that fades out
+// towards the baseline (no axes, gridlines, dots, or labels). Coloured by
+// overall direction: up = success, down = error.
+//
+// Used inline wherever a KPI is listed: the space dashboard summary card and
+// the KPI list. Renders nothing when there is no history to plot.
+export function KpiSparkline({ entries, width = 56, height = 24, testId }: KpiSparklineProps) {
+  const pad = 2;
+
+  // The gradient lives in the SVG's own <defs>, so each instance needs an id of
+  // its own to reference (colons from useId are not valid in a URL fragment).
+  const gradientId = `kpi-sparkline-gradient-${React.useId().replace(/:/g, "")}`;
+
+  if (entries.length === 0) return null;
+
+  const values = entries.map((e) => e.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || Math.abs(max) || 1;
+
+  const innerWidth = width - pad * 2;
+  const innerHeight = height - pad * 2;
+
+  const x = (index: number) => (entries.length === 1 ? width / 2 : pad + (innerWidth * index) / (entries.length - 1));
+  const y = (value: number) => pad + innerHeight * (1 - (value - min) / span);
+
+  // Both the line and its gradient are drawn in `currentColor`, so the
+  // direction is expressed once as a text colour.
+  const direction = values[values.length - 1]! - values[0]!;
+  const colorClass =
+    direction > 0 ? "text-callout-success-content" : direction < 0 ? "text-callout-error-content" : "text-blue-500";
+
+  if (entries.length === 1) {
+    const cy = height / 2;
+    return (
+      <svg width={width} height={height} className="shrink-0" aria-hidden data-test-id={testId}>
+        <line
+          x1={pad}
+          x2={width - pad}
+          y1={cy}
+          y2={cy}
+          className="stroke-surface-outline"
+          strokeWidth={1.5}
+          strokeDasharray="3 3"
+        />
+        <circle cx={width / 2} cy={cy} r={2} className="fill-blue-500" />
+      </svg>
+    );
+  }
+
+  const linePath = entries.map((entry, index) => `${index === 0 ? "M" : "L"} ${x(index)} ${y(entry.value)}`).join(" ");
+  const areaPath = `${linePath} L ${x(entries.length - 1)} ${height} L ${x(0)} ${height} Z`;
+
+  return (
+    <svg width={width} height={height} className={classNames("shrink-0", colorClass)} aria-hidden data-test-id={testId}>
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity={0.25} />
+          <stop offset="100%" stopColor="currentColor" stopOpacity={0} />
+        </linearGradient>
+      </defs>
+
+      <path d={areaPath} fill={`url(#${gradientId})`} />
+      <path
+        d={linePath}
+        className="stroke-current"
+        strokeWidth={1.5}
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/turboui/src/SpaceKpisPage/KpiSummaryCard.tsx
+++ b/turboui/src/SpaceKpisPage/KpiSummaryCard.tsx
@@ -4,6 +4,7 @@ import { GhostButton } from "../Button";
 import { IconChartColumn } from "../icons";
 import classNames from "../utils/classnames";
 
+import { KpiSparkline } from "./KpiSparkline";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
 import { formatValue, latestEntry, latestTrend } from "./utils";
@@ -79,52 +80,8 @@ function KpiRow({ kpi }: { kpi: SpaceKpisPage.Kpi }) {
         )}
       </div>
 
-      <Sparkline entries={kpi.entries} />
+      <KpiSparkline entries={kpi.entries} />
     </div>
-  );
-}
-
-// Minimal, dependency-free sparkline — the same SVG plotting approach as
-// KpiLineChart, stripped down to just a trend line (no axes, gridlines, dots,
-// or labels). Coloured by overall direction: up = success, down = error.
-function Sparkline({ entries }: { entries: SpaceKpisPage.KpiEntry[] }) {
-  const width = 56;
-  const height = 24;
-  const pad = 2;
-
-  if (entries.length === 0) return null;
-
-  const values = entries.map((e) => e.value);
-  const min = Math.min(...values);
-  const max = Math.max(...values);
-  const span = max - min || Math.abs(max) || 1;
-
-  const innerWidth = width - pad * 2;
-  const innerHeight = height - pad * 2;
-
-  const x = (index: number) => (entries.length === 1 ? width / 2 : pad + (innerWidth * index) / (entries.length - 1));
-  const y = (value: number) => pad + innerHeight * (1 - (value - min) / span);
-
-  const direction = values[values.length - 1]! - values[0]!;
-  const strokeClass =
-    direction > 0 ? "stroke-callout-success-content" : direction < 0 ? "stroke-callout-error-content" : "stroke-blue-500";
-
-  if (entries.length === 1) {
-    const cy = height / 2;
-    return (
-      <svg width={width} height={height} className="shrink-0" aria-hidden>
-        <line x1={pad} x2={width - pad} y1={cy} y2={cy} className="stroke-surface-outline" strokeWidth={1.5} strokeDasharray="3 3" />
-        <circle cx={width / 2} cy={cy} r={2} className="fill-blue-500" />
-      </svg>
-    );
-  }
-
-  const linePath = entries.map((entry, index) => `${index === 0 ? "M" : "L"} ${x(index)} ${y(entry.value)}`).join(" ");
-
-  return (
-    <svg width={width} height={height} className="shrink-0" aria-hidden>
-      <path d={linePath} className={strokeClass} strokeWidth={1.5} fill="none" strokeLinejoin="round" strokeLinecap="round" />
-    </svg>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -14,7 +14,8 @@ import { mockChampionSearch, mockCurrentUser, mockKpis, mockKpisLink, mockPeople
 // Demonstrates the end-to-end KPIs experience described in the POC:
 //   - a KPIs space tool using the same page chrome (breadcrumb header + tool
 //     title) as the other space tools (Work Map, Tasks)
-//   - a list view: name, unit, cadence, champion, latest value + trend
+//   - a list view: name, unit, champion, an inline history sparkline,
+//     latest value + trend
 //   - a detail view: line chart of history, last update + champion + cadence, "Log update"
 //   - a "New KPI" form (name, unit, cadence, champion picker)
 //   - editing a KPI in place on its own page: its name in the page title, its

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -98,6 +98,19 @@ describe("SpaceKpisPage layout", () => {
     });
   });
 
+  // Champion, history, and latest value sit inside the same <a> as the name, so
+  // clicking anywhere on the row opens the KPI.
+  test("the whole row is the link to the KPI's page", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage();
+    const row = container.querySelector(`[data-test-id="kpi-row-${target.id}"]`)!;
+
+    expect(row.tagName).toBe("A");
+    expect(row).toHaveAttribute("href", target.link);
+    expect(row).toHaveTextContent(target.champion!.fullName);
+    expect(row).toHaveTextContent(formatNumber(target.latestEntry!.value));
+  });
+
   test("opening a KPI moves its name into the header and swaps the primary action to 'Log update'", () => {
     const target = mockKpis[0]!;
     const { container } = renderPage({ selectedKpi: target });
@@ -365,8 +378,20 @@ describe("SpaceKpisPage list latest value", () => {
     const { container } = renderPage({ kpis: [kpi] });
 
     const row = container.querySelector(`[data-test-id="kpi-row-${kpi.id}"]`)!;
-    expect(row).toHaveTextContent("123 USD");
+    expect(row).toHaveTextContent("123");
+    expect(row).not.toHaveTextContent("USD");
     expect(row).not.toHaveTextContent("No data");
+  });
+
+  // The list carries a bounded window of recent entries, so each row can show
+  // where the KPI has been next to where it is now.
+  test("plots the recent history inline for KPIs that have any", () => {
+    const { container } = renderPage();
+    const plotted = mockKpis.find((kpi) => kpi.entries.length > 1)!;
+    const noHistory = mockKpis.find((kpi) => kpi.entries.length === 0)!;
+
+    expect(container.querySelector(`[data-test-id="kpi-sparkline-${plotted.id}"]`)).toBeInTheDocument();
+    expect(container.querySelector(`[data-test-id="kpi-sparkline-${noHistory.id}"]`)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a History column on the space KPI list with a shared sparkline (gradient fill, colored by overall direction) between champion and latest value.
- Load a bounded window of recent entries on `list_kpis` so the list can plot a trend without fetching full history.
- Tighten the list: drop cadence and unit copy from the table, make the whole row a link, and keep the table centered at a compact width.

## Test plan
- [ ] Open a space KPIs page with several KPIs that have history; confirm sparklines render between champion and latest value.
- [ ] Confirm a KPI with no entries has an empty history cell and "No data" for the value.
- [ ] Click anywhere on a row and land on that KPI's page.
- [ ] Confirm cadence is only on the KPI page / new form, not in the list.
- [ ] Confirm latest value is a number only (percent still shows `%`).


Made with [Cursor](https://cursor.com)