### PR TITLE
feat: Surface KPI updates on Review for champions

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -3083,6 +3083,7 @@ export type ReviewAssignmentTypes =
   | "space_task"
   | "project_task"
   | "milestone"
+  | "kpi_update"
   | "project_retrospective"
   | "goal_retrospective";
 

--- a/app/lib/operately/assignments/assignment.ex
+++ b/app/lib/operately/assignments/assignment.ex
@@ -13,7 +13,9 @@ defmodule Operately.Assignments.Assignment do
   alias Operately.Goals.{Goal, Update}
   alias Operately.Tasks.Task
   alias Operately.Groups.Group
+  alias Operately.Kpis.Kpi
   alias Operately.Activities.Activity
+  alias Operately.Assignments.KpiSchedule
   alias Operately.ContextualDates.{ContextualDate, Timeframe}
   alias OperatelyWeb.Paths
 
@@ -111,6 +113,23 @@ defmodule Operately.Assignments.Assignment do
       role: :owner,
       action_label: milestone.title,
       path: Paths.project_milestone_path(company, milestone),
+      origin: origin
+    })
+  end
+
+  # KPI update (champion role)
+  def build(%Kpi{space: %Group{}} = kpi, company) do
+    origin = build_space_origin(company, kpi.space)
+    {due_date, _period_end} = KpiSchedule.current_period(kpi.cadence)
+
+    build_with_enrichment(%{
+      resource_id: Paths.kpi_id(kpi),
+      name: kpi.name,
+      due: due_date,
+      type: :kpi_update,
+      role: :owner,
+      action_label: "Log update for #{kpi.name}",
+      path: Paths.space_kpi_path(company, kpi.space, kpi),
       origin: origin
     })
   end

--- a/app/lib/operately/assignments/kpi_schedule.ex
+++ b/app/lib/operately/assignments/kpi_schedule.ex
@@ -1,0 +1,21 @@
+defmodule Operately.Assignments.KpiSchedule do
+  @moduledoc """
+  Defines the reporting period in which a KPI champion must log an update.
+
+  Weekly periods follow ISO weeks (Monday through Sunday). Monthly periods
+  follow calendar months. The first day of the period is the assignment's due
+  date, so an unlogged update remains visible and overdue until it is recorded.
+  """
+
+  def current_period(cadence, today \\ Date.utc_today())
+
+  def current_period(:weekly, today) do
+    period_start = Date.add(today, 1 - Date.day_of_week(today))
+    {period_start, Date.add(period_start, 6)}
+  end
+
+  def current_period(:monthly, today) do
+    period_start = Date.beginning_of_month(today)
+    {period_start, Date.end_of_month(today)}
+  end
+end

--- a/app/lib/operately/assignments/loader.ex
+++ b/app/lib/operately/assignments/loader.ex
@@ -7,6 +7,7 @@ defmodule Operately.Assignments.Loader do
   alias Operately.Comments.CommentThread
   alias Operately.Activities.Activity
   alias Operately.Assignments.Assignment
+  alias Operately.Assignments.KpiSchedule
 
   @due_soon_window_in_days 1
 
@@ -20,7 +21,8 @@ defmodule Operately.Assignments.Loader do
       Task.async(fn -> load_pending_goal_retrospective_acknowledgements(company, person) end),
       Task.async(fn -> load_pending_tasks(company, person) end),
       Task.async(fn -> load_pending_space_tasks(company, person) end),
-      Task.async(fn -> load_pending_milestones(company, person) end)
+      Task.async(fn -> load_pending_milestones(company, person) end),
+      Task.async(fn -> load_pending_kpi_updates(company, person) end)
     ]
     |> Task.await_many()
     |> List.flatten()
@@ -36,7 +38,8 @@ defmodule Operately.Assignments.Loader do
       Task.async(fn -> count_pending_goal_retrospective_acknowledgements(person) end),
       Task.async(fn -> count_pending_tasks(person) end),
       Task.async(fn -> count_pending_space_tasks(person) end),
-      Task.async(fn -> count_pending_milestones(person) end)
+      Task.async(fn -> count_pending_milestones(person) end),
+      Task.async(fn -> count_pending_kpi_updates(person) end)
     ]
     |> Task.await_many()
     |> Enum.sum()
@@ -119,6 +122,42 @@ defmodule Operately.Assignments.Loader do
       where: champion.id == ^person.id,
       where: is_nil(project.deleted_at) and is_nil(m.deleted_at),
       where: project.status == "active" and is_nil(project.closed_at)
