### PR TITLE
fix: Show success toasts when copying and archiving project templates

### DIFF
--- a/app/test/support/features/project_templates_steps.ex
+++ b/app/test/support/features/project_templates_steps.ex
@@ -196,6 +196,7 @@ defmodule Operately.Support.Features.ProjectTemplatesSteps do
     |> UI.click(testid: "duplicate-project-template")
     |> UI.assert_has(testid: "project-template-page")
     |> UI.assert_text(name)
+    |> assert_template_duplicated_toast()
     |> Map.put(:template, Repo.get_by!(ProjectTemplate, name: name))
   end
 
@@ -207,7 +208,7 @@ defmodule Operately.Support.Features.ProjectTemplatesSteps do
     |> UI.click_text("Archive")
     |> UI.assert_text("This template will leave project creation and can be restored later.")
     |> UI.click_button("Archive template")
-    |> UI.sleep(300)
+    |> assert_template_archived_toast()
   end
 
   step :restore_template_from_library, ctx, template_key do
@@ -238,6 +239,19 @@ defmodule Operately.Support.Features.ProjectTemplatesSteps do
     |> UI.assert_text("This template will leave project creation and can be restored later.")
     |> UI.click_button("Archive template")
     |> UI.assert_text("Archived")
+    |> assert_template_archived_toast()
+  end
+
+  step :assert_template_duplicated_toast, ctx do
+    ctx
+    |> UI.assert_text("Template duplicated")
+    |> UI.assert_text("You're now editing the copy.")
+  end
+
+  step :assert_template_archived_toast, ctx do
+    ctx
+    |> UI.assert_text("Template archived")
+    |> UI.assert_text("It can be restored later.")
   end
 
   step :assert_template_actions_hidden, ctx, template_key do

--- a/app/test/support/features/project_templates_steps.ex
+++ b/app/test/support/features/project_templates_steps.ex
@@ -219,7 +219,7 @@ defmodule Operately.Support.Features.ProjectTemplatesSteps do
     |> UI.click_text("Restore")
     |> UI.assert_text("This template will return to active use and project creation.")
     |> UI.click_button("Restore template")
-    |> UI.sleep(300)
+    |> assert_template_restored_toast()
   end
 
   step :delete_template_from_library, ctx, template_key do
@@ -252,6 +252,12 @@ defmodule Operately.Support.Features.ProjectTemplatesSteps do
     ctx
     |> UI.assert_text("Template archived")
     |> UI.assert_text("It can be restored later.")
+  end
+
+  step :assert_template_restored_toast, ctx do
+    ctx
+    |> UI.assert_text("Template restored")
+    |> UI.assert_text("It's available for project creation again.")
   end
 
   step :assert_template_actions_hidden, ctx, template_key do

--- a/turboui/src/ProjectTemplateLifecycle/index.test.tsx
+++ b/turboui/src/ProjectTemplateLifecycle/index.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { showSuccessToast } from "../Toasts";
+import { ProjectTemplateLifecycleDialogs } from ".";
+
+jest.mock("../Toasts", () => ({
+  showSuccessToast: jest.fn(),
+  showErrorToast: jest.fn(),
+  showInfoToast: jest.fn(),
+}));
+
+const template = { id: "template-1", name: "Launch kit" };
+
+function handlers(overrides: Partial<React.ComponentProps<typeof ProjectTemplateLifecycleDialogs>> = {}) {
+  return {
+    onDuplicate: jest.fn().mockResolvedValue({ success: true }),
+    onArchive: jest.fn().mockResolvedValue({ success: true }),
+    onRestore: jest.fn().mockResolvedValue({ success: true }),
+    onDelete: jest.fn().mockResolvedValue({ success: true }),
+    onClose: jest.fn(),
+    ...overrides,
+  };
+}
+
+describe("ProjectTemplateLifecycleDialogs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a success toast after duplicating a template", async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<ProjectTemplateLifecycleDialogs action="duplicate" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Duplicate template" }));
+
+    await waitFor(() => expect(props.onDuplicate).toHaveBeenCalledWith("template-1", "Copy of Launch kit"));
+    expect(showSuccessToast).toHaveBeenCalledWith("Template duplicated", "You're now editing the copy.");
+  });
+
+  it("does not toast when duplicating fails", async () => {
+    const user = userEvent.setup();
+    const props = handlers({
+      onDuplicate: jest.fn().mockResolvedValue({ success: false, error: "Could not duplicate" }),
+    });
+    render(<ProjectTemplateLifecycleDialogs action="duplicate" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Duplicate template" }));
+
+    await waitFor(() => expect(props.onDuplicate).toHaveBeenCalled());
+    expect(showSuccessToast).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast after archiving a template", async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<ProjectTemplateLifecycleDialogs action="archive" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Archive template" }));
+
+    await waitFor(() => expect(props.onArchive).toHaveBeenCalledWith("template-1"));
+    expect(showSuccessToast).toHaveBeenCalledWith("Template archived", "It can be restored later.");
+  });
+
+  it("does not toast when archiving fails", async () => {
+    const user = userEvent.setup();
+    const props = handlers({
+      onArchive: jest.fn().mockResolvedValue({ success: false, error: "Could not archive" }),
+    });
+    render(<ProjectTemplateLifecycleDialogs action="archive" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Archive template" }));
+
+    await waitFor(() => expect(props.onArchive).toHaveBeenCalled());
+    expect(showSuccessToast).not.toHaveBeenCalled();
+  });
+});

