### PR TITLE
feat: Allow comments on KPI updates

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -517,6 +517,14 @@ export interface ActivityContentKpiCreated {
   kpiName: string;
 }
 
+export interface ActivityContentKpiEntryCommented {
+  __typename: "activity_content_kpi_entry_commented";
+  space: Space;
+  kpi: Kpi | null;
+  entry: KpiEntry | null;
+  comment: Comment | null;
+}
+
 export interface ActivityContentMessageArchiving {
   __typename: "activity_content_message_archiving";
   companyId?: string | null;
@@ -1767,6 +1775,7 @@ export interface KpiEntry {
   value: number;
   period: string;
   recordedBy?: Person | null;
+  commentsCount?: number | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
 }
@@ -2776,6 +2785,7 @@ export type ActivityContent =
   | ActivityContentDiscussionEditing
   | ActivityContentDiscussionPosting
   | ActivityContentKpiCreated
+  | ActivityContentKpiEntryCommented
   | ActivityContentGoalArchived
   | ActivityContentGoalCheckIn
   | ActivityContentGoalCheckInAcknowledgement
@@ -2918,7 +2928,8 @@ export type CommentParentType =
   | "resource_hub_link"
   | "space_task"
   | "project_task"
-  | "milestone";
+  | "milestone"
+  | "kpi_entry";
 
 export type ContextualDateType = "day" | "month" | "quarter" | "year";
 
@@ -3003,7 +3014,8 @@ export type ReactionParentType =
   | "space_task"
   | "resource_hub_document"
   | "resource_hub_file"
-  | "resource_hub_link";
+  | "resource_hub_link"
+  | "kpi_entry";
 
 export type ResourceAccessTypes = "space" | "goal" | "project";
 

--- a/app/assets/js/features/CommentSection/mentionSearchScope.test.ts
+++ b/app/assets/js/features/CommentSection/mentionSearchScope.test.ts
@@ -43,4 +43,14 @@ describe("findMentionedScope", () => {
       } as any),
     ).toEqual({ type: "resource_hub", id: "hub-1" });
   });
+
+  test("uses the space scope for KPI update comments", () => {
+    expect(
+      findMentionedScope({
+        parentType: "kpi_entry",
+        kpiEntry: { id: "entry-1" },
+        space: { id: "space-1" },
+      } as any),
+    ).toEqual({ type: "space", id: "space-1" });
+  });
 });

--- a/app/assets/js/features/CommentSection/mentionSearchScope.ts
+++ b/app/assets/js/features/CommentSection/mentionSearchScope.ts
@@ -38,5 +38,7 @@ export function findMentionedScope(props: Comments.CommentableResource): SearchS
       }
 
       throw new Error("CommentThread must have either goal or project defined");
+    case "kpi_entry":
+      return { type: "space", id: props.space.id };
   }
 }

--- a/app/assets/js/features/CommentSection/useComments.tsx
+++ b/app/assets/js/features/CommentSection/useComments.tsx
@@ -98,5 +98,7 @@ function findParent(props: Comments.CommentableResource) {
     case "project_discussion":
     case "goal_discussion":
       return props.thread;
+    case "kpi_entry":
+      return props.kpiEntry;
   }
 }

--- a/app/assets/js/features/activities/KpiEntryCommented/index.test.tsx
+++ b/app/assets/js/features/activities/KpiEntryCommented/index.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ActivityHandler, { DISPLAYED_IN_FEED } from "..";
+
+jest.mock("turboui", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+  Summary: ({ content }: { content: unknown }) => <span>{JSON.stringify(content)}</span>,
+}));
+
+jest.mock("@/hooks/useRichEditorHandlers", () => ({
+  useRichEditorHandlers: () => ({ mentionedPersonLookup: async () => null }),
+}));
+
+jest.mock("@/routes/paths", () => ({
+  usePaths: () => ({
+    spacePath: (id: string) => `/spaces/${id}`,
+    spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+    spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+    homePath: () => "/acme",
+  }),
+}));
+
+const paths: any = {
+  homePath: () => "/acme",
+  spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+  spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+};
+
+describe("kpi_entry_commented activities", () => {
+  const activity: any = {
+    action: "kpi_entry_commented",
+    author: { fullName: "Jo Smith" },
+    content: {
+      space: { id: "space-1", name: "General" },
+      kpi: { id: "kpi-1", name: "Weekly active users" },
+      comment: { id: "comment-1", content: JSON.stringify({ type: "doc", content: [] }) },
+    },
+  };
+
+  it("renders and includes the activity in the feed", () => {
+    const title = renderToStaticMarkup(<>{ActivityHandler.FeedItemTitle({ activity, page: "feed" })}</>);
+
+    expect(DISPLAYED_IN_FEED).toContain("kpi_entry_commented");
+    expect(title).toContain("Jo");
+    expect(title).toContain("commented");
+    expect(title).toContain("Weekly active users");
+    expect(title).toContain("update in the");
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationTitle({ activity })}</>)).toBe("Re: Weekly active users");
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationLocation({ activity })}</>)).toBe("General");
+  });
+
+  it("links to the KPI page", () => {
+    expect(ActivityHandler.pagePath(paths, activity)).toBe("/spaces/space-1/kpis/kpi-1#comment-1");
+  });
+});

--- a/app/assets/js/features/activities/KpiEntryCommented/index.tsx
+++ b/app/assets/js/features/activities/KpiEntryCommented/index.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+
+import type { ActivityContentKpiEntryCommented } from "@/api";
+import type { Activity } from "@/models/activities";
+import type { ActivityHandler } from "../interfaces";
+
+import { usePaths } from "@/routes/paths";
+import { Link, Summary } from "turboui";
+import { commentPath, commentedLink, feedTitle, spaceLink } from "./../feedItemLinks";
+import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
+import { parseCommentContent } from "@/models/comments";
+
+const KpiEntryCommented: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, activity: Activity): string {
+    const { comment, kpi, space } = content(activity);
+
+    if (space?.id && kpi?.id) {
+      return commentPath(paths.spaceKpiPath(space.id, kpi.id), comment);
+    }
+
+    if (space?.id) return paths.spaceKpisPath(space.id);
+    return paths.homePath();
+  },
+
+  PageTitle(_props: { activity: any }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const paths = usePaths();
+    const { comment, space, kpi } = content(activity);
+
+    const kpiPath = space?.id && kpi?.id ? paths.spaceKpiPath(space.id, kpi.id) : space?.id ? paths.spaceKpisPath(space.id) : paths.homePath();
+    const action = kpi ? commentedLink(kpiPath, comment) : "commented";
+    const kpiLink = kpi ? <Link to={kpiPath}>{kpi.name}</Link> : "a KPI";
+
+    if (page === "space") {
+      return feedTitle(activity, action, "on a", kpiLink, "update");
+    }
+
+    return feedTitle(activity, action, "on a", kpiLink, "update in the", spaceLink(space), "space");
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const { mentionedPersonLookup } = useRichEditorHandlers();
+    const { comment } = content(activity);
+
+    if (!comment?.content) {
+      return null;
+    }
+
+    const commentContent = parseCommentContent(comment.content);
+
+    if (!commentContent) {
+      return null;
+    }
+
+    return <Summary content={commentContent} characterCount={200} mentionedPersonLookup={mentionedPersonLookup} />;
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const { kpi } = content(activity);
+    const kpiName = kpi?.name ? kpi.name : "a KPI";
+    return "Re: " + kpiName;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).space?.name ?? null;
+  },
+};
+
+function content(activity: Activity): ActivityContentKpiEntryCommented {
+  return activity.content as ActivityContentKpiEntryCommented;
+}
+
+export default KpiEntryCommented;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -65,6 +65,7 @@ export default ActivityHandler;
 
 export const DISPLAYED_IN_FEED = [
   "kpi_created",
+  "kpi_entry_commented",
   "goal_check_toggled",
   "goal_check_removing",
   "goal_check_adding",
@@ -208,6 +209,7 @@ import GoalCheckInCommented from "@/features/activities/GoalCheckInCommented";
 import GoalClosing from "@/features/activities/GoalClosing";
 import GoalCreated from "@/features/activities/GoalCreated";
 import KpiCreated from "@/features/activities/KpiCreated";
+import KpiEntryCommented from "@/features/activities/KpiEntryCommented";
 import GoalDiscussionCreation from "@/features/activities/GoalDiscussionCreation";
 import GoalEditing from "@/features/activities/GoalEditing";
 import GoalReopening from "@/features/activities/GoalReopening";
@@ -324,6 +326,7 @@ function handler(activity: Activity) {
     .with("goal_closing", () => GoalClosing)
     .with("goal_created", () => GoalCreated)
     .with("kpi_created", () => KpiCreated)
+    .with("kpi_entry_commented", () => KpiEntryCommented)
     .with("goal_discussion_creation", () => GoalDiscussionCreation)
     .with("goal_editing", () => GoalEditing)
     .with("goal_reopening", () => GoalReopening)

--- a/app/assets/js/models/comments/CommentableResource.tsx
+++ b/app/assets/js/models/comments/CommentableResource.tsx
@@ -47,6 +47,12 @@ interface ParentCommentThread {
   project?: { id: string };
 }
 
+interface ParentKpiEntry {
+  kpiEntry: { id: string };
+  space: { id: string };
+  parentType: "kpi_entry";
+}
+
 export type CommentableResource =
   | ParentDiscussion
   | ParentProjectCheckIn
@@ -55,4 +61,5 @@ export type CommentableResource =
   | ParentResourceHubFile
   | ParentResourceHubLink
   | ParentGoalUpdate
-  | ParentCommentThread;
+  | ParentCommentThread
+  | ParentKpiEntry;

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -35,5 +35,6 @@ function parseKpiEntryForTurboUi(paths: Paths, entry: ApiKpiEntry): SpaceKpisPag
     value: entry.value,
     recordedAt: new Date(entry.period),
     recordedBy: parsePersonForTurboUi(paths, entry.recordedBy),
+    commentsCount: entry.commentsCount ?? 0,
   };
 }

--- a/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+import { useComments, useCommentSectionProps } from "@/features/CommentSection";
+import { CommentSection } from "turboui";
+
+interface KpiEntryCommentsProps {
+  entryId: string;
+  spaceId: string;
+  canComment: boolean;
+}
+
+export function KpiEntryComments({ entryId, spaceId, canComment }: KpiEntryCommentsProps) {
+  const form = useComments({
+    parentType: "kpi_entry",
+    kpiEntry: { id: entryId },
+    space: { id: spaceId },
+  });
+  const comments = useCommentSectionProps({
+    form,
+    commentParentType: "kpi_entry",
+    canComment,
+  });
+
+  if (!comments) return null;
+
+  return <CommentSection {...comments} />;
+}

