### PR TITLE
fix: Remove created date from template milestone sidebar

### DIFF
--- a/app/assets/js/pages/ProjectTemplateMilestonePage/index.tsx
+++ b/app/assets/js/pages/ProjectTemplateMilestonePage/index.tsx
@@ -6,7 +6,6 @@ import * as People from "@/models/people";
 import { persistTemplateChange } from "@/models/projectTemplates";
 import { useTemplateTaskSlideInProps } from "@/models/projectTemplates/useTemplateTaskSlideInProps";
 import { useTemplateTasksForTurboUi } from "@/models/projectTemplates/useTemplateTasksForTurboUi";
-import * as Time from "@/utils/time";
 import { compareIds, usePaths } from "@/routes/paths";
 import type { PageModule } from "@/routes/types";
 import React from "react";
@@ -100,7 +99,6 @@ function Page() {
       onDueOffsetDaysChange={(dueOffsetDays) => {
         void onMilestoneUpdate(milestone.id, { dueOffsetDays });
       }}
-      insertedAt={Time.parseDate(milestone.insertedAt) ?? undefined}
       onDelete={handleDelete}
       tasks={tasks}
       statuses={statuses}

--- a/turboui/src/MilestonePage/MilestonePage.stories.tsx
+++ b/turboui/src/MilestonePage/MilestonePage.stories.tsx
@@ -668,7 +668,6 @@ function TemplateMilestoneStory({
     },
     dueOffsetDays: offsetDays,
     onDueOffsetDaysChange: setOffsetDays,
-    insertedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
     tasks,
     statuses: templateStatuses,
     milestones: sampleTemplateMilestones,

--- a/turboui/src/MilestonePage/components/Sidebar.test.tsx
+++ b/turboui/src/MilestonePage/components/Sidebar.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router";
+
+import { defaultFormattedTimePreferences } from "../../FormattedTime";
+import { Sidebar } from "./Sidebar";
+import type { MilestonePage } from "../types";
+
+function getByDataTestId(testId: string) {
+  const element = document.querySelector<HTMLElement>(`[data-test-id="${testId}"]`);
+  if (!element) throw new Error(`Could not find element with data-test-id="${testId}"`);
+  return element;
+}
+
+function templateState(): MilestonePage.TemplateState {
+  return {
+    variant: "project-template",
+    template: { id: "template-1", name: "Launch template", archived: false },
+    space: { id: "space-1", name: "Product", link: "/spaces/product" },
+    projectTemplatesLink: "/spaces/product/project-templates",
+    templateLink: "/spaces/product/project-templates/template-1",
+    updateTemplateName: async () => true,
+    permissions: { canEdit: true },
+    tasksCount: 0,
+    discussionsCount: 0,
+    docsAndFilesCount: 0,
+    milestoneId: "milestone-1",
+    title: "Launch",
+    onMilestoneTitleChange: async () => true,
+    description: null,
+    onDescriptionChange: async () => true,
+    dueOffsetDays: 3,
+    onDueOffsetDaysChange: () => undefined,
+    tasks: [],
+    statuses: [],
+    milestones: [],
+    personSearch: { people: [], onSearch: async () => undefined },
+    richTextHandlers: {} as never,
+    formattedTimePreferences: defaultFormattedTimePreferences,
+    isTaskModalOpen: false,
+    setIsTaskModalOpen: () => undefined,
+    isDeleteModalOpen: false,
+    openDeleteModal: () => undefined,
+    closeDeleteModal: () => undefined,
+  };
+}
+
+describe("MilestonePage Sidebar", () => {
+  it("does not show a created date on template milestones", () => {
+    render(
+      <MemoryRouter>
+        <Sidebar {...templateState()} />
+      </MemoryRouter>,
+    );
+
+    const sidebar = getByDataTestId("template-milestone-sidebar");
+
+    expect(document.querySelector('[data-test-id="template-milestone-due-offset"]')).toBeInTheDocument();
+    expect(within(sidebar).queryByText("Created")).not.toBeInTheDocument();
+  });
+});

--- a/turboui/src/MilestonePage/components/Sidebar.tsx
+++ b/turboui/src/MilestonePage/components/Sidebar.tsx
@@ -36,14 +36,6 @@ export function Sidebar(props: MilestonePage.State) {
             formattedTimePreferences={props.formattedTimePreferences}
           />
         )}
-        {features.showInsertedAt && isTemplateMilestoneState(props) && props.insertedAt && (
-          <SidebarSection title="Created">
-            <div className="flex items-center gap-1.5 text-sm text-content-dimmed">
-              <IconCalendar size={14} />
-              <FormattedTime {...props.formattedTimePreferences} time={props.insertedAt} format="short-date" />
-            </div>
-          </SidebarSection>
-        )}
         {features.showSubscriptions && isProjectMilestoneState(props) && <SidebarNotificationSection {...props.subscriptions} />}
         <SidebarActions onDelete={props.openDeleteModal} canEdit={canEdit} />
       </div>

--- a/turboui/src/MilestonePage/types.ts
+++ b/turboui/src/MilestonePage/types.ts
@@ -125,7 +125,6 @@ export namespace MilestonePage {
     onDescriptionChange: (newDescription: any) => Promise<boolean>;
     dueOffsetDays: number | null;
     onDueOffsetDaysChange: (value: number | null) => void;
-    insertedAt?: Date;
 
     onDelete?: () => void;
 

--- a/turboui/src/MilestonePage/variantFeatures.test.ts
+++ b/turboui/src/MilestonePage/variantFeatures.test.ts
@@ -11,7 +11,6 @@ describe("MilestonePage.variantFeatures", () => {
       showCreatedBy: true,
       showCompletedOn: true,
       showKanbanLink: true,
-      showInsertedAt: false,
       showProjectTasks: true,
       showTemplateTasks: false,
       sidebarTestId: "sidebar",
@@ -19,7 +18,7 @@ describe("MilestonePage.variantFeatures", () => {
     });
   });
 
-  it("shows relative due date and hides status, activity, and subscriptions for template milestones", () => {
+  it("shows relative due date and hides status, activity, subscriptions, and created date for template milestones", () => {
     expect(variantFeatures("project-template")).toEqual({
       showStatus: false,
       showCalendarDueDate: false,
@@ -29,7 +28,6 @@ describe("MilestonePage.variantFeatures", () => {
       showCreatedBy: false,
       showCompletedOn: false,
       showKanbanLink: false,
-      showInsertedAt: true,
       showProjectTasks: false,
       showTemplateTasks: true,
       sidebarTestId: "template-milestone-sidebar",

--- a/turboui/src/MilestonePage/variantFeatures.ts
+++ b/turboui/src/MilestonePage/variantFeatures.ts
@@ -9,7 +9,6 @@ export interface VariantFeatures {
   showCreatedBy: boolean;
   showCompletedOn: boolean;
   showKanbanLink: boolean;
-  showInsertedAt: boolean;
   showProjectTasks: boolean;
   showTemplateTasks: boolean;
   sidebarTestId: "sidebar" | "template-milestone-sidebar";
@@ -28,7 +27,6 @@ export function variantFeatures(variant: Variant): VariantFeatures {
         showCreatedBy: true,
         showCompletedOn: true,
         showKanbanLink: true,
-        showInsertedAt: false,
         showProjectTasks: true,
         showTemplateTasks: false,
         sidebarTestId: "sidebar",
@@ -44,7 +42,6 @@ export function variantFeatures(variant: Variant): VariantFeatures {
         showCreatedBy: false,
         showCompletedOn: false,
         showKanbanLink: false,
-        showInsertedAt: true,
         showProjectTasks: false,
         showTemplateTasks: true,
         sidebarTestId: "template-milestone-sidebar",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5140

Template project milestones showed a **Created** date in the sidebar. That timestamp is not useful when editing a reusable template, so this change removes it.

### Changes
- Hide the created-date field on the template milestone sidebar
- Remove the `showInsertedAt` variant flag and the unused `insertedAt` prop that existed only for this field
- Cover the sidebar with a TurboUI test that the created date is gone

Project milestones still show who created the milestone and when.

### CI
Rebased onto `main` after [#5031](https://github.com/operately/operately/pull/5031). That commit made `normalizeRichTextContent` return `undefined`, which TipTap `setContent` does not accept. This PR also coerces missing editor content to an empty string so lint/build can pass.

### Screenshots

Template milestone sidebar (Created date removed):

[Template milestone sidebar without created date](https://cursor.com/agents/bc-20150051-ce72-4b35-aef2-05b06be914df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftemplate_milestone_sidebar_without_created.webp)

Project milestone sidebar still includes Created:

[Project milestone sidebar still has created](https://cursor.com/agents/bc-20150051-ce72-4b35-aef2-05b06be914df/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fproject_milestone_sidebar_still_has_created.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20150051-ce72-4b35-aef2-05b06be914df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20150051-ce72-4b35-aef2-05b06be914df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