--- a/turboui/src/ProjectTemplateLifecycle/index.test.tsx
+++ b/turboui/src/ProjectTemplateLifecycle/index.test.tsx
@@ -76,4 +76,28 @@ describe("ProjectTemplateLifecycleDialogs", () => {
     await waitFor(() => expect(props.onArchive).toHaveBeenCalled());
     expect(showSuccessToast).not.toHaveBeenCalled();
   });
+
+  it("shows a success toast after restoring a template", async () => {
+    const user = userEvent.setup();
+    const props = handlers();
+    render(<ProjectTemplateLifecycleDialogs action="restore" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Restore template" }));
+
+    await waitFor(() => expect(props.onRestore).toHaveBeenCalledWith("template-1"));
+    expect(showSuccessToast).toHaveBeenCalledWith("Template restored", "It's available for project creation again.");
+  });
+
+  it("does not toast when restoring fails", async () => {
+    const user = userEvent.setup();
+    const props = handlers({
+      onRestore: jest.fn().mockResolvedValue({ success: false, error: "Could not restore" }),
+    });
+    render(<ProjectTemplateLifecycleDialogs action="restore" template={template} {...props} />);
+
+    await user.click(screen.getByRole("button", { name: "Restore template" }));
+
+    await waitFor(() => expect(props.onRestore).toHaveBeenCalled());
+    expect(showSuccessToast).not.toHaveBeenCalled();
+  });
 });

--- a/turboui/src/ProjectTemplateLifecycle/index.tsx
+++ b/turboui/src/ProjectTemplateLifecycle/index.tsx
@@ -134,6 +134,10 @@ function successToast(action: ProjectTemplateLifecycleAction) {
     return { title: "Template archived", description: "It can be restored later." };
   }
 
+  if (action === "restore") {
+    return { title: "Template restored", description: "It's available for project creation again." };
+  }
+
   return null;
 }
 

--- a/turboui/src/ProjectTemplateLifecycle/index.tsx
+++ b/turboui/src/ProjectTemplateLifecycle/index.tsx
@@ -4,6 +4,7 @@ import { ConfirmDialog } from "../ConfirmDialog";
 import * as Forms from "../Forms";
 import Modal from "../Modal";
 import { IconArchive, IconRotate, IconTrash } from "../icons";
+import { showSuccessToast } from "../Toasts";
 
 export type ProjectTemplateLifecycleAction = "duplicate" | "archive" | "restore" | "delete";
 
@@ -46,6 +47,7 @@ export function ProjectTemplateLifecycleDialogs(props: ProjectTemplateLifecycle.
   return (
     <LifecycleConfirmDialog
       {...copy}
+      action={action}
       testId={`${action}-project-template-dialog`}
       onCancel={props.onClose}
       onConfirm={() => lifecycleHandler(props, action)(template.id)}
@@ -62,6 +64,7 @@ function DuplicateTemplateModal(
     submit: async () => {
       const result = await props.onDuplicate(props.template.id, form.values.name.trim());
       if (!result.success) throw new Error(result.error ?? "The template could not be duplicated. Try again.");
+      notifyLifecycleSuccess("duplicate");
       props.onClose();
     },
     cancel: props.onClose,
@@ -90,10 +93,12 @@ function DuplicateTemplateModal(
 }
 
 function LifecycleConfirmDialog({
+  action,
   onConfirm,
   onSuccess,
   ...props
 }: Omit<React.ComponentProps<typeof ConfirmDialog>, "isOpen" | "onConfirm"> & {
+  action: Exclude<ProjectTemplateLifecycleAction, "duplicate">;
   onConfirm: () => Promise<ProjectTemplateLifecycle.MutationResult>;
   onSuccess: () => void;
 }) {
@@ -103,13 +108,33 @@ function LifecycleConfirmDialog({
     setConfirming(true);
     try {
       const result = await onConfirm();
-      if (result.success) onSuccess();
+      if (result.success) {
+        notifyLifecycleSuccess(action);
+        onSuccess();
+      }
     } finally {
       setConfirming(false);
     }
   }
 
   return <ConfirmDialog {...props} isOpen onConfirm={() => void confirm()} confirming={confirming} />;
+}
+
+function notifyLifecycleSuccess(action: ProjectTemplateLifecycleAction) {
+  const message = successToast(action);
+  if (message) showSuccessToast(message.title, message.description);
+}
+
+function successToast(action: ProjectTemplateLifecycleAction) {
+  if (action === "duplicate") {
+    return { title: "Template duplicated", description: "You're now editing the copy." };
+  }
+
+  if (action === "archive") {
+    return { title: "Template archived", description: "It can be restored later." };
+  }
+
+  return null;
 }
 
 function lifecycleHandler(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5142.

Duplicating, archiving, or restoring a project template could leave you on a page that looked unchanged, so it was hard to tell whether the action worked.

This adds success toasts after those mutations complete, on both the template library and the template editor:

- **Duplicate:** "Template duplicated" — "You're now editing the copy."
- **Archive:** "Template archived" — "It can be restored later."
- **Restore:** "Template restored" — "It's available for project creation again."

Failed mutations still show the existing error toasts and do not show a success toast.

## TurboUI primitives reused

- `showSuccessToast` from TurboUI `Toasts`

No new interactive controls were added.

## Tests

- Unit tests for the shared lifecycle dialogs
- Feature coverage on the existing duplicate, archive, and restore flows

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-651e7feb-1548-467b-861b-5a189cd64f0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-651e7feb-1548-467b-861b-5a189cd64f0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