--- a/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
@@ -7,9 +7,13 @@ interface KpiEntryCommentsProps {
   entryId: string;
   spaceId: string;
   canComment: boolean;
+
+  // The recorded-updates log behind the panel shows each update's comment
+  // count, so it has to be told when the thread grows or shrinks.
+  onCommentsChanged: () => void;
 }
 
-export function KpiEntryComments({ entryId, spaceId, canComment }: KpiEntryCommentsProps) {
+export function KpiEntryComments({ entryId, spaceId, canComment, onCommentsChanged }: KpiEntryCommentsProps) {
   const form = useComments({
     parentType: "kpi_entry",
     kpiEntry: { id: entryId },
@@ -23,5 +27,16 @@ export function KpiEntryComments({ entryId, spaceId, canComment }: KpiEntryComme
 
   if (!comments) return null;
 
-  return <CommentSection {...comments} />;
+  const addComment = async (content: unknown) => {
+    const result = await comments.onAddComment(content);
+    onCommentsChanged();
+    return result;
+  };
+
+  const deleteComment = async (commentId: string) => {
+    await comments.onDeleteComment?.(commentId);
+    onCommentsChanged();
+  };
+
+  return <CommentSection {...comments} onAddComment={addComment} onDeleteComment={deleteComment} />;
 }

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -4,6 +4,7 @@ import { Navigate, useNavigate } from "react-router";
 import { showErrorToast, SpaceKpisPage } from "turboui";
 import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/types";
 
+import * as Comments from "@/models/comments";
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as Kpis from "@/models/kpis";
@@ -29,6 +30,7 @@ export function Page() {
   const [editKpi] = Kpis.useEditKpi();
   const [deleteKpi] = Kpis.useDeleteKpi();
   const [logKpiEntry] = Kpis.useLogKpiEntry();
+  const [createComment] = Comments.useCreateComment();
 
   const kpisLink = paths.spaceKpisPath(space.id!);
   const parsedKpis = React.useMemo(() => kpis.map((k) => Kpis.parseKpiForTurboUi(paths, k)), [kpis, paths]);
@@ -102,9 +104,25 @@ export function Page() {
       else refresh();
     });
 
+  // The value is recorded first and the note is a comment on it, so a failed
+  // note must not report the update as failed — that would invite logging the
+  // same value twice.
   const onRecordEntry = async (input: SpaceKpisPageTypes.RecordEntryInput) =>
     run(async () => {
-      await logKpiEntry({ kpiId: input.kpiId, value: input.value, period: input.period });
+      const res = await logKpiEntry({ kpiId: input.kpiId, value: input.value, period: input.period });
+
+      if (input.comment) {
+        try {
+          await createComment({
+            entityId: res.entry.id,
+            entityType: "kpi_entry",
+            content: Comments.stringifyCommentContent(input.comment),
+          });
+        } catch {
+          showErrorToast("Note not posted", "The value was recorded, but the note wasn't saved.");
+        }
+      }
+
       refresh();
     });
 
@@ -133,6 +151,7 @@ export function Page() {
                 entryId={entry.id}
                 spaceId={space.id!}
                 canComment={space.permissions?.canComment ?? false}
+                onCommentsChanged={refresh}
               />
             )
           : undefined

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -13,6 +13,7 @@ import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
 import { usePaths } from "@/routes/paths";
 import { useCompanyLoaderData } from "@/routes/useCompanyLoaderData";
 import { useLoadedData, useRefresh } from "./loader";
+import { KpiEntryComments } from "./KpiEntryComments";
 
 export function Page() {
   const paths = usePaths();
@@ -124,6 +125,18 @@ export function Page() {
       onDescriptionChange={onDescriptionChange}
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
+      canComment={space.permissions?.canComment ?? false}
+      renderEntryComments={
+        selectedKpi
+          ? (entry) => (
+              <KpiEntryComments
+                entryId={entry.id}
+                spaceId={space.id!}
+                canComment={space.permissions?.canComment ?? false}
+              />
+            )
+          : undefined
+      }
     />
   );
 }

--- a/app/lib/operately/activities/content/kpi_entry_commented.ex
+++ b/app/lib/operately/activities/content/kpi_entry_commented.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Activities.Content.KpiEntryCommented do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :kpi, Operately.Kpis.Kpi
+    belongs_to :entry, Operately.Kpis.KpiEntry
+    belongs_to :comment, Operately.Updates.Comment
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required(__schema__(:fields))
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/notifications/kpi_entry_commented.ex
+++ b/app/lib/operately/activities/notifications/kpi_entry_commented.ex
@@ -1,0 +1,40 @@
+defmodule Operately.Activities.Notifications.KpiEntryCommented do
+  @moduledoc """
+  Notifies people subscribed to the KPI, plus the person who recorded the update.
+
+  The person who authored the comment is excluded.
+  """
+
+  alias Operately.Kpis
+  alias Operately.Kpis.{KpiEntry, Notifications}
+  alias Operately.Repo
+
+  def dispatch(activity) do
+    kpi = Kpis.get_kpi(activity.content["kpi_id"])
+    entry = Repo.get(KpiEntry, activity.content["entry_id"])
+
+    person_ids =
+      case kpi do
+        nil -> []
+        kpi -> Notifications.get_subscribers(kpi, ignore: [activity.author_id])
+      end
+
+    recorded_by_id =
+      case entry do
+        %KpiEntry{recorded_by_id: id} when id != activity.author_id -> id
+        _ -> nil
+      end
+
+    [recorded_by_id | person_ids]
+    |> Enum.filter(& &1)
+    |> Enum.uniq()
+    |> Enum.map(fn id ->
+      %{
+        person_id: id,
+        activity_id: activity.id,
+        should_send_email: true
+      }
+    end)
+    |> Operately.Notifications.bulk_create()
+  end
+end

--- a/app/lib/operately/kpis.ex
+++ b/app/lib/operately/kpis.ex
@@ -8,7 +8,8 @@ defmodule Operately.Kpis do
     "kpi_created",
     "kpi_edited",
     "kpi_deleted",
-    "kpi_entry_logged"
+    "kpi_entry_logged",
+    "kpi_entry_commented"
   ]
 
   def kpi_actions, do: @kpi_actions

--- a/app/lib/operately/kpis/kpi_entry.ex
+++ b/app/lib/operately/kpis/kpi_entry.ex
@@ -1,14 +1,21 @@
 defmodule Operately.Kpis.KpiEntry do
   use Operately.Schema
+  use Operately.Repo.Getter
 
   schema "kpi_entries" do
     belongs_to(:kpi, Operately.Kpis.Kpi, foreign_key: :kpi_id)
     belongs_to(:recorded_by, Operately.People.Person, foreign_key: :recorded_by_id)
 
+    has_one(:access_context, through: [:kpi, :access_context])
+    has_many(:comments, Operately.Updates.Comment, where: [entity_type: :kpi_entry], foreign_key: :entity_id)
+
     field(:value, :float)
     field(:period, :date)
+    field(:comments_count, :integer, virtual: true, default: 0)
 
     timestamps()
+    requester_access_level()
+    request_info()
   end
 
   def changeset(attrs = %{}) do

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -33,6 +33,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     {"project_retrospective_commented", %{resource: :comment, resource_id: {:content, "comment_id"}}},
     {"project_task_commented", %{resource: :comment, resource_id: {:content, "comment_id"}}},
     {"space_task_commented", %{resource: :comment, resource_id: {:content, "comment_id"}}},
+    {"kpi_entry_commented", %{resource: :comment, resource_id: {:content, "comment_id"}}},
     {"discussion_comment_submitted", %{resource: :comment, resource_id: {:content, "comment_id"}}},
     {"discussion_posting", %{resource: :message, resource_id: {:content, "discussion_id"}}},
     {"discussion_editing", %{resource: :message, resource_id: {:content, "discussion_id"}}},

--- a/app/lib/operately/operations/comment_adding.ex
+++ b/app/lib/operately/operations/comment_adding.ex
@@ -47,6 +47,7 @@ defmodule Operately.Operations.CommentAdding do
   defp find_action(%Operately.ResourceHubs.Link{}), do: :resource_hub_link_commented
   defp find_action(%Operately.Tasks.Task{project: %Operately.Projects.Project{}}), do: :project_task_commented
   defp find_action(%Operately.Tasks.Task{space: %Operately.Groups.Group{}}), do: :space_task_commented
+  defp find_action(%Operately.Kpis.KpiEntry{}), do: :kpi_entry_commented
   defp find_action(e), do: raise("Unknown entity type #{inspect(e)}")
 
   defp ensure_subscription_step(multi, creator) do

--- a/app/lib/operately/operations/comment_adding/activity.ex
+++ b/app/lib/operately/operations/comment_adding/activity.ex
@@ -112,6 +112,20 @@ defmodule Operately.Operations.CommentAdding.Activity do
     end)
   end
 
+  def insert(multi, creator, action = :kpi_entry_commented, entity) do
+    entity = Operately.Repo.preload(entity, :kpi)
+
+    Activities.insert_sync(multi, creator.id, action, fn changes ->
+      %{
+        company_id: creator.company_id,
+        space_id: entity.kpi.space_id,
+        kpi_id: entity.kpi_id,
+        entry_id: entity.id,
+        comment_id: changes.comment.id
+      }
+    end)
+  end
+
   def insert(multi, creator, action = :comment_added, %Operately.Comments.CommentThread{} = entity) do
     activity = Operately.Repo.preload(entity, :activity).activity
 

--- a/app/lib/operately/operations/comment_adding/subscriptions.ex
+++ b/app/lib/operately/operations/comment_adding/subscriptions.ex
@@ -12,6 +12,7 @@ defmodule Operately.Operations.CommentAdding.Subscriptions do
   def update(multi, :resource_hub_link_commented, content), do: execute_update(multi, content)
   def update(multi, :project_task_commented, content), do: execute_update(multi, content)
   def update(multi, :space_task_commented, content), do: execute_update(multi, content)
+  def update(multi, :kpi_entry_commented, content), do: execute_kpi_entry_update(multi, content)
   def update(multi, _, _), do: multi
 
   defp execute_update(multi, content) do
@@ -27,5 +28,18 @@ defmodule Operately.Operations.CommentAdding.Subscriptions do
         preload: :subscriptions
       ])
     end)
+  end
+
+  # KPI updates share the KPI's subscription list rather than carrying their own.
+  defp execute_kpi_entry_update(multi, content) do
+    multi
+    |> Multi.run(:subscription_list, fn _, %{comment: comment} ->
+      entry = Operately.Repo.get!(Operately.Kpis.KpiEntry, comment.entity_id)
+
+      SubscriptionList.get(:system, parent_id: entry.kpi_id, opts: [
+        preload: :subscriptions
+      ])
+    end)
+    |> Operately.Operations.Notifications.Subscription.update_mentioned_people(content)
   end
 end

