### PR TITLE
feat: Include ARM64 support in the official production image

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -227,12 +227,11 @@ blocks:
         commands:
           - checkout
           - cache restore
+          - make docker.buildx.setup
       jobs:
         - name: "Docker Release"
           commands:
-            - docker pull operately/operately:latest
-            - make docker.build
-            - 'if [[ "$SEMAPHORE_GIT_BRANCH" = "main" && "$SEMAPHORE_GIT_REF_TYPE" = "branch" ]]; then make docker.push; else echo "Skipping Docker push"; fi'
+            - 'if [[ "$SEMAPHORE_GIT_BRANCH" = "main" && "$SEMAPHORE_GIT_REF_TYPE" = "branch" ]]; then make docker.buildx.push; else make docker.build; fi'
 
   - name: Collect Test Timings
     dependencies:

--- a/Makefile
+++ b/Makefile
@@ -404,26 +404,46 @@ test.timings.merge:
 #
 
 DOCKER_IMAGE_TAG = $(shell git rev-parse --short HEAD)
+DOCKER_PLATFORMS ?= linux/amd64,linux/arm64
+DOCKER_BUILDX_BUILDER ?= prodimage-builder
+DOCKER_IMAGE_TAGS = -t operately/operately:latest -t operately/operately:$(DOCKER_IMAGE_TAG)
 
 inject.rel.version:
 	sed -i -E 's/dev-version/$(shell date +%Y-%m-%d)-$(DOCKER_IMAGE_TAG)/g' app/lib/operately.ex
 
+# docker-container builder required to produce a multi-platform manifest list.
+# Override DOCKER_BUILDX_BUILDER if several builders may share a Docker daemon.
+docker.buildx.setup:
+	docker buildx inspect $(DOCKER_BUILDX_BUILDER) >/dev/null 2>&1 || \
+		docker buildx create --name $(DOCKER_BUILDX_BUILDER) --driver docker-container
+	docker buildx use $(DOCKER_BUILDX_BUILDER)
+	docker buildx inspect --bootstrap
+
+# Native-arch build loaded into the local daemon. Used locally and on PR CI so we
+# do not emulate linux/arm64 on every branch.
 docker.build:
 	$(MAKE) inject.rel.version
-	docker build -f Dockerfile.prod -t operately/operately:latest -t operately/operately:$(DOCKER_IMAGE_TAG) .
+	docker buildx build -f Dockerfile.prod $(DOCKER_IMAGE_TAGS) --load .
 
-docker.push:
-	docker push operately/operately:$(DOCKER_IMAGE_TAG)
-	docker push operately/operately:latest
+# Build linux/amd64 and linux/arm64 and push them as one manifest list. Multi-arch
+# images cannot be --load'ed into the daemon, so build and push are one step.
+docker.buildx.push: docker.buildx.setup
+	$(MAKE) inject.rel.version
+	docker buildx build --platform $(DOCKER_PLATFORMS) -f Dockerfile.prod \
+		$(DOCKER_IMAGE_TAGS) --push .
+
+docker.push: docker.buildx.push
 
 #
 # Release related tasks
 #
 
+# Copy the published multi-arch manifest to the version tag. pull/tag/push would
+# flatten it to a single architecture.
 release.tag.docker:
-	docker pull operately/operately:$(DOCKER_IMAGE_TAG)
-	docker tag operately/operately:$(DOCKER_IMAGE_TAG) operately/operately:$(VERSION)
-	docker push operately/operately:$(VERSION)
+	docker buildx imagetools create \
+		-t operately/operately:$(VERSION) \
+		operately/operately:$(DOCKER_IMAGE_TAG)
 
 release.build.singlehost:
 	elixir app/rel/single-host/build.exs $(VERSION)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #4850

The official production image (`operately/operately`) was built with plain `docker build`, so it only shipped the CI host architecture (amd64). The development image already publishes both `linux/amd64` and `linux/arm64`.

This change makes the production image multi-arch the same way:

- **PR / local:** `make docker.build` builds the native architecture and `--load`s it into the local daemon. No QEMU emulation, so PR CI stays fast.
- **main:** `make docker.buildx.push` builds `linux/amd64` and `linux/arm64` and pushes a single manifest list.
- **releases:** `make release.tag.docker` copies that manifest with `docker buildx imagetools create` instead of pull/tag/push, which would flatten it to one architecture.

`Dockerfile.prod` is unchanged: the Elixir builder and Debian runner images already publish arm64 variants, and Node is installed from the multi-arch NodeSource repo.

A previous attempt in #4911 built both platforms on every PR (slow under QEMU) and used `docker pull`/`tag`/`push` for retagging. This PR follows the original plan and the review notes from that attempt.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8164294-b034-409f-b50b-dc5032f2c80b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8164294-b034-409f-b50b-dc5032f2c80b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