+    )
+  end
+
+  #
+  # KPI updates (champion role)
+  #
+
+  defp load_pending_kpi_updates(company, person) do
+    from([kpi: k, space: s] in pending_kpi_updates_query(person),
+      preload: [space: s]
+    )
+    |> Repo.all()
+    |> Enum.map(&Assignment.build(&1, company))
+  end
+
+  defp count_pending_kpi_updates(person) do
+    from([kpi: k] in pending_kpi_updates_query(person), select: count(k.id))
+    |> Repo.one()
+    |> default_zero()
+  end
+
+  defp pending_kpi_updates_query(person) do
+    {weekly_start, weekly_end} = KpiSchedule.current_period(:weekly)
+    {monthly_start, monthly_end} = KpiSchedule.current_period(:monthly)
+
+    from(k in Operately.Kpis.Kpi,
+      as: :kpi,
+      join: space in assoc(k, :space),
+      as: :space,
+      left_join: entry in assoc(k, :entries),
+      on:
+        (k.cadence == :weekly and entry.period >= ^weekly_start and entry.period <= ^weekly_end) or
+          (k.cadence == :monthly and entry.period >= ^monthly_start and entry.period <= ^monthly_end),
+      where: k.champion_id == ^person.id,
+      where: is_nil(space.deleted_at),
+      where: is_nil(entry.id)
     )
   end
 

--- a/app/lib/operately/operations/kpi_creation.ex
+++ b/app/lib/operately/operations/kpi_creation.ex
@@ -15,6 +15,7 @@ defmodule Operately.Operations.KpiCreation do
     |> insert_activity(creator)
     |> Repo.transaction()
     |> Repo.extract_result(:kpi)
+    |> broadcast_assignments_count()
   end
 
   defp insert_kpi(multi, attrs) do
@@ -52,4 +53,11 @@ defmodule Operately.Operations.KpiCreation do
       }
     end)
   end
+
+  defp broadcast_assignments_count({:ok, %Kpi{champion_id: champion_id}} = result) when not is_nil(champion_id) do
+    OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+    result
+  end
+
+  defp broadcast_assignments_count(result), do: result
 end

--- a/app/lib/operately/operations/kpi_deleting.ex
+++ b/app/lib/operately/operations/kpi_deleting.ex
@@ -10,6 +10,7 @@ defmodule Operately.Operations.KpiDeleting do
     |> Multi.delete(:kpi, kpi)
     |> Repo.transaction()
     |> Repo.extract_result(:kpi)
+    |> broadcast_assignments_count(kpi)
   end
 
   defp insert_activity(multi, author, kpi) do
@@ -22,4 +23,11 @@ defmodule Operately.Operations.KpiDeleting do
       }
     end)
   end
+
+  defp broadcast_assignments_count({:ok, _deleted_kpi} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do
+    OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+    result
+  end
+
+  defp broadcast_assignments_count(result, _kpi), do: result
 end

--- a/app/lib/operately/operations/kpi_editing.ex
+++ b/app/lib/operately/operations/kpi_editing.ex
@@ -12,6 +12,7 @@ defmodule Operately.Operations.KpiEditing do
     |> insert_activity(author, kpi)
     |> Repo.transaction()
     |> Repo.extract_result(:kpi)
+    |> broadcast_assignments_count(kpi)
   end
 
   defp subscribe_champion(multi) do
@@ -31,4 +32,15 @@ defmodule Operately.Operations.KpiEditing do
       }
     end)
   end
+
+  defp broadcast_assignments_count({:ok, updated_kpi} = result, previous_kpi) do
+    [previous_kpi.champion_id, updated_kpi.champion_id]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.each(&OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: &1))
+
+    result
+  end
+
+  defp broadcast_assignments_count(result, _previous_kpi), do: result
 end

--- a/app/lib/operately/operations/kpi_entry_logging.ex
+++ b/app/lib/operately/operations/kpi_entry_logging.ex
@@ -10,6 +10,7 @@ defmodule Operately.Operations.KpiEntryLogging do
     |> insert_activity(author, kpi)
     |> Repo.transaction()
     |> Repo.extract_result(:entry)
+    |> broadcast_assignments_count(kpi)
   end
 
   defp insert_entry(multi, kpi, attrs) do
@@ -37,4 +38,11 @@ defmodule Operately.Operations.KpiEntryLogging do
       }
     end)
   end