--- a/app/lib/operately/updates.ex
+++ b/app/lib/operately/updates.ex
@@ -73,6 +73,17 @@ defmodule Operately.Updates do
           where: comment.id == ^id
         )
 
+      :kpi_entry ->
+        from(comment in Comment,
+          as: :comment,
+          join: entry in Operately.Kpis.KpiEntry,
+          on: entry.id == comment.entity_id,
+          join: kpi in assoc(entry, :kpi),
+          join: space in assoc(kpi, :space),
+          as: :resource,
+          where: comment.id == ^id
+        )
+
       :comment_thread ->
         from(c in Comment,
           as: :comment,

--- a/app/lib/operately/updates/comment.ex
+++ b/app/lib/operately/updates/comment.ex
@@ -19,6 +19,7 @@ defmodule Operately.Updates.Comment do
       :resource_hub_link,
       :project_task,
       :space_task,
+      :kpi_entry,
     ]
 
     field :content, :map

--- a/app/lib/operately_email/digest_parent.ex
+++ b/app/lib/operately_email/digest_parent.ex
@@ -23,4 +23,14 @@ defmodule OperatelyEmail.DigestParent do
       name: milestone.project.name
     }
   end
+
+  def for_kpi(kpi) do
+    kpi = Operately.Repo.preload(kpi, :space)
+
+    %{
+      id: kpi.space.id,
+      type: :space,
+      name: kpi.space.name
+    }
+  end
 end

--- a/app/lib/operately_email/emails/kpi_entry_commented_email.ex
+++ b/app/lib/operately_email/emails/kpi_entry_commented_email.ex
@@ -1,0 +1,47 @@
+defmodule OperatelyEmail.Emails.KpiEntryCommentedEmail do
+  import OperatelyEmail.Mailers.ActivityMailer
+
+  alias OperatelyWeb.Paths
+  alias Operately.{Repo, Updates}
+  alias Operately.Kpis
+
+  def send(person, activity) do
+    %{author: author = %{company: company}} = Repo.preload(activity, author: :company)
+
+    kpi = Kpis.get_kpi!(activity.content["kpi_id"]) |> Repo.preload(:space)
+    comment = Updates.get_comment!(activity.content["comment_id"])
+
+    company
+    |> new()
+    |> from(author)
+    |> to(person)
+    |> subject(where: kpi.space.name, who: author, action: "commented on a KPI update: #{kpi.name}")
+    |> assign(:author, author)
+    |> assign(:comment, comment)
+    |> assign(:name, kpi.name)
+    |> assign(:cta_url, Paths.space_kpi_path(company, kpi.space, kpi, comment) |> Paths.to_url())
+    |> render("kpi_entry_commented")
+  end
+
+  def buffered_item(_person, activity) do
+    kpi = Kpis.get_kpi!(activity.content["kpi_id"]) |> Repo.preload(:space)
+    comment = Updates.get_comment!(activity.content["comment_id"])
+    author = Repo.preload(activity, :author).author
+    company = Repo.preload(author, :company).company
+    parent = OperatelyEmail.DigestParent.for_kpi(kpi)
+    %{html: excerpt_html, text: excerpt_text} = OperatelyEmail.RichTextExcerpt.excerpt(comment.content)
+
+    %{
+      parent_id: parent.id,
+      parent_type: parent.type,
+      parent_name: parent.name,
+      headline: "commented on a KPI update for \"#{kpi.name}\"",
+      excerpt_html: excerpt_html,
+      excerpt_text: excerpt_text,
+      item_url: Paths.space_kpi_path(company, kpi.space, kpi, comment) |> Paths.to_url(),
+      actor_name: Operately.People.Person.short_name(author),
+      occurred_at: activity.inserted_at,
+      coalesce_key: nil
+    }
+  end
+end

--- a/app/lib/operately_email/templates/kpi_entry_commented.html.eex
+++ b/app/lib/operately_email/templates/kpi_entry_commented.html.eex
@@ -1,0 +1,13 @@
+<%= title("#{short_name(@author)} commented on a KPI update for #{@name}") %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= rich_text(@comment.content) %>
+<% end %>
+
+<%= spacer() %>
+
+<%= row do %>
+  <%= cta_button(@cta_url, "View Comment") %>
+<% end %>

--- a/app/lib/operately_email/templates/kpi_entry_commented.text.eex
+++ b/app/lib/operately_email/templates/kpi_entry_commented.text.eex
@@ -1,0 +1,3 @@
+<%= short_name(@author) %> commented on a KPI update for <%= @name %>.
+
+Link: <%= @cta_url %>

--- a/app/lib/operately_web/api/comments/create.ex
+++ b/app/lib/operately_web/api/comments/create.ex
@@ -67,6 +67,7 @@ defmodule OperatelyWeb.Api.Comments.Create do
       :project_task -> Task.get(person, id: id, opts: [preload: :project])
       :space_task -> Task.get(person, id: id, opts: [preload: :space])
       :milestone -> Milestone.get(person, id: id)
+      :kpi_entry -> Operately.Kpis.KpiEntry.get(person, id: id, opts: [preload: :kpi])
     end
   end
 
@@ -84,6 +85,7 @@ defmodule OperatelyWeb.Api.Comments.Create do
       :project_task -> Projects.Permissions.check(parent.request_info.access_level, :can_comment, company_read_only: company_read_only)
       :space_task -> Groups.Permissions.check(parent.request_info.access_level, :can_comment, company_read_only: company_read_only)
       :milestone -> Projects.Permissions.check(parent.request_info.access_level, :can_comment, company_read_only: company_read_only)
+      :kpi_entry -> Groups.Permissions.check(parent.request_info.access_level, :can_comment, company_read_only: company_read_only)
     end
   end
 

--- a/app/lib/operately_web/api/comments/list.ex
+++ b/app/lib/operately_web/api/comments/list.ex
@@ -73,6 +73,19 @@ defmodule OperatelyWeb.Api.Comments.List do
     |> load_notifications(person, action: "space_task_commented")
   end
 
+  defp load(id, :kpi_entry, person) do
+    from(c in Comment,
+      join: entry in Operately.Kpis.KpiEntry, on: c.entity_id == entry.id,
+      join: kpi in assoc(entry, :kpi),
+      join: space in assoc(kpi, :space), as: :space,
+      where: entry.id == ^id and c.entity_type == :kpi_entry
+    )
+    |> preload_resources()
+    |> filter_by_view_access(person.id, named_binding: :space)
+    |> Repo.all()
+    |> load_notifications(person, action: "kpi_entry_commented")
+  end
+
   defp load(id, :goal_update, person) do
     from(c in Comment, join: u in Operately.Goals.Update, on: c.entity_id == u.id, as: :update, where: u.id == ^id)
     |> preload_resources()

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -77,7 +77,7 @@ defmodule OperatelyWeb.Api.Kpis do
 
         kpi ->
           # Entries are ordered by period so the chart renders history in order.
-          entries = Kpis.list_entries(kpi_id) |> Repo.preload(:recorded_by)
+          entries = Kpis.list_entries(kpi_id) |> Repo.preload(:recorded_by) |> Operately.Updates.Comment.load_comments_count()
           {:ok, %{Repo.preload(kpi, [:champion, subscription_list: [subscriptions: :person]]) | entries: entries}}
       end
     end

--- a/app/lib/operately_web/api/reactions/create.ex
+++ b/app/lib/operately_web/api/reactions/create.ex
@@ -98,6 +98,7 @@ defmodule OperatelyWeb.Api.Reactions.Create do
       :resource_hub_document -> ResourceHubs.Permissions.check(parent.requester_access_level, :can_comment_on_document, company_read_only: company_read_only)
       :resource_hub_file -> ResourceHubs.Permissions.check(parent.requester_access_level, :can_comment_on_file, company_read_only: company_read_only)
       :resource_hub_link -> ResourceHubs.Permissions.check(parent.requester_access_level, :can_comment_on_link, company_read_only: company_read_only)
+      :kpi_entry -> Groups.Permissions.check(parent.requester_access_level, :can_comment, company_read_only: company_read_only)
     end
   end
 

--- a/app/lib/operately_web/api/serializers/activity_content/kpi_entry_commented.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/kpi_entry_commented.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.KpiEntryCommented do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      space: Serializer.serialize(content.space, level: :essential),
+      kpi: Serializer.serialize(content.kpi, level: :essential),
+      entry: Serializer.serialize(content.entry, level: :essential),
+      comment: Serializer.serialize(content.comment)
+    }
+  end
+end

--- a/app/lib/operately_web/api/serializers/kpi_entry.ex
+++ b/app/lib/operately_web/api/serializers/kpi_entry.ex
@@ -7,6 +7,7 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.KpiEntry do
       value: entry.value,
       period: Serializer.serialize(entry.period),
       recorded_by: Serializer.serialize(entry.recorded_by),
+      comments_count: Map.get(entry, :comments_count) || 0,
       inserted_at: Serializer.serialize(entry.inserted_at),
       updated_at: Serializer.serialize(entry.updated_at)
     }

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -252,6 +252,13 @@ defmodule OperatelyWeb.Api.Types do
     field :kpi_name, :string
   end
 
+  object :activity_content_kpi_entry_commented, for: Operately.Activities.Content.KpiEntryCommented do
+    field :space, :space, null: false
+    field :kpi, :kpi, null: true
+    field :entry, :kpi_entry, null: true
+    field :comment, :comment, null: true
+  end
+
   object :activity_content_goal_target_updating, for: Operately.Activities.Content.GoalTargetUpdating do
     field :company, :company
     field :space, :space
@@ -615,7 +622,8 @@ defmodule OperatelyWeb.Api.Types do
       :space_task,
       :resource_hub_document,
       :resource_hub_file,
-      :resource_hub_link
+      :resource_hub_link,
+      :kpi_entry
     ]
   )
 
@@ -1065,6 +1073,7 @@ defmodule OperatelyWeb.Api.Types do
     field :value, :float, null: false
     field :period, :date, null: false
     field? :recorded_by, :person, null: true
+    field? :comments_count, :integer, null: true
     field? :inserted_at, :datetime, null: true
     field? :updated_at, :datetime, null: true
   end
@@ -1126,6 +1135,7 @@ defmodule OperatelyWeb.Api.Types do
       :activity_content_discussion_editing,
       :activity_content_discussion_posting,
       :activity_content_kpi_created,
+      :activity_content_kpi_entry_commented,
       :activity_content_goal_archived,
       :activity_content_goal_check_in,
       :activity_content_goal_check_in_acknowledgement,
