### PR TITLE
feat: Enable task keyboard shortcuts on template task boards

### DIFF
--- a/turboui/src/MilestonePage/components/TasksSection.tsx
+++ b/turboui/src/MilestonePage/components/TasksSection.tsx
@@ -10,7 +10,14 @@ export function TasksSection(props: MilestonePage.State) {
   const { selectedTaskId, setSelectedTaskId, taskSlideIn } = useTaskSlideIn(props);
 
   if (isTemplateMilestoneState(props)) {
-    return <TemplateTasksSection {...props} taskSlideIn={taskSlideIn} onTaskOpen={setSelectedTaskId} />;
+    return (
+      <TemplateTasksSection
+        {...props}
+        taskSlideIn={taskSlideIn}
+        selectedTaskId={selectedTaskId}
+        onTaskOpen={setSelectedTaskId}
+      />
+    );
   }
 
   return (

--- a/turboui/src/MilestonePage/components/TemplateTasksSection.tsx
+++ b/turboui/src/MilestonePage/components/TemplateTasksSection.tsx
@@ -6,6 +6,7 @@ import { calculateMilestoneStats } from "../../TaskBoard/components/MilestoneCar
 import { TemplateTaskList } from "../../TaskBoard/components/TemplateTaskList";
 import { InlineTaskCreator } from "../../TaskBoard/components/InlineTaskCreator";
 import { useInlineTaskCreator } from "../../TaskBoard/hooks/useInlineTaskCreator";
+import { useTaskKeyboardNavigation } from "../../TaskBoard/hooks/useTaskKeyboardNavigation";
 import * as Types from "../../TaskBoard/types";
 import type { TemplateProjectPage } from "../../TemplateProjectPage";
 import { compareIds } from "../../utils/ids";
@@ -25,10 +26,19 @@ export function TemplateTasksSection({
   onTaskReorder,
   personSearch,
   taskSlideIn,
+  selectedTaskId,
   onTaskOpen,
   setIsTaskModalOpen,
 }: MilestonePage.TemplateState & Props) {
   const canEdit = permissions.canEdit || false;
+  const {
+    containerRef: keyboardNavigationRef,
+    selectedTaskId: keyboardSelectedTaskId,
+    clearSelection: clearTaskSelection,
+    scopeBind: keyboardNavigationScopeBind,
+  } = useTaskKeyboardNavigation<HTMLDivElement>({
+    clearSelectionWithEscape: !selectedTaskId,
+  });
   const orderedTasks = React.useMemo(() => {
     const orderingState =
       milestones.find((milestone) => compareIds(milestone.id, milestoneId))?.tasksOrderingState ?? [];
@@ -41,7 +51,7 @@ export function TemplateTasksSection({
     closeCreator,
     creatorRef,
     hoverBind,
-  } = useInlineTaskCreator({ requireHover: false });
+  } = useInlineTaskCreator({ requireHover: false, onOpen: clearTaskSelection });
   const stats = calculateMilestoneStats(templateTasksAsBoardTasks(orderedTasks));
   const completionPercentage = calculateCompletionPercentage(stats);
   const handleCreateTask = React.useCallback(
@@ -97,16 +107,19 @@ export function TemplateTasksSection({
         ) : null
       }
     >
-      <TemplateTaskList
-        tasks={orderedTasks}
-        destinationMilestoneId={milestoneId}
-        canEdit={canEdit}
-        onTaskReorder={onTaskReorder}
-        taskRowProps={taskRowProps}
-        onTaskOpen={onTaskOpen}
-        inlineCreateRow={inlineCreator}
-        emptyState={<TaskSectionEmptyState inlineCreator={inlineCreator} showCreationPrompt={canEdit} />}
-      />
+      <div ref={keyboardNavigationRef} {...keyboardNavigationScopeBind}>
+        <TemplateTaskList
+          tasks={orderedTasks}
+          destinationMilestoneId={milestoneId}
+          canEdit={canEdit}
+          onTaskReorder={onTaskReorder}
+          taskRowProps={taskRowProps}
+          onTaskOpen={onTaskOpen}
+          selectedTaskId={keyboardSelectedTaskId}
+          inlineCreateRow={inlineCreator}
+          emptyState={<TaskSectionEmptyState inlineCreator={inlineCreator} showCreationPrompt={canEdit} />}
+        />
+      </div>
     </TaskSectionLayout>
   );
 }
@@ -132,5 +145,6 @@ function calculateCompletionPercentage(stats: Types.MilestoneStats) {
 
 type Props = {
   taskSlideIn: React.ReactNode;
+  selectedTaskId: string | null;
   onTaskOpen: (taskId: string | null) => void;
 };

--- a/turboui/src/RelativeDayField/index.test.tsx
+++ b/turboui/src/RelativeDayField/index.test.tsx
@@ -115,4 +115,20 @@ describe("RelativeDayField", () => {
 
     expect(screen.getByRole("button", { name: "Set relative date" })).toHaveClass("[&>span]:text-transparent");
   });
+
+  it("opens for editing when a parent sets isOpen", () => {
+    render(<RelativeDayField value={1} onChange={jest.fn()} isOpen />);
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("notifies the parent when editing starts", () => {
+    const onOpenChange = jest.fn();
+    render(<RelativeDayField value={1} onChange={jest.fn()} isOpen={false} onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByText("1 day after project starts"));
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
 });

--- a/turboui/src/RelativeDayField/index.tsx
+++ b/turboui/src/RelativeDayField/index.tsx
@@ -16,6 +16,8 @@ export namespace RelativeDayField {
     testId?: string;
     className?: string;
     hideCalendarIcon?: boolean;
+    isOpen?: boolean;
+    onOpenChange?: (isOpen: boolean) => void;
   }
 }
 
@@ -36,11 +38,20 @@ export function RelativeDayField({
   testId = "relative-day-field",
   className,
   hideCalendarIcon = false,
+  isOpen,
+  onOpenChange,
 }: RelativeDayField.Props) {
-  const [isEditing, setIsEditing] = React.useState(false);
+  const isOpenControlled = isOpen !== undefined;
+  const [internalIsEditing, setInternalIsEditing] = React.useState(false);
+  const isEditing = isOpenControlled ? !!isOpen : internalIsEditing;
   const [inputValue, setInputValue] = React.useState(value === null ? "" : String(value));
   const [error, setError] = React.useState<string | null>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const setIsEditing = (next: boolean) => {
+    if (!isOpenControlled) setInternalIsEditing(next);
+    onOpenChange?.(next);
+  };
 
   React.useEffect(() => {
     if (!isEditing) setInputValue(value === null ? "" : String(value));

--- a/turboui/src/TaskBoard/KanbanView/Card.test.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Card.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Card } from "./Card";
+import { OPEN_TASK_DUE_DATE_EVENT } from "../hooks/useTaskKeyboardNavigation";
+import type { TaskBoard } from "../components";
+import type { StatusSelector } from "../../StatusSelector";
+
+const sortableRef: { current: HTMLElement | null } = { current: null };
+
+jest.mock("../../utils/PragmaticDragAndDrop", () => ({
+  DropIndicator: () => null,
+  useSortableItem: () => ({
+    ref: sortableRef,
+    isDragging: false,
+    closestEdge: null,
+  }),
+}));
+
+const pendingStatus: StatusSelector.StatusOption = {
+  id: "pending",
+  value: "pending",
+  label: "Not started",
+  color: "gray",
+  icon: "circleDashed",
+  index: 0,
+};
+
+function makeTask(overrides: Partial<TaskBoard.Task> = {}): TaskBoard.Task {
+  return {
+    id: "task-1",
+    title: "Publish announcement",
+    status: pendingStatus,
+    description: null,
+    link: "#",
+    milestone: null,
+    dueDate: null,
+    type: "project",
+    ...overrides,
+  };
+}
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof Card>> = {}) {
+  return render(
+    <Card
+      task={makeTask({ dueOffsetDays: 12 })}
+      containerId="pending"
+      index={0}
+      draggedItemId={null}
+      onTaskDueOffsetDaysChange={jest.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+function openDueDateShortcut() {
+  const card = document.querySelector('[data-test-id="kanban-card-task-1"]');
+  if (!card) throw new Error("kanban card not found");
+  fireEvent(card, new Event(OPEN_TASK_DUE_DATE_EVENT, { bubbles: true, cancelable: true }));
+}
+
+describe("Kanban Card due date offset", () => {
+  it("renders the relative due date instead of a calendar date", () => {
+    renderCard();
+
+    expect(screen.getByText("12 days after project starts")).toBeInTheDocument();
+    expect(document.querySelector('[data-test-id="kanban-card-due-offset-task-1"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-test-id="kanban-card-due-date-task-1"]')).not.toBeInTheDocument();
+  });
+
+  it("opens the due date offset field from the keyboard shortcut event", () => {
+    renderCard();
+
+    openDueDateShortcut();
+
+    expect(document.querySelector('[data-test-id="kanban-card-due-offset-task-1-input"]')).toBeInTheDocument();
+  });
+
+  it("does not open the due date offset field when it is read-only", () => {
+    renderCard({ onTaskDueOffsetDaysChange: undefined });
+
+    openDueDateShortcut();
+
+    expect(document.querySelector('[data-test-id="kanban-card-due-offset-task-1-input"]')).not.toBeInTheDocument();
+  });
+
+  it("saves a due date offset from the field", () => {
+    const onTaskDueOffsetDaysChange = jest.fn();
+    renderCard({ onTaskDueOffsetDaysChange });
+
+    openDueDateShortcut();
+    const input = document.querySelector('[data-test-id="kanban-card-due-offset-task-1-input"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "18" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onTaskDueOffsetDaysChange).toHaveBeenCalledWith("task-1", 18);
+  });
+
+  it("keeps a calendar due date on project tasks", () => {
+    renderCard({
+      task: makeTask(),
+      onTaskDueOffsetDaysChange: undefined,
+      onTaskDueDateChange: jest.fn(),
+    });
+
+    expect(document.querySelector('[data-test-id="kanban-card-due-date-task-1"]')).toBeInTheDocument();
+    expect(document.querySelector('[data-test-id="kanban-card-due-offset-task-1"]')).not.toBeInTheDocument();
+  });
+});

--- a/turboui/src/TaskBoard/KanbanView/Card.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Card.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { IconFileText, IconGripVertical, IconMessageCircle } from "../../icons";
 import { DateField } from "../../DateField";
+import { RelativeDayField } from "../../RelativeDayField";
 import { AssigneesField } from "../../AssigneesField";
 import classNames from "../../utils/classnames";
 import { DropIndicator, useSortableItem } from "../../utils/PragmaticDragAndDrop";
@@ -21,6 +22,7 @@ interface CardProps {
   draggedItemId: string | null;
   onTaskAssigneeChange?: TaskBoardProps["onTaskAssigneeChange"];
   onTaskDueDateChange?: TaskBoardProps["onTaskDueDateChange"];
+  onTaskDueOffsetDaysChange?: TaskBoardProps["onTaskDueOffsetDaysChange"];
   assigneePersonSearch?: TaskBoardProps["assigneePersonSearch"];
   showDropIndicator?: boolean;
   onTaskClick?: (taskId: string) => void;
@@ -34,6 +36,7 @@ export function Card({
   draggedItemId,
   onTaskAssigneeChange,
   onTaskDueDateChange,
+  onTaskDueOffsetDaysChange,
   assigneePersonSearch,
   showDropIndicator = true,
   onTaskClick,
@@ -41,6 +44,7 @@ export function Card({
 }: CardProps) {
   const [currentAssignees, setCurrentAssignees] = useState<TaskBoard.Person[]>(task.assignees || []);
   const [currentDueDate, setCurrentDueDate] = useState<DateField.ContextualDate | null>(task.dueDate || null);
+  const [currentDueOffsetDays, setCurrentDueOffsetDays] = useState<number | null>(task.dueOffsetDays ?? null);
   const [assigneeFieldOpen, setAssigneeFieldOpen] = useState(false);
   const [dueDateFieldOpen, setDueDateFieldOpen] = useState(false);
   const { ref, isDragging, closestEdge } = useSortableItem({
@@ -63,7 +67,11 @@ export function Card({
     };
 
     const openDueDateField = () => {
-      if (!onTaskDueDateChange) return;
+      if (usesRelativeDueDate(task)) {
+        if (!onTaskDueOffsetDaysChange) return;
+      } else if (!onTaskDueDateChange) {
+        return;
+      }
 
       prepareFocusRestore();
       setDueDateFieldOpen(true);
@@ -81,7 +89,16 @@ export function Card({
       element.removeEventListener(OPEN_TASK_DUE_DATE_EVENT, openDueDateField);
       element.removeEventListener(OPEN_TASK_EVENT, openTask);
     };
-  }, [assigneePersonSearch, onTaskClick, onTaskDueDateChange, prepareFocusRestore, ref, task.id]);
+  }, [
+    assigneePersonSearch,
+    onTaskClick,
+    onTaskDueDateChange,
+    onTaskDueOffsetDaysChange,
+    prepareFocusRestore,
+    ref,
+    task.dueOffsetDays,
+    task.id,
+  ]);
 
   useEffect(() => {
     setCurrentAssignees(task.assignees || []);
@@ -89,7 +106,8 @@ export function Card({
 
   useEffect(() => {
     setCurrentDueDate(task.dueDate || null);
-  }, [task.dueDate, task.id]);
+    setCurrentDueOffsetDays(task.dueOffsetDays ?? null);
+  }, [task.dueDate, task.dueOffsetDays, task.id]);
 
   const handleAssigneesChange = useCallback(
     (newAssignees: TaskBoard.Person[]) => {
@@ -107,15 +125,24 @@ export function Card({
     [onTaskDueDateChange, task.id],
   );
 
+  const handleDueOffsetDaysChange = useCallback(
+    (dueOffsetDays: number | null) => {
+      setCurrentDueOffsetDays(dueOffsetDays);
+      onTaskDueOffsetDaysChange?.(task.id, dueOffsetDays);
+    },
+    [onTaskDueOffsetDaysChange, task.id],
+  );
+
   const isDimmed = draggedItemId === task.id;
   const dropIndicatorEdge = showDropIndicator ? closestEdge : null;
   const shouldShowDescriptionIndicator = Boolean(task.hasDescription);
   const shouldShowCommentsIndicator = Boolean(task.hasComments);
   const shouldShowCommentCount = task.commentCount !== undefined;
+  const hasDueDate = usesRelativeDueDate(task) ? currentDueOffsetDays !== null : Boolean(currentDueDate);
   const dateFieldClassName = classNames({
-    "[&>span]:text-transparent": !currentDueDate,
-    "group-hover:[&>span]:text-content-dimmed": !currentDueDate,
-    "group-focus-within:[&>span]:text-content-dimmed": !currentDueDate,
+    "[&>span]:text-transparent": !hasDueDate,
+    "group-hover:[&>span]:text-content-dimmed": !hasDueDate,
+    "group-focus-within:[&>span]:text-content-dimmed": !hasDueDate,
   });
 
   const stopDragFromInteractive = (event: React.MouseEvent) => {
@@ -201,22 +228,37 @@ export function Card({
 
             <div className="flex items-center gap-2 flex-shrink-0">
               <div onMouseDown={stopDragFromInteractive}>
-                <DateField
-                  date={currentDueDate}
-                  onDateSelect={handleDueDateChange}
-                  variant="inline"
-                  hideCalendarIcon={true}
-                  showOverdueWarning={!task.status?.closed}
-                  placeholder={currentDueDate ? "" : "Set due date"}
-                  readonly={!onTaskDueDateChange}
-                  size="small"
-                  calendarOnly
-                  className={dateFieldClassName}
-                  testId={createTestId("kanban-card-due-date", task.id)}
-                  isOpen={dueDateFieldOpen}
-                  onOpenChange={handleDueDateFieldOpenChange}
-                  onCloseAutoFocus={restoreFocusOnCloseAutoFocus}
-                />
+                {usesRelativeDueDate(task) ? (
+                  <RelativeDayField
+                    value={currentDueOffsetDays}
+                    onChange={onTaskDueOffsetDaysChange ? handleDueOffsetDaysChange : undefined}
+                    variant="inline"
+                    hideCalendarIcon={true}
+                    placeholder={hasDueDate ? "" : "Set when due"}
+                    readonly={!onTaskDueOffsetDaysChange}
+                    className={dateFieldClassName}
+                    testId={createTestId("kanban-card-due-offset", task.id)}
+                    isOpen={dueDateFieldOpen}
+                    onOpenChange={handleDueDateFieldOpenChange}
+                  />
+                ) : (
+                  <DateField
+                    date={currentDueDate}
+                    onDateSelect={handleDueDateChange}
+                    variant="inline"
+                    hideCalendarIcon={true}
+                    showOverdueWarning={!task.status?.closed}
+                    placeholder={currentDueDate ? "" : "Set due date"}
+                    readonly={!onTaskDueDateChange}
+                    size="small"
+                    calendarOnly
+                    className={dateFieldClassName}
+                    testId={createTestId("kanban-card-due-date", task.id)}
+                    isOpen={dueDateFieldOpen}
+                    onOpenChange={handleDueDateFieldOpenChange}
+                    onCloseAutoFocus={restoreFocusOnCloseAutoFocus}
+                  />
+                )}
               </div>
 
               <div onMouseDown={stopDragFromInteractive}>
@@ -247,4 +289,8 @@ export function Card({
       </div>
     </div>
   );
+}
+
+function usesRelativeDueDate(task: TaskBoard.Task): boolean {
+  return task.dueOffsetDays !== undefined;
 }

--- a/turboui/src/TaskBoard/KanbanView/Column.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Column.tsx
@@ -18,6 +18,7 @@ interface Props {
   draggedItemId: string | null;
   onTaskAssigneeChange?: TaskBoardProps["onTaskAssigneeChange"];
   onTaskDueDateChange?: TaskBoardProps["onTaskDueDateChange"];
+  onTaskDueOffsetDaysChange?: TaskBoardProps["onTaskDueOffsetDaysChange"];
   assigneePersonSearch?: TaskBoardProps["assigneePersonSearch"];
   targetLocation: BoardLocation | null;
   placeholderHeight: number | null;
@@ -41,6 +42,7 @@ export function Column({
   draggedItemId,
   onTaskAssigneeChange,
   onTaskDueDateChange,
+  onTaskDueOffsetDaysChange,
   assigneePersonSearch,
   targetLocation,
   placeholderHeight,
@@ -157,6 +159,7 @@ export function Column({
                 draggedItemId={draggedItemId}
                 onTaskAssigneeChange={onTaskAssigneeChange}
                 onTaskDueDateChange={onTaskDueDateChange}
+                onTaskDueOffsetDaysChange={onTaskDueOffsetDaysChange}
                 assigneePersonSearch={assigneePersonSearch}
                 showDropIndicator={shouldShowDropIndicator}
                 onTaskClick={onTaskClick}

--- a/turboui/src/TaskBoard/KanbanView/Kanban.tsx
+++ b/turboui/src/TaskBoard/KanbanView/Kanban.tsx
@@ -22,6 +22,7 @@ interface Props {
   statuses: StatusSelector.StatusOption[];
   onTaskAssigneeChange?: TaskBoardProps["onTaskAssigneeChange"];
   onTaskDueDateChange?: TaskBoardProps["onTaskDueDateChange"];
+  onTaskDueOffsetDaysChange?: TaskBoardProps["onTaskDueOffsetDaysChange"];
   assigneePersonSearch?: TaskBoardProps["assigneePersonSearch"];
   onTaskCreate?: TaskBoardProps["onTaskCreate"];
   onAddStatusClick?: () => void;
@@ -42,6 +43,7 @@ export function Kanban({
   statuses,
   onTaskAssigneeChange,
   onTaskDueDateChange,
+  onTaskDueOffsetDaysChange,
   assigneePersonSearch,
   onTaskCreate,
   onAddStatusClick,
@@ -114,6 +116,7 @@ export function Kanban({
               placeholderHeight={placeholderHeight}
               onTaskAssigneeChange={onTaskAssigneeChange}
               onTaskDueDateChange={onTaskDueDateChange}
+              onTaskDueOffsetDaysChange={onTaskDueOffsetDaysChange}
               assigneePersonSearch={assigneePersonSearch}
               onCreateTask={undefined}
               dragHandleRef={undefined}
@@ -141,6 +144,7 @@ export function Kanban({
                   placeholderHeight={placeholderHeight}
                   onTaskAssigneeChange={onTaskAssigneeChange}
                   onTaskDueDateChange={onTaskDueDateChange}
+                  onTaskDueOffsetDaysChange={onTaskDueOffsetDaysChange}
                   assigneePersonSearch={assigneePersonSearch}
                   onCreateTask={onTaskCreate ? (title) => handleTaskCreate(title, status.value) : undefined}
                   dragHandleRef={dragHandleRef}

--- a/turboui/src/TaskBoard/KanbanView/index.test.tsx
+++ b/turboui/src/TaskBoard/KanbanView/index.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { KanbanBoard } from ".";
+import type { KanbanBoardProps } from "./types";
+import type { TaskBoard } from "../components";
+import type { StatusSelector } from "../../StatusSelector";
+
+const search = {
+  params: new URLSearchParams("taskId=task-1"),
+};
+
+jest.mock("react-router", () => {
+  const actual = jest.requireActual("react-router");
+  const setSearchParams = jest.fn((next: URLSearchParams | ((current: URLSearchParams) => URLSearchParams)) => {
+    if (typeof next === "function") next(new URLSearchParams(search.params));
+  });
+
+  return {
+    ...actual,
+    useSearchParams: () => [search.params, setSearchParams],
+  };
+});
+
+jest.mock("../../utils/PragmaticDragAndDrop", () => ({
+  useBoardDnD: () => ({
+    draggedItemId: null,
+    destination: null,
+    draggedItemDimensions: null,
+  }),
+  useSortableList: () => undefined,
+}));
+
+jest.mock("./Kanban", () => ({
+  Kanban: () => <div data-test-id="kanban-columns" />,
+}));
+
+jest.mock("./TaskSlideIn", () => ({
+  TaskSlideIn: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
+    isOpen ? (
+      <div data-test-id="task-slide-in">
+        <button type="button" data-test-id="slide-in-close-button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+const pendingStatus: StatusSelector.StatusOption = {
+  id: "pending",
+  value: "pending",
+  label: "Not started",
+  color: "gray",
+  icon: "circleDashed",
+  index: 0,
+};
+
+function makeTask(overrides: Partial<TaskBoard.Task> = {}): TaskBoard.Task {
+  return {
+    id: "task-1",
+    title: "Publish announcement",
+    status: pendingStatus,
+    description: null,
+    link: "#",
+    milestone: null,
+    dueDate: null,
+    dueOffsetDays: 12,
+    type: "project",
+    ...overrides,
+  };
+}
+
+function boardProps(tasks: TaskBoard.Task[]): KanbanBoardProps {
+  return {
+    tasks,
+    statuses: [pendingStatus],
+    kanbanState: { pending: tasks.map((task) => task.id) },
+    canEdit: true,
+    getTaskPageProps: () => ({ variant: "template", name: "Publish announcement" }) as never,
+  };
+}
+
+describe("KanbanBoard task slide-in", () => {
+  beforeEach(() => {
+    search.params = new URLSearchParams("taskId=task-1");
+  });
+
+  it("does not reopen the slide-in when tasks are remapped before the URL catches up", () => {
+    const view = render(<KanbanBoard {...boardProps([makeTask()])} />);
+
+    expect(document.querySelector('[data-test-id="task-slide-in"]')).toBeInTheDocument();
+
+    act(() => {
+      document.querySelector<HTMLButtonElement>('[data-test-id="slide-in-close-button"]')?.click();
+    });
+    expect(document.querySelector('[data-test-id="task-slide-in"]')).not.toBeInTheDocument();
+
+    view.rerender(<KanbanBoard {...boardProps([makeTask()])} />);
+    expect(document.querySelector('[data-test-id="task-slide-in"]')).not.toBeInTheDocument();
+  });
+});

--- a/turboui/src/TaskBoard/KanbanView/index.tsx
+++ b/turboui/src/TaskBoard/KanbanView/index.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { StatusSelector } from "../../StatusSelector";
 import { useBoardDnD, useSortableList } from "../../utils/PragmaticDragAndDrop";
-import { useSearchParams } from "react-router";
 import { Kanban } from "./Kanban";
 import { TaskSlideIn } from "./TaskSlideIn";
 import { AddStatusModal } from "./AddStatusModal";
 import { DeleteStatusModal } from "./DeleteStatusModal";
 import type { KanbanBoardProps, KanbanStatus, KanbanState, TaskSlideInContext } from "./types";
 import type { TaskBoard } from "../components";
+import { useTaskSlideInSelection } from "../hooks/useTaskSlideInSelection";
 
 export function KanbanBoard(props: KanbanBoardProps) {
   const { statuses, kanbanState: kanbanStateProp, onStatusesChange, onTaskKanbanChange, milestone } = props;
@@ -312,53 +312,16 @@ function useTaskSlideIn({
   spaceSearch,
   getTaskPageProps,
 }: KanbanBoardProps) {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const { selectedTaskId, setSelectedTaskId } = useTaskSlideInSelection({
+    tasks,
+    enabled: Boolean(getTaskPageProps),
+  });
 
   const taskById = useMemo(() => {
     const map = new Map<string, TaskBoard.Task>();
     tasks.forEach((task) => map.set(task.id, task));
     return map;
   }, [tasks]);
-
-  const taskIdFromUrl = useMemo(() => {
-    const value = searchParams.get("taskId");
-    return value && value.length > 0 ? value : null;
-  }, [searchParams]);
-
-  const [selectedTaskId, setSelectedTaskIdState] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!taskIdFromUrl) {
-      setSelectedTaskIdState(null);
-      return;
-    }
-
-    if (taskById.has(taskIdFromUrl)) {
-      setSelectedTaskIdState(taskIdFromUrl);
-      return;
-    }
-
-    const next = new URLSearchParams(searchParams);
-    next.delete("taskId");
-    setSearchParams(next, { replace: true });
-    setSelectedTaskIdState(null);
-  }, [taskById, taskIdFromUrl, searchParams, setSearchParams]);
-
-  const setSelectedTaskId = useCallback(
-    (taskId: string | null) => {
-      const next = new URLSearchParams(searchParams);
-
-      if (taskId) {
-        next.set("taskId", taskId);
-      } else {
-        next.delete("taskId");
-      }
-
-      setSearchParams(next, { replace: true });
-      setSelectedTaskIdState(taskId);
-    },
-    [searchParams, setSearchParams],
-  );
 
   const taskSlideInContext: TaskSlideInContext = useMemo(
     () => ({

--- a/turboui/src/TaskBoard/KanbanView/index.tsx
+++ b/turboui/src/TaskBoard/KanbanView/index.tsx
@@ -106,6 +106,7 @@ export function KanbanBoard(props: KanbanBoardProps) {
         statuses={orderedStatuses}
         onTaskAssigneeChange={props.onTaskAssigneeChange}
         onTaskDueDateChange={props.onTaskDueDateChange}
+        onTaskDueOffsetDaysChange={props.onTaskDueOffsetDaysChange}
         assigneePersonSearch={props.assigneePersonSearch}
         onTaskCreate={props.onTaskCreate}
         canEdit={props.canEdit}

--- a/turboui/src/TaskBoard/KanbanView/types.ts
+++ b/turboui/src/TaskBoard/KanbanView/types.ts
@@ -84,6 +84,7 @@ export interface KanbanBoardProps {
   onTaskCreate?: TaskBoardProps["onTaskCreate"];
   onTaskAssigneeChange?: TaskBoardProps["onTaskAssigneeChange"];
   onTaskDueDateChange?: TaskBoardProps["onTaskDueDateChange"];
+  onTaskDueOffsetDaysChange?: TaskBoardProps["onTaskDueOffsetDaysChange"];
   onTaskRemindersChange?: TaskBoardProps["onTaskRemindersChange"];
   onTaskStatusChange?: TaskBoardProps["onTaskStatusChange"];
   onTaskMilestoneChange?: (taskId: string, milestone: TaskBoard.Milestone | null) => void;

--- a/turboui/src/TaskBoard/components/TemplateTaskList.tsx
+++ b/turboui/src/TaskBoard/components/TemplateTaskList.tsx
@@ -20,6 +20,7 @@ export function TemplateTaskList({
   emptyState,
   dragState,
   highlighted = false,
+  selectedTaskId = null,
 }: TemplateTaskListProps) {
   const listRef = React.useRef<HTMLDivElement>(null);
   const dropContainerId = destinationMilestoneId ?? ROOT_TASKS_CONTAINER_ID;
@@ -87,6 +88,7 @@ export function TemplateTaskList({
             index={index}
             containerId={dropContainerId}
             isDraggable={isDraggingEnabled}
+            selected={task.id === selectedTaskId}
           />
         </React.Fragment>
       ))}
@@ -118,4 +120,5 @@ export interface TemplateTaskListProps {
     placeholderHeight: number | null;
   };
   highlighted?: boolean;
+  selectedTaskId?: string | null;
 }

--- a/turboui/src/TaskBoard/types.ts
+++ b/turboui/src/TaskBoard/types.ts
@@ -70,6 +70,7 @@ export interface Task {
   milestone: Milestone | null;
   points?: number;
   dueDate: DateField.ContextualDate | null;
+  dueOffsetDays?: number | null;
   reminders?: TaskPage.Reminder[];
   closedAt?: Date | null;
   hasDescription?: boolean;
@@ -188,6 +189,7 @@ export interface TaskBoardProps {
   onMilestoneCreate?: (milestone: NewMilestonePayload) => void;
   onTaskAssigneeChange: (taskId: string, assignees: Person[]) => void;
   onTaskDueDateChange: (taskId: string, dueDate: DateField.ContextualDate | null) => void;
+  onTaskDueOffsetDaysChange?: (taskId: string, dueOffsetDays: number | null) => void;
   onTaskRemindersChange?: (taskId: string, reminders: TaskPage.Reminder[]) => Promise<boolean> | boolean;
   onTaskStatusChange: (taskId: string, status: Status | null) => void;
   onTaskMilestoneChange?: (taskId: string, milestoneId: string | null, index: number) => void;

--- a/turboui/src/TemplateProjectPage/TaskBoard.tsx
+++ b/turboui/src/TemplateProjectPage/TaskBoard.tsx
@@ -195,6 +195,9 @@ function BoardView({
           })),
         })
       }
+      onTaskDueOffsetDaysChange={
+        canEdit ? (taskId, dueOffsetDays) => void props.onTaskUpdate?.(taskId, { dueOffsetDays }) : undefined
+      }
       onTaskStatusChange={handleStatusChange}
       onTaskMilestoneChange={(taskId, milestone) =>
         void props.onTaskUpdate?.(taskId, { milestoneId: milestone?.id ?? null })

--- a/turboui/src/TemplateProjectPage/TaskBoard.tsx
+++ b/turboui/src/TemplateProjectPage/TaskBoard.tsx
@@ -17,6 +17,7 @@ import {
 import { TemplateTaskList } from "../TaskBoard/components/TemplateTaskList";
 import { InlineTaskCreator } from "../TaskBoard/components/InlineTaskCreator";
 import { useInlineTaskCreator } from "../TaskBoard/hooks/useInlineTaskCreator";
+import { useTaskKeyboardNavigation } from "../TaskBoard/hooks/useTaskKeyboardNavigation";
 import { useTaskSlideInSelection } from "../TaskBoard/hooks/useTaskSlideInSelection";
 import { TaskSlideIn } from "../TaskBoard/KanbanView/TaskSlideIn";
 import type { KanbanState, TemplateTaskSlideInContext } from "../TaskBoard/KanbanView/types";
@@ -230,9 +231,17 @@ function ListView({
   const [createMilestoneId, setCreateMilestoneId] = React.useState<string | undefined>();
   const [isCreatingMilestone, setIsCreatingMilestone] = React.useState(false);
   const slideInEnabled = Boolean(props.getTemplateTaskPageProps);
-  const { selectedTaskId, setSelectedTaskId } = useTaskSlideInSelection({
+  const { selectedTaskId: slideInTaskId, setSelectedTaskId: setSlideInTaskId } = useTaskSlideInSelection({
     tasks: props.tasks,
     enabled: slideInEnabled,
+  });
+  const {
+    containerRef: keyboardNavigationRef,
+    selectedTaskId: keyboardSelectedTaskId,
+    clearSelection: clearTaskSelection,
+    scopeBind: keyboardNavigationScopeBind,
+  } = useTaskKeyboardNavigation<HTMLDivElement>({
+    clearSelectionWithEscape: !slideInTaskId,
   });
   const isDraggingEnabled = canEdit && Boolean(props.onTaskReorder);
   const handleTaskMove = React.useCallback(
@@ -252,8 +261,8 @@ function ListView({
   const activeDestination = isDraggingEnabled ? destination : null;
   const slideInContext = useTemplateSlideInContext(props, canEdit);
   const taskPageProps =
-    selectedTaskId && props.getTemplateTaskPageProps
-      ? props.getTemplateTaskPageProps(selectedTaskId, slideInContext)
+    slideInTaskId && props.getTemplateTaskPageProps
+      ? props.getTemplateTaskPageProps(slideInTaskId, slideInContext)
       : null;
   const openCreateModal = (milestoneId?: string) => {
     setCreateMilestoneId(milestoneId);
@@ -307,11 +316,15 @@ function ListView({
         onCreate={props.onMilestoneCreate}
       />
       <TaskSlideIn
-        isOpen={Boolean(selectedTaskId)}
-        onClose={() => setSelectedTaskId(null)}
+        isOpen={Boolean(slideInTaskId)}
+        onClose={() => setSlideInTaskId(null)}
         taskPageProps={taskPageProps}
       />
-      <div className="overflow-hidden rounded-md border border-surface-outline bg-surface-base">
+      <div
+        ref={keyboardNavigationRef}
+        {...keyboardNavigationScopeBind}
+        className="overflow-hidden rounded-md border border-surface-outline bg-surface-base"
+      >
         {orderedMilestones.map((milestone) => {
           const milestoneTasks = tasks.filter((task) => task.milestoneId === (milestone?.id ?? null));
           const containerId = milestone?.id ?? ROOT_TASKS_CONTAINER_ID;
@@ -333,8 +346,10 @@ function ListView({
               draggedItemId={activeDraggedItemId}
               destination={activeDestination}
               placeholderHeight={draggedItemDimensions?.height ?? null}
-              onTaskOpen={slideInEnabled ? setSelectedTaskId : undefined}
+              onTaskOpen={slideInEnabled ? setSlideInTaskId : undefined}
               onRequestAdvancedCreate={() => openCreateModal(milestone?.id)}
+              selectedTaskId={keyboardSelectedTaskId}
+              onInlineCreateOpen={clearTaskSelection}
             />
           );
         })}
@@ -394,6 +409,8 @@ function TaskSection({
   placeholderHeight,
   onTaskOpen,
   onRequestAdvancedCreate,
+  selectedTaskId,
+  onInlineCreateOpen,
 }: {
   title: string;
   link?: string;
@@ -409,10 +426,14 @@ function TaskSection({
   placeholderHeight: number | null;
   onTaskOpen?: (taskId: string | null) => void;
   onRequestAdvancedCreate: () => void;
+  selectedTaskId: string | null;
+  onInlineCreateOpen: () => void;
 }) {
   const sectionRef = React.useRef<HTMLElement>(null);
   const defaultStatus = props.statuses[0];
-  const { open: creatorOpen, openCreator, closeCreator, creatorRef, hoverBind } = useInlineTaskCreator();
+  const { open: creatorOpen, openCreator, closeCreator, creatorRef, hoverBind } = useInlineTaskCreator({
+    onOpen: onInlineCreateOpen,
+  });
   const handleCreateTask = React.useCallback(
     (name: string) => {
       if (!defaultStatus || !props.onTaskCreate) return;
@@ -515,6 +536,7 @@ function TaskSection({
         emptyState={<TaskSectionEmptyState inlineCreator={inlineCreator} showCreationPrompt={canEdit} />}
         dragState={{ draggedItemId, destination, placeholderHeight }}
         highlighted={isRootDropTarget}
+        selectedTaskId={selectedTaskId}
       />
     </section>
   );

--- a/turboui/src/TemplateProjectPage/TaskRow.tsx
+++ b/turboui/src/TemplateProjectPage/TaskRow.tsx
@@ -7,6 +7,13 @@ import { AvatarList } from "../Avatar";
 import { Tooltip } from "../Tooltip";
 import { IconAlertTriangleFilled, IconX } from "../icons";
 import { DescriptionIndicator } from "../TaskBoard/components/DescriptionIndicator";
+import {
+  OPEN_TASK_ASSIGNEE_EVENT,
+  OPEN_TASK_DUE_DATE_EVENT,
+  OPEN_TASK_EVENT,
+  OPEN_TASK_STATUS_EVENT,
+} from "../TaskBoard/hooks/useTaskKeyboardNavigation";
+import { useShortcutFieldFocusRestore } from "../TaskBoard/hooks/useShortcutFieldFocusRestore";
 import { isContentEmpty } from "../RichContent";
 import type { TemplateProjectPage } from ".";
 import { useSortableItem } from "../utils/PragmaticDragAndDrop";
@@ -24,6 +31,7 @@ export function TaskRow({
   index,
   containerId,
   isDraggable,
+  selected = false,
 }: {
   task: TemplateProjectPage.Task;
   props: TemplateProjectPage.Props;
@@ -32,6 +40,7 @@ export function TaskRow({
   index: number;
   containerId: string;
   isDraggable: boolean;
+  selected?: boolean;
 }) {
   const activeAssignees = React.useMemo(
     () => (task.assignees ?? []).filter((assignee) => assignee.active && assignee.person),
@@ -49,12 +58,18 @@ export function TaskRow({
   const confirmedAssignees = React.useRef(activePeople);
   const pendingAssignees = React.useRef<AssigneesField.Person[] | null>(null);
   const latestUpdate = React.useRef(0);
-  const { ref, isDragging } = useSortableItem<HTMLDivElement>({
+  const [assigneeFieldOpen, setAssigneeFieldOpen] = React.useState(false);
+  const [statusFieldOpen, setStatusFieldOpen] = React.useState(false);
+  const [dueDateFieldOpen, setDueDateFieldOpen] = React.useState(false);
+  const rowRef = React.useRef<HTMLDivElement | null>(null);
+  const { ref: sortableRef, isDragging } = useSortableItem<HTMLDivElement>({
     itemId: task.id,
     index,
     containerId,
     disabled: !isDraggable,
   });
+  const { prepareFocusRestore, restoreFocusAfterOpenChange, restoreFocusOnCloseAutoFocus } =
+    useShortcutFieldFocusRestore(rowRef as React.RefObject<HTMLElement>);
 
   React.useEffect(() => {
     confirmedAssignees.current = activePeople;
@@ -88,24 +103,103 @@ export function TaskRow({
     [activeAssignees, props.onTaskUpdate, task.id],
   );
 
+  const setRowRef = (element: HTMLDivElement | null) => {
+    rowRef.current = element;
+    if (sortableRef) {
+      (sortableRef as React.MutableRefObject<HTMLDivElement | null>).current = element;
+    }
+  };
+
+  React.useEffect(() => {
+    const element = rowRef.current;
+    if (!element) return;
+
+    const openAssigneeField = () => {
+      if (!canEdit || !props.personSearch) return;
+
+      prepareFocusRestore();
+      setAssigneeFieldOpen(true);
+    };
+
+    const openStatusField = () => {
+      if (!canEdit || !props.onTaskUpdate) return;
+
+      prepareFocusRestore();
+      setStatusFieldOpen(true);
+    };
+
+    const openDueDateField = () => {
+      if (!canEdit || !props.onTaskUpdate) return;
+
+      prepareFocusRestore();
+      setDueDateFieldOpen(true);
+    };
+
+    const openTask = () => {
+      onClick?.();
+    };
+
+    element.addEventListener(OPEN_TASK_ASSIGNEE_EVENT, openAssigneeField);
+    element.addEventListener(OPEN_TASK_STATUS_EVENT, openStatusField);
+    element.addEventListener(OPEN_TASK_DUE_DATE_EVENT, openDueDateField);
+    element.addEventListener(OPEN_TASK_EVENT, openTask);
+    return () => {
+      element.removeEventListener(OPEN_TASK_ASSIGNEE_EVENT, openAssigneeField);
+      element.removeEventListener(OPEN_TASK_STATUS_EVENT, openStatusField);
+      element.removeEventListener(OPEN_TASK_DUE_DATE_EVENT, openDueDateField);
+      element.removeEventListener(OPEN_TASK_EVENT, openTask);
+    };
+  }, [canEdit, onClick, prepareFocusRestore, props.onTaskUpdate, props.personSearch]);
+
+  const handleAssigneeFieldOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setAssigneeFieldOpen(isOpen);
+      restoreFocusAfterOpenChange(isOpen);
+    },
+    [restoreFocusAfterOpenChange],
+  );
+
+  const handleStatusFieldOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setStatusFieldOpen(isOpen);
+      restoreFocusAfterOpenChange(isOpen);
+    },
+    [restoreFocusAfterOpenChange],
+  );
+
+  const handleDueDateFieldOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setDueDateFieldOpen(isOpen);
+      restoreFocusAfterOpenChange(isOpen);
+    },
+    [restoreFocusAfterOpenChange],
+  );
+
   const stopDragFromInteractive = (event: React.MouseEvent) => event.stopPropagation();
   const hasDueDate = task.dueOffsetDays !== null;
 
   return (
     <div
-      ref={ref}
-      className={classNames("group/task-row border-b border-surface-outline last:border-b-0 focus-visible:outline-none", {
-        "cursor-grab active:cursor-grabbing": isDraggable && !isDragging,
-        "cursor-grabbing bg-surface-accent": isDragging,
-      })}
+      ref={setRowRef}
+      className={classNames(
+        "group/task-row border-b border-surface-outline last:border-b-0 focus-visible:outline-none",
+        {
+          "cursor-grab active:cursor-grabbing": isDraggable && !isDragging,
+          "cursor-grabbing bg-surface-accent": isDragging,
+        },
+      )}
       data-test-id={`template-task-${task.id}`}
       data-task-row-id={task.id}
+      data-selected={selected ? "true" : "false"}
+      tabIndex={-1}
+      aria-selected={selected}
     >
       <div
         className={classNames(
           "flex items-center gap-3 px-4 py-2.5 transition-colors",
-          "bg-surface-base hover:bg-surface-highlight",
-          "group-focus-visible/task-row:bg-[rgba(224,242,254,0.75)] group-focus-visible/task-row:shadow-[inset_0_0_0_2px_var(--color-brand-1)] dark:group-focus-visible/task-row:bg-[rgba(37,99,235,0.20)]",
+          selected
+            ? "bg-[rgba(224,242,254,0.75)] shadow-[inset_0_0_0_2px_var(--color-brand-1)] dark:bg-[rgba(37,99,235,0.20)]"
+            : "bg-surface-base hover:bg-surface-highlight group-focus-visible/task-row:bg-[rgba(224,242,254,0.75)] group-focus-visible/task-row:shadow-[inset_0_0_0_2px_var(--color-brand-1)] dark:group-focus-visible/task-row:bg-[rgba(37,99,235,0.20)]",
         )}
       >
         <div onMouseDown={stopDragFromInteractive}>
@@ -115,6 +209,9 @@ export function TaskRow({
             onChange={(status) => props.onTaskUpdate?.(task.id, { status })}
             readonly={!canEdit}
             size="md"
+            isOpen={statusFieldOpen}
+            onOpenChange={handleStatusFieldOpenChange}
+            onCloseAutoFocus={restoreFocusOnCloseAutoFocus}
           />
         </div>
         <div className="min-w-0 flex-1" onMouseDown={stopDragFromInteractive}>
@@ -139,6 +236,8 @@ export function TaskRow({
             hideCalendarIcon={!hasDueDate}
             className={hasDueDate ? undefined : EMPTY_DUE_DATE_REVEAL_CLASS}
             testId={`template-task-${task.id}-due-offset`}
+            isOpen={dueDateFieldOpen}
+            onOpenChange={handleDueDateFieldOpenChange}
           />
         </div>
         <div
@@ -158,6 +257,9 @@ export function TaskRow({
               avatarOnly
               maxAvatars={4}
               testId={`template-task-${task.id}-assignees`}
+              isOpen={assigneeFieldOpen}
+              onOpenChange={handleAssigneeFieldOpenChange}
+              onCloseAutoFocus={restoreFocusOnCloseAutoFocus}
             />
           ) : (
             <AssigneesField

--- a/turboui/src/TemplateProjectPage/index.test.tsx
+++ b/turboui/src/TemplateProjectPage/index.test.tsx
@@ -180,6 +180,7 @@ beforeEach(() => {
   mockBoardState = { draggedItemId: null, destination: null, draggedItemDimensions: null };
   mockUseSortableItem.mockClear();
   window.localStorage.removeItem("templateTaskBoard:taskDisplayMode");
+  HTMLElement.prototype.scrollIntoView = jest.fn();
 });
 
 describe("TemplateProjectPage", () => {
@@ -1285,6 +1286,71 @@ describe("TemplateProjectPage", () => {
     expect(screen.getByRole("heading", { name: "Create Task" })).toBeInTheDocument();
   });
 
+  it("selects template tasks with j and k and clears the selection with Escape", () => {
+    renderPage(createTwoTaskBoardProps(), "/templates/template-1?tab=tasks");
+
+    fireTaskKey("j", 74);
+    expect(document.querySelector('[data-test-id="template-task-task-1"]')).toHaveAttribute("data-selected", "true");
+
+    fireTaskKey("j", 74);
+    expect(document.querySelector('[data-test-id="template-task-task-2"]')).toHaveAttribute("data-selected", "true");
+    expect(document.querySelector('[data-test-id="template-task-task-1"]')).toHaveAttribute("data-selected", "false");
+
+    fireTaskKey("k", 75);
+    expect(document.querySelector('[data-test-id="template-task-task-1"]')).toHaveAttribute("data-selected", "true");
+
+    fireTaskKey("Escape", 27);
+    expect(document.querySelector('[data-test-id="template-task-task-1"]')).toHaveAttribute("data-selected", "false");
+    expect(document.querySelector('[data-test-id="template-task-task-2"]')).toHaveAttribute("data-selected", "false");
+  });
+
+  it("opens the selected template task with Enter", () => {
+    const getTemplateTaskPageProps = jest.fn((taskId: string) => ({
+      variant: "template",
+      name: taskId === "task-1" ? "Publish announcement" : "Prepare screenshots",
+    }));
+    renderPage(
+      createTwoTaskBoardProps({ getTemplateTaskPageProps: getTemplateTaskPageProps as never }),
+      "/templates/template-1?tab=tasks",
+    );
+
+    fireTaskKey("j", 74);
+    fireTaskKey("Enter", 13);
+
+    expect(document.querySelector('[data-test-id="task-slide-in"]')).toHaveTextContent("Publish announcement");
+    expect(getTemplateTaskPageProps).toHaveBeenCalledWith(
+      "task-1",
+      expect.objectContaining({ tasks: expect.any(Array) }),
+    );
+  });
+
+  it("opens the selected template task assignee picker with a", () => {
+    renderPage(createTwoTaskBoardProps(), "/templates/template-1?tab=tasks");
+
+    fireTaskKey("j", 74);
+    fireTaskKey("a", 65);
+
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+  });
+
+  it("opens the selected template task status picker with s", () => {
+    renderPage(createTwoTaskBoardProps(), "/templates/template-1?tab=tasks");
+
+    fireTaskKey("j", 74);
+    fireTaskKey("s", 83);
+
+    expect(screen.getByPlaceholderText("Change status...")).toBeInTheDocument();
+  });
+
+  it("opens the selected template task due date with d", () => {
+    renderPage(createTwoTaskBoardProps(), "/templates/template-1?tab=tasks");
+
+    fireTaskKey("j", 74);
+    fireTaskKey("d", 68);
+
+    expect(document.querySelector('[data-test-id="template-task-task-1-due-offset-input"]')).toBeInTheDocument();
+  });
+
   it("opens the task slide-in when a task title is clicked", () => {
     const getTemplateTaskPageProps = jest.fn(() => ({ variant: "template", name: "Publish announcement" }));
     renderPage(
@@ -1931,6 +1997,22 @@ function setupFileInputMock(files: File[]) {
   });
 
   return () => createElementSpy.mockRestore();
+}
+
+function createTwoTaskBoardProps(overrides: Partial<Types.Props> = {}): Types.Props {
+  const first = createProps().tasks[0]!;
+  const second = { ...first, id: "task-2", name: "Prepare screenshots", dueOffsetDays: 5 };
+
+  return createProps({
+    tasks: [first, second],
+    milestones: [{ ...createProps().milestones[0]!, tasksOrderingState: ["task-1", "task-2"] }],
+    ...overrides,
+  });
+}
+
+function fireTaskKey(key: "j" | "k" | "a" | "s" | "d" | "Enter" | "Escape", keyCode: number) {
+  fireEvent.keyDown(document, { key, keyCode, which: keyCode });
+  fireEvent.keyUp(document, { key, keyCode, which: keyCode });
 }
 
 function taskIdsIn(milestoneId: string) {

--- a/turboui/src/TemplateProjectPage/kanbanAdapters.test.ts
+++ b/turboui/src/TemplateProjectPage/kanbanAdapters.test.ts
@@ -1,0 +1,47 @@
+import { toBoardTask } from "./kanbanAdapters";
+import type { TemplateProjectPage } from ".";
+import type { StatusSelector } from "../StatusSelector";
+
+const status: StatusSelector.StatusOption = {
+  id: "todo",
+  value: "todo",
+  label: "To do",
+  color: "gray",
+  icon: "circleDashed",
+  index: 0,
+};
+
+const milestone: TemplateProjectPage.Milestone = {
+  id: "milestone-1",
+  title: "Release",
+  description: null,
+  dueOffsetDays: 14,
+  tasksOrderingState: ["task-1"],
+  tasksKanbanState: {},
+  link: "/templates/template-1/milestones/milestone-1",
+};
+
+function makeTask(overrides: Partial<TemplateProjectPage.Task> = {}): TemplateProjectPage.Task {
+  return {
+    id: "task-1",
+    name: "Publish announcement",
+    description: null,
+    milestoneId: "milestone-1",
+    priority: null,
+    size: null,
+    dueOffsetDays: 12,
+    status,
+    reminders: [],
+    ...overrides,
+  };
+}
+
+describe("toBoardTask", () => {
+  it("copies due offset days onto board tasks so kanban cards can edit them", () => {
+    expect(toBoardTask(makeTask(), [milestone]).dueOffsetDays).toBe(12);
+  });
+
+  it("keeps an unset due offset as null instead of omitting it", () => {
+    expect(toBoardTask(makeTask({ dueOffsetDays: null }), [milestone]).dueOffsetDays).toBeNull();
+  });
+});

--- a/turboui/src/TemplateProjectPage/kanbanAdapters.ts
+++ b/turboui/src/TemplateProjectPage/kanbanAdapters.ts
@@ -33,6 +33,7 @@ export function toBoardTask(
     ),
     milestone: milestone ? toBoardMilestone(milestone) : null,
     dueDate: null,
+    dueOffsetDays: task.dueOffsetDays,
     hasDescription: !isContentEmpty(task.description),
     type: "project",
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #5138.

Task management shortcuts (`j`/`k`, Enter, `a`, `s`, `d`, Escape) already worked on project task lists via `useTaskKeyboardNavigation`. Template task lists on the template page and template milestone page now use that same hook and event wiring, so the shortcuts behave the same way there.

### Changes
- Mount the existing task keyboard navigation hook on the template Tasks list and template milestone task section
- Teach template task rows to listen for the same open-task / assignee / status / due-date events as project task rows
- Allow `RelativeDayField` to be opened by a parent so `d` can edit the relative due date

### Tests
- Template task board: select with `j`/`k`, open with Enter, open assignee/status/due-date fields, clear with Escape
- `RelativeDayField` controlled `isOpen` / `onOpenChange`

No new TurboUI primitives. Reused `StatusSelector`, `AssigneesField`, and `RelativeDayField`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-341efbb8-b748-4c58-8c40-cb7f8084404d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-341efbb8-b748-4c58-8c40-cb7f8084404d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

