### PR TITLE
feat: Move KPI update comments into a slide-in

### DIFF
--- a/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/KpiEntryComments.tsx
@@ -7,9 +7,13 @@ interface KpiEntryCommentsProps {
   entryId: string;
   spaceId: string;
   canComment: boolean;
+
+  // The recorded-updates log behind the panel shows each update's comment
+  // count, so it has to be told when the thread grows or shrinks.
+  onCommentsChanged: () => void;
 }
 
-export function KpiEntryComments({ entryId, spaceId, canComment }: KpiEntryCommentsProps) {
+export function KpiEntryComments({ entryId, spaceId, canComment, onCommentsChanged }: KpiEntryCommentsProps) {
   const form = useComments({
     parentType: "kpi_entry",
     kpiEntry: { id: entryId },
@@ -23,5 +27,16 @@ export function KpiEntryComments({ entryId, spaceId, canComment }: KpiEntryComme
 
   if (!comments) return null;
 
-  return <CommentSection {...comments} />;
+  const addComment = async (content: unknown) => {
+    const result = await comments.onAddComment(content);
+    onCommentsChanged();
+    return result;
+  };
+
+  const deleteComment = async (commentId: string) => {
+    await comments.onDeleteComment?.(commentId);
+    onCommentsChanged();
+  };
+
+  return <CommentSection {...comments} onAddComment={addComment} onDeleteComment={deleteComment} />;
 }

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -4,6 +4,7 @@ import { Navigate, useNavigate } from "react-router";
 import { showErrorToast, SpaceKpisPage } from "turboui";
 import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/types";
 
+import * as Comments from "@/models/comments";
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as Kpis from "@/models/kpis";
@@ -29,6 +30,7 @@ export function Page() {
   const [editKpi] = Kpis.useEditKpi();
   const [deleteKpi] = Kpis.useDeleteKpi();
   const [logKpiEntry] = Kpis.useLogKpiEntry();
+  const [createComment] = Comments.useCreateComment();
 
   const kpisLink = paths.spaceKpisPath(space.id!);
   const parsedKpis = React.useMemo(() => kpis.map((k) => Kpis.parseKpiForTurboUi(paths, k)), [kpis, paths]);
@@ -102,9 +104,25 @@ export function Page() {
       else refresh();
     });
 
+  // The value is recorded first and the note is a comment on it, so a failed
+  // note must not report the update as failed — that would invite logging the
+  // same value twice.
   const onRecordEntry = async (input: SpaceKpisPageTypes.RecordEntryInput) =>
     run(async () => {
-      await logKpiEntry({ kpiId: input.kpiId, value: input.value, period: input.period });
+      const res = await logKpiEntry({ kpiId: input.kpiId, value: input.value, period: input.period });
+
+      if (input.comment) {
+        try {
+          await createComment({
+            entityId: res.entry.id,
+            entityType: "kpi_entry",
+            content: Comments.stringifyCommentContent(input.comment),
+          });
+        } catch {
+          showErrorToast("Note not posted", "The value was recorded, but the note wasn't saved.");
+        }
+      }
+
       refresh();
     });
 
@@ -133,6 +151,7 @@ export function Page() {
                 entryId={entry.id}
                 spaceId={space.id!}
                 canComment={space.permissions?.canComment ?? false}
+                onCommentsChanged={refresh}
               />
             )
           : undefined

--- a/app/test/features/kpi_comments_test.exs
+++ b/app/test/features/kpi_comments_test.exs
@@ -11,5 +11,13 @@ defmodule Operately.Features.KpiCommentsTest do
     |> Steps.open_update_comments()
     |> Steps.leave_comment()
     |> Steps.assert_comment_visible()
+    |> Steps.assert_update_comment_count(1)
+  end
+
+  feature "log an update with a note", ctx do
+    ctx
+    |> Steps.visit_kpi_page()
+    |> Steps.log_update(value: "456", note: "Enterprise renewals landed early.")
+    |> Steps.assert_note_is_first_comment_on_latest_update(note: "Enterprise renewals landed early.")
   end
 end

--- a/app/test/support/features/kpi_comments_steps.ex
+++ b/app/test/support/features/kpi_comments_steps.ex
@@ -38,4 +38,35 @@ defmodule Operately.Support.Features.KpiCommentsSteps do
   step :assert_comment_visible, ctx do
     UI.assert_text(ctx, "This is a comment.")
   end
+
+  # The comment count lives in the recorded-updates log behind the panel, so it
+  # has to catch up while the thread is still open.
+  step :assert_update_comment_count, ctx, count do
+    UI.assert_text(ctx, to_string(count), testid: "entry-comments-toggle-#{Paths.kpi_entry_id(ctx.entry)}")
+  end
+
+  step :log_update, ctx, opts do
+    ctx
+    |> UI.click(testid: "kpi-detail-log-update")
+    |> UI.fill(testid: "value", with: opts[:value])
+    |> UI.fill_rich_text(testid: "log-update-modal", with: opts[:note])
+    |> UI.click(testid: "submit")
+    |> UI.refute_has(testid: "log-update-modal")
+  end
+
+  step :assert_note_is_first_comment_on_latest_update, ctx, opts do
+    entry = latest_entry(ctx.kpi)
+
+    ctx
+    |> UI.assert_text("1", testid: "entry-comments-toggle-#{Paths.kpi_entry_id(entry)}")
+    |> UI.click(testid: "entry-comments-toggle-#{Paths.kpi_entry_id(entry)}")
+    |> UI.assert_text(opts[:note])
+  end
+
+  defp latest_entry(kpi) do
+    import Ecto.Query, only: [from: 2]
+
+    from(e in Operately.Kpis.KpiEntry, where: e.kpi_id == ^kpi.id, order_by: [desc: e.period], limit: 1)
+    |> Operately.Repo.one!()
+  end
 end

--- a/turboui/src/CommentSection/CommentInput.tsx
+++ b/turboui/src/CommentSection/CommentInput.tsx
@@ -113,7 +113,7 @@ function CommentInputActive({
   return (
     <div className="py-6 not-first:border-t border-stroke-base flex items-start gap-3" data-test-id="new-comment-form">
       <Avatar person={currentUser} size="normal" />
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <div className="border border-surface-outline rounded-lg overflow-hidden">
           <Editor editor={editor} hideBorder padding="p-0" />
 

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -8,6 +8,7 @@ import { PersonField } from "../PersonField";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { TextField } from "../TextField";
+import { SlideIn } from "../SlideIn";
 import { showErrorToast, showSuccessToast } from "../Toasts";
 import { IconLink, IconMessage, IconTrash } from "../icons";
 import { KpiLineChart } from "./KpiLineChart";
@@ -81,6 +82,7 @@ export function KpiDetail({
           <EntriesTable
             entries={kpi.entries}
             unit={fields.unit}
+            kpiName={fields.name}
             canComment={canComment}
             renderEntryComments={renderEntryComments}
           />
@@ -321,18 +323,26 @@ function CadenceField({
   );
 }
 
+// The comment composer's editor toolbar needs about 570px before it starts
+// clipping, so the panel keeps a floor of 680px and only narrows to the full
+// screen when the window itself is smaller than that.
+const COMMENTS_PANEL_WIDTH = "min(100%, max(70%, 680px))";
+
 function EntriesTable({
   entries,
   unit,
+  kpiName,
   canComment,
   renderEntryComments,
 }: {
   entries: SpaceKpisPage.KpiEntry[];
   unit: string;
+  kpiName: string;
   canComment: boolean;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
 }) {
   const [openEntryId, setOpenEntryId] = React.useState<string | null>(null);
+  const openEntry = entries.find((entry) => entry.id === openEntryId) ?? null;
 
   if (entries.length === 0) return null;
 
@@ -359,52 +369,99 @@ function EntriesTable({
               const canOpenComments = Boolean(renderEntryComments) && (canComment || commentsCount > 0);
 
               return (
-                <React.Fragment key={entry.id}>
-                  <tr className="border-b border-stroke-dimmed last:border-b-0" data-test-id={`entry-row-${entry.id}`}>
-                    <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
-                    <td className="px-4 py-2">
-                      {entry.recordedBy ? (
-                        <div className="flex items-center gap-2">
-                          <Avatar person={entry.recordedBy} size="tiny" />
-                          <span className="text-content-base">{entry.recordedBy.fullName}</span>
-                        </div>
-                      ) : (
-                        <span className="text-content-subtle">Unknown</span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2 text-right font-medium text-content-accent">{formatValue(entry.value, unit)}</td>
-                    <td className="px-4 py-2 text-right">
-                      {canOpenComments ? (
-                        <button
-                          type="button"
-                          className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
-                          onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
-                          data-test-id={`entry-comments-toggle-${entry.id}`}
-                          aria-expanded={isOpen}
-                        >
-                          <IconMessage size={14} />
-                          {commentsCount > 0 ? commentsCount : "Comment"}
-                        </button>
-                      ) : commentsCount > 0 ? (
-                        <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
-                          <IconMessage size={14} />
-                          {commentsCount}
-                        </span>
-                      ) : null}
-                    </td>
-                  </tr>
-                  {isOpen && renderEntryComments && (
-                    <tr className="border-b border-stroke-dimmed last:border-b-0 bg-surface-base" data-test-id={`entry-comments-${entry.id}`}>
-                      <td colSpan={4} className="px-4 py-4">
-                        {renderEntryComments(entry)}
-                      </td>
-                    </tr>
-                  )}
-                </React.Fragment>
+                <tr
+                  key={entry.id}
+                  className="border-b border-stroke-dimmed last:border-b-0"
+                  data-test-id={`entry-row-${entry.id}`}
+                >
+                  <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
+                  <td className="px-4 py-2">
+                    {entry.recordedBy ? (
+                      <div className="flex items-center gap-2">
+                        <Avatar person={entry.recordedBy} size="tiny" />
+                        <span className="text-content-base">{entry.recordedBy.fullName}</span>
+                      </div>
+                    ) : (
+                      <span className="text-content-subtle">Unknown</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2 text-right font-medium text-content-accent">
+                    {formatValue(entry.value, unit)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    {canOpenComments ? (
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+                        onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
+                        data-test-id={`entry-comments-toggle-${entry.id}`}
+                        aria-expanded={isOpen}
+                      >
+                        <IconMessage size={14} />
+                        {commentsCount > 0 ? commentsCount : "Comment"}
+                      </button>
+                    ) : commentsCount > 0 ? (
+                      <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
+                        <IconMessage size={14} />
+                        {commentsCount}
+                      </span>
+                    ) : null}
+                  </td>
+                </tr>
               );
             })}
           </tbody>
         </table>
+      </div>
+
+      <SlideIn
+        isOpen={Boolean(openEntry && renderEntryComments)}
+        onClose={() => setOpenEntryId(null)}
+        width={COMMENTS_PANEL_WIDTH}
+        testId="entry-comments-slide-in"
+        header={openEntry ? <EntryCommentsHeader entry={openEntry} unit={unit} kpiName={kpiName} /> : undefined}
+      >
+        {openEntry && renderEntryComments && (
+          <div className="px-6 py-4" data-test-id={`entry-comments-${openEntry.id}`}>
+            {renderEntryComments(openEntry)}
+          </div>
+        )}
+      </SlideIn>
+    </div>
+  );
+}
+
+// The update under discussion leads the panel: the value it recorded, then who
+// logged it and when. The KPI name sits above as context, since the panel covers
+// the page that would otherwise carry it.
+function EntryCommentsHeader({
+  entry,
+  unit,
+  kpiName,
+}: {
+  entry: SpaceKpisPage.KpiEntry;
+  unit: string;
+  kpiName: string;
+}) {
+  return (
+    <div className="border-b border-stroke-base px-6 py-4 pr-12" data-test-id="entry-comments-header">
+      <div className="text-xs text-content-dimmed">{kpiName}</div>
+
+      <h2 className="mt-1 text-2xl font-bold leading-none text-content-accent">{formatValue(entry.value, unit)}</h2>
+
+      <div className="mt-2 flex flex-wrap items-center gap-1.5 text-xs text-content-dimmed">
+        {entry.recordedBy ? (
+          <>
+            <span>Logged by</span>
+            <Avatar person={entry.recordedBy} size={16} />
+            <span>
+              <span className="font-medium text-content-base">{entry.recordedBy.fullName}</span> on{" "}
+              {formatShortDate(entry.recordedAt)}
+            </span>
+          </>
+        ) : (
+          <span>Logged on {formatShortDate(entry.recordedAt)}</span>
+        )}
       </div>
     </div>
   );

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.test.tsx
@@ -1,10 +1,37 @@
 import * as React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { LogUpdateForm } from "./LogUpdateForm";
 import type { SpaceKpisPage } from "./types";
+
+// The note field wraps the rich editor, which needs a real DOM to run. Stand it
+// in with a stub that lets a test push content the way typing would.
+const richEditor = {
+  onUpdate: undefined as ((args: { json: unknown }) => void) | undefined,
+  json: null as unknown,
+};
+
+jest.mock("../RichEditor", () => ({
+  Editor: () => <div data-test-id="log-update-note-editor" />,
+  useEditor: (props: { onUpdate?: (args: { json: unknown }) => void }) => {
+    richEditor.onUpdate = props.onUpdate;
+
+    return {
+      editor: { commands: { setContent: jest.fn() }, getJSON: () => richEditor.json },
+      localDraftRestored: false,
+      clearLocalDraft: () => undefined,
+    };
+  },
+}));
+
+function typeNote(text: string) {
+  const json = { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text }] }] };
+  act(() => richEditor.onUpdate?.({ json }));
+  return json;
+}
 
 // This codebase tags elements with `data-test-id` (not the default
 // `data-testid`); resolve them via the attribute selector.
@@ -42,6 +69,7 @@ function renderForm(overrides: Partial<React.ComponentProps<typeof LogUpdateForm
     isOpen: true,
     onClose: () => {},
     onRecord,
+    richTextHandlers: createMockRichEditorHandlers(),
     ...overrides,
   };
   render(<LogUpdateForm {...props} />);
@@ -61,9 +89,7 @@ describe("LogUpdateForm date affordance", () => {
     fireEvent.change(getByTestId("value"), { target: { value: "42" } });
     await user.click(getByTestId("submit"));
 
-    await waitFor(() =>
-      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }),
-    );
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
   });
 
   test("'Change date' reveals and focuses the date input", async () => {
@@ -92,8 +118,49 @@ describe("LogUpdateForm date affordance", () => {
     fireEvent.change(getByTestId("log-update-period"), { target: { value: "2026-01-15" } });
     await user.click(getByTestId("submit"));
 
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 7, period: "2026-01-15" }));
+  });
+});
+
+// A value on its own rarely explains itself, so the form takes an optional note
+// that is posted as the first comment on the update.
+describe("LogUpdateForm note", () => {
+  beforeEach(() => {
+    richEditor.json = null;
+    richEditor.onUpdate = undefined;
+  });
+
+  test("sends the note alongside the value", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    const note = typeNote("Enterprise renewals landed early this month.");
+    await user.click(getByTestId("submit"));
+
     await waitFor(() =>
-      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 7, period: "2026-01-15" }),
+      expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today(), comment: note }),
     );
+  });
+
+  test("is optional: an untouched note is not sent", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    await user.click(getByTestId("submit"));
+
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
+  });
+
+  test("is optional: a note holding only blank space is not sent", async () => {
+    const user = userEvent.setup();
+    const { onRecord } = renderForm();
+
+    fireEvent.change(getByTestId("value"), { target: { value: "42" } });
+    typeNote("   ");
+    await user.click(getByTestId("submit"));
+
+    await waitFor(() => expect(onRecord).toHaveBeenCalledWith({ kpiId: kpi.id, value: 42, period: today() }));
   });
 });

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
-import { Form, NumberInput, Submit, useForm } from "../Forms";
+import { Form, NumberInput, RichTextArea, Submit, useForm } from "../Forms";
 import { Modal } from "../Modal";