@@ -2440,7 +2450,8 @@ defmodule OperatelyWeb.Api.Types do
       :resource_hub_link,
       :space_task,
       :project_task,
-      :milestone
+      :milestone,
+      :kpi_entry
     ]
   )
 

--- a/app/lib/operately_web/mcp/helpers.ex
+++ b/app/lib/operately_web/mcp/helpers.ex
@@ -23,7 +23,8 @@ defmodule OperatelyWeb.Mcp.Helpers do
     "file" => :resource_hub_file,
     "link" => :resource_hub_link,
     "project_task" => :project_task,
-    "space_task" => :space_task
+    "space_task" => :space_task,
+    "kpi_update" => :kpi_entry
   }
 
   def decode_id(id) when is_binary(id) do

--- a/app/lib/operately_web/mcp/tools/comments/create.ex
+++ b/app/lib/operately_web/mcp/tools/comments/create.ex
@@ -16,7 +16,8 @@ defmodule OperatelyWeb.Mcp.Tools.Comments.Create do
     "file" => :resource_hub_file,
     "link" => :resource_hub_link,
     "project_task" => :project_task,
-    "space_task" => :space_task
+    "space_task" => :space_task,
+    "kpi_update" => :kpi_entry
   }
 
   @impl true

--- a/app/lib/operately_web/paths.ex
+++ b/app/lib/operately_web/paths.ex
@@ -224,6 +224,18 @@ defmodule OperatelyWeb.Paths do
     create_path([company_id(company), "spaces", space_id(space), "kanban"])
   end
 
+  def space_kpis_path(company = %Company{}, space = %Group{}) do
+    create_path([company_id(company), "spaces", space_id(space), "kpis"])
+  end
+
+  def space_kpi_path(company = %Company{}, space = %Group{}, kpi) do
+    create_path([company_id(company), "spaces", space_id(space), "kpis", kpi_id(kpi)])
+  end
+
+  def space_kpi_path(company = %Company{}, space = %Group{}, kpi, comment = %Comment{}) do
+    space_kpi_path(company, space, kpi) <> "#" <> comment_id(comment)
+  end
+
   def space_task_path(company = %Company{}, space = %Group{}, task = %Operately.Tasks.Task{}) do
     create_path([company_id(company), "spaces", space_id(space), "kanban"]) <> "?taskId=#{task_id(task)}"
   end

--- a/app/test/features/kpi_comments_test.exs
+++ b/app/test/features/kpi_comments_test.exs
@@ -11,5 +11,13 @@ defmodule Operately.Features.KpiCommentsTest do
     |> Steps.open_update_comments()
     |> Steps.leave_comment()
     |> Steps.assert_comment_visible()
+    |> Steps.assert_update_comment_count(1)
+  end
+
+  feature "log an update with a note", ctx do
+    ctx
+    |> Steps.visit_kpi_page()
+    |> Steps.log_update(value: "456", note: "Enterprise renewals landed early.")
+    |> Steps.assert_note_is_first_comment_on_latest_update(note: "Enterprise renewals landed early.")
   end
 end

--- a/app/test/features/kpi_comments_test.exs
+++ b/app/test/features/kpi_comments_test.exs
@@ -1,0 +1,15 @@
+defmodule Operately.Features.KpiCommentsTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.KpiCommentsSteps, as: Steps
+
+  setup ctx, do: Steps.setup(ctx)
+
+  feature "comment on a KPI update", ctx do
+    ctx
+    |> Steps.visit_kpi_page()
+    |> Steps.open_update_comments()
+    |> Steps.leave_comment()
+    |> Steps.assert_comment_visible()
+  end
+end

--- a/app/test/operately/kpis/kpi_entry_test.exs
+++ b/app/test/operately/kpis/kpi_entry_test.exs
@@ -1,0 +1,28 @@
+defmodule Operately.Kpis.KpiEntryTest do
+  use Operately.DataCase
+
+  import Operately.KpisFixtures
+
+  alias Operately.Access.Binding
+  alias Operately.Kpis.KpiEntry
+  alias Operately.Support.Factory
+
+  setup ctx do
+    ctx
+    |> Factory.setup()
+    |> Factory.add_space(:space)
+    |> Factory.add_space_member(:member, :space)
+    |> Factory.add_company_member(:outsider)
+  end
+
+  test "get/2 loads an entry for a space member and denies outsiders", ctx do
+    kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+    entry = kpi_entry_fixture(ctx.creator, kpi)
+
+    assert {:ok, loaded} = KpiEntry.get(ctx.member, id: entry.id)
+    assert loaded.id == entry.id
+    assert loaded.request_info.access_level >= Binding.view_access()
+
+    assert {:error, :not_found} = KpiEntry.get(ctx.outsider, id: entry.id)
+  end
+end

--- a/app/test/operately/mcp/tools_test.exs
+++ b/app/test/operately/mcp/tools_test.exs
@@ -273,7 +273,8 @@ defmodule Operately.Mcp.ToolsTest do
              "file",
              "link",
              "project_task",
-             "space_task"
+             "space_task",
+             "kpi_update"
            ])
 
     assert create_comment["_meta"]["securitySchemes"] == [%{"type" => "oauth2", "scopes" => ["mcp:write"]}]

--- a/app/test/operately/operations/comment_adding_test.exs
+++ b/app/test/operately/operations/comment_adding_test.exs
@@ -934,6 +934,50 @@ defmodule Operately.Operations.CommentAddingTest do
     end
   end
 
+  describe "Commenting on a KPI update" do
+    @action "kpi_entry_commented"
+
+    setup ctx do
+      ctx =
+        ctx
+        |> Factory.add_space(:space)
+        |> Factory.add_space_member(:champion, :space)
+        |> Factory.add_space_member(:member, :space)
+
+      kpi = Operately.KpisFixtures.kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id)
+      entry = Operately.KpisFixtures.kpi_entry_fixture(ctx.creator, kpi)
+
+      Map.merge(ctx, %{kpi: kpi, entry: entry})
+    end
+
+    test "adds a comment to the KPI update", ctx do
+      {:ok, comment} = CommentAdding.run(ctx.member, ctx.entry, "kpi_entry", RichText.rich_text("Looks high"))
+
+      assert comment.entity_id == ctx.entry.id
+      assert comment.entity_type == :kpi_entry
+      assert comment.content == RichText.rich_text("Looks high")
+    end
+
+    test "notifies the KPI champion and the person who recorded the update", ctx do
+      {:ok, comment} =
+        Oban.Testing.with_testing_mode(:manual, fn ->
+          CommentAdding.run(ctx.member, ctx.entry, "kpi_entry", RichText.rich_text("Looks high"))
+        end)
+
+      activity = get_activity(comment, @action)
+
+      assert notifications_count(action: @action) == 0
+
+      perform_job(activity.id)
+
+      notified_ids = activity.id |> fetch_notifications(action: @action) |> Enum.map(& &1.person_id)
+
+      assert ctx.champion.id in notified_ids
+      assert ctx.creator.id in notified_ids
+      refute ctx.member.id in notified_ids
+    end
+  end
+
   describe "author subscription" do
     setup ctx do
       ctx

--- a/app/test/operately_web/api/comments/create_test.exs
+++ b/app/test/operately_web/api/comments/create_test.exs
@@ -9,6 +9,7 @@ defmodule OperatelyWeb.Api.Comments.CreateTest do
   import Operately.CommentsFixtures
   import Operately.MessagesFixtures
   import Operately.ResourceHubsFixtures
+  import Operately.KpisFixtures
 
   alias Operately.{Notifications, Updates}
   alias Operately.Notifications.SubscriptionList
@@ -117,6 +118,29 @@ defmodule OperatelyWeb.Api.Comments.CreateTest do
 
         case @test.expected do
           200 -> assert count_comments(task.id, :space_task) == 1
+          403 -> assert res.message == "You don't have permission to perform this action"
+          404 -> assert res.message == "The requested resource was not found"
+        end
+      end
+    end
+
+    tabletest @space_table do
+      test "kpi entry - if caller has levels company=#{@test.company}, space=#{@test.space} on the space, then expect code=#{@test.expected}", ctx do
+        space = create_space(ctx, @test.company, @test.space)
+        kpi = kpi_fixture(ctx.creator, space_id: space.id)
+        entry = kpi_entry_fixture(ctx.creator, kpi)
+
+        assert {code, res} =
+                 mutation(ctx.conn, [:comments, :create], %{
+                   entity_id: Paths.kpi_entry_id(entry),
+                   entity_type: "kpi_entry",
+                   content: RichText.rich_text("Content", :as_string)
+                 })
+
+        assert code == @test.expected
+
+        case @test.expected do
+          200 -> assert count_comments(entry.id, :kpi_entry) == 1
           403 -> assert res.message == "You don't have permission to perform this action"
           404 -> assert res.message == "The requested resource was not found"
         end

--- a/app/test/operately_web/api/comments/list_test.exs
+++ b/app/test/operately_web/api/comments/list_test.exs
@@ -9,6 +9,7 @@ defmodule OperatelyWeb.Api.Comments.ListTest do
   import Operately.ProjectsFixtures
   import Operately.CommentsFixtures
   import Operately.MessagesFixtures
+  import Operately.KpisFixtures
 
   alias Operately.Repo
   alias Operately.Support.RichText
@@ -381,6 +382,53 @@ defmodule OperatelyWeb.Api.Comments.ListTest do
                query(ctx.conn, [:comments, :list], %{
                  entity_id: Paths.goal_update_id(update),
                  entity_type: "goal_update"
+               })
+
+      assert length(res.comments) == 0
+    end
+  end
+
+  describe "permissions - kpi entry" do
+    setup ctx do
+      ctx = register_and_log_in_account(ctx)
+      creator = person_fixture(%{company_id: ctx.company.id})
+      space = group_fixture(creator, %{company_id: ctx.company.id})
+
+      Map.merge(ctx, %{creator: creator, space: space})
+    end
+
+    test "space members can list comments on a KPI update", ctx do
+      add_person_to_space(ctx)
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+      entry = kpi_entry_fixture(ctx.creator, kpi)
+
+      comments =
+        Enum.map(1..3, fn _ ->
+          add_comment(ctx, entry, "kpi_entry")
+        end)
+
+      assert {200, res} =
+               query(ctx.conn, [:comments, :list], %{
+                 entity_id: Paths.kpi_entry_id(entry),
+                 entity_type: "kpi_entry"
+               })
+
+      assert_comments(res, comments)
+    end
+
+    test "non-members cannot list comments on a KPI update", ctx do
+      space = group_fixture(ctx.creator, %{company_id: ctx.company.id, company_permissions: Binding.no_access()})
+      kpi = kpi_fixture(ctx.creator, space_id: space.id)
+      entry = kpi_entry_fixture(ctx.creator, kpi)
+
+      Enum.each(1..3, fn _ ->
+        add_comment(ctx, entry, "kpi_entry")
+      end)
+
+      assert {200, res} =
+               query(ctx.conn, [:comments, :list], %{
+                 entity_id: Paths.kpi_entry_id(entry),
+                 entity_type: "kpi_entry"
                })
 
       assert length(res.comments) == 0