+
+  defp broadcast_assignments_count({:ok, _entry} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do
+    OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+    result
+  end
+
+  defp broadcast_assignments_count(result, _kpi), do: result
 end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -515,6 +515,7 @@ defmodule OperatelyWeb.Api.Types do
       :space_task,
       :project_task,
       :milestone,
+      :kpi_update,
       :project_retrospective,
       :goal_retrospective
     ]

--- a/app/test/operately/assignments/kpi_schedule_test.exs
+++ b/app/test/operately/assignments/kpi_schedule_test.exs
@@ -1,0 +1,21 @@
+defmodule Operately.Assignments.KpiScheduleTest do
+  use ExUnit.Case, async: true
+
+  alias Operately.Assignments.KpiSchedule
+
+  describe "current_period/2" do
+    test "returns the Monday through Sunday period for weekly KPIs" do
+      assert KpiSchedule.current_period(:weekly, ~D[2026-08-26]) == {
+               ~D[2026-08-24],
+               ~D[2026-08-30]
+             }
+    end
+
+    test "returns the calendar month for monthly KPIs" do
+      assert KpiSchedule.current_period(:monthly, ~D[2026-08-26]) == {
+               ~D[2026-08-01],
+               ~D[2026-08-31]
+             }
+    end
+  end
+end

--- a/app/test/operately/assignments/loader_test.exs
+++ b/app/test/operately/assignments/loader_test.exs
@@ -1,10 +1,13 @@
 defmodule Operately.Assignments.LoaderTest do
   use Operately.DataCase
 
+  import Operately.KpisFixtures
+
   alias Operately.Assignments.Loader
   alias OperatelyWeb.Paths
   alias Operately.Repo
   alias Operately.ContextualDates.ContextualDate
+  alias Operately.Assignments.KpiSchedule
 
   setup ctx do
     ctx
@@ -413,6 +416,56 @@ defmodule Operately.Assignments.LoaderTest do
 
       assignments = Loader.load(ctx.champion, ctx.company)
       refute Enum.any?(assignments, &(&1.type == :goal_update and &1.role == :owner))
+    end
+  end
+
+  describe "KPI updates" do
+    test "returns a pending KPI assignment for its champion", ctx do
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, cadence: :weekly)
+      {due_date, _period_end} = KpiSchedule.current_period(kpi.cadence)
+
+      [assignment] = Loader.load(ctx.champion, ctx.company)
+
+      assert assignment.resource_id == Paths.kpi_id(kpi)
+      assert assignment.type == :kpi_update
+      assert assignment.role == :owner
+      assert assignment.action_label == "Log update for #{kpi.name}"
+      assert assignment.due == due_date
+      assert assignment.path == Paths.space_kpi_path(ctx.company, ctx.space, kpi)
+      assert assignment.origin.type == :space
+      assert assignment.origin.name == ctx.space.name
+    end
+
+    test "does not return a KPI after an entry is logged in its current cadence period", ctx do
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, cadence: :monthly)
+      {period_start, _due_date} = KpiSchedule.current_period(kpi.cadence)
+      kpi_entry_fixture(ctx.champion, kpi, period: period_start)
+
+      assert Loader.load(ctx.champion, ctx.company) == []
+    end
+
+    test "an entry from a previous cadence period does not complete the current assignment", ctx do
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, cadence: :weekly)
+      {period_start, _due_date} = KpiSchedule.current_period(kpi.cadence)
+      kpi_entry_fixture(ctx.champion, kpi, period: Date.add(period_start, -1))
+
+      assert [%{type: :kpi_update, resource_id: resource_id}] = Loader.load(ctx.champion, ctx.company)
+      assert resource_id == Paths.kpi_id(kpi)
+    end
+
+    test "does not return KPIs for another person or from a deleted space", ctx do
+      kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id)
+
+      assert Loader.load(ctx.reviewer, ctx.company) == []
+
+      Repo.soft_delete(ctx.space)
+      assert Loader.load(ctx.champion, ctx.company) == []
+    end
+
+    test "counts a pending KPI when its cadence deadline is due soon", ctx do
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id, champion_id: ctx.champion.id, cadence: :weekly)
+
+      assert Loader.count(ctx.champion) == 1
     end
   end
 

--- a/app/test/operately_email/assignments_email_test.exs
+++ b/app/test/operately_email/assignments_email_test.exs
@@ -2,9 +2,11 @@ defmodule OperatelyEmail.AssignmentsEmailTest do
   use Operately.DataCase
 
   import Swoosh.TestAssertions
