### PR TITLE
fix: Align cancel link with submit button on template discussions

### DIFF
--- a/turboui/src/Forms/Submit.tsx
+++ b/turboui/src/Forms/Submit.tsx
@@ -30,9 +30,9 @@ export function Submit(props: SubmitProps) {
   const buttonType = submitOnEnter ? "submit" : "button";
 
   const containerStyles = classNames(
-    "mt-8 flex items-center gap-2",
+    "flex items-center gap-2",
     layout === "centered" ? "justify-center" : "justify-start",
-    containerClassName,
+    containerClassName ?? "mt-8",
   );
 
   const handleSubmit = async (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/turboui/src/Forms/index.test.tsx
+++ b/turboui/src/Forms/index.test.tsx
@@ -1087,6 +1087,47 @@ describe("Forms", () => {
     expect(submitContainer).toHaveClass("justify-center", "custom-submit-container");
   });
 
+  test("uses a default top margin on the submit container", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Roadmap" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <Submit saveText="Post Discussion" testId="post-discussion" />
+        </Form>
+      );
+    }
+
+    const { container } = render(<Harness />);
+    const submitContainer = container.querySelector('[data-test-id="post-discussion"]')?.parentElement;
+
+    expect(submitContainer).toHaveClass("mt-8");
+  });
+
+  test("lets containerClassName replace the default top margin", () => {
+    function Harness() {
+      const form = useForm({
+        fields: { name: "Roadmap" },
+        submit: async () => undefined,
+      });
+
+      return (
+        <Form form={form}>
+          <Submit saveText="Post Discussion" containerClassName="mt-0" testId="post-discussion" />
+        </Form>
+      );
+    }
+
+    const { container } = render(<Harness />);
+    const submitContainer = container.querySelector('[data-test-id="post-discussion"]')?.parentElement;
+
+    expect(submitContainer).toHaveClass("mt-0");
+    expect(submitContainer).not.toHaveClass("mt-8");
+  });
+
   test("uses submit button type when submitOnEnter is enabled", () => {
     function Harness() {
       const form = useForm({

--- a/turboui/src/TemplateDiscussionForm/index.stories.tsx
+++ b/turboui/src/TemplateDiscussionForm/index.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
+
+import { TemplateDiscussionForm } from "./index";
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
+
+const meta = {
+  title: "Pages/TemplateDiscussionForm",
+  component: TemplateDiscussionForm,
+  parameters: {
+    layout: "fullscreen",
+    reactRouter: {
+      path: "/project-templates/template-1/discussions/new",
+      routePath: "/project-templates/:templateId/discussions/new",
+    },
+  },
+} satisfies Meta<typeof TemplateDiscussionForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NewDiscussion: Story = {
+  args: {} as TemplateDiscussionForm.Props,
+  render: () => (
+    <TemplateDiscussionForm
+      pageTitle={["New Discussion", "Launch Playbook"]}
+      navigation={[
+        { to: "/spaces/space-1", label: "Product" },
+        { to: "/spaces/space-1/project-templates", label: "Project Templates" },
+        { to: "/project-templates/template-1", label: "Launch Playbook" },
+        { to: "/project-templates/template-1?tab=discussions", label: "Discussions" },
+      ]}
+      richTextHandlers={createMockRichEditorHandlers()}
+      cancelLink="/project-templates/template-1?tab=discussions"
+      submitLabel="Post Discussion"
+      onSubmit={async (values) => {
+        console.log("Submit", values);
+        return true;
+      }}
+    />
+  ),
+};

--- a/turboui/src/TemplateDiscussionForm/index.test.tsx
+++ b/turboui/src/TemplateDiscussionForm/index.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router";
+
+import { createMockRichEditorHandlers } from "../utils/storybook/richEditor";
+import { TemplateDiscussionForm } from ".";
+
+function renderForm() {
+  return render(
+    <MemoryRouter>
+      <TemplateDiscussionForm
+        pageTitle={["New Discussion", "Launch template"]}
+        navigation={[{ to: "/templates", label: "Project Templates" }]}
+        richTextHandlers={createMockRichEditorHandlers()}
+        cancelLink="/templates/template-1?tab=discussions"
+        submitLabel="Post Discussion"
+        onSubmit={async () => true}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("TemplateDiscussionForm", () => {
+  it("aligns the cancel link with the submit button", () => {
+    renderForm();
+
+    const submitButton = screen.getByRole("button", { name: "Post Discussion" });
+    const cancelLink = screen.getByRole("link", { name: "Cancel" });
+    const actions = submitButton.parentElement?.parentElement;
+
+    expect(actions).toHaveClass("flex", "items-center");
+    expect(actions).toContainElement(cancelLink);
+    expect(submitButton.parentElement).toHaveClass("mt-0");
+    expect(submitButton.parentElement).not.toHaveClass("mt-8");
+    expect(cancelLink).toHaveClass("inline-flex", "items-center");
+  });
+});

--- a/turboui/src/TemplateDiscussionForm/index.tsx
+++ b/turboui/src/TemplateDiscussionForm/index.tsx
@@ -68,7 +68,9 @@ export function TemplateDiscussionForm(props: TemplateDiscussionForm.Props) {
               testId="save-template-discussion"
               containerClassName="mt-0"
             />
-            <DimmedLink to={props.cancelLink}>Cancel</DimmedLink>
+            <DimmedLink to={props.cancelLink} className="inline-flex items-center">
+              Cancel
+            </DimmedLink>
           </div>
         </Forms.Form>
       </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5139

On the project template discussion form, the Cancel link sat above the Post Discussion button. `Forms.Submit` always applied `mt-8`, so `containerClassName="mt-0"` never overrode it (Tailwind keeps the later utility). That extra top margin on the button wrapper, but not the link, caused the misalignment.

This change applies the default submit margin only when `containerClassName` is omitted, and vertically centers the Cancel link with the button. The same pattern is used on other discussion forms, so they pick up the fix as well.

**TurboUI primitives reused:** `Forms.Submit`, `DimmedLink`, `PrimaryButton`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef09925f-4f6a-40d7-8dbe-6dc34d9aaa3f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef09925f-4f6a-40d7-8dbe-6dc34d9aaa3f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