--- a/app/test/operately_web/api/kpis/get_kpi_test.exs
+++ b/app/test/operately_web/api/kpis/get_kpi_test.exs
@@ -39,6 +39,7 @@ defmodule OperatelyWeb.Api.Kpis.GetKpiTest do
       assert Jason.decode!(res.kpi.description) == description
       periods = Enum.map(res.kpi.entries, & &1.period)
       assert periods == ["2026-01-01", "2026-02-01", "2026-03-01"]
+      assert Enum.all?(res.kpi.entries, &(&1.comments_count == 0))
       assert res.kpi.subscription_list
       assert res.kpi.subscription_list.parent_type == "kpi"
     end

--- a/app/test/operately_web/controllers/mcp_controller_test.exs
+++ b/app/test/operately_web/controllers/mcp_controller_test.exs
@@ -183,7 +183,8 @@ defmodule OperatelyWeb.McpControllerTest do
              "file",
              "link",
              "project_task",
-             "space_task"
+             "space_task",
+             "kpi_update"
            ])
 
     assert create_comment_tool["securitySchemes"] == [%{"type" => "oauth2", "scopes" => ["mcp:write"]}]

--- a/app/test/operately_web/mcp/tools/comments/create_test.exs
+++ b/app/test/operately_web/mcp/tools/comments/create_test.exs
@@ -58,10 +58,14 @@ defmodule OperatelyWeb.Mcp.Tools.Comments.CreateTest do
         |> Factory.add_message(:discussion, :board)
         |> Factory.create_space_task(:task, :space)
 
+      kpi = Operately.KpisFixtures.kpi_fixture(ctx.creator, space_id: ctx.space.id)
+      entry = Operately.KpisFixtures.kpi_entry_fixture(ctx.creator, kpi)
+
       conn = ToolConnHelper.conn_with_assigns(ctx.account, ctx.company, ctx.creator, ["mcp:read", "mcp:write"])
 
       assert_created_comment(conn, Paths.message_id(ctx.discussion), "space_discussion", "Comment on space discussion")
       assert_created_comment(conn, Paths.task_id(ctx.task), "space_task", "Comment on space task")
+      assert_created_comment(conn, Paths.kpi_entry_id(entry), "kpi_update", "Comment on KPI update")
     end
 
     test "creates comments for resource hub resources" do

--- a/app/test/support/factory/comments.ex
+++ b/app/test/support/factory/comments.ex
@@ -46,5 +46,6 @@ defmodule Operately.Support.Factory.Comments do
   defp find_entity_type(%Operately.ResourceHubs.Link{}), do: "resource_hub_link"
   defp find_entity_type(%Operately.Projects.Milestone{}), do: "project_milestone"
   defp find_entity_type(%Operately.Tasks.Task{}), do: "project_task"
+  defp find_entity_type(%Operately.Kpis.KpiEntry{}), do: "kpi_entry"
   defp find_entity_type(%Operately.Updates.Comment{}), do: "comment"
 end

--- a/app/test/support/features/kpi_comments_steps.ex
+++ b/app/test/support/features/kpi_comments_steps.ex
@@ -1,0 +1,41 @@
+defmodule Operately.Support.Features.KpiCommentsSteps do
+  use Operately.FeatureCase
+
+  import Operately.KpisFixtures
+
+  def setup(ctx) do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.enable_feature("space_kpis")
+      |> Factory.add_space(:space)
+      |> Factory.log_in_person(:creator)
+
+    kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+    entry = kpi_entry_fixture(ctx.creator, kpi)
+
+    Map.merge(ctx, %{kpi: kpi, entry: entry})
+  end
+
+  step :visit_kpi_page, ctx do
+    UI.visit(ctx, Paths.space_kpi_path(ctx.company, ctx.space, ctx.kpi))
+  end
+
+  step :open_update_comments, ctx do
+    ctx
+    |> UI.assert_has(testid: "kpi-detail")
+    |> UI.click(testid: "entry-comments-toggle-#{Paths.kpi_entry_id(ctx.entry)}")
+  end
+
+  step :leave_comment, ctx do
+    ctx
+    |> UI.click(testid: "add-comment")
+    |> UI.fill_rich_text("This is a comment.")
+    |> UI.click(testid: "post-comment")
+    |> UI.refute_has(testid: "post-comment")
+  end
+
+  step :assert_comment_visible, ctx do
+    UI.assert_text(ctx, "This is a comment.")
+  end
+end

--- a/app/test/support/features/kpi_comments_steps.ex
+++ b/app/test/support/features/kpi_comments_steps.ex
@@ -38,4 +38,35 @@ defmodule Operately.Support.Features.KpiCommentsSteps do
   step :assert_comment_visible, ctx do
     UI.assert_text(ctx, "This is a comment.")
   end
+
+  # The comment count lives in the recorded-updates log behind the panel, so it
+  # has to catch up while the thread is still open.
+  step :assert_update_comment_count, ctx, count do
+    UI.assert_text(ctx, to_string(count), testid: "entry-comments-toggle-#{Paths.kpi_entry_id(ctx.entry)}")
+  end
+
+  step :log_update, ctx, opts do
+    ctx
+    |> UI.click(testid: "kpi-detail-log-update")
+    |> UI.fill(testid: "value", with: opts[:value])
+    |> UI.fill_rich_text(testid: "log-update-modal", with: opts[:note])
+    |> UI.click(testid: "submit")
+    |> UI.refute_has(testid: "log-update-modal")
+  end
+
+  step :assert_note_is_first_comment_on_latest_update, ctx, opts do
+    entry = latest_entry(ctx.kpi)
+
+    ctx
+    |> UI.assert_text("1", testid: "entry-comments-toggle-#{Paths.kpi_entry_id(entry)}")
+    |> UI.click(testid: "entry-comments-toggle-#{Paths.kpi_entry_id(entry)}")
+    |> UI.assert_text(opts[:note])
+  end
+
+  defp latest_entry(kpi) do
+    import Ecto.Query, only: [from: 2]
+
+    from(e in Operately.Kpis.KpiEntry, where: e.kpi_id == ^kpi.id, order_by: [desc: e.period], limit: 1)
+    |> Operately.Repo.one!()
+  end
 end

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -4446,6 +4446,65 @@
           }
         ]
       },