+import { emptyContent, isContentEmpty } from "../RichContent";
+import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import type { SpaceKpisPage } from "./types";
 import { formatShortDate, formatValue, latestEntry } from "./utils";
 
@@ -10,6 +12,7 @@ interface LogUpdateFormProps {
   isOpen: boolean;
   onClose: () => void;
   onRecord: (input: SpaceKpisPage.RecordEntryInput) => Promise<SpaceKpisPage.MutationResult>;
+  richTextHandlers: RichEditorHandlers;
 }
 
 // Local `YYYY-MM-DD` for today, used as the default period so logging is a
@@ -31,7 +34,7 @@ function formatPeriodLabel(period: string): string {
 
 // Single-KPI "Log update" form → calls the `logKpiEntry` mutation.
 // This POC intentionally has NO "update all KPIs at once" batch UI — one KPI at a time.
-export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormProps) {
+export function LogUpdateForm({ kpi, isOpen, onClose, onRecord, richTextHandlers }: LogUpdateFormProps) {
   const [submitError, setSubmitError] = React.useState<string | null>(null);
 
   // The date defaults to today and stays a low-prominence affordance; revealing
@@ -41,9 +44,10 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
   const periodInputRef = React.useRef<HTMLInputElement>(null);
 
   // `value` is stored as a string because NumberInput is text-backed; it is
-  // coerced to a number on submit for the mutation.
-  const form = useForm<{ value: string; period: string }>({
-    fields: { value: "", period: today() },
+  // coerced to a number on submit for the mutation. `note` holds rich text and
+  // is posted as the update's first comment when it isn't left blank.
+  const form = useForm<{ value: string; period: string; note: Record<string, unknown> }>({
+    fields: { value: "", period: today(), note: emptyContent() },
     validate: (addError) => {
       if (form.values.value.trim() === "" || Number.isNaN(Number(form.values.value))) {
         addError("value", "Enter a value");
@@ -56,7 +60,13 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
       if (!kpi) return;
       setSubmitError(null);
 
-      const result = await onRecord({ kpiId: kpi.id, value: Number(form.values.value), period: form.values.period });
+      const note = form.values.note;
+      const result = await onRecord({
+        kpiId: kpi.id,
+        value: Number(form.values.value),
+        period: form.values.period,
+        comment: isContentEmpty(note) ? undefined : note,
+      });
 
       if (result.success) {
         form.actions.reset();
@@ -118,12 +128,13 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
                 className="w-full rounded-lg border border-surface-outline bg-surface-base px-3 py-1.5 text-sm text-content-accent"
                 data-test-id="log-update-period"
               />
-              {form.errors["period"] && (
-                <div className="mt-1 text-sm text-content-error">{form.errors["period"]}</div>
-              )}
+              {form.errors["period"] && <div className="mt-1 text-sm text-content-error">{form.errors["period"]}</div>}
             </div>
           ) : (
-            <div className="flex items-center gap-2 text-sm text-content-dimmed" data-test-id="log-update-period-summary">
+            <div
+              className="flex items-center gap-2 text-sm text-content-dimmed"
+              data-test-id="log-update-period-summary"
+            >
               <span>
                 Logging for{" "}
                 <span className="font-medium text-content-base">
@@ -140,6 +151,18 @@ export function LogUpdateForm({ kpi, isOpen, onClose, onRecord }: LogUpdateFormP
               </button>
             </div>
           )}
+        </div>
+
+        <div className="mt-4">
+          <RichTextArea
+            field="note"
+            label="Note (optional)"
+            placeholder="What's behind this number?"
+            richTextHandlers={richTextHandlers}
+            height="min-h-[80px]"
+            hideToolbar
+          />
+          <p className="mt-1 text-xs text-content-dimmed">Posted as the first comment on this update.</p>
         </div>
 
         {submitError && (

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -2,6 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { useParams } from "react-router";
 
+import { CommentSection } from "../CommentSection";
+import type { CommentSectionItem } from "../CommentSection";
+import { defaultFormattedTimePreferences } from "../utils/storybook/formattedTime";
 import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
 import { useMockSubscriptions } from "../utils/storybook/subscriptions";
 import { SpaceKpisPage } from "./index";
@@ -107,9 +110,7 @@ function Harness(args: HarnessArgs) {
 
     setKpis((prev) =>
       prev.map((kpi) =>
-        kpi.id === input.id
-          ? { ...kpi, name: input.name, unit: input.unit, cadence: input.cadence, champion }
-          : kpi,
+        kpi.id === input.id ? { ...kpi, name: input.name, unit: input.unit, cadence: input.cadence, champion } : kpi,
       ),
     );
 
@@ -154,7 +155,8 @@ function Harness(args: HarnessArgs) {
                 value: input.value,
                 recordedAt: new Date(),
                 recordedBy: mockCurrentUser,
-                commentsCount: 0,
+                // The app posts the note as the update's first comment.
+                commentsCount: input.comment ? 1 : 0,
               };
               return { ...kpi, latestEntry: entry, entries: [...kpi.entries, entry] };
             })()
@@ -184,6 +186,42 @@ function Harness(args: HarnessArgs) {
       error={args.error}
       canManage={args.canManage}
       subscriptions={subscriptions}
+      canComment
+      renderEntryComments={(entry) => <EntryComments key={entry.id} />}
+    />
+  );
+}
+
+// Stands in for the app's KpiEntryComments bridge, which loads the thread for a
+// recorded update and posts to the comments API.
+function EntryComments() {
+  const [items, setItems] = React.useState<CommentSectionItem[]>([]);
+
+  return (
+    <CommentSection
+      items={items}
+      currentUser={{ ...mockCurrentUser, profileLink: mockCurrentUser.profileLink ?? "#" }}
+      canComment
+      commentParentType="kpi_entry"
+      richTextHandlers={createMockRichEditorHandlers()}
+      formattedTimePreferences={defaultFormattedTimePreferences}
+      onAddComment={(content) => {
+        setItems((prev) => [
+          ...prev,
+          {
+            type: "comment",
+            value: {
+              id: `comment-${prev.length + 1}`,
+              content: JSON.stringify(content),
+              author: { ...mockCurrentUser, profileLink: mockCurrentUser.profileLink ?? "#" },
+              insertedAt: new Date().toISOString(),
+              reactions: [],
+            },
+          },
+        ]);
+        return true;
+      }}
+      onEditComment={() => true}
     />
   );
 }
@@ -197,6 +235,25 @@ export const Default: Story = {
 // chart, trend, champion + cadence, and the recorded-updates log.
 export const DetailView: Story = {
   parameters: kpiRoute("kpi-mrr"),
+};
+
+// The comment thread for a recorded update, opened in a slide-in from the
+// "Recorded updates" log. Guards against the composer overflowing the panel.
+export const UpdateComments: Story = {
+  parameters: kpiRoute("kpi-mrr"),
+  play: async ({ canvasElement }) => {
+    const toggle = canvasElement.querySelector<HTMLButtonElement>('[data-test-id^="entry-comments-toggle-"]');
+    toggle?.click();
+  },
+};
+
+// Logging an update, including the optional note that the app posts as the
+// update's first comment.
+export const LogUpdate: Story = {
+  parameters: kpiRoute("kpi-mrr"),
+  play: async ({ canvasElement }) => {
+    canvasElement.querySelector<HTMLButtonElement>('[data-test-id="kpi-detail-log-update"]')?.click();
+  },
 };
 
 // Edge case: a KPI with a single entry can't plot a trend line yet, so its page

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -581,7 +581,13 @@ describe("SpaceKpisPage create & log", () => {
       const [kpi, setKpi] = React.useState(base);
 
       const onRecordEntry = async (input: SpaceKpisPageNS.RecordEntryInput) => {
-        const entry = { id: "new-entry", value: input.value, recordedAt: new Date(), recordedBy: null, commentsCount: 0 };
+        const entry = {
+          id: "new-entry",
+          value: input.value,
+          recordedAt: new Date(),
+          recordedBy: null,
+          commentsCount: 0,
+        };
         setKpi((current) => ({ ...current, entries: [...current.entries, entry] }));
 
         return { success: true };
@@ -611,7 +617,7 @@ describe("SpaceKpisPage create & log", () => {
 });
 
 describe("SpaceKpisPage KPI update comments", () => {
-  test("opens comments on a recorded update", async () => {
+  test("opens comments on a recorded update in a slide-in", async () => {
     const user = userEvent.setup();
     const target = mockKpis[0]!;
     const entry = target.entries[target.entries.length - 1]!;
@@ -623,6 +629,49 @@ describe("SpaceKpisPage KPI update comments", () => {
     });
 
     await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
-    expect(await findByTestId("entry-comments-body")).toHaveTextContent("Write a comment");
+
+    const slideIn = await findByTestId("entry-comments-slide-in");
+    expect(slideIn).toHaveTextContent("Write a comment");
+
+    const row = document.querySelector(`[data-test-id="entry-row-${entry.id}"]`);
+    expect(row).not.toHaveTextContent("Write a comment");
+  });
+
+  // Opening the thread hides the table behind it, so the panel has to say which
+  // update is being discussed: its value, who logged it, and when.
+  test("names the update being commented on, with who logged it and when", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({ selectedKpi: target, canComment: true, renderEntryComments: () => null });
+
+    await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
+
+    const header = await findByTestId("entry-comments-header");
+    expect(header).toHaveTextContent(target.name);
+    expect(header).toHaveTextContent(formatValue(entry.value, target.unit));
+    expect(header).toHaveTextContent(entry.recordedBy!.fullName);
+    expect(header).toHaveTextContent(formatShortDate(entry.recordedAt));
+  });
+
+  test("closes the update comments slide-in", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({
+      selectedKpi: target,
+      canComment: true,
+      renderEntryComments: () => <div data-test-id="entry-comments-body">Write a comment</div>,
+    });
+
+    await user.click(await findByTestId(`entry-comments-toggle-${entry.id}`));
+    await findByTestId("entry-comments-slide-in");
+    await user.click(await findByTestId("slide-in-close-button"));
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-test-id="entry-comments-slide-in"]')).not.toBeInTheDocument();
+    });
   });
 });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -105,6 +105,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         isOpen={logKpiId !== null}
         onClose={() => setLogKpiId(null)}
         onRecord={props.onRecordEntry}
+        richTextHandlers={props.richTextHandlers}
       />
     </PageNew>
   );
@@ -237,9 +238,7 @@ function KpisContent(props: KpisContentProps) {
     );
   }
 
-  return (
-    <KpiList kpis={props.kpis} canManage={props.canManage} onNewKpi={props.onOpenNew} />
-  );
+  return <KpiList kpis={props.kpis} canManage={props.canManage} onNewKpi={props.onOpenNew} />;
 }
 
 function LoadingState() {

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -88,6 +88,10 @@ export namespace SpaceKpisPage {
     kpiId: string;
     value: number;
     period: string;
+
+    // Optional note explaining the value, posted as the update's first comment.
+    // Absent when the author left the note blank.
+    comment?: Record<string, unknown>;
   }
 
   export type MutationResult = { success: boolean; id?: string; error?: string };
@@ -125,7 +129,7 @@ export namespace SpaceKpisPage {
     richTextHandlers: RichEditorHandlers;
 
     // Comments on a recorded update. The app supplies the comment thread so
-    // TurboUI stays free of API calls; omit it in stories that only show the table.
+    // TurboUI stays free of API calls; opening a row shows it in a slide-in.
     renderEntryComments?: (entry: KpiEntry) => ReactNode;
     canComment?: boolean;
 


### PR DESCRIPTION
Stacked on #5134 (base: `feat/kpi-entry-comments`).

## Summary

- A recorded update now opens its comment thread in a slide-in panel instead of expanding inside the table row, which had no room for the comment composer (its toolbar was clipped). The panel keeps a 680px floor so the composer fits, and goes full width on narrow screens.
- The panel header names what you are commenting on: the KPI, the recorded value as the headline, and who logged it and when.
- Logging an update takes an optional note, posted as the update's first comment, so a number can arrive with its explanation. Implemented with `Forms.RichTextArea` with the toolbar hidden, so mentions still work while the field stays compact in the small modal.
- The comment count in "Recorded updates" now updates as soon as a comment is posted or deleted, instead of waiting for the next page load.

TurboUI primitives reused: `SlideIn`, `Modal`, `Forms.RichTextArea`, `Forms.NumberInput`, `Forms.Submit`, `Avatar`, `CommentSection`. No new hand-rolled controls.

Note on the bridge: the value is recorded before the note is posted, so a failed note shows an error toast rather than reporting the whole update as failed — reporting failure would invite logging the same value twice.

## UI

Both screens have Storybook stories under `Pages/SpaceKpisPage` for review:

- `UpdateComments` — the thread in the slide-in, headed by "Monthly Recurring Revenue / 1.4M USD / Logged by Martin Smith on Jul 29".
- `LogUpdate` — the log-update modal with the "Note (optional)" field and the hint that it is posted as the first comment.

## Test plan

- [x] `turboui` Jest: new coverage for the panel header content (KPI name, value, who and when) and for the note being omitted when left blank or whitespace-only.
- [x] Feature test `app/test/features/kpi_comments_test.exs`: commenting bumps the count in the log while the panel is open; logging an update with a note finds that note as the first comment on the new update.
- [x] Storybook stories verified in a browser at several viewport widths (no clipping).
- [x] `tsc` clean for `turboui` and `app`.
