### PR TITLE
feat: tweak new version notice

### DIFF
--- a/turboui/src/CompanyNavigation/UpdateBadge.tsx
+++ b/turboui/src/CompanyNavigation/UpdateBadge.tsx
@@ -5,18 +5,16 @@ import { PRODUCT_RELEASES_PAGE_URL } from "../ProductReleaseAnnouncement";
 import classNames from "../utils/classnames";
 import { CompanyNavigationUpdate } from "./types";
 
-// Compact "New" pill, in the spirit of Notion/GitHub status chips and Linear's
-// announcement chip: a live dot and a short label. The badge carries its own
-// left margin so the navbar does not keep a gap when no update is available.
 const badgeClassName = classNames(
-  "ml-2.5 inline-flex items-center gap-1",
-  "rounded-full px-2 py-0.5",
-  "text-[11px] font-medium leading-none whitespace-nowrap",
-  "bg-brand-1/10 text-brand-1",
+  "ml-2.5 inline-flex shrink-0 items-center gap-1.5",
+  "rounded-md py-1 pl-1 pr-2",
+  "text-xs font-medium leading-none whitespace-nowrap",
+  "bg-callout-info-bg text-callout-info-content",
   "ring-1 ring-inset ring-brand-1/20",
-  "hover:bg-brand-1/15 hover:ring-brand-1/35",
-  "dark:bg-brand-1/20 dark:ring-brand-1/30 dark:hover:bg-brand-1/30",
-  "transition-colors cursor-pointer",
+  "hover:bg-blue-100 hover:ring-brand-1/35",
+  "dark:ring-brand-1/40 dark:hover:bg-blue-800",
+  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-1",
+  "cursor-pointer",
 );
 
 export function UpdateBadge({ update }: { update?: CompanyNavigationUpdate | null }) {
@@ -30,12 +28,13 @@ export function UpdateBadge({ update }: { update?: CompanyNavigationUpdate | nul
       target="_blank"
       external={href.startsWith("http")}
       className={badgeClassName}
-      title={`Operately ${update.version} is available. This instance is running an older version.`}
+      title={`Operately ${update.version} is available. This instance is running an older version. View release notes.`}
       testId="update-available-badge"
     >
-      <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-brand-1" aria-hidden="true" />
-      <span>New</span>
-      <span className="font-semibold">{update.version}</span>
+      <span className="size-1.5 shrink-0 rounded-full bg-callout-info-content" aria-hidden="true" />
+      <span>
+        <span className="font-semibold tabular-nums">{update.version}</span> available
+      </span>
     </DivLink>
   );
 }

--- a/turboui/src/CompanyNavigation/index.test.tsx
+++ b/turboui/src/CompanyNavigation/index.test.tsx
@@ -87,12 +87,15 @@ describe("CompanyNavigation", () => {
     expect(document.querySelector(`[data-test-id="update-available-badge"]`)).not.toBeInTheDocument();
   });
 
-  it("shows a New pill with the version when enabled and an update is available", () => {
+  it("clearly identifies the available update and its version", () => {
     renderNav({ showCurrentVersion: true, availableUpdate: { version: "v1.8" } });
 
     const badge = getByTestId("update-available-badge");
 
-    expect(badge).toHaveTextContent("New");
-    expect(badge).toHaveTextContent("v1.8");
+    expect(badge).toHaveTextContent("v1.8 available");
+    expect(badge).toHaveAttribute(
+      "title",
+      "Operately v1.8 is available. This instance is running an older version. View release notes.",
+    );
   });
 });


### PR DESCRIPTION
This branch contains one focused change to the navigation update badge.

- Changed the label from **“New v1.8”** to **“v1.8 available”**.
- Reworked the badge into a compact rounded rectangle with:
  - Semantic info colors for better light/dark contrast
  - Theme-specific hover states
  - A visible keyboard-focus outline
  - A non-shrinking layout for long company names
  - A small semantic status dot
  - Bold, tabular version numbers
- Expanded the tooltip to say:
  - “Operately v1.8 is available. This instance is running an older version. View release notes.”
- Updated the component test to verify the new label and tooltip.

The release-note link, new-tab behavior, update detection, and feature gating are unchanged.