### PR TITLE
feat: refine project templates index

### DIFF
--- a/turboui/src/ProjectTemplatesPage/TemplateCard.tsx
+++ b/turboui/src/ProjectTemplatesPage/TemplateCard.tsx
@@ -64,10 +64,10 @@ export function TemplateCard({
           )}
         </div>
         <p className="mt-2 line-clamp-3 flex-1 text-sm text-content-dimmed">{description || "No description"}</p>
-        <div className="mt-5 flex items-center justify-between gap-3 border-t border-surface-outline pt-3 text-xs text-content-dimmed">
-          <div className="flex min-w-0 items-center gap-2">
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-t border-surface-outline pt-3 text-xs text-content-dimmed">
+          <div className="flex min-w-32 flex-1 items-center gap-2">
             {template.creator ? <Avatar person={template.creator} size={20} /> : null}
-            <span className="truncate">{template.creator?.fullName ?? "Creator unavailable"}</span>
+            <span className="min-w-0 break-words">{template.creator?.fullName ?? "Creator unavailable"}</span>
           </div>
           <span className="shrink-0">
             Updated{" "}

--- a/turboui/src/ProjectTemplatesPage/index.test.tsx
+++ b/turboui/src/ProjectTemplatesPage/index.test.tsx
@@ -98,11 +98,13 @@ describe("ProjectTemplatesPage", () => {
     const page = container.querySelector('[data-test-id="project-templates-page"]');
     const title = screen.getByText("Project Templates");
     const newTemplateButton = screen.getByRole("button", { name: "New template" });
+    const header = title.parentElement?.parentElement;
 
     expect(page?.parentElement).toHaveClass("lg:max-w-5xl");
     expect(title).toHaveClass("text-lg", "md:text-2xl", "font-extrabold");
-    expect(title.parentElement).toHaveClass("text-center", "flex-1");
-    expect(newTemplateButton.parentElement).toHaveClass("w-[30%]");
+    expect(title.parentElement).toHaveClass("min-w-0", "text-center");
+    expect(header).toHaveClass("grid", "grid-cols-[auto_minmax(0,1fr)]", "sm:grid-cols-[30%_minmax(0,1fr)_30%]");
+    expect(newTemplateButton.parentElement).toHaveClass("min-w-0");
   });
 
   it("groups company templates by Space and renders card metadata", () => {
@@ -122,7 +124,7 @@ describe("ProjectTemplatesPage", () => {
   });
 
   it("renders a Space-scoped library without company grouping", () => {
-    renderPage({
+    const { container } = renderPage({
       scope: "space",
       navigation: [{ to: "/spaces/space-1", label: "Marketing" }],
       fixedSpace: spaces[0],
@@ -132,6 +134,9 @@ describe("ProjectTemplatesPage", () => {
     expect(screen.getByRole("link", { name: "Marketing" })).toHaveAttribute("href", "/spaces/space-1");
     expect(screen.queryByRole("link", { name: "Product" })).not.toBeInTheDocument();
     expect(screen.queryByTestId("project-template-space-filter")).not.toBeInTheDocument();
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Active" })).not.toBeInTheDocument();
+    expect(container.querySelector('[data-test-id="project-template-grid"]')).toHaveClass("lg:grid-cols-2");
   });
 
   it("filters templates locally by search", () => {
@@ -179,7 +184,7 @@ describe("ProjectTemplatesPage", () => {
     expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Active" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Create template" })).not.toBeInTheDocument();
-    expect(newTemplateButton.parentElement).toHaveClass("w-[30%]");
+    expect(newTemplateButton.parentElement).toHaveClass("min-w-0");
 
     await user.click(newTemplateButton);
     expect(screen.getByRole("heading", { name: "New project template" })).toBeInTheDocument();
@@ -199,7 +204,7 @@ describe("ProjectTemplatesPage", () => {
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "missing" } });
 
     expect(screen.getByText("No matching templates.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Active" })).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Clear filters" }));
     expect(screen.getByText("Campaign launch")).toBeInTheDocument();
     expect(screen.getByRole("searchbox")).toHaveValue("");

--- a/turboui/src/ProjectTemplatesPage/index.tsx
+++ b/turboui/src/ProjectTemplatesPage/index.tsx
@@ -73,9 +73,16 @@ export function ProjectTemplatesPage(props: ProjectTemplatesPage.Props) {
   );
   const isFiltered =
     search.trim() !== "" || (props.scope === "company" && selectedSpace !== null) || archiveStatus !== "active";
+  const templatesForArchiveStatus = templates.filter((template) => matchesArchiveStatus(template, archiveStatus));
   const visibleTemplates = filterTemplates(templates, search, selectedSpace?.id, archiveStatus);
   const hasTemplates = templates.length > 0;
   const hasArchivedTemplates = templates.some((template) => Boolean(template.archivedAt));
+  const hasMultipleTemplates = templatesForArchiveStatus.length > 1;
+  const hasMultipleSpaces = new Set(templatesForArchiveStatus.map((template) => template.space.id)).size > 1;
+  const showSearch = hasMultipleTemplates || search.trim() !== "";
+  const showSpaceFilter = props.scope === "company" && (hasMultipleSpaces || selectedSpace !== null);
+  const showArchiveStatus = hasArchivedTemplates || archiveStatus === "archived";
+  const showBrowsingControls = showSearch || showSpaceFilter || showArchiveStatus;
 
   const clearFilters = () => {
     setSearch("");
@@ -113,45 +120,58 @@ export function ProjectTemplatesPage(props: ProjectTemplatesPage.Props) {
           }
         />
 
-        {hasTemplates && (
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="relative w-full sm:max-w-sm">
-              <IconSearch
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-content-dimmed"
-              />
-              <Forms.Input
-                type="text"
-                name="project-template-search"
-                role="searchbox"
-                aria-label="Search project templates"
-                placeholder="Search project templates…"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                className="py-2 pl-9 pr-9 text-base sm:text-sm"
-                testId="project-template-search"
-              />
-              {search && (
-                <button
-                  type="button"
-                  aria-label="Clear search"
-                  onClick={() => setSearch("")}
-                  className="absolute right-3 top-1/2 z-10 -translate-y-1/2 text-content-dimmed hover:text-content-accent"
-                >
-                  <IconX size={16} aria-hidden="true" />
-                </button>
-              )}
-            </div>
-            {props.scope === "company" && (
-              <SpaceField
-                space={selectedSpace}
-                setSpace={setSelectedSpace}
-                search={filterSpaceSearch}
-                emptyStateMessage="All Spaces"
-                testId="project-template-space-filter"
-              />
+        {hasTemplates && showBrowsingControls && (
+          <div
+            className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+            data-test-id="project-template-toolbar"
+          >
+            {(showSearch || showSpaceFilter) && (
+              <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
+                {showSearch && (
+                  <div className="relative w-full sm:max-w-sm">
+                    <IconSearch
+                      size={16}
+                      className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2 text-content-dimmed"
+                    />
+                    <Forms.Input
+                      type="text"
+                      name="project-template-search"
+                      role="searchbox"
+                      aria-label="Search project templates"
+                      placeholder="Search project templates…"
+                      value={search}
+                      onChange={(event) => setSearch(event.target.value)}
+                      className="py-2 pl-9 pr-9 text-base sm:text-sm"
+                      testId="project-template-search"
+                    />
+                    {search && (
+                      <button
+                        type="button"
+                        aria-label="Clear search"
+                        onClick={() => setSearch("")}
+                        className="absolute right-3 top-1/2 z-10 -translate-y-1/2 text-content-dimmed hover:text-content-accent"
+                      >
+                        <IconX size={16} aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
+                )}
+                {showSpaceFilter && (
+                  <SpaceField
+                    space={selectedSpace}
+                    setSpace={setSelectedSpace}
+                    search={filterSpaceSearch}
+                    emptyStateMessage="All Spaces"
+                    testId="project-template-space-filter"
+                  />
+                )}
+              </div>
             )}
-            <ArchiveStatusMenu value={archiveStatus} onChange={setArchiveStatus} />
+            {showArchiveStatus && (
+              <div className="sm:ml-auto">
+                <ArchiveStatusMenu value={archiveStatus} onChange={setArchiveStatus} />
+              </div>
+            )}
           </div>
         )}
 
@@ -263,7 +283,7 @@ function TemplateGrid(
   },
 ) {
   return (
-    <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="mt-8 grid gap-4 lg:grid-cols-2" data-test-id="project-template-grid">
       {props.templates.map((template) => (
         <TemplateCard key={template.id} template={template} {...props} />
       ))}
@@ -282,7 +302,7 @@ function ArchiveStatusMenu({ value, onChange }: { value: ArchiveStatus; onChange
       customTrigger={
         <button
           type="button"
-          className="inline-flex items-center gap-2 rounded-md border border-surface-outline bg-surface-base px-3 py-1.5 text-sm text-content-dimmed transition hover:bg-surface-accent hover:text-content-base"
+          className="inline-flex w-full items-center justify-between gap-2 rounded-md border border-surface-outline bg-surface-base px-3 py-1.5 text-sm text-content-dimmed hover:bg-surface-accent hover:text-content-base sm:w-auto sm:justify-start"
         >
           {label} <IconChevronDown size={16} />
         </button>
@@ -306,10 +326,14 @@ function filterTemplates(
     const searchableText = `${template.name} ${plainDescription(template.description)}`.toLowerCase();
     const matchesSearch = normalizedSearch === "" || searchableText.includes(normalizedSearch);
     const matchesSpace = !spaceId || template.space.id === spaceId;
-    const matchesArchiveStatus = archiveStatus === "archived" ? Boolean(template.archivedAt) : !template.archivedAt;
+    const matchesStatus = matchesArchiveStatus(template, archiveStatus);
 
-    return matchesSearch && matchesSpace && matchesArchiveStatus;
+    return matchesSearch && matchesSpace && matchesStatus;
   });
+}
+
+function matchesArchiveStatus(template: ProjectTemplate, archiveStatus: ArchiveStatus) {
+  return archiveStatus === "archived" ? Boolean(template.archivedAt) : !template.archivedAt;
 }
 
 function CreateTemplateModal({

--- a/turboui/src/ResourceHub/Header.tsx
+++ b/turboui/src/ResourceHub/Header.tsx
@@ -8,16 +8,18 @@ interface HeaderProps {
 
 export function Header({ title, actions }: HeaderProps) {
   const className = classNames(
-    "flex items-center justify-between mb-6 pt-5 pb-4 border-b border-stroke-base -mx-4 sm:-mx-8 -mt-4 sm:-mt-8 px-4 sm:px-8",
+    "grid items-center mb-6 pt-5 pb-4 border-b border-stroke-base -mx-4 sm:-mx-8 -mt-4 sm:-mt-8 px-4 sm:px-8",
+    actions ? "grid-cols-[auto_minmax(0,1fr)] gap-3" : "grid-cols-1",
+    "sm:grid-cols-[30%_minmax(0,1fr)_30%] sm:gap-0",
   );
 
   return (
     <div className={className}>
-      <div className="w-[30%]">{actions}</div>
-      <div className="w-[50%] text-center flex-1">
-        <div className="text-content-accent text-lg md:text-2xl font-extrabold">{title}</div>
+      <div className="min-w-0">{actions}</div>
+      <div className="min-w-0 text-center">
+        <div className="text-balance text-content-accent text-lg md:text-2xl font-extrabold">{title}</div>
       </div>
-      <div className="w-[30%]" />
+      <div className="hidden min-w-0 sm:block" />
     </div>
   );
 }


### PR DESCRIPTION
- Single-template libraries now hide unused search and archive controls.
- Search appears with multiple templates; the Space filter appears with multiple represented Spaces.
- Archive status appears only when archived templates exist.
- Visible controls balance across the toolbar.
- Template cards use two columns at large widths.
- Creator metadata wraps instead of truncating.
- The shared Space-section header now keeps actions and titles readable on mobile.