### PR TITLE
feat: hide completed milestones when showing options for a task

### DIFF
--- a/turboui/src/MilestoneField/index.stories.tsx
+++ b/turboui/src/MilestoneField/index.stories.tsx
@@ -51,7 +51,7 @@ const mockMilestones: Milestone[] = [
     id: "2",
     name: "Beta Testing Complete",
     dueDate: createContextualDate(new Date("2024-02-01"), "day"),
-    status: "complete" as const,
+    status: "done" as const,
     projectLink: "/projects/beta",
   },
   {

--- a/turboui/src/MilestoneField/index.test.tsx
+++ b/turboui/src/MilestoneField/index.test.tsx
@@ -6,6 +6,24 @@ import { MilestoneField } from "./index";
 
 const milestones = [{ id: "m-1", name: "Launch" }];
 
+function getByTestId(testId: string): HTMLElement {
+  const element = document.querySelector(`[data-test-id="${testId}"]`);
+  if (!(element instanceof HTMLElement)) throw new Error(`Missing element with data-test-id="${testId}"`);
+
+  return element;
+}
+
+function queryByTestId(testId: string): HTMLElement | null {
+  return document.querySelector(`[data-test-id="${testId}"]`);
+}
+
+function openMilestoneField() {
+  const trigger = getByTestId("milestone-field").closest("button");
+  if (!(trigger instanceof HTMLButtonElement)) throw new Error("Missing milestone field trigger");
+
+  fireEvent.click(trigger);
+}
+
 describe("MilestoneField", () => {
   beforeAll(() => {
     Element.prototype.scrollIntoView = jest.fn();
@@ -43,7 +61,6 @@ describe("MilestoneField", () => {
     const trigger = document.querySelector('[data-test-id="milestone-field"]')?.closest("button");
     expect(trigger).toHaveClass("border-surface-outline");
     expect(trigger).toHaveClass("w-full");
-    expect(trigger).toHaveTextContent("No milestone");
   });
 
   it("hides completed milestones behind a disclosure and prioritizes active keyboard selection", () => {
@@ -62,15 +79,17 @@ describe("MilestoneField", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Select milestone"));
+    openMilestoneField();
 
     const options = Array.from(document.querySelectorAll('[data-test-id^="milestone-field-search-result-"]'));
 
-    expect(options.map((option) => option.textContent)).toEqual(["Active milestone"]);
-    expect(screen.queryByText("Completed milestone")).not.toBeInTheDocument();
-    expect(screen.getByText("1 completed milestone")).toBeInTheDocument();
+    expect(options.map((option) => option.getAttribute("data-test-id"))).toEqual([
+      "milestone-field-search-result-active-milestone",
+    ]);
+    expect(queryByTestId("milestone-field-search-result-completed-milestone")).not.toBeInTheDocument();
+    expect(getByTestId("milestone-field-completed-milestones-toggle")).toHaveAttribute("aria-expanded", "false");
 
-    fireEvent.keyDown(screen.getByPlaceholderText("Find or create milestone..."), { key: "Enter" });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
 
     expect(setMilestone).toHaveBeenCalledWith({ id: "active", name: "Active milestone", status: "pending" });
   });
@@ -87,9 +106,13 @@ describe("MilestoneField", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("Select milestone"));
-    fireEvent.click(screen.getByText("1 completed milestone"));
-    fireEvent.click(screen.getByText("Completed milestone"));
+    openMilestoneField();
+
+    const completedMilestonesToggle = getByTestId("milestone-field-completed-milestones-toggle");
+    fireEvent.click(completedMilestonesToggle);
+
+    expect(completedMilestonesToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(getByTestId("milestone-field-search-result-completed-milestone"));
 
     expect(setMilestone).toHaveBeenCalledWith({ id: "completed", name: "Completed milestone", status: "done" });
   });

--- a/turboui/src/MilestoneField/index.test.tsx
+++ b/turboui/src/MilestoneField/index.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { MilestoneField } from "./index";
@@ -7,6 +7,10 @@ import { MilestoneField } from "./index";
 const milestones = [{ id: "m-1", name: "Launch" }];
 
 describe("MilestoneField", () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
   it("keeps the default trigger unbordered", () => {
     render(
       <MilestoneField
@@ -40,5 +44,53 @@ describe("MilestoneField", () => {
     expect(trigger).toHaveClass("border-surface-outline");
     expect(trigger).toHaveClass("w-full");
     expect(trigger).toHaveTextContent("No milestone");
+  });
+
+  it("hides completed milestones behind a disclosure and prioritizes active keyboard selection", () => {
+    const setMilestone = jest.fn();
+
+    render(
+      <MilestoneField
+        milestone={null}
+        setMilestone={setMilestone}
+        milestones={[
+          { id: "completed", name: "Completed milestone", status: "done" },
+          { id: "active", name: "Active milestone", status: "pending" },
+        ]}
+        onSearch={async () => undefined}
+        testId="milestone-field"
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Select milestone"));
+
+    const options = Array.from(document.querySelectorAll('[data-test-id^="milestone-field-search-result-"]'));
+
+    expect(options.map((option) => option.textContent)).toEqual(["Active milestone"]);
+    expect(screen.queryByText("Completed milestone")).not.toBeInTheDocument();
+    expect(screen.getByText("1 completed milestone")).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByPlaceholderText("Find or create milestone..."), { key: "Enter" });
+
+    expect(setMilestone).toHaveBeenCalledWith({ id: "active", name: "Active milestone", status: "pending" });
+  });
+
+  it("keeps completed milestones selectable", () => {
+    const setMilestone = jest.fn();
+
+    render(
+      <MilestoneField
+        milestone={null}
+        setMilestone={setMilestone}
+        milestones={[{ id: "completed", name: "Completed milestone", status: "done" }]}
+        onSearch={async () => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Select milestone"));
+    fireEvent.click(screen.getByText("1 completed milestone"));
+    fireEvent.click(screen.getByText("Completed milestone"));
+
+    expect(setMilestone).toHaveBeenCalledWith({ id: "completed", name: "Completed milestone", status: "done" });
   });
 });

--- a/turboui/src/MilestoneField/index.tsx
+++ b/turboui/src/MilestoneField/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { DateField } from "../DateField";
 import FormattedTime, { type FormattedTimePreferences } from "../FormattedTime";
-import { IconCircleX, IconExternalLink, IconFlag, IconSearch } from "../icons";
+import { IconChevronDown, IconChevronRight, IconCircleX, IconExternalLink, IconFlag, IconSearch } from "../icons";
 import { DivLink } from "../Link";
 import classNames from "../utils/classnames";
 import { createTestId, TestableElement } from "../TestableElement";
@@ -316,7 +316,10 @@ function DialogMenuOption({ icon, label, linkTo, onClick, testId }: DialogMenuOp
 
 function DialogSearch({ state }: { state: State }) {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [showCompletedMilestones, setShowCompletedMilestones] = React.useState(false);
   const itemRefs = React.useRef<(HTMLDivElement | null)[]>([]);
+  const { activeMilestones, completedMilestones } = groupMilestonesByCompletion(state.milestones);
+  const visibleMilestones = showCompletedMilestones ? [...activeMilestones, ...completedMilestones] : activeMilestones;
 
   // Reset selected index when search results change
   React.useEffect(() => {
@@ -332,7 +335,7 @@ function DialogSearch({ state }: { state: State }) {
   }, [selectedIndex]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const totalOptions = state.milestones.length;
+    const totalOptions = visibleMilestones.length;
 
     switch (e.key) {
       case "ArrowDown":
@@ -345,7 +348,7 @@ function DialogSearch({ state }: { state: State }) {
         break;
       case "Enter":
         e.preventDefault();
-        const selectedMilestone = state.milestones[selectedIndex];
+        const selectedMilestone = visibleMilestones[selectedIndex];
         if (selectedMilestone) {
           state.setMilestone(selectedMilestone);
           state.setSearchQuery(""); // Clear search query
@@ -359,6 +362,41 @@ function DialogSearch({ state }: { state: State }) {
         break;
     }
   };
+
+  const renderMilestone = (milestone: Milestone, index: number) => (
+    <div
+      key={milestone.id}
+      ref={(el) => (itemRefs.current[index] = el)}
+      className={classNames(
+        "flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer",
+        milestone.status === "done" && "text-content-dimmed",
+        {
+          "bg-surface-dimmed": index === selectedIndex,
+          "hover:bg-surface-dimmed": index !== selectedIndex,
+        },
+      )}
+      onClick={() => {
+        state.setMilestone(milestone);
+        state.setSearchQuery(""); // Clear search query
+        state.setIsOpen(false);
+      }}
+      onMouseEnter={() => setSelectedIndex(index)}
+      data-test-id={createTestId(state.testId, "search-result", milestone.name)}
+    >
+      <div className="flex items-start gap-1.5 truncate">
+        <IconFlag size={18} className="text-blue-500 shrink-0 mt-0.5" />
+        <div className="truncate">
+          <div className="text-sm truncate">{milestone.name || milestone.title}</div>
+          {milestone.dueDate?.date && state.formattedTimePreferences && (
+            <div className="text-xs text-content-dimmed">
+              Due{" "}
+              <FormattedTime {...state.formattedTimePreferences} time={milestone.dueDate.date} format="short-date" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 
   return (
     <div className="p-1">
@@ -374,40 +412,28 @@ function DialogSearch({ state }: { state: State }) {
       </div>
 
       <div className="overflow-y-auto pt-0.5 pb-0.5" style={{ maxHeight: 210 }}>
-        {state.milestones.map((milestone, index) => (
-          <div
-            key={milestone.id}
-            ref={(el) => (itemRefs.current[index] = el)}
-            className={classNames("flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer", {
-              "bg-surface-dimmed": index === selectedIndex,
-              "hover:bg-surface-dimmed": index !== selectedIndex,
-            })}
+        {activeMilestones.map(renderMilestone)}
+
+        {completedMilestones.length > 0 && (
+          <button
+            type="button"
+            className="flex w-full items-center gap-1.5 rounded px-1.5 py-1.5 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+            aria-expanded={showCompletedMilestones}
             onClick={() => {
-              state.setMilestone(milestone);
-              state.setSearchQuery(""); // Clear search query
-              state.setIsOpen(false);
+              setShowCompletedMilestones((isVisible) => !isVisible);
+              setSelectedIndex(0);
             }}
-            onMouseEnter={() => setSelectedIndex(index)}
-            data-test-id={createTestId(state.testId, "search-result", milestone.name)}
+            data-test-id={createTestId(state.testId, "completed-milestones-toggle")}
           >
-            <div className="flex items-start gap-1.5 truncate">
-              <IconFlag size={18} className="text-blue-500 shrink-0 mt-0.5" />
-              <div className="truncate">
-                <div className="text-sm truncate">{milestone.name || milestone.title}</div>
-                {milestone.dueDate?.date && state.formattedTimePreferences && (
-                  <div className="text-xs text-content-dimmed">
-                    Due{" "}
-                    <FormattedTime
-                      {...state.formattedTimePreferences}
-                      time={milestone.dueDate.date}
-                      format="short-date"
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        ))}
+            {showCompletedMilestones ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+            <span>
+              {completedMilestones.length} completed milestone{completedMilestones.length === 1 ? "" : "s"}
+            </span>
+          </button>
+        )}
+
+        {showCompletedMilestones &&
+          completedMilestones.map((milestone, index) => renderMilestone(milestone, activeMilestones.length + index))}
 
         {state.milestones.length === 0 && state.searchQuery && (
           <div className="px-1.5 py-2 text-sm text-content-dimmed text-center">No milestones found</div>
@@ -415,4 +441,19 @@ function DialogSearch({ state }: { state: State }) {
       </div>
     </div>
   );
+}
+
+function groupMilestonesByCompletion(milestones: Milestone[]) {
+  const activeMilestones: Milestone[] = [];
+  const completedMilestones: Milestone[] = [];
+
+  milestones.forEach((milestone) => {
+    if (milestone.status === "done") {
+      completedMilestones.push(milestone);
+    } else {
+      activeMilestones.push(milestone);
+    }
+  });
+
+  return { activeMilestones, completedMilestones };
 }


### PR DESCRIPTION
now it looks like this:
<img width="590" height="600" alt="CleanShot 2026-08-27 at 17 29 22@2x" src="https://github.com/user-attachments/assets/9625a5ca-e273-4f71-bad4-dd77e5e92ba4" />

fixes #5160.