+  import Operately.KpisFixtures
 
   alias Operately.ContextualDates.ContextualDate
   alias Operately.Support.Factory
+  alias OperatelyWeb.Paths
   alias OperatelyEmail.Emails.AssignmentsEmail
 
   setup ctx do
@@ -50,6 +52,27 @@ defmodule OperatelyEmail.AssignmentsEmailTest do
       email.to == [{"", ctx.second_assignee.email}] and
         email.subject == "#{ctx.company.name}: Your work for today" and
         email.html_body =~ "Shared urgent task"
+    end)
+  end
+
+  test "includes pending KPI updates for the champion", ctx do
+    flush_emails()
+
+    kpi =
+      kpi_fixture(ctx.first_assignee,
+        space_id: ctx.space.id,
+        champion_id: ctx.first_assignee.id,
+        name: "Weekly sign-ups",
+        cadence: :weekly
+      )
+
+    AssignmentsEmail.send(ctx.first_assignee)
+
+    assert_email_sent(fn email ->
+      email.to == [{"", ctx.first_assignee.email}] and
+        email.html_body =~ "Weekly sign-ups" and
+        email.html_body =~ "Log update for Weekly sign-ups" and
+        email.html_body =~ Paths.to_url(Paths.space_kpi_path(ctx.company, ctx.space, kpi))
     end)
   end
 

--- a/app/test/operately_web/api/people/get_assignments_count_test.exs
+++ b/app/test/operately_web/api/people/get_assignments_count_test.exs
@@ -1,6 +1,8 @@
 defmodule OperatelyWeb.Api.People.GetAssignmentsCountTest do
   use OperatelyWeb.TurboCase
 
+  import Operately.KpisFixtures
+
   alias Operately.Repo
   alias Operately.Goals.{Goal, Update}
   alias Operately.Projects.{Project, CheckIn}
@@ -97,6 +99,17 @@ defmodule OperatelyWeb.Api.People.GetAssignmentsCountTest do
 
       assert {200, %{count: count}} = query(ctx.conn, [:people, :get_assignments_count], %{})
       assert count == 6
+    end
+
+    test "counts a pending KPI until its champion logs the current period", ctx do
+      kpi = kpi_fixture(ctx.person, space_id: ctx.space.id, champion_id: ctx.person.id, cadence: :monthly)
+
+      assert {200, %{count: 1}} = query(ctx.conn, [:people, :get_assignments_count], %{})
+
+      {period_start, _period_end} = Operately.Assignments.KpiSchedule.current_period(kpi.cadence)
+      kpi_entry_fixture(ctx.person, kpi, period: period_start)
+
+      assert {200, %{count: 0}} = query(ctx.conn, [:people, :get_assignments_count], %{})
     end
   end
 

--- a/app/test/operately_web/api/people/list_assignments_test.exs
+++ b/app/test/operately_web/api/people/list_assignments_test.exs
@@ -9,6 +9,7 @@ defmodule OperatelyWeb.Api.People.ListAssignmentsTest do
   alias Operately.ContextualDates.ContextualDate
 
   import Operately.PeopleFixtures
+  import Operately.KpisFixtures
 
   describe "security" do
     test "it requires authentication", ctx do
@@ -713,6 +714,29 @@ defmodule OperatelyWeb.Api.People.ListAssignmentsTest do
       assert length(reviewer_goal_updates) == 1
       assert length(tasks) == 1
       assert length(milestones) == 1
+    end
+
+    test "serializes pending KPI updates for the champion", ctx do
+      kpi =
+        kpi_fixture(ctx.person,
+          space_id: ctx.space.id,
+          champion_id: ctx.person.id,
+          name: "Weekly sign-ups",
+          cadence: :weekly
+        )
+
+      assert {200, %{due_soon: due_soon}} = query(ctx.conn, [:people, :list_assignments], %{})
+
+      assignments = Enum.flat_map(due_soon, & &1.assignments)
+      assignment = Enum.find(assignments, &(&1.resource_id == Paths.kpi_id(kpi)))
+
+      assert assignment.name == "Weekly sign-ups"
+      assert assignment.type == "kpi_update"
+      assert assignment.role == "owner"
+      assert assignment.action_label == "Log update for Weekly sign-ups"
+      assert assignment.path == Paths.space_kpi_path(ctx.company, ctx.space, kpi)
+      assert assignment.origin.type == "space"
+      assert assignment.origin.name == ctx.space.name
     end
   end
 

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -7,6 +7,7 @@
         "space_task",
         "project_task",
         "milestone",