+      "activity_content_kpi_entry_commented": {
+        "fields": [
+          {
+            "default": null,
+            "name": "__typename",
+            "type": {
+              "name": "string",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
+          },
+          {
+            "default": null,
+            "name": "space",
+            "type": {
+              "name": "space",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": false
+          },
+          {
+            "default": null,
+            "name": "kpi",
+            "type": {
+              "name": "kpi",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": true
+          },
+          {
+            "default": null,
+            "name": "entry",
+            "type": {
+              "name": "kpi_entry",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": true
+          },
+          {
+            "default": null,
+            "name": "comment",
+            "type": {
+              "name": "comment",
+              "kind": "named"
+            },
+            "optional": false,
+            "has_default": false,
+            "nullable": true
+          }
+        ]
+      },
       "activity_content_guest_invited": {
         "fields": [
           {
@@ -9633,6 +9692,17 @@
           },
           {
             "default": null,
+            "name": "description",
+            "type": {
+              "name": "string",
+              "kind": "named"
+            },
+            "optional": true,
+            "has_default": false,
+            "nullable": true
+          },
+          {
+            "default": null,
             "name": "champion",
             "type": {
               "name": "person",
@@ -9662,6 +9732,17 @@
                 "kind": "named"
               },
               "kind": "list"
+            },
+            "optional": true,
+            "has_default": false,
+            "nullable": true
+          },
+          {
+            "default": null,
+            "name": "subscription_list",
+            "type": {
+              "name": "subscription_list",
+              "kind": "named"
             },
             "optional": true,
             "has_default": false,
@@ -12845,6 +12926,17 @@
             "name": "recorded_by",
             "type": {
               "name": "person",
+              "kind": "named"
+            },
+            "optional": true,
+            "has_default": false,
+            "nullable": true
+          },
+          {
+            "default": null,
+            "name": "comments_count",
+            "type": {
+              "name": "integer",
               "kind": "named"
             },
             "optional": true,
@@ -21547,6 +21639,10 @@
           "kind": "named"
         },
         {
+          "name": "activity_content_kpi_entry_commented",
+          "kind": "named"
+        },
+        {
           "name": "activity_content_goal_archived",
           "kind": "named"
         },
@@ -21994,7 +22090,8 @@
         "resource_hub_link",
         "space_task",
         "project_task",
-        "milestone"
+        "milestone",
+        "kpi_entry"
       ],
       "search_scope_options": [
         "company",
@@ -22083,7 +22180,8 @@
         "project",
         "milestone",
         "project_task",
-        "space_task"
+        "space_task",
+        "kpi"
       ],
       "project_template_schedule_field": [
         "start_date",
@@ -22254,7 +22352,8 @@
         "space_task",
         "resource_hub_document",
         "resource_hub_file",
-        "resource_hub_link"
+        "resource_hub_link",
+        "kpi_entry"
       ],
       "project_template_archive_status": [
         "active",
@@ -28787,7 +28886,7 @@
           "default": null,
           "name": "description",
           "type": {
-            "name": "string",
+            "name": "json",
             "kind": "named"
           },
           "optional": true,
@@ -28914,7 +29013,7 @@
           "default": null,
           "name": "description",
           "type": {
-            "name": "string",
+            "name": "json",
             "kind": "named"
           },
           "optional": true,

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -397,6 +397,14 @@ export interface ActivityContentKpiCreated {
   kpiName: string;
 }
 
+export interface ActivityContentKpiEntryCommented {
+  __typename: "activity_content_kpi_entry_commented";
+  space: Space;
+  kpi: Kpi | null;
+  entry: KpiEntry | null;
+  comment: Comment | null;
+}
+
 export interface ActivityContentMessageArchiving {
   __typename: "activity_content_message_archiving";
   companyId?: string | null;
@@ -1647,6 +1655,7 @@ export interface KpiEntry {
   value: number;
   period: string;
   recordedBy?: Person | null;
+  commentsCount?: number | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
 }
@@ -2656,6 +2665,7 @@ export type ActivityContent =
   | ActivityContentDiscussionEditing
   | ActivityContentDiscussionPosting
   | ActivityContentKpiCreated
+  | ActivityContentKpiEntryCommented
   | ActivityContentGoalArchived
   | ActivityContentGoalCheckIn
   | ActivityContentGoalCheckInAcknowledgement
@@ -2798,7 +2808,8 @@ export type CommentParentType =
   | "resource_hub_link"
   | "space_task"
   | "project_task"
-  | "milestone";
+  | "milestone"
+  | "kpi_entry";
 
 export type ContextualDateType = "day" | "month" | "quarter" | "year";
 
@@ -2883,7 +2894,8 @@ export type ReactionParentType =
   | "space_task"
   | "resource_hub_document"
   | "resource_hub_file"
-  | "resource_hub_link";
+  | "resource_hub_link"
+  | "kpi_entry";
 
 export type ResourceAccessTypes = "space" | "goal" | "project";
 

--- a/turboui/src/CommentSection/CommentInput.tsx
+++ b/turboui/src/CommentSection/CommentInput.tsx
@@ -113,7 +113,7 @@ function CommentInputActive({
   return (
     <div className="py-6 not-first:border-t border-stroke-base flex items-start gap-3" data-test-id="new-comment-form">
       <Avatar person={currentUser} size="normal" />
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <div className="border border-surface-outline rounded-lg overflow-hidden">
           <Editor editor={editor} hideBorder padding="p-0" />
 

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -9,7 +9,7 @@ import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { TextField } from "../TextField";
 import { showErrorToast, showSuccessToast } from "../Toasts";
-import { IconLink, IconTrash } from "../icons";
+import { IconLink, IconMessage, IconTrash } from "../icons";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
@@ -20,10 +20,12 @@ interface KpiDetailProps {
   kpi: SpaceKpisPage.Kpi;
   fields: KpiFields;
   canManage: boolean;
+  canComment?: boolean;
   championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
   onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
   onDelete: () => void;
   richTextHandlers: RichEditorHandlers;
+  renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
   subscriptions?: SpaceKpisPage.Props["subscriptions"];
 }
 
@@ -34,10 +36,12 @@ export function KpiDetail({
   kpi,
   fields,
   canManage,
+  canComment = false,
   championSearch,
   onDescriptionChange,
   onDelete,
   richTextHandlers,
+  renderEntryComments,
   subscriptions,
 }: KpiDetailProps) {
   const [description, setDescription] = React.useState(kpi.description);
@@ -74,7 +78,12 @@ export function KpiDetail({
             <KpiLineChart entries={kpi.entries} unit={fields.unit} />
           </div>
 
-          <EntriesTable entries={kpi.entries} unit={fields.unit} />
+          <EntriesTable
+            entries={kpi.entries}
+            unit={fields.unit}
+            canComment={canComment}
+            renderEntryComments={renderEntryComments}
+          />
         </div>
       </div>
 
@@ -312,7 +321,19 @@ function CadenceField({
   );
 }
 
-function EntriesTable({ entries, unit }: { entries: SpaceKpisPage.KpiEntry[]; unit: string }) {
+function EntriesTable({
+  entries,
+  unit,
+  canComment,
+  renderEntryComments,
+}: {
+  entries: SpaceKpisPage.KpiEntry[];
+  unit: string;
+  canComment: boolean;
+  renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
+}) {
+  const [openEntryId, setOpenEntryId] = React.useState<string | null>(null);
+
   if (entries.length === 0) return null;
 
   // Show newest first in the log, even though entries are stored oldest -> newest.
@@ -328,31 +349,60 @@ function EntriesTable({ entries, unit }: { entries: SpaceKpisPage.KpiEntry[]; un
               <th className="px-4 py-2 font-medium">Date</th>
               <th className="px-4 py-2 font-medium">Recorded by</th>
               <th className="px-4 py-2 text-right font-medium">Value</th>
+              <th className="px-4 py-2 text-right font-medium">Comments</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((entry) => (
-              <tr
-                key={entry.id}
-                className="border-b border-stroke-dimmed last:border-b-0"
-                data-test-id={`entry-row-${entry.id}`}
-              >
-                <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
-                <td className="px-4 py-2">
-                  {entry.recordedBy ? (
-                    <div className="flex items-center gap-2">
-                      <Avatar person={entry.recordedBy} size="tiny" />
-                      <span className="text-content-base">{entry.recordedBy.fullName}</span>
-                    </div>
-                  ) : (
-                    <span className="text-content-subtle">Unknown</span>
+            {rows.map((entry) => {
+              const isOpen = openEntryId === entry.id;
+              const commentsCount = entry.commentsCount ?? 0;
+              const canOpenComments = Boolean(renderEntryComments) && (canComment || commentsCount > 0);
+
+              return (
+                <React.Fragment key={entry.id}>
+                  <tr className="border-b border-stroke-dimmed last:border-b-0" data-test-id={`entry-row-${entry.id}`}>
+                    <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
+                    <td className="px-4 py-2">
+                      {entry.recordedBy ? (
+                        <div className="flex items-center gap-2">
+                          <Avatar person={entry.recordedBy} size="tiny" />
+                          <span className="text-content-base">{entry.recordedBy.fullName}</span>
+                        </div>
+                      ) : (
+                        <span className="text-content-subtle">Unknown</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2 text-right font-medium text-content-accent">{formatValue(entry.value, unit)}</td>
+                    <td className="px-4 py-2 text-right">
+                      {canOpenComments ? (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+                          onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
+                          data-test-id={`entry-comments-toggle-${entry.id}`}
+                          aria-expanded={isOpen}
+                        >
+                          <IconMessage size={14} />
+                          {commentsCount > 0 ? commentsCount : "Comment"}
+                        </button>
+                      ) : commentsCount > 0 ? (
+                        <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
+                          <IconMessage size={14} />
+                          {commentsCount}
+                        </span>
+                      ) : null}
+                    </td>
+                  </tr>
+                  {isOpen && renderEntryComments && (
+                    <tr className="border-b border-stroke-dimmed last:border-b-0 bg-surface-base" data-test-id={`entry-comments-${entry.id}`}>
+                      <td colSpan={4} className="px-4 py-4">
+                        {renderEntryComments(entry)}
+                      </td>
+                    </tr>
                   )}
-                </td>
-                <td className="px-4 py-2 text-right font-medium text-content-accent">
-                  {formatValue(entry.value, unit)}
-                </td>
-              </tr>
-            ))}
+                </React.Fragment>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -8,6 +8,7 @@ import { PersonField } from "../PersonField";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { TextField } from "../TextField";
+import { SlideIn } from "../SlideIn";
 import { showErrorToast, showSuccessToast } from "../Toasts";
 import { IconLink, IconMessage, IconTrash } from "../icons";
 import { KpiLineChart } from "./KpiLineChart";
@@ -81,6 +82,7 @@ export function KpiDetail({
           <EntriesTable
             entries={kpi.entries}
             unit={fields.unit}
+            kpiName={fields.name}
             canComment={canComment}
             renderEntryComments={renderEntryComments}
           />
@@ -321,18 +323,26 @@ function CadenceField({
   );
 }
 
+// The comment composer's editor toolbar needs about 570px before it starts
+// clipping, so the panel keeps a floor of 680px and only narrows to the full
+// screen when the window itself is smaller than that.
+const COMMENTS_PANEL_WIDTH = "min(100%, max(70%, 680px))";
+
 function EntriesTable({
   entries,
   unit,
+  kpiName,
   canComment,
   renderEntryComments,
 }: {
   entries: SpaceKpisPage.KpiEntry[];
   unit: string;
+  kpiName: string;
   canComment: boolean;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
 }) {
   const [openEntryId, setOpenEntryId] = React.useState<string | null>(null);
+  const openEntry = entries.find((entry) => entry.id === openEntryId) ?? null;
 
   if (entries.length === 0) return null;
 
@@ -359,52 +369,99 @@ function EntriesTable({
               const canOpenComments = Boolean(renderEntryComments) && (canComment || commentsCount > 0);
 
               return (
-                <React.Fragment key={entry.id}>
-                  <tr className="border-b border-stroke-dimmed last:border-b-0" data-test-id={`entry-row-${entry.id}`}>
-                    <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
-                    <td className="px-4 py-2">
-                      {entry.recordedBy ? (
-                        <div className="flex items-center gap-2">
-                          <Avatar person={entry.recordedBy} size="tiny" />
-                          <span className="text-content-base">{entry.recordedBy.fullName}</span>
-                        </div>
-                      ) : (
-                        <span className="text-content-subtle">Unknown</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 text-right font-medium text-content-accent">{formatValue(entry.value, unit)}</td>
-                    <td className="px-4 py-2 text-right">
-                      {canOpenComments ? (
-                        <button
-                          type="button"
-                          className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
-                          onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
-                          data-test-id={`entry-comments-toggle-${entry.id}`}
-                          aria-expanded={isOpen}
-                        >
-                          <IconMessage size={14} />
-                          {commentsCount > 0 ? commentsCount : "Comment"}
-                        </button>
-                      ) : commentsCount > 0 ? (
-                        <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
-                          <IconMessage size={14} />
-                          {commentsCount}
-                        </span>
-                      ) : null}
-                    </td>
-                  </tr>
-                  {isOpen && renderEntryComments && (
-                    <tr className="border-b border-stroke-dimmed last:border-b-0 bg-surface-base" data-test-id={`entry-comments-${entry.id}`}>
-                      <td colSpan={4} className="px-4 py-4">
-                        {renderEntryComments(entry)}
-                      </td>
-                    </tr>
-                  )}
-                </React.Fragment>
+                <tr
+                  key={entry.id}
+                  className="border-b border-stroke-dimmed last:border-b-0"
+                  data-test-id={`entry-row-${entry.id}`}
+                >
+                  <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
+                  <td className="px-4 py-2">
+                    {entry.recordedBy ? (
+                      <div className="flex items-center gap-2">
+                        <Avatar person={entry.recordedBy} size="tiny" />
+                        <span className="text-content-base">{entry.recordedBy.fullName}</span>
+                      </div>
+                    ) : (
+                      <span className="text-content-subtle">Unknown</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right font-medium text-content-accent">
+                    {formatValue(entry.value, unit)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {canOpenComments ? (
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+                        onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
+                        data-test-id={`entry-comments-toggle-${entry.id}`}
+                        aria-expanded={isOpen}
+                      >
+                        <IconMessage size={14} />
+                        {commentsCount > 0 ? commentsCount : "Comment"}
+                      </button>
+                    ) : commentsCount > 0 ? (
+                      <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
+                        <IconMessage size={14} />
+                        {commentsCount}
+                      </span>
+                    ) : null}
+                  </td>
+                </tr>
               );
             })}
           </tbody>
         </table>
+      </div>
+
+      <SlideIn
+        isOpen={Boolean(openEntry && renderEntryComments)}
+        onClose={() => setOpenEntryId(null)}
+        width={COMMENTS_PANEL_WIDTH}
+        testId="entry-comments-slide-in"
+        header={openEntry ? <EntryCommentsHeader entry={openEntry} unit={unit} kpiName={kpiName} /> : undefined}
+      >
+        {openEntry && renderEntryComments && (
+          <div className="px-6 py-4" data-test-id={`entry-comments-${openEntry.id}`}>
+            {renderEntryComments(openEntry)}
+          </div>
+        )}
+      </SlideIn>
+    </div>
+  );
+}
+
+// The update under discussion leads the panel: the value it recorded, then who
+// logged it and when. The KPI name sits above as context, since the panel covers
+// the page that would otherwise carry it.
+function EntryCommentsHeader({
+  entry,
+  unit,
+  kpiName,
+}: {
+  entry: SpaceKpisPage.KpiEntry;
+  unit: string;
+  kpiName: string;
+}) {
+  return (
+    <div className="border-b border-stroke-base px-6 py-4 pr-12" data-test-id="entry-comments-header">
+      <div className="text-xs text-content-dimmed">{kpiName}</div>
+
+      <h2 className="mt-1 text-2xl font-bold leading-none text-content-accent">{formatValue(entry.value, unit)}</h2>
+
+      <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-content-dimmed">
+        {entry.recordedBy ? (
+          <>
+            <span>Logged by</span>
+            <Avatar person={entry.recordedBy} size={16} />
+            <span>
+              <span className="font-medium text-content-base">{entry.recordedBy.fullName}</span> on{" "}
+              {formatShortDate(entry.recordedAt)}
+            </span>
+          </>
+        ) : (
+          <span>Logged on {formatShortDate(entry.recordedAt)}</span>
+        )}
       </div>
     </div>
   );

--- a/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
@@ -7,7 +7,7 @@ import type { SpaceKpisPage } from "./types";
 import { formatShortDate } from "./utils";
 
 function entry(id: string, value: number): SpaceKpisPage.KpiEntry {
-  return { id, value, recordedAt: new Date(`2026-01-0${id}`), recordedBy: null };
+  return { id, value, recordedAt: new Date(`2026-01-0${id}`), recordedBy: null, commentsCount: 0 };
 }
 
 describe("KpiLineChart y-axis", () => {

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
@@ -1,10 +1,37 @@
 import * as React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { LogUpdateForm } from "./LogUpdateForm";
 import type { SpaceKpisPage } from "./types";
+
+// The note field wraps the rich editor, which needs a real DOM to run. Stand it
+// in with a stub that lets a test push content the way typing would.
+const richEditor = {
+  onUpdate: undefined as ((args: { json: unknown }) => void) | undefined,
+  json: null as unknown,
+};
+
+jest.mock("../RichEditor", () => ({
+  Editor: () => <div data-test-id="log-update-note-editor" />,
+  useEditor: (props: { onUpdate?: (args: { json: unknown }) => void }) => {
+    richEditor.onUpdate = props.onUpdate;
+
+    return {
+      editor: { commands: { setContent: jest.fn() }, getJSON: () => richEditor.json },
+      localDraftRestored: false,
+      clearLocalDraft: () => undefined,
+    };
+  },
+}));
+
+function typeNote(text: string) {
+  const json = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] };
+  act(() => richEditor.onUpdate?.({ json }));
+  return json;
+}
 
 // This codebase tags elements with `data-test-id` (not the default
 // `data-testid`); resolve them via the attribute selector.
@@ -42,6 +69,7 @@ function renderForm(overrides: Partial<React.ComponentProps<typeof LogUpdateForm
     isOpen: true,
     onClose: () => {},
     onRecord,
+    richTextHandlers: createMockRichEditorHandlers(),
     ...overrides,
   };
   render(<LogUpdateForm {...props} />);
@@ -61,9 +89,7 @@ describe("LogUpdateForm date affordance", () => {
     fireEvent.change(getByTestId("value"), { target: { value: "42" } });
     await user.click(getByTestId("submit"));
 
-    await waitFor(() =>
-      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }),
-    );
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
   });
 
   test("'Change date' reveals and focuses the date input", async () => {
@@ -92,8 +118,49 @@ describe("LogUpdateForm date affordance", () => {
     fireEvent.change(getByTestId("log-update-period"), { target: { value: "2026-01-15" } });
     await user.click(getByTestId("submit"));
 
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 7, period: "2026-01-15" }));
+  });
+});
+
+// A value on its own rarely explains itself, so the form takes an optional note
+// that is posted as the first comment on the update.
+describe("LogUpdateForm note", () => {
+  beforeEach(() => {
+    richEditor.json = null;
+    richEditor.onUpdate = undefined;
+  });
+
+  test("sends the note alongside the value", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    const note = typeNote("Enterprise renewals landed early this month.");
+    await user.click(getByTestId("submit"));
+
     await waitFor(() =>
-      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 7, period: "2026-01-15" }),
+      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today(), comment: note }),
     );
+  });
+
+  test("is optional: an untouched note is not sent", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    await user.click(getByTestId("submit"));
+
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
+  });
+
+  test("is optional: a note holding only blank space is not sent", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    typeNote("   ");
+    await user.click(getByTestId("submit"));
+
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
   });
 });

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
-import { Form, NumberInput, Submit, useForm } from "../Forms";
+import { Form, NumberInput, RichTextArea, Submit, useForm } from "../Forms";
 import { Modal } from "../Modal";
+import { emptyContent, isContentEmpty } from "../RichContent";
+import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import type { SpaceKpisPage } from "./types";
 import { formatShortDate, formatValue, latestEntry } from "./utils";
 
@@ -10,6 +12,7 @@ interface LogUpdateFormProps {
   isOpen: boolean;
   onClose: () => void;
   onRecord: (input: SpaceKpisPage.RecordEntryInput) => Promise<SpaceKpisPage.MutationResult>;
+  richTextHandlers: RichEditorHandlers;
 }
 
 // Local `YYYY-MM-DD` for today, used as the default period so logging is a
@@ -31,7 +34,7 @@ function formatPeriodLabel(period: string): string {
 
 // Single-KPI "Log update" form → calls the `logKpiEntry` mutation.
 // This POC intentionally has NO "update all KPIs at once" batch UI — one KPI at a time.
-export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormProps) {
+export function LogUpdateForm({ kpi, isOpen, onClose, onRecord, richTextHandlers }: LogUpdateFormProps) {
   const [submitError, setSubmitError] = React.useState<string | null>(null);
 
   // The date defaults to today and stays a low-prominence affordance; revealing
@@ -41,9 +44,10 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
   const periodInputRef = React.useRef<HTMLInputElement>(null);
 
   // `value` is stored as a string because NumberInput is text-backed; it is
-  // coerced to a number on submit for the mutation.
-  const form = useForm<{ value: string; period: string }>({
-    fields: { value: "", period: today() },
+  // coerced to a number on submit for the mutation. `note` holds rich text and
+  // is posted as the update's first comment when it isn't left blank.
+  const form = useForm<{ value: string; period: string; note: Record<string, unknown> }>({
+    fields: { value: "", period: today(), note: emptyContent() },
     validate: (addError) => {
       if (form.values.value.trim() === "" || Number.isNaN(Number(form.values.value))) {
         addError("value", "Enter a value");
@@ -56,7 +60,13 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
       if (!kpi) return;
       setSubmitError(null);
 
-      const result = await onRecord({ kpiId: kpi.id, value: Number(form.values.value), period: form.values.period });
+      const note = form.values.note;
+      const result = await onRecord({
+        kpiId: kpi.id,
+        value: Number(form.values.value),
+        period: form.values.period,
+        comment: isContentEmpty(note) ? undefined : note,
+      });
 
       if (result.success) {
         form.actions.reset();
@@ -118,12 +128,13 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
                 className="w-full rounded-lg border border-surface-outline bg-surface-base px-3 py-1.5 text-sm text-content-accent"
                 data-test-id="log-update-period"
               />
-              {form.errors["period"] && (
-                <div className="mt-1 text-sm text-content-error">{form.errors["period"]}</div>
-              )}
+              {form.errors["period"] && <div className="mt-1 text-sm text-content-error">{form.errors["period"]}</div>}
             </div>
           ) : (
-            <div className="flex items-center gap-2 text-sm text-content-dimmed" data-test-id="log-update-period-summary">
+            <div
+              className="flex items-center gap-2 text-sm text-content-dimmed"
+              data-test-id="log-update-period-summary"
+            >
               <span>
                 Logging for{" "}
                 <span className="font-medium text-content-base">
@@ -140,6 +151,18 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
               </button>
             </div>
           )}
+        </div>
+
+        <div className="mt-4">
+          <RichTextArea
+            field="note"
+            label="Note (optional)"
+            placeholder="What's behind this number?"
+            richTextHandlers={richTextHandlers}
+            height="min-h-[80px]"
+            hideToolbar
+          />
+          <p className="mt-1 text-xs text-content-dimmed">Posted as the first comment on this update.</p>
         </div>
 
         {submitError && (

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -154,6 +154,7 @@ function Harness(args: HarnessArgs) {
                 value: input.value,
                 recordedAt: new Date(),
                 recordedBy: mockCurrentUser,
+                commentsCount: 0,
               };
               return { ...kpi, latestEntry: entry, entries: [...kpi.entries, entry] };
             })()

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { useParams } from "react-router";
 
+import { CommentSection } from "../CommentSection";
+import type { CommentSectionItem } from "../CommentSection";
+import { defaultFormattedTimePreferences } from "../utils/storybook/formattedTime";
 import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { useMockSubscriptions } from "../utils/storybook/subscriptions";
 import { SpaceKpisPage } from "./index";
@@ -107,9 +110,7 @@ function Harness(args: HarnessArgs) {
 
     setKpis((prev) =>
       prev.map((kpi) =>
-        kpi.id === input.id
-          ? { ...kpi, name: input.name, unit: input.unit, cadence: input.cadence, champion }
-          : kpi,
+        kpi.id === input.id ? { ...kpi, name: input.name, unit: input.unit, cadence: input.cadence, champion } : kpi,
       ),
     );
 
@@ -154,7 +155,8 @@ function Harness(args: HarnessArgs) {
                 value: input.value,
                 recordedAt: new Date(),
                 recordedBy: mockCurrentUser,
-                commentsCount: 0,
+                // The app posts the note as the update's first comment.
+                commentsCount: input.comment ? 1 : 0,
               };
               return { ...kpi, latestEntry: entry, entries: [...kpi.entries, entry] };
             })()
@@ -184,6 +186,42 @@ function Harness(args: HarnessArgs) {
       error={args.error}
       canManage={args.canManage}
       subscriptions={subscriptions}
+      canComment
+      renderEntryComments={(entry) => <EntryComments key={entry.id} />}
+    />
+  );
+}
+
+// Stands in for the app's KpiEntryComments bridge, which loads the thread for a
+// recorded update and posts to the comments API.
+function EntryComments() {
+  const [items, setItems] = React.useState<CommentSectionItem[]>([]);
+
+  return (
+    <CommentSection
+      items={items}
+      currentUser={{ ...mockCurrentUser, profileLink: mockCurrentUser.profileLink ?? "#" }}
+      canComment
+      commentParentType="kpi_entry"
+      richTextHandlers={createMockRichEditorHandlers()}
+      formattedTimePreferences={defaultFormattedTimePreferences}
+      onAddComment={(content) => {
+        setItems((prev) => [
+          ...prev,
+          {
+            type: "comment",
+            value: {
+              id: `comment-${prev.length + 1}`,
+              content: JSON.stringify(content),
+              author: { ...mockCurrentUser, profileLink: mockCurrentUser.profileLink ?? "#" },
+              insertedAt: new Date().toISOString(),
+              reactions: [],
+            },
+          },
+        ]);
+        return true;
+      }}
+      onEditComment={() => true}
     />
   );
 }
@@ -197,6 +235,25 @@ export const Default: Story = {
 // chart, trend, champion + cadence, and the recorded-updates log.
 export const DetailView: Story = {
   parameters: kpiRoute("kpi-mrr"),
+};
+
+// The comment thread for a recorded update, opened in a slide-in from the
+// "Recorded updates" log. Guards against the composer overflowing the panel.
+export const UpdateComments: Story = {
+  parameters: kpiRoute("kpi-mrr"),
+  play: async ({ canvasElement }) => {
+    const toggle = canvasElement.querySelector<HTMLButtonElement>('[data-test-id^="entry-comments-toggle-"]');
+    toggle?.click();
+  },
+};
+
+// Logging an update, including the optional note that the app posts as the
+// update's first comment.
+export const LogUpdate: Story = {
+  parameters: kpiRoute("kpi-mrr"),
+  play: async ({ canvasElement }) => {
+    canvasElement.querySelector<HTMLButtonElement>('[data-test-id="kpi-detail-log-update"]')?.click();
+  },
 };
 
 // Edge case: a KPI with a single entry can't plot a trend line yet, so its page

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -581,7 +581,13 @@ describe("SpaceKpisPage create & log", () => {
       const [kpi, setKpi] = React.useState(base);
 
       const onRecordEntry = async (input: SpaceKpisPageNS.RecordEntryInput) => {
-        const entry = { id: "new-entry", value: input.value, recordedAt: new Date(), recordedBy: null, commentsCount: 0 };
+        const entry = {
+          id: "new-entry",
+          value: input.value,
+          recordedAt: new Date(),
+          recordedBy: null,
+          commentsCount: 0,
+        };
         setKpi((current) => ({ ...current, entries: [...current.entries, entry] }));
 
         return { success: true };
@@ -611,7 +617,7 @@ describe("SpaceKpisPage create & log", () => {
 });
 
 describe("SpaceKpisPage KPI update comments", () => {
-  test("opens comments on a recorded update", async () => {
+  test("opens comments on a recorded update in a slide-in", async () => {
     const user = userEvent.setup();
     const target = mockKpis[0]!;
     const entry = target.entries[target.entries.length - 1]!;
@@ -623,6 +629,49 @@ describe("SpaceKpisPage KPI update comments", () => {
     });
 
     await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
-    expect(await findByTestId("entry-comments-body")).toHaveTextContent("Write a comment");
+
+    const slideIn = await findByTestId("entry-comments-slide-in");
+    expect(slideIn).toHaveTextContent("Write a comment");
+
+    const row = document.querySelector(`[data-test-id="entry-row-${entry.id}"]`);
+    expect(row).not.toHaveTextContent("Write a comment");
+  });
+
+  // Opening the thread hides the table behind it, so the panel has to say which
+  // update is being discussed: its value, who logged it, and when.
+  test("names the update being commented on, with who logged it and when", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({ selectedKpi: target, canComment: true, renderEntryComments: () => null });
+
+    await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
+
+    const header = await findByTestId("entry-comments-header");
+    expect(header).toHaveTextContent(target.name);
+    expect(header).toHaveTextContent(formatValue(entry.value, target.unit));
+    expect(header).toHaveTextContent(entry.recordedBy!.fullName);
+    expect(header).toHaveTextContent(formatShortDate(entry.recordedAt));
+  });
+
+  test("closes the update comments slide-in", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({
+      selectedKpi: target,
+      canComment: true,
+      renderEntryComments: () => <div data-test-id="entry-comments-body">Write a comment</div>,
+    });
+
+    await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
+    await findByTestId("entry-comments-slide-in");
+    await user.click(await findByTestId("slide-in-close-button"));
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-test-id="entry-comments-slide-in"]')).not.toBeInTheDocument();
+    });
   });
 });

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -371,7 +371,7 @@ describe("SpaceKpisPage list latest value", () => {
       champion: null,
       insertedAt: new Date(),
       link: `${kpisLink}/kpi-throughput`,
-      latestEntry: { id: "e1", value: 123, recordedAt: new Date(), recordedBy: null },
+      latestEntry: { id: "e1", value: 123, recordedAt: new Date(), recordedBy: null, commentsCount: 0 },
       entries: [],
     };
 
@@ -581,7 +581,7 @@ describe("SpaceKpisPage create & log", () => {
       const [kpi, setKpi] = React.useState(base);
 
       const onRecordEntry = async (input: SpaceKpisPageNS.RecordEntryInput) => {
-        const entry = { id: "new-entry", value: input.value, recordedAt: new Date(), recordedBy: null };
+        const entry = { id: "new-entry", value: input.value, recordedAt: new Date(), recordedBy: null, commentsCount: 0 };
         setKpi((current) => ({ ...current, entries: [...current.entries, entry] }));
 
         return { success: true };

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -609,3 +609,20 @@ describe("SpaceKpisPage create & log", () => {
     await findByTestId("kpi-line-chart");
   });
 });
+
+describe("SpaceKpisPage KPI update comments", () => {
+  test("opens comments on a recorded update", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({
+      selectedKpi: target,
+      canComment: true,
+      renderEntryComments: () => <div data-test-id="entry-comments-body">Write a comment</div>,
+    });
+
+    await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
+    expect(await findByTestId("entry-comments-body")).toHaveTextContent("Write a comment");
+  });
+});

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -226,10 +226,12 @@ function KpisContent(props: KpisContentProps) {
         kpi={selectedKpi}
         fields={openKpi}
         canManage={props.canManage}
+        canComment={props.canComment}
         championSearch={props.championSearch}
         onDescriptionChange={props.onDescriptionChange}
         onDelete={props.onOpenDelete}
         richTextHandlers={props.richTextHandlers}
+        renderEntryComments={props.renderEntryComments}
         subscriptions={props.subscriptions}
       />
     );

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -105,6 +105,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         isOpen={logKpiId !== null}
         onClose={() => setLogKpiId(null)}
         onRecord={props.onRecordEntry}
+        richTextHandlers={props.richTextHandlers}
       />
     </PageNew>
   );
@@ -237,9 +238,7 @@ function KpisContent(props: KpisContentProps) {
     );
   }
 
-  return (
-    <KpiList kpis={props.kpis} canManage={props.canManage} onNewKpi={props.onOpenNew} />
-  );
+  return <KpiList kpis={props.kpis} canManage={props.canManage} onNewKpi={props.onOpenNew} />;
 }
 
 function LoadingState() {

--- a/turboui/src/SpaceKpisPage/mockData.tsx
+++ b/turboui/src/SpaceKpisPage/mockData.tsx
@@ -49,6 +49,7 @@ function makeEntries(
       value: sample.value,
       recordedAt: daysAgo(sample.daysAgo),
       recordedBy: sample.by,
+      commentsCount: 0,
     }))
     .sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
 }

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -8,6 +8,7 @@
 // Intentionally simpler than Goals/Targets: raw value + unit only, no
 // target/threshold fields.
 //
+import type { ReactNode } from "react";
 import type { Navigation } from "../Page/Navigation";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import { SidebarNotificationSection } from "../SidebarSection";
@@ -36,6 +37,7 @@ export namespace SpaceKpisPage {
     value: number;
     recordedAt: Date;
     recordedBy: Person | null;
+    commentsCount: number;
   }
 
   export interface Kpi {
@@ -121,6 +123,11 @@ export namespace SpaceKpisPage {
     onDeleteKpi: (kpiId: string) => Promise<MutationResult>;
     onRecordEntry: (input: RecordEntryInput) => Promise<MutationResult>;
     richTextHandlers: RichEditorHandlers;
+
+    // Comments on a recorded update. The app supplies the comment thread so
+    // TurboUI stays free of API calls; omit it in stories that only show the table.
+    renderEntryComments?: (entry: KpiEntry) => ReactNode;
+    canComment?: boolean;
 
     // Route-loader driven data states.
     loading?: boolean;

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -88,6 +88,10 @@ export namespace SpaceKpisPage {
     kpiId: string;
     value: number;
     period: string;
+
+    // Optional note explaining the value, posted as the update's first comment.
+    // Absent when the author left the note blank.
+    comment?: Record<string, unknown>;
   }
 
   export type MutationResult = { success: boolean; id?: string; error?: string };
@@ -125,7 +129,7 @@ export namespace SpaceKpisPage {
     richTextHandlers: RichEditorHandlers;
 
     // Comments on a recorded update. The app supplies the comment thread so
-    // TurboUI stays free of API calls; omit it in stories that only show the table.
+    // TurboUI stays free of API calls; opening a row shows it in a slide-in.
     renderEntryComments?: (entry: KpiEntry) => ReactNode;
     canComment?: boolean;
 


### PR DESCRIPTION
## Summary
- Let space members with comment access discuss any recorded KPI value from the KPI page.
- Notify KPI subscribers, the champion, and the person who logged the update (with mention handling on the KPI subscription list).
- Surface comments in the activity feed, email, MCP `create_comment` (`kpi_update`), and the CLI catalog.

## Test plan
- [ ] Open a KPI with recorded updates and confirm each row has a Comment control.
- [ ] Post, edit, react to, and delete a comment on an update.
- [ ] Confirm a space member with view-only access cannot post comments.
- [ ] Confirm the champion / subscriber receives a notification (and email) after someone else comments.
- [ ] Mention someone in a KPI-update comment and confirm they are subscribed to the KPI.


Made with [Cursor](https://cursor.com)