### PR TITLE
feat: Lead the KPI page with its name and put the current value on the chart

### DIFF
--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -30,9 +30,10 @@ interface KpiDetailProps {
   subscriptions?: SpaceKpisPage.Props["subscriptions"];
 }
 
-// The KPI name, back navigation and the "Log update" action live in the shared
-// page header (see index.tsx). The latest value is in the sidebar last-update
-// card, so the main column is the history chart and the recorded-updates log.
+// The KPI's name leads its page, with the current reading beside it, so the two
+// questions a KPI answers — which metric is this, and where does it stand — are
+// answered before the description, chart and recorded-updates log below.
+// Back navigation and the "Log update" action live in the page header (index.tsx).
 export function KpiDetail({
   kpi,
   fields,
@@ -58,39 +59,43 @@ export function KpiDetail({
   };
 
   return (
-    <div className="sm:grid sm:grid-cols-12 sm:gap-8" data-test-id="kpi-detail">
-      <div className="space-y-12 sm:col-span-8">
-        <PageDescription
-          description={description}
-          onDescriptionChange={saveDescription}
-          richTextHandlers={richTextHandlers}
-          label="Description"
-          placeholder="Describe this KPI..."
-          zeroStatePlaceholder="Add a description..."
-          testId="kpi-description"
-          emptyTestId="kpi-description-empty"
-          localDraftKey={`kpi:${kpi.id}:description`}
-          canEdit={canManage}
-        />
+    <div className="sm:grid sm:grid-cols-12" data-test-id="kpi-detail">
+      <div className="space-y-10 sm:col-span-8 sm:pr-8">
+        <div className="space-y-6">
+          <Heading fields={fields} canManage={canManage} />
 
-        <div>
-          <div className="rounded-lg border border-stroke-base bg-surface-base p-4">
-            <h2 className="mb-3 text-sm font-bold text-content-accent">History</h2>
-            <KpiLineChart entries={kpi.entries} unit={fields.unit} />
-          </div>
-
-          <EntriesTable
-            entries={kpi.entries}
-            unit={fields.unit}
-            kpiName={fields.name}
-            canComment={canComment}
-            renderEntryComments={renderEntryComments}
+          <PageDescription
+            description={description}
+            onDescriptionChange={saveDescription}
+            richTextHandlers={richTextHandlers}
+            label="Description"
+            placeholder="Describe this KPI..."
+            zeroStatePlaceholder="Add a description..."
+            testId="kpi-description"
+            emptyTestId="kpi-description-empty"
+            localDraftKey={`kpi:${kpi.id}:description`}
+            canEdit={canManage}
           />
         </div>
+
+        <div
+          className="space-y-4 rounded-lg border border-stroke-base bg-surface-base px-5 pb-3 pt-4"
+          data-test-id="kpi-history"
+        >
+          <CurrentValue kpi={kpi} unit={fields.unit} />
+          <KpiLineChart entries={kpi.entries} unit={fields.unit} />
+        </div>
+
+        <EntriesTable
+          entries={kpi.entries}
+          unit={fields.unit}
+          kpiName={fields.name}
+          canComment={canComment}
+          renderEntryComments={renderEntryComments}
+        />
       </div>
 
       <KpiSidebar
-        kpi={kpi}
         fields={fields}
         canManage={canManage}
         championSearch={championSearch}
@@ -101,15 +106,62 @@ export function KpiDetail({
   );
 }
 
+// Section heading matching the description's, so the page reads as one column of
+// evenly weighted sections rather than a stack of differently styled cards.
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h2 className="font-bold">{title}</h2>
+      <div className="mt-2">{children}</div>
+    </div>
+  );
+}
+
+// A KPI is renamed where its name is read, the way a task is renamed on its own
+// page. The editable field cannot live inside a heading element, so the role is
+// set on its container to keep the page's heading.
+function Heading({ fields, canManage }: { fields: KpiFields; canManage: boolean }) {
+  return (
+    <div role="heading" aria-level={1} className="min-w-0" data-test-id="kpi-heading">
+      <TextField
+        className="text-2xl font-bold leading-tight text-content-accent"
+        text={fields.name}
+        onChange={(name) => fields.update({ name })}
+        readonly={!canManage}
+        trimBeforeSave
+        testId="kpi-name"
+      />
+    </div>
+  );
+}
+
+// The KPI's latest reading, leading the chart it is the newest point of, with
+// the change since the entry before it and the date it was recorded. Who
+// recorded it is in the recorded-updates log. With no entries there is no
+// reading to show and the chart says so instead.
+function CurrentValue({ kpi, unit }: { kpi: SpaceKpisPage.Kpi; unit: string }) {
+  const latest = latestEntry(kpi);
+  if (!latest) return null;
+
+  return (
+    <div data-test-id="kpi-current-value">
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold leading-none text-content-accent">{formatValue(latest.value, unit)}</span>
+        <TrendIndicator delta={latestTrend(kpi)} variant="badge" />
+      </div>
+
+      <div className="mt-1.5 text-xs leading-none text-content-dimmed">as of {formatShortDate(latest.recordedAt)}</div>
+    </div>
+  );
+}
+
 function KpiSidebar({
-  kpi,
   fields,
   canManage,
   championSearch,
   onDelete,
   subscriptions,
 }: {
-  kpi: SpaceKpisPage.Kpi;
   fields: KpiFields;
   canManage: boolean;
   championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
@@ -120,8 +172,6 @@ function KpiSidebar({
 
   return (
     <aside className="mt-8 space-y-6 sm:col-span-4 sm:mt-0 sm:pl-8" data-test-id="kpi-sidebar">
-      <LastUpdate kpi={kpi} unit={fields.unit} canManage={canManage} />
-
       <SidebarSection title="Champion">
         {canManage ? (
           <PersonField
@@ -202,49 +252,6 @@ function Actions({ canManage, onDelete }: { canManage: boolean; onDelete: () => 
   return (
     <SidebarSection title="Actions">
       <ActionList actions={actions} />
-    </SidebarSection>
-  );
-}
-
-// The KPI's current reading, and the only place the latest value appears on the
-// detail page. The value leads, with the change since the previous entry beside
-// it; when it was recorded and by whom are supporting details underneath.
-function LastUpdate({ kpi, unit, canManage }: { kpi: SpaceKpisPage.Kpi; unit: string; canManage: boolean }) {
-  const latest = latestEntry(kpi);
-  const trend = latestTrend(kpi);
-
-  if (!latest) {
-    return (
-      <SidebarSection title="Last update">
-        <p className="text-sm text-content-dimmed" data-test-id="kpi-last-update-empty">
-          {canManage
-            ? "No updates yet. Log the first value to start tracking."
-            : "No updates yet. Values appear here as they are logged."}
-        </p>
-      </SidebarSection>
-    );
-  }
-
-  return (
-    <SidebarSection title="Last update">
-      <div data-test-id="kpi-last-update">
-        <div className="flex items-center gap-2">
-          <div className="text-3xl font-bold leading-none text-content-accent">{formatValue(latest.value, unit)}</div>
-          <TrendIndicator delta={trend} />
-        </div>
-
-        <div className="mt-2 flex items-center gap-1.5 text-xs text-content-dimmed">
-          <span>{formatShortDate(latest.recordedAt)}</span>
-
-          {latest.recordedBy && (
-            <>
-              <span aria-hidden="true">·</span>
-              <Avatar person={latest.recordedBy} size={16} />
-              <span>{latest.recordedBy.fullName.split(" ")[0]}</span>
-            </>
-          )}
-        </div>
-      </div>
     </SidebarSection>
   );
 }
@@ -350,8 +357,7 @@ function EntriesTable({
   const rows = [...entries].reverse();
 
   return (
-    <div className="mt-6">
-      <h2 className="mb-3 text-sm font-bold text-content-accent">Recorded updates</h2>
+    <Section title="Recorded updates">
       <div className="overflow-hidden rounded-lg border border-stroke-base">
         <table className="w-full text-sm">
           <thead>
@@ -371,11 +377,13 @@ function EntriesTable({
               return (
                 <tr
                   key={entry.id}
-                  className="border-b border-stroke-dimmed last:border-b-0"
+                  className="border-b border-stroke-dimmed last:border-b-0 hover:bg-surface-highlight"
                   data-test-id={`entry-row-${entry.id}`}
                 >
-                  <td className="px-4 py-2 text-content-base">{formatShortDate(entry.recordedAt)}</td>
-                  <td className="px-4 py-2">
+                  <td className="whitespace-nowrap px-4 py-2.5 text-content-base">
+                    {formatShortDate(entry.recordedAt)}
+                  </td>
+                  <td className="px-4 py-2.5">
                     {entry.recordedBy ? (
                       <div className="flex items-center gap-2">
                         <Avatar person={entry.recordedBy} size="tiny" />
@@ -385,10 +393,10 @@ function EntriesTable({
                       <span className="text-content-subtle">Unknown</span>
                     )}
                   </td>
-                  <td className="px-4 py-2 text-right font-medium text-content-accent">
+                  <td className="whitespace-nowrap px-4 py-2.5 text-right font-medium text-content-accent">
                     {formatValue(entry.value, unit)}
                   </td>
-                  <td className="px-4 py-2 text-right">
+                  <td className="px-4 py-2.5 text-right">
                     {canOpenComments ? (
                       <button
                         type="button"
@@ -396,9 +404,10 @@ function EntriesTable({
                         onClick={() => setOpenEntryId(isOpen ? null : entry.id)}
                         data-test-id={`entry-comments-toggle-${entry.id}`}
                         aria-expanded={isOpen}
+                        aria-label={commentsCount > 0 ? `${commentsCount} comments` : "Comment on this update"}
                       >
                         <IconMessage size={14} />
-                        {commentsCount > 0 ? commentsCount : "Comment"}
+                        {commentsCount > 0 ? commentsCount : null}
                       </button>
                     ) : commentsCount > 0 ? (
                       <span className="inline-flex items-center gap-1.5 text-xs text-content-dimmed">
@@ -427,7 +436,7 @@ function EntriesTable({
           </div>
         )}
       </SlideIn>
-    </div>
+    </Section>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/KpiLineChart.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.tsx
@@ -21,8 +21,9 @@ export function KpiLineChart({ entries, unit, height = 220 }: KpiLineChartProps)
     return (
       <Placeholder
         title="No data yet"
-        hint="Log an update to see values plotted over time."
+        hint="Values appear here once they are logged."
         testId="kpi-line-chart-empty"
+        height={height}
       />
     );
   }
@@ -31,8 +32,9 @@ export function KpiLineChart({ entries, unit, height = 220 }: KpiLineChartProps)
     return (
       <Placeholder
         title="Only one update so far"
-        hint="Log another update to start plotting a trend line."
+        hint="A second update is needed to plot a trend line."
         testId="kpi-line-chart-single"
+        height={height}
       />
     );
   }
@@ -254,9 +256,13 @@ function Tooltip({ point, unit }: { point: ChartPoint; unit: string }) {
   );
 }
 
-function Placeholder({ title, hint, testId }: { title: string; hint: string; testId: string }) {
+function Placeholder({ title, hint, testId, height }: { title: string; hint: string; testId: string; height: number }) {
   return (
-    <div className="flex flex-col items-center justify-center px-6 py-12 text-center" data-test-id={testId}>
+    <div
+      className="flex flex-col items-center justify-center px-6 text-center"
+      style={{ height }}
+      data-test-id={testId}
+    >
       <div className="text-sm font-medium text-content-dimmed">{title}</div>
       <div className="mt-1 text-xs text-content-subtle">{hint}</div>
     </div>

--- a/turboui/src/SpaceKpisPage/KpiLineChart.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.tsx
@@ -15,12 +15,26 @@ interface KpiLineChartProps {
 //
 // Deliberately dependency-free so it renders identically in Storybook and the app.
 export function KpiLineChart({ entries, unit, height = 220 }: KpiLineChartProps) {
+  // Until there are two points to join there is nothing to plot, and the current
+  // value is already on the page, so these states only say what is missing.
   if (entries.length === 0) {
-    return <EmptyChart height={height} />;
+    return (
+      <Placeholder
+        title="No data yet"
+        hint="Log an update to see values plotted over time."
+        testId="kpi-line-chart-empty"
+      />
+    );
   }
 
   if (entries.length === 1) {
-    return <SinglePointChart entry={entries[0]!} unit={unit} height={height} />;
+    return (
+      <Placeholder
+        title="Only one update so far"
+        hint="Log another update to start plotting a trend line."
+        testId="kpi-line-chart-single"
+      />
+    );
   }
 
   return <MultiPointChart entries={entries} unit={unit} height={height} />;
@@ -28,6 +42,20 @@ export function KpiLineChart({ entries, unit, height = 220 }: KpiLineChartProps)
 
 const PADDING = { top: 16, right: 16, bottom: 28, left: 44 };
 const VIEW_WIDTH = 640;
+
+// Steps a reader recognises as round, so the gridlines are labelled 1.5M / 750K
+// rather than the raw 1.47M / 734.9K the data happens to reach. Halves of these
+// are round too, which matters because the middle gridline is labelled as well.
+const AXIS_STEPS = [1, 1.2, 1.4, 1.6, 1.8, 2, 2.5, 3, 4, 5, 6, 8, 10];
+
+function roundedAxisMax(value: number): number {
+  if (value <= 0) return 1;
+
+  const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
+  const step = AXIS_STEPS.find((candidate) => value <= candidate * magnitude) ?? 10;
+
+  return step * magnitude;
+}
 
 function MultiPointChart({ entries, unit, height }: Required<KpiLineChartProps>) {
   const [hoveredIndex, setHoveredIndex] = React.useState<number | null>(null);
@@ -42,7 +70,7 @@ function MultiPointChart({ entries, unit, height }: Required<KpiLineChartProps>)
   // headroom above the largest value so the line is not glued to the top edge.
   const span = max - min || Math.abs(max) || 1;
   const yMin = 0;
-  const yMax = max + span * 0.15;
+  const yMax = roundedAxisMax(max + span * 0.15);
 
   const innerWidth = VIEW_WIDTH - PADDING.left - PADDING.right;
   const innerHeight = height - PADDING.top - PADDING.bottom;
@@ -226,32 +254,11 @@ function Tooltip({ point, unit }: { point: ChartPoint; unit: string }) {
   );
 }
 
-function SinglePointChart({ entry, unit, height }: { entry: SpaceKpisPage.KpiEntry; unit: string; height: number }) {
+function Placeholder({ title, hint, testId }: { title: string; hint: string; testId: string }) {
   return (
-    <div
-      className="flex flex-col items-center justify-center rounded-lg border border-dashed border-surface-outline bg-surface-dimmed text-center"
-      style={{ height }}
-      data-test-id="kpi-line-chart-single"
-    >
-      <div className="text-2xl font-bold text-content-accent">
-        {formatNumber(entry.value)}
-        {unit ? <span className="ml-1 text-base font-medium text-content-dimmed">{unit}</span> : null}
-      </div>
-      <div className="mt-1 text-sm text-content-dimmed">Recorded {formatShortDate(entry.recordedAt)}</div>
-      <div className="mt-3 text-xs text-content-subtle">Log another update to start plotting a trend line.</div>
-    </div>
-  );
-}
-
-function EmptyChart({ height }: { height: number }) {
-  return (
-    <div
-      className="flex flex-col items-center justify-center rounded-lg border border-dashed border-surface-outline bg-surface-dimmed text-center"
-      style={{ height }}
-      data-test-id="kpi-line-chart-empty"
-    >
-      <div className="text-sm font-medium text-content-dimmed">No data yet</div>
-      <div className="mt-1 text-xs text-content-subtle">Log an update to see values plotted over time.</div>
+    <div className="flex flex-col items-center justify-center px-6 py-12 text-center" data-test-id={testId}>
+      <div className="text-sm font-medium text-content-dimmed">{title}</div>
+      <div className="mt-1 text-xs text-content-subtle">{hint}</div>
     </div>
   );
 }

--- a/turboui/src/SpaceKpisPage/TrendIndicator.tsx
+++ b/turboui/src/SpaceKpisPage/TrendIndicator.tsx
@@ -1,30 +1,45 @@
 import React from "react";
 
 import { IconChevronDown, IconChevronUp, IconMinus } from "../icons";
+import classNames from "../utils/classnames";
 import { formatNumber } from "./utils";
 
-// Compact up/down/flat badge showing the change since the previous entry.
-// `delta === null` means we cannot compute a trend yet (fewer than 2 entries).
-export function TrendIndicator({ delta }: { delta: number | null }) {
+// Compact up/down/flat change since the previous entry. `delta === null` means we
+// cannot compute a trend yet (fewer than 2 entries).
+//
+// The plain variant sits in dense contexts such as list rows; the badge variant
+// carries a tinted pill so it holds its own next to a KPI's headline value.
+export function TrendIndicator({ delta, variant = "plain" }: { delta: number | null; variant?: "plain" | "badge" }) {
   if (delta === null) return null;
+
+  const isBadge = variant === "badge";
 
   if (delta === 0) {
     return (
-      <span className="inline-flex items-center gap-0.5 text-xs text-content-dimmed" title="No change">
+      <span
+        className={classNames("inline-flex items-center gap-0.5 text-xs text-content-dimmed", {
+          "rounded-full bg-surface-dimmed px-1.5 py-0.5": isBadge,
+        })}
+        title="No change"
+      >
         <IconMinus size={12} />
       </span>
     );
   }
 
   const isUp = delta > 0;
-  const className = isUp ? "text-callout-success-content" : "text-callout-error-content";
   const Icon = isUp ? IconChevronUp : IconChevronDown;
 
+  const className = classNames("inline-flex items-center gap-0.5 text-xs font-medium", {
+    "text-callout-success-content": isUp,
+    "text-callout-error-content": !isUp,
+    "rounded-full px-1.5 py-0.5": isBadge,
+    "bg-callout-success-bg": isBadge && isUp,
+    "bg-callout-error-bg": isBadge && !isUp,
+  });
+
   return (
-    <span
-      className={`inline-flex items-center gap-0.5 text-xs font-medium ${className}`}
-      title={`${isUp ? "+" : "−"}${formatNumber(Math.abs(delta))} vs previous`}
-    >
+    <span className={className} title={`${isUp ? "+" : "−"}${formatNumber(Math.abs(delta))} vs previous`}>
       <Icon size={12} />
       {formatNumber(Math.abs(delta))}
     </span>

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -19,9 +19,10 @@ import { mockChampionSearch, mockCurrentUser, mockKpis, mockKpisLink, mockPeople
 //     title) as the other space tools (Work Map, Tasks)
 //   - a list view: name, unit, champion, an inline history sparkline,
 //     latest value + trend
-//   - a detail view: line chart of history, last update + champion + cadence, "Log update"
+//   - a detail view: name + current value, line chart of history, champion +
+//     cadence, "Log update"
 //   - a "New KPI" form (name, unit, cadence, champion picker)
-//   - editing a KPI in place on its own page: its name in the page title, its
+//   - editing a KPI in place on its own page: its name above the description, its
 //     unit, cadence and champion in the sidebar, and a sidebar Actions section
 //     offering Copy URL and Delete (with a destructive confirmation)
 //   - single-KPI "Log update" only — NO "update all KPIs at once" batch UI

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -111,19 +111,25 @@ describe("SpaceKpisPage layout", () => {
     expect(row).toHaveTextContent(formatNumber(target.latestEntry!.value));
   });
 
-  test("opening a KPI moves its name into the header and swaps the primary action to 'Log update'", () => {
+  // The KPI's name leads its own page rather than sitting in the compact tool
+  // header, so the page reads name -> description -> history.
+  test("opening a KPI leads the page with its name and swaps the primary action to 'Log update'", () => {
     const target = mockKpis[0]!;
     const { container } = renderPage({ selectedKpi: target });
 
-    // KPI name becomes the header title...
     expect(screen.getByRole("heading", { name: target.name })).toBeInTheDocument();
 
-    // ...and "KPIs" becomes a breadcrumb linking back to the list.
-    const backCrumb = container.querySelector('[data-test-id="kpis-breadcrumb"]');
-    expect(backCrumb).toHaveAttribute("href", kpisLink);
+    const heading = container.querySelector('[data-test-id="kpi-heading"]')!;
+    const description = container.querySelector('[data-test-id="kpi-description"]')!;
+    expect(heading.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    // The header keeps only the trail back to the list, not the name.
+    const header = container.querySelector<HTMLElement>("header")!;
+    expect(header).not.toHaveTextContent(target.name);
+    expect(header.querySelector('[data-test-id="kpis-breadcrumb"]')).toHaveAttribute("href", kpisLink);
 
     // The header action is now "Log update", not "New KPI".
-    expect(container.querySelector('[data-test-id="kpi-detail-log-update"]')).toBeInTheDocument();
+    expect(header.querySelector('[data-test-id="kpi-detail-log-update"]')).toBeInTheDocument();
     expect(container.querySelector('[data-test-id="new-kpi"]')).not.toBeInTheDocument();
   });
 
@@ -133,7 +139,6 @@ describe("SpaceKpisPage layout", () => {
     const sidebar = container.querySelector<HTMLElement>('[data-test-id="kpi-sidebar"]')!;
 
     expect(sidebar).toBeInTheDocument();
-    expect(within(sidebar).getByText("Last update")).toBeInTheDocument();
     expect(within(sidebar).getByText("Champion")).toBeInTheDocument();
     expect(within(sidebar).getByText(target.champion!.fullName)).toBeInTheDocument();
     expect(within(sidebar).getByText("Cadence")).toBeInTheDocument();
@@ -186,60 +191,50 @@ describe("SpaceKpisPage layout", () => {
     expect(screen.queryByText("Add a description...")).not.toBeInTheDocument();
   });
 
-  // Mirrors a project's last check-in: the sidebar answers what was recorded,
-  // when, and by whom. The main column used to repeat the value as a headline;
-  // it must not, now that the sidebar card is the source of truth.
-  test("shows the last update in the sidebar with its value, date and who recorded it", () => {
+  // The latest value is the newest point of the history chart, so it leads that
+  // chart instead of being repeated elsewhere on the page. When it was recorded
+  // is shown with it; by whom is left to the recorded-updates log.
+  test("shows the current value at the head of the history chart", () => {
     const target = mockKpis[0]!;
     const latest = target.entries[target.entries.length - 1]!;
     const { container } = renderPage({ selectedKpi: target });
-    const card = container.querySelector<HTMLElement>('[data-test-id="kpi-last-update"]')!;
+    const history = container.querySelector<HTMLElement>('[data-test-id="kpi-history"]')!;
+    const value = history.querySelector<HTMLElement>('[data-test-id="kpi-current-value"]')!;
 
-    expect(card).toBeInTheDocument();
-    expect(within(card).getByText(formatShortDate(latest.recordedAt))).toBeInTheDocument();
-    expect(within(card).getByText(formatValue(latest.value, target.unit))).toBeInTheDocument();
-    expect(within(card).getByText(latest.recordedBy!.fullName.split(" ")[0]!)).toBeInTheDocument();
+    expect(within(value).getByText(formatValue(latest.value, target.unit))).toBeInTheDocument();
+    expect(value).toHaveTextContent(formatShortDate(latest.recordedAt));
   });
 
-  // The value alone doesn't say whether the KPI is moving, so the card carries
-  // the signed change against the entry before it.
-  test("shows the change against the previous entry beside the last value", () => {
+  // The value alone doesn't say whether the KPI is moving, so it carries the
+  // signed change against the entry before it.
+  test("shows the change against the previous entry beside the current value", () => {
     const target = mockKpis[0]!;
     const entries = target.entries;
     const delta = entries[entries.length - 1]!.value - entries[entries.length - 2]!.value;
     const { container } = renderPage({ selectedKpi: target });
-    const card = container.querySelector<HTMLElement>('[data-test-id="kpi-last-update"]')!;
+    const value = container.querySelector<HTMLElement>('[data-test-id="kpi-current-value"]')!;
 
-    expect(within(card).getByText(formatNumber(Math.abs(delta)))).toBeInTheDocument();
-    expect(within(card).getByTitle(`+${formatNumber(Math.abs(delta))} vs previous`)).toBeInTheDocument();
+    expect(within(value).getByText(formatNumber(Math.abs(delta)))).toBeInTheDocument();
+    expect(within(value).getByTitle(`+${formatNumber(Math.abs(delta))} vs previous`)).toBeInTheDocument();
   });
 
   test("shows no change indicator when a KPI has only one update", () => {
     const target = mockKpis.find((kpi) => kpi.entries.length === 1)!;
     const { container } = renderPage({ selectedKpi: target });
-    const card = container.querySelector<HTMLElement>('[data-test-id="kpi-last-update"]')!;
+    const value = container.querySelector<HTMLElement>('[data-test-id="kpi-current-value"]')!;
 
-    expect(within(card).getByText(formatValue(target.entries[0]!.value, target.unit))).toBeInTheDocument();
-    expect(card.querySelector("[title$='vs previous']")).not.toBeInTheDocument();
+    expect(within(value).getByText(formatValue(target.entries[0]!.value, target.unit))).toBeInTheDocument();
+    expect(value.querySelector("[title$='vs previous']")).not.toBeInTheDocument();
   });
 
-  test("prompts editors to log the first value when a KPI has no updates", () => {
+  // With nothing logged there is no reading to show, so the chart's empty state
+  // carries the message on its own rather than pairing it with a blank value.
+  test("shows no value at all when nothing has been logged", () => {
     const target = mockKpis.find((kpi) => kpi.entries.length === 0)!;
     const { container } = renderPage({ selectedKpi: target });
 
-    expect(container.querySelector('[data-test-id="kpi-last-update"]')).not.toBeInTheDocument();
-    expect(container.querySelector('[data-test-id="kpi-last-update-empty"]')).toHaveTextContent(
-      "Log the first value to start tracking",
-    );
-  });
-
-  test("read-only viewers are not prompted to log a value for a KPI with no updates", () => {
-    const target = mockKpis.find((kpi) => kpi.entries.length === 0)!;
-    const { container } = renderPage({ selectedKpi: target, canManage: false });
-
-    const empty = container.querySelector('[data-test-id="kpi-last-update-empty"]');
-    expect(empty).toBeInTheDocument();
-    expect(empty).not.toHaveTextContent("Log the first value");
+    expect(container.querySelector('[data-test-id="kpi-current-value"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-test-id="kpi-line-chart-empty"]')).toBeInTheDocument();
   });
 
   test("editors can change the champion from the sidebar", async () => {
@@ -396,7 +391,7 @@ describe("SpaceKpisPage list latest value", () => {
 });
 
 // These tests cover the answer to "how can I edit or delete a KPI?": its fields
-// are edited in place on its own page — the name in the title, the unit,
+// are edited in place on its own page — the name in the page heading, the unit,
 // cadence and champion in the sidebar — and deleting it is a sidebar action,
 // the way a task page works. Nothing is tucked away behind an overflow menu.
 describe("SpaceKpisPage edit & delete", () => {
@@ -415,7 +410,7 @@ describe("SpaceKpisPage edit & delete", () => {
     });
   }
 
-  test("editors can rename a KPI from the page title", async () => {
+  test("editors can rename a KPI from the page heading", async () => {
     const target = mockKpis[0]!;
     const onEditKpi = jest.fn().mockResolvedValue({ success: true, id: target.id });
 
@@ -441,7 +436,7 @@ describe("SpaceKpisPage edit & delete", () => {
 
   // A rejected edit must not leave the page showing a value the server does not
   // have, so the field goes back to what it was.
-  test("a rejected rename reverts the title", async () => {
+  test("a rejected rename reverts the heading", async () => {
     const target = mockKpis[0]!;
     const onEditKpi = jest.fn().mockResolvedValue({ success: false, error: "Name is already taken" });
 

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -4,7 +4,6 @@ import { ErrorCallout } from "../Callouts";
 import { BlackLink } from "../Link";
 import { PageNew } from "../Page";
 import type { Navigation } from "../Page/Navigation";
-import { TextField } from "../TextField";
 import { IconChartColumn, IconChevronRight } from "../icons";
 
 import { DeleteKpiModal } from "./DeleteKpiModal";
@@ -30,8 +29,8 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   // entries the list omits) arrives with the route.
   const selectedKpi = props.selectedKpi ?? null;
 
-  // The open KPI's fields are edited in place — in the page title and the
-  // sidebar — so they are held here and shared by both.
+  // The open KPI's fields are edited in place — its name above the description,
+  // the rest in the sidebar — so they are held here and shared by both.
   const openKpi = useKpiFields(selectedKpi, props.onEditKpi);
 
   // An update is logged from the open KPI's page, whose permalink may be opened
@@ -68,8 +67,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
       <PageHeader
         navigation={props.navigation}
         kpisLink={props.kpisLink}
-        openKpi={openKpi}
-        canManage={canManage}
+        isKpiOpen={openKpi !== null}
         primaryAction={primaryAction}
       />
 
@@ -120,85 +118,90 @@ interface HeaderAction {
 interface PageHeaderProps {
   navigation: Navigation.Item[];
   kpisLink: string;
-  openKpi: KpiFields | null;
-  canManage: boolean;
+  isKpiOpen: boolean;
   primaryAction: HeaderAction | null;
 }
 
 // Breadcrumb + title header shared visual language with the Work Map / Tasks
-// tools. When a KPI is open, the tool title becomes a breadcrumb back to the
-// list and the KPI name is shown as the current crumb.
+// tools. On a KPI's own page the name leads the content instead (see
+// KpiDetail), so the header collapses to the trail back to the list with the
+// page action beside it.
 function PageHeader(props: PageHeaderProps) {
+  if (props.isKpiOpen) {
+    return (
+      <header className="border-b border-surface-outline px-4 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <Breadcrumbs navigation={props.navigation} kpisLink={props.kpisLink} isKpiOpen />
+          <PrimaryAction action={props.primaryAction} />
+        </div>
+      </header>
+    );
+  }
+
   return (
     <header className="border-b border-surface-outline px-4 py-3">
-      <nav className="mt-1 flex items-center gap-0.5" aria-label="Breadcrumb">
-        {props.navigation.map((item, index) => (
-          <React.Fragment key={index}>
-            <BlackLink to={item.to} className="text-xs leading-snug text-content-dimmed" underline="hover">
-              {item.label}
-            </BlackLink>
-            <IconChevronRight size={10} className="text-content-dimmed" />
-          </React.Fragment>
-        ))}
-
-        {props.openKpi ? (
-          <BlackLink
-            to={props.kpisLink}
-            className="text-xs leading-snug text-content-dimmed"
-            underline="hover"
-            testId="kpis-breadcrumb"
-          >
-            KPIs
-          </BlackLink>
-        ) : (
-          <span className="text-xs leading-snug text-content-dimmed">KPIs</span>
-        )}
-      </nav>
+      <Breadcrumbs navigation={props.navigation} kpisLink={props.kpisLink} isKpiOpen={false} />
 
       <div className="mt-1 flex items-center justify-between gap-4">
         <div className="flex min-w-0 items-center gap-2">
           <IconChartColumn size={20} className="shrink-0 text-content-dimmed" />
-          <Title openKpi={props.openKpi} canManage={props.canManage} />
+          <h1 className="text-sm font-bold text-content-accent sm:text-base">KPIs</h1>
         </div>
 
-        <div className="flex items-center gap-1.5">
-          {props.primaryAction && (
-            <button
-              type="button"
-              className="rounded-lg bg-brand-1 px-3 py-1.5 text-sm font-medium text-white-1 hover:bg-blue-600"
-              onClick={props.primaryAction.onClick}
-              data-test-id={props.primaryAction.testId}
-            >
-              {props.primaryAction.label}
-            </button>
-          )}
-        </div>
+        <PrimaryAction action={props.primaryAction} />
       </div>
     </header>
   );
 }
 
-const titleClass = "text-sm font-bold text-content-accent sm:text-base";
+function Breadcrumbs({
+  navigation,
+  kpisLink,
+  isKpiOpen,
+}: {
+  navigation: Navigation.Item[];
+  kpisLink: string;
+  isKpiOpen: boolean;
+}) {
+  return (
+    <nav className="mt-1 flex min-w-0 items-center gap-0.5" aria-label="Breadcrumb">
+      {navigation.map((item, index) => (
+        <React.Fragment key={index}>
+          <BlackLink to={item.to} className="text-xs leading-snug text-content-dimmed" underline="hover">
+            {item.label}
+          </BlackLink>
+          <IconChevronRight size={10} className="text-content-dimmed" />
+        </React.Fragment>
+      ))}
 
-// A KPI is renamed where its name is read — in the page title — the way a task
-// is renamed on its own page. The editable field cannot live inside a heading
-// element, so the role is set on its container to keep the page's heading.
-function Title({ openKpi, canManage }: { openKpi: KpiFields | null; canManage: boolean }) {
-  if (!openKpi) {
-    return <h1 className={titleClass}>KPIs</h1>;
-  }
+      {isKpiOpen ? (
+        <BlackLink
+          to={kpisLink}
+          className="text-xs leading-snug text-content-dimmed"
+          underline="hover"
+          testId="kpis-breadcrumb"
+        >
+          KPIs
+        </BlackLink>
+      ) : (
+        <span className="text-xs leading-snug text-content-dimmed">KPIs</span>
+      )}
+    </nav>
+  );
+}
+
+function PrimaryAction({ action }: { action: HeaderAction | null }) {
+  if (!action) return null;
 
   return (
-    <div role="heading" aria-level={1} className="min-w-0">
-      <TextField
-        className={titleClass}
-        text={openKpi.name}
-        onChange={(name) => openKpi.update({ name })}
-        readonly={!canManage}
-        trimBeforeSave
-        testId="kpi-name"
-      />
-    </div>
+    <button
+      type="button"
+      className="shrink-0 rounded-lg bg-brand-1 px-3 py-1.5 text-sm font-medium text-white-1 hover:bg-blue-600"
+      onClick={action.onClick}
+      data-test-id={action.testId}
+    >
+      {action.label}
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- Move the KPI name out of the compact tool header and into the page as the heading above the description, so a KPI's own page reads like a task or goal.
- Drop the sidebar last-update card and put the current value, trend, and as-of date at the top of the history chart, which is the series it belongs to.
- Tighten the detail layout: round chart axis labels, badge-style trend, consistent recorded-updates heading, and collapse the header to breadcrumbs plus Log update when a KPI is open.

## Test plan
- [ ] Open a KPI with several updates: name is the page heading, current value leads the chart (not the sidebar), description sits under the name.
- [ ] Hover the chart and confirm axis labels stay round (e.g. 1.6M / 800K / 0).
- [ ] Open a KPI with one update and one with none: empty/single-entry chart copy still makes sense and does not duplicate the value.
- [ ] Rename the KPI from the heading; confirm a failed rename reverts.
- [ ] Log update still lives in the header; sidebar still has champion, cadence, unit, notifications, Copy URL, and Delete.


Made with [Cursor](https://cursor.com)