### PR TITLE
fix: Label KPI chart dates on calendar ticks

### DIFF
--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -2,6 +2,7 @@ import Api, { Kpi as ApiKpi, KpiAnnotation as ApiKpiAnnotation, KpiEntry as ApiK
 import { Paths } from "@/routes/paths";
 import { parsePersonForTurboUi } from "@/models/people";
 import type { SpaceKpisPage } from "turboui/SpaceKpisPage/types";
+import { fromIsoDate } from "turboui/SpaceKpisPage/utils";
 
 export type { Kpi } from "@/api";
 
@@ -15,8 +16,9 @@ export const useAddKpiAnnotation = Api.kpis.useAddKpiAnnotation;
 export const useEditKpiAnnotation = Api.kpis.useEditKpiAnnotation;
 export const useDeleteKpiAnnotation = Api.kpis.useDeleteKpiAnnotation;
 
-// Map the API KPI shape onto the presentational turboui shape. The `period` /
-// timestamps arrive as ISO strings and are parsed into `Date`s for the chart.
+// Map the API KPI shape onto the presentational turboui shape. Date-only
+// `period` / annotation values arrive as `YYYY-MM-DD` and are parsed as local
+// calendar days so the chart axis is not shifted by UTC midnight.
 export function parseKpiForTurboUi(paths: Paths, kpi: ApiKpi): SpaceKpisPage.Kpi {
   return {
     id: kpi.id,
@@ -37,7 +39,7 @@ function parseKpiEntryForTurboUi(paths: Paths, entry: ApiKpiEntry): SpaceKpisPag
   return {
     id: entry.id,
     value: entry.value,
-    recordedAt: new Date(entry.period),
+    recordedAt: fromIsoDate(entry.period),
     recordedBy: parsePersonForTurboUi(paths, entry.recordedBy),
     commentsCount: entry.commentsCount ?? 0,
   };
@@ -46,7 +48,7 @@ function parseKpiEntryForTurboUi(paths: Paths, entry: ApiKpiEntry): SpaceKpisPag
 function parseKpiAnnotationForTurboUi(paths: Paths, annotation: ApiKpiAnnotation): SpaceKpisPage.KpiAnnotation {
   return {
     id: annotation.id,
-    date: new Date(annotation.date),
+    date: fromIsoDate(annotation.date),
     title: annotation.title,
     createdBy: parsePersonForTurboUi(paths, annotation.createdBy),
   };

--- a/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
@@ -40,6 +40,69 @@ describe("KpiLineChart y-axis", () => {
   });
 });
 
+describe("KpiLineChart x-axis", () => {
+  function entryOn(id: string, date: Date): SpaceKpisPage.KpiEntry {
+    return { id, value: 100, recordedAt: date, recordedBy: null, commentsCount: 0 };
+  }
+
+  function axisLabels(entries: SpaceKpisPage.KpiEntry[]): string[] {
+    const { container } = render(<KpiLineChart entries={entries} unit="users" />);
+
+    return Array.from(container.querySelectorAll('[data-test-id="kpi-chart-x-axis-tick"] text')).map((node) =>
+      String(node.textContent),
+    );
+  }
+
+  // The old axis labelled only the first and last entry, which left a
+  // multi-year series with no way to tell where any middle point sits in time.
+  test("labels dates between the first and last entry", () => {
+    const labels = axisLabels([
+      entryOn("1", new Date(2024, 2, 1)),
+      entryOn("2", new Date(2025, 5, 1)),
+      entryOn("3", new Date(2026, 7, 15)),
+    ]);
+
+    expect(labels.length).toBeGreaterThan(2);
+  });
+
+  // A lone "Jul" between two years leaves the reader inferring which July it is
+  // from a neighbouring label.
+  test("names the year on every axis label of a multi-year series", () => {
+    const labels = axisLabels([entryOn("1", new Date(2024, 2, 1)), entryOn("2", new Date(2026, 7, 15))]);
+
+    expect(labels.length).toBeGreaterThan(1);
+    labels.forEach((label) => expect(label).toMatch(/\d{4}/));
+  });
+
+  test("keeps every axis label inside the chart viewport", () => {
+    const { container } = render(
+      <KpiLineChart entries={[entryOn("1", new Date(2024, 2, 1)), entryOn("2", new Date(2026, 7, 15))]} unit="users" />,
+    );
+
+    const labels = Array.from(container.querySelectorAll('[data-test-id="kpi-chart-x-axis-tick"] text'));
+    expect(labels.length).toBeGreaterThan(0);
+
+    labels.forEach((label) => {
+      const x = Number(label.getAttribute("x"));
+      const anchor = label.getAttribute("text-anchor");
+
+      expect(x).toBeGreaterThanOrEqual(0);
+      expect(x).toBeLessThanOrEqual(640);
+      if (x < 78) expect(anchor).toBe("start");
+      if (x > 590) expect(anchor).toBe("end");
+    });
+  });
+
+  test("includes the year in tooltips when the series spans more than one year", () => {
+    const entries = [entryOn("1", new Date(2024, 2, 1)), entryOn("2", new Date(2026, 7, 15))];
+    const { container } = render(<KpiLineChart entries={entries} unit="users" />);
+
+    fireEvent.mouseEnter(container.querySelector('[data-test-id="kpi-chart-hover-band-0"]')!);
+
+    expect(container.querySelector('[data-test-id="kpi-chart-tooltip"]')).toHaveTextContent("2024");
+  });
+});
+
 describe("KpiLineChart hover", () => {
   const entries = [entry("1", 810), entry("2", 848), entry("3", 802)];
 

--- a/turboui/src/SpaceKpisPage/KpiLineChart.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { timeAxisTicks } from "./timeAxis";
 import type { SpaceKpisPage } from "./types";
 import { formatNumber, formatShortDate, formatValue } from "./utils";
 
@@ -118,9 +119,10 @@ function MultiPointChart({
   const tMax = Math.max(...times);
   const tSpan = tMax - tMin;
 
+  const xAtTime = (time: number) => PADDING.left + (innerWidth * (time - tMin)) / tSpan;
   const xAt = (time: number, index: number) => {
     if (tSpan <= 0) return PADDING.left + (innerWidth * index) / (entries.length - 1);
-    return PADDING.left + (innerWidth * (time - tMin)) / tSpan;
+    return xAtTime(time);
   };
   const y = (value: number) => PADDING.top + innerHeight * (1 - (value - yMin) / (yMax - yMin));
 
@@ -140,6 +142,12 @@ function MultiPointChart({
 
   const gridLines = [yMax, (yMax + yMin) / 2, yMin];
   const baseline = PADDING.top + innerHeight;
+
+  const axisTicks = tSpan > 0 ? timeAxisTicks(new Date(tMin), new Date(tMax)) : [];
+  // A series crossing a year boundary needs the year in its tooltips too, or a
+  // reader hovering "Aug 15" cannot tell which August they are looking at.
+  const spansYears = new Date(tMin).getFullYear() !== new Date(tMax).getFullYear();
+
   const hovered = hoveredIndex === null ? null : (points[hoveredIndex] ?? null);
   const hoveredAnnotation = annotationMarks.find((mark) => mark.annotation.id === hoveredAnnotationId) ?? null;
 
@@ -180,6 +188,34 @@ function MultiPointChart({
           </g>
         ))}
 
+        {/* Dates on calendar boundaries rather than on the first and last entry,
+            so the reader can place any part of the line in time. */}
+        {axisTicks.map((tick) => {
+          const cx = xAtTime(tick.time);
+
+          return (
+            <g key={tick.time} data-test-id="kpi-chart-x-axis-tick">
+              <line
+                x1={cx}
+                x2={cx}
+                y1={baseline}
+                y2={baseline + 4}
+                className="stroke-surface-outline"
+                strokeWidth={1}
+              />
+              <text
+                x={cx}
+                y={baseline + 18}
+                textAnchor={labelAnchor(cx)}
+                className="fill-content-dimmed"
+                style={{ fontSize: 11 }}
+              >
+                {tick.label}
+              </text>
+            </g>
+          );
+        })}
+
         {/* Behind the series, so the data line reads as one unbroken stroke and
             the annotation only whispers where on the timeline it sits. */}
         {annotationMarks.map((mark) => (
@@ -218,26 +254,14 @@ function MultiPointChart({
         )}
 
         {points.map((p, i) => (
-          <g key={p.entry.id}>
-            <circle
-              cx={p.cx}
-              cy={p.cy}
-              r={hoveredIndex === i && !hoveredAnnotation ? 6 : 4}
-              className="fill-surface-base stroke-blue-500"
-              strokeWidth={2}
-            />
-            {(i === 0 || i === points.length - 1) && (
-              <text
-                x={p.cx}
-                y={baseline + 18}
-                textAnchor={i === 0 ? "start" : "end"}
-                className="fill-content-dimmed"
-                style={{ fontSize: 11 }}
-              >
-                {formatShortDate(p.entry.recordedAt)}
-              </text>
-            )}
-          </g>
+          <circle
+            key={p.entry.id}
+            cx={p.cx}
+            cy={p.cy}
+            r={hoveredIndex === i && !hoveredAnnotation ? 6 : 4}
+            className="fill-surface-base stroke-blue-500"
+            strokeWidth={2}
+          />
         ))}
 
         {/* Invisible bands, one per entry, so hovering anywhere in a point's
@@ -313,13 +337,23 @@ function MultiPointChart({
         ))}
 
         {hoveredAnnotation ? (
-          <AnnotationTooltip mark={hoveredAnnotation} baseline={baseline} />
+          <AnnotationTooltip mark={hoveredAnnotation} baseline={baseline} withYear={spansYears} />
         ) : hovered ? (
-          <Tooltip point={hovered} unit={unit} />
+          <Tooltip point={hovered} unit={unit} withYear={spansYears} />
         ) : null}
       </svg>
     </div>
   );
+}
+
+// Ticks at the very edges of the plot would have half their label hanging
+// outside the viewport, so those two align to the inside instead.
+const LABEL_EDGE = 34;
+
+function labelAnchor(cx: number): "start" | "middle" | "end" {
+  if (cx - PADDING.left < LABEL_EDGE) return "start";
+  if (VIEW_WIDTH - PADDING.right - cx < LABEL_EDGE) return "end";
+  return "middle";
 }
 
 interface ChartPoint {
@@ -330,9 +364,9 @@ interface ChartPoint {
 
 const TOOLTIP = { height: 40, paddingX: 10, valueFontSize: 12, dateFontSize: 11, gap: 12 };
 
-function Tooltip({ point, unit }: { point: ChartPoint; unit: string }) {
+function Tooltip({ point, unit, withYear }: { point: ChartPoint; unit: string; withYear: boolean }) {
   const valueLabel = formatValue(point.entry.value, unit);
-  const dateLabel = formatShortDate(point.entry.recordedAt);
+  const dateLabel = formatShortDate(point.entry.recordedAt, { withYear });
 
   // Approximate the text width from character counts: measuring rendered SVG
   // text would require a layout pass the chart otherwise does not need.
@@ -387,11 +421,13 @@ const ANNOTATION_TOOLTIP = { paddingX: 11, paddingTop: 8, lineHeight: 15, titleM
 function AnnotationTooltip({
   mark,
   baseline,
+  withYear,
 }: {
   mark: { annotation: SpaceKpisPage.KpiAnnotation; cx: number };
   baseline: number;
+  withYear: boolean;
 }) {
-  const dateLabel = formatShortDate(mark.annotation.date);
+  const dateLabel = formatShortDate(mark.annotation.date, { withYear });
   const title = truncate(mark.annotation.title, ANNOTATION_TOOLTIP.titleMaxChars);
 
   const lines = 2;

--- a/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
+++ b/turboui/src/SpaceKpisPage/LogUpdateForm.tsx
@@ -5,7 +5,7 @@ import { Modal } from "../Modal";
 import { emptyContent, isContentEmpty } from "../RichContent";
 import type { RichEditorHandlers } from "../RichEditor/useEditor";
 import type { SpaceKpisPage } from "./types";
-import { formatShortDate, formatValue, latestEntry } from "./utils";
+import { formatShortDate, formatValue, fromIsoDate, latestEntry } from "./utils";
 
 interface LogUpdateFormProps {
   kpi: SpaceKpisPage.Kpi | null;
@@ -27,9 +27,7 @@ function today(): string {
 // via `new Date(string)`, which would treat the value as UTC) so the displayed
 // date matches the picked calendar day.
 function formatPeriodLabel(period: string): string {
-  const [year, month, day] = period.split("-").map(Number);
-  if (!year || !month || !day) return period;
-  return formatShortDate(new Date(year, month - 1, day));
+  return formatShortDate(fromIsoDate(period));
 }
 
 // Single-KPI "Log update" form → calls the `logKpiEntry` mutation.

--- a/turboui/src/SpaceKpisPage/timeAxis.test.ts
+++ b/turboui/src/SpaceKpisPage/timeAxis.test.ts
@@ -1,0 +1,97 @@
+import { timeAxisTicks } from "./timeAxis";
+
+// Local-time constructor: the axis labels calendar days, so a UTC-parsed string
+// would shift the expected labels depending on the machine's timezone.
+function at(year: number, month: number, day: number, hour = 0): Date {
+  return new Date(year, month - 1, day, hour);
+}
+
+function labels(from: Date, to: Date, maxTicks?: number): string[] {
+  return timeAxisTicks(from, to, maxTicks).map((tick) => tick.label);
+}
+
+describe("timeAxisTicks", () => {
+  test("labels days for a range of a couple of weeks", () => {
+    expect(labels(at(2026, 3, 2), at(2026, 3, 14))).toEqual(["Mar 2, 2026", "Mar 5", "Mar 8", "Mar 11", "Mar 14"]);
+  });
+
+  // Inside a single year the year is named once and never repeated: it would
+  // say nothing the first label has not already said.
+  test("labels months for a range of about a year", () => {
+    expect(labels(at(2026, 1, 15), at(2026, 12, 20))).toEqual(["Mar 2026", "May", "Jul", "Sep", "Nov"]);
+  });
+
+  test("keeps month ticks on calendar quarters", () => {
+    expect(labels(at(2025, 2, 10), at(2026, 6, 30))).toEqual([
+      "Apr 2025",
+      "Jul 2025",
+      "Oct 2025",
+      "Jan 2026",
+      "Apr 2026",
+    ]);
+  });
+
+  test("labels years for a range of many years", () => {
+    expect(labels(at(2013, 5, 1), at(2026, 5, 1))).toEqual(["2015", "2020", "2025"]);
+  });
+
+  test("names the year on every tick when the range crosses years", () => {
+    expect(labels(at(2024, 3, 1), at(2026, 8, 15))).toEqual([
+      "Jul 2024",
+      "Jan 2025",
+      "Jul 2025",
+      "Jan 2026",
+      "Jul 2026",
+    ]);
+  });
+
+  test("names the year only where it changes once the axis is dense", () => {
+    expect(labels(at(2024, 3, 1), at(2026, 8, 15), 12)).toEqual([
+      "Apr 2024",
+      "Jul",
+      "Oct",
+      "Jan 2025",
+      "Apr",
+      "Jul",
+      "Oct",
+      "Jan 2026",
+      "Apr",
+      "Jul",
+    ]);
+  });
+
+  test("never returns more ticks than the chart has room for", () => {
+    const ranges: [Date, Date][] = [
+      [at(2026, 3, 1), at(2026, 3, 8)],
+      [at(2026, 1, 1), at(2026, 4, 1)],
+      [at(2024, 1, 1), at(2026, 8, 15)],
+      [at(1998, 1, 1), at(2026, 8, 15)],
+    ];
+
+    ranges.forEach(([from, to]) => {
+      expect(labels(from, to).length).toBeLessThanOrEqual(6);
+    });
+  });
+
+  test("labels the day when the whole range sits inside it", () => {
+    expect(labels(at(2026, 3, 2, 9), at(2026, 3, 2, 17))).toEqual(["Mar 2, 2026"]);
+  });
+
+  test("labels a single point when the range has no span", () => {
+    expect(labels(at(2026, 3, 2), at(2026, 3, 2))).toEqual(["Mar 2, 2026"]);
+  });
+
+  test("returns ticks inside the requested range, in order", () => {
+    const from = at(2024, 3, 1);
+    const to = at(2026, 8, 15);
+    const ticks = timeAxisTicks(from, to);
+
+    ticks.forEach((tick) => {
+      expect(tick.time).toBeGreaterThanOrEqual(from.getTime());
+      expect(tick.time).toBeLessThanOrEqual(to.getTime());
+    });
+
+    const times = ticks.map((tick) => tick.time);
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+});

--- a/turboui/src/SpaceKpisPage/timeAxis.test.ts
+++ b/turboui/src/SpaceKpisPage/timeAxis.test.ts
@@ -1,7 +1,9 @@
 import { timeAxisTicks } from "./timeAxis";
 
 // Local-time constructor: the axis labels calendar days, so a UTC-parsed string
-// would shift the expected labels depending on the machine's timezone.
+// would shift the expected labels depending on the machine's timezone. Callers
+// that receive backend `:date` values as `YYYY-MM-DD` must parse them with
+// `fromIsoDate` (local midnight), not `new Date(iso)`.
 function at(year: number, month: number, day: number, hour = 0): Date {
   return new Date(year, month - 1, day, hour);
 }

--- a/turboui/src/SpaceKpisPage/timeAxis.ts
+++ b/turboui/src/SpaceKpisPage/timeAxis.ts
@@ -6,6 +6,10 @@
 // boundaries the reader already thinks in — days, months, quarters, years — at
 // the finest spacing that still fits, so the shape of the line can be read
 // against real dates.
+//
+// Ticks are computed in local calendar time. Date-only API values must be
+// parsed with `fromIsoDate`; `new Date("YYYY-MM-DD")` is UTC midnight and would
+// land on the previous day in negative-offset timezones.
 
 export interface TimeAxisTick {
   time: number;

--- a/turboui/src/SpaceKpisPage/timeAxis.ts
+++ b/turboui/src/SpaceKpisPage/timeAxis.ts
@@ -1,0 +1,153 @@
+// Date labels for a chart's horizontal axis.
+//
+// Labelling only the first and last point tells a reader when a series starts
+// and ends but nothing about what lies between, so a line covering two years
+// reads the same as one covering two weeks. These ticks instead sit on calendar
+// boundaries the reader already thinks in — days, months, quarters, years — at
+// the finest spacing that still fits, so the shape of the line can be read
+// against real dates.
+
+export interface TimeAxisTick {
+  time: number;
+  label: string;
+}
+
+type Granularity = "day" | "month" | "year";
+
+interface Spacing {
+  granularity: Granularity;
+  step: number;
+}
+
+// Ordered coarse to fine: the finest spacing that fits wins, so a short range
+// gets days and a long one gets years without the caller choosing.
+const SPACINGS: Spacing[] = [
+  { granularity: "year", step: 10 },
+  { granularity: "year", step: 5 },
+  { granularity: "year", step: 2 },
+  { granularity: "year", step: 1 },
+  { granularity: "month", step: 6 },
+  { granularity: "month", step: 3 },
+  { granularity: "month", step: 2 },
+  { granularity: "month", step: 1 },
+  { granularity: "day", step: 14 },
+  { granularity: "day", step: 7 },
+  { granularity: "day", step: 3 },
+  { granularity: "day", step: 2 },
+  { granularity: "day", step: 1 },
+];
+
+// Labels carrying a year need roughly a sixth of the chart's width, so more than
+// this many would crowd into each other.
+const MAX_TICKS = 6;
+
+// While the labels stay this far apart, every one of them names its year: a
+// lone "Jul" between two years is something the reader has to work out from a
+// neighbouring label. Denser axes drop the repetition to stay legible.
+const MAX_TICKS_WITH_REPEATED_YEAR = 6;
+
+export function timeAxisTicks(from: Date, to: Date, maxTicks: number = MAX_TICKS): TimeAxisTick[] {
+  const start = from.getTime();
+  const end = to.getTime();
+
+  if (end <= start) return label([new Date(start)], "day");
+
+  const fitted = fit(start, end, maxTicks);
+  if (fitted) return label(fitted.dates, fitted.spacing.granularity);
+
+  // Nothing lands inside the range: it is shorter than a day, or so long that
+  // even decades would crowd. Its endpoints still say what it covers.
+  return label(distinctDays(start, end), "day");
+}
+
+// The finest spacing whose boundaries both fit the width and give at least two
+// dates, since a single tick says no more than an endpoint label would.
+function fit(start: number, end: number, maxTicks: number): { spacing: Spacing; dates: Date[] } | null {
+  let fitted: { spacing: Spacing; dates: Date[] } | null = null;
+
+  for (const spacing of SPACINGS) {
+    const dates = boundaries(start, end, spacing);
+    if (dates.length > maxTicks) break;
+    if (dates.length >= 2) fitted = { spacing, dates };
+  }
+
+  return fitted;
+}
+
+function boundaries(start: number, end: number, spacing: Spacing): Date[] {
+  const dates: Date[] = [];
+
+  for (let cursor = firstBoundary(start, spacing); cursor.getTime() <= end; cursor = advance(cursor, spacing)) {
+    dates.push(cursor);
+  }
+
+  return dates;
+}
+
+function firstBoundary(start: number, spacing: Spacing): Date {
+  const date = new Date(start);
+
+  if (spacing.granularity === "year") {
+    const aligned = Math.ceil(date.getFullYear() / spacing.step) * spacing.step;
+    const boundary = new Date(aligned, 0, 1);
+    return boundary.getTime() >= start ? boundary : new Date(aligned + spacing.step, 0, 1);
+  }
+
+  if (spacing.granularity === "month") {
+    // Counted from January so a 3-month step lands on calendar quarters rather
+    // than on whichever month the data happens to begin in.
+    const boundary = new Date(date.getFullYear(), 0, 1);
+    while (boundary.getTime() < start) boundary.setMonth(boundary.getMonth() + spacing.step);
+    return boundary;
+  }
+
+  // Days have no equivalent anchor, so they are counted from the range's own start.
+  const boundary = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  if (boundary.getTime() < start) boundary.setDate(boundary.getDate() + 1);
+  return boundary;
+}
+
+function advance(date: Date, spacing: Spacing): Date {
+  const next = new Date(date);
+
+  if (spacing.granularity === "year") next.setFullYear(next.getFullYear() + spacing.step);
+  else if (spacing.granularity === "month") next.setMonth(next.getMonth() + spacing.step);
+  else next.setDate(next.getDate() + spacing.step);
+
+  return next;
+}
+
+function distinctDays(start: number, end: number): Date[] {
+  const first = new Date(start);
+  const last = new Date(end);
+
+  return isSameDay(first, last) ? [first] : [first, last];
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+// An axis staying inside one calendar year names it once, on the first tick,
+// since repeating it would say nothing. One crossing years names it on every
+// tick it has room for, and otherwise wherever the year turns.
+function label(dates: Date[], granularity: Granularity): TimeAxisTick[] {
+  const crossesYears = dates.length > 0 && dates[0]!.getFullYear() !== dates[dates.length - 1]!.getFullYear();
+  const repeatYear = crossesYears && dates.length <= MAX_TICKS_WITH_REPEATED_YEAR;
+
+  return dates.map((date, index) => {
+    const previous = dates[index - 1];
+    const withYear = repeatYear || !previous || previous.getFullYear() !== date.getFullYear();
+
+    return { time: date.getTime(), label: formatTick(date, granularity, withYear) };
+  });
+}
+
+function formatTick(date: Date, granularity: Granularity, withYear: boolean): string {
+  const year: Intl.DateTimeFormatOptions = withYear ? { year: "numeric" } : {};
+
+  if (granularity === "year") return date.toLocaleDateString(undefined, { year: "numeric" });
+  if (granularity === "month") return date.toLocaleDateString(undefined, { month: "short", ...year });
+
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", ...year });
+}

--- a/turboui/src/SpaceKpisPage/utils.test.ts
+++ b/turboui/src/SpaceKpisPage/utils.test.ts
@@ -1,0 +1,17 @@
+import { fromIsoDate, toIsoDate } from "./utils";
+
+describe("fromIsoDate", () => {
+  // `new Date("2026-01-01")` is UTC midnight, which is the previous calendar
+  // day west of UTC. The stored period is a calendar date, not an instant.
+  test("parses YYYY-MM-DD as a local calendar day", () => {
+    const date = fromIsoDate("2026-01-01");
+
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(0);
+    expect(date.getDate()).toBe(1);
+  });
+
+  test("round-trips with toIsoDate", () => {
+    expect(toIsoDate(fromIsoDate("2024-03-01"))).toBe("2024-03-01");
+  });
+});

--- a/turboui/src/SpaceKpisPage/utils.ts
+++ b/turboui/src/SpaceKpisPage/utils.ts
@@ -61,12 +61,14 @@ export function latestTrend(kpi: SpaceKpisPage.Kpi): number | null {
 
 // Self-contained short date (e.g. "Apr 5" / "Apr 5, 2026") so components render
 // identically in Storybook and the app without a FormattedTime preferences context.
-export function formatShortDate(date: Date): string {
+// The year is dropped for the current year unless the caller needs it, as a chart
+// spanning several years does.
+export function formatShortDate(date: Date, { withYear = false }: { withYear?: boolean } = {}): string {
   const sameYear = date.getFullYear() === new Date().getFullYear();
   return date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
-    year: sameYear ? undefined : "numeric",
+    year: withYear || !sameYear ? "numeric" : undefined,
   });
 }
 

--- a/turboui/src/SpaceKpisPage/utils.ts
+++ b/turboui/src/SpaceKpisPage/utils.ts
@@ -79,3 +79,11 @@ export function toIsoDate(date: Date): string {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+
+// Inverse of `toIsoDate`. `new Date("YYYY-MM-DD")` is UTC midnight, which is
+// the previous calendar day in negative-offset timezones; parse the parts as
+// a local date so axis ticks and labels match the stored period.
+export function fromIsoDate(iso: string): Date {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(year!, month! - 1, day);
+}


### PR DESCRIPTION
## Summary
- KPI history charts now label the x-axis on calendar boundaries (days, months, quarters, or years) instead of only the first and last entry, so a multi-year series can be read against real dates.
- Multi-year axes name the year on every tick so a lone "Jul" is not ambiguous; tooltips include the year when the series crosses a year boundary.

## Test plan
- [ ] Open a KPI with history spanning multiple years and confirm ticks such as `Jul 2024`, `Jan 2025`, `Jul 2025`
- [ ] Open a KPI with a few weeks of data and confirm day-level ticks
- [ ] Hover points and annotations on a multi-year chart and confirm the tooltip includes the year
- [ ] Confirm labels at the left and right edges stay inside the chart


Made with [Cursor](https://cursor.com)