+        "kpi_update",
         "project_retrospective",
         "goal_retrospective"
       ],

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -2963,6 +2963,7 @@ export type ReviewAssignmentTypes =
   | "space_task"
   | "project_task"
   | "milestone"
+  | "kpi_update"
   | "project_retrospective"
   | "goal_retrospective";
 

--- a/turboui/src/ReviewPage/AssignmentsList.tsx
+++ b/turboui/src/ReviewPage/AssignmentsList.tsx
@@ -2,7 +2,16 @@ import React from "react";
 
 import { BlackLink, DivLink } from "../Link";
 import { FormattedTime, type FormattedTimePreferences } from "../FormattedTime";
-import { IconCalendar, IconFlag, IconGoalPlain, IconMessage, IconProjectPlain, IconSquare, IconTent } from "../icons";
+import {
+  IconCalendar,
+  IconChartColumn,
+  IconFlag,
+  IconGoalPlain,
+  IconMessage,
+  IconProjectPlain,
+  IconSquare,
+  IconTent,
+} from "../icons";
 import { createTestId } from "../TestableElement";
 
 import { ReviewPageV2 } from ".";
@@ -13,6 +22,7 @@ const TYPE_ICON: Record<ReviewPageV2.AssignmentType, typeof IconSquare> = {
   space_task: IconSquare,
   project_task: IconSquare,
   milestone: IconFlag,
+  kpi_update: IconChartColumn,
   project_retrospective: IconMessage,
   goal_retrospective: IconMessage,
 };

--- a/turboui/src/ReviewPage/index.tsx
+++ b/turboui/src/ReviewPage/index.tsx
@@ -11,7 +11,15 @@ import type { FormattedTimePreferences } from "../FormattedTime";
 
 export namespace ReviewPageV2 {
   export type AssignmentRole = "owner" | "reviewer";
-  export type AssignmentType = "check_in" | "goal_update" | "space_task" | "project_task" | "milestone" | "project_retrospective" | "goal_retrospective";
+  export type AssignmentType =
+    | "check_in"
+    | "goal_update"
+    | "space_task"
+    | "project_task"
+    | "milestone"
+    | "kpi_update"
+    | "project_retrospective"
+    | "goal_retrospective";
   export type OriginType = "project" | "goal" | "space";
   export type DueStatus = "overdue" | "due_today" | "due_soon" | "upcoming" | "none";
 

--- a/turboui/src/ReviewPage/stories/mockData.ts
+++ b/turboui/src/ReviewPage/stories/mockData.ts
@@ -117,6 +117,15 @@ const engagementGoal: ReviewPageV2.AssignmentOrigin = {
   dueDate: getDateOffset(9),
 };
 
+const productSpace: ReviewPageV2.AssignmentOrigin = {
+  id: "space-product",
+  name: "Product",
+  type: "space",
+  path: "/spaces/product",
+  spaceName: "Product",
+  dueDate: null,
+};
+
 const rawDueSoonAssignments = [
   // Overdue items
   {
@@ -162,6 +171,17 @@ const rawDueSoonAssignments = [
     actionLabel: "Submit goal check-in",
     path: "/goals/customer-satisfaction/updates/latest",
     origin: customerSatisfaction,
+    taskStatus: null,
+  },
+  {
+    resourceId: "kpi-weekly-signups",
+    name: "Weekly sign-ups",
+    due: getDateOffset(-2),
+    type: "kpi_update",
+    role: "owner",
+    actionLabel: "Log update for Weekly sign-ups",
+    path: "/spaces/product/kpis/weekly-signups",
+    origin: productSpace,
     taskStatus: null,
   },
   // Due soon


### PR DESCRIPTION
## Summary
- Add pending KPI updates to the assignments loader, Review page, reminder emails, and assignments count for KPI champions.
- Treat a KPI as due for the current weekly (Mon–Sun) or monthly cadence window until an entry is logged in that period.
- Refresh the assignments badge when a KPI is created, edited, deleted, or logged.

## Test plan
- [ ] Create a weekly KPI with yourself as champion and confirm it appears on Review grouped under the space.
- [ ] Log an update for the current period and confirm the assignment and badge count go away.
- [ ] Confirm assignment reminder email includes “Log update for …” with a link to the KPI.
- [ ] Confirm a non-champion does not see the KPI on Review.


Made with [Cursor](https://cursor.com)