### PR TITLE
feat: Allow editing already logged KPI values

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -554,6 +554,17 @@ export interface ActivityContentKpiEntryCommented {
   comment: Comment | null;
 }
 
+export interface ActivityContentKpiEntryEdited {
+  __typename: "activity_content_kpi_entry_edited";
+  space: Space;
+  kpi: Kpi | null;
+  entry: KpiEntry | null;
+  oldValue: number;
+  newValue: number;
+  oldPeriod: string;
+  newPeriod: string;
+}
+
 export interface ActivityContentMessageArchiving {
   __typename: "activity_content_message_archiving";
   companyId?: string | null;
@@ -1817,8 +1828,18 @@ export interface KpiEntry {
   period: string;
   recordedBy?: Person | null;
   commentsCount?: number | null;
+  edits?: KpiEntryEdit[] | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
+}
+
+export interface KpiEntryEdit {
+  __typename: "kpi_entry_edit";
+  id: Id;
+  previousValue: number;
+  previousPeriod: string;
+  editedBy?: Person | null;
+  insertedAt?: string | null;
 }
 
 export interface McpGrant {
@@ -2846,6 +2867,7 @@ export type ActivityContent =
   | ActivityContentDiscussionPosting
   | ActivityContentKpiCreated
   | ActivityContentKpiEntryCommented
+  | ActivityContentKpiEntryEdited
   | ActivityContentKpiAnnotationAdded
   | ActivityContentKpiAnnotationEdited
   | ActivityContentKpiAnnotationDeleted
@@ -5210,6 +5232,16 @@ export interface KpisEditKpiAnnotationResult {
   annotation: KpiAnnotation;
 }
 
+export interface KpisEditKpiEntryInput {
+  entryId: Id;
+  value?: number | null;
+  period?: string | null;
+}
+
+export interface KpisEditKpiEntryResult {
+  entry: KpiEntry;
+}
+
 export interface KpisLogKpiEntryInput {
   kpiId: Id;
   value: number;
@@ -7134,6 +7166,10 @@ class ApiNamespaceKpis {
 
   async editKpiAnnotation(input: KpisEditKpiAnnotationInput): Promise<KpisEditKpiAnnotationResult> {
     return this.client.post("/kpis/edit_kpi_annotation", input);
+  }
+
+  async editKpiEntry(input: KpisEditKpiEntryInput): Promise<KpisEditKpiEntryResult> {
+    return this.client.post("/kpis/edit_kpi_entry", input);
   }
 
   async logKpiEntry(input: KpisLogKpiEntryInput): Promise<KpisLogKpiEntryResult> {
@@ -10079,6 +10115,16 @@ export default {
         queryKey: buildApiQueryKey(defaultApiClient, "/kpis/list_kpis", input),
         queryFn: () => defaultApiClient.apiNamespaceKpis.listKpis(input),
         staleTime: Infinity,
+      }),
+
+    editKpiEntry: (input: KpisEditKpiEntryInput) => defaultApiClient.apiNamespaceKpis.editKpiEntry(input),
+    useEditKpiEntry: () =>
+      useMutation<KpisEditKpiEntryInput, KpisEditKpiEntryResult>((input) =>
+        defaultApiClient.apiNamespaceKpis.editKpiEntry(input),
+      ),
+    editKpiEntryMutationOptions: () =>
+      mutationOptions({
+        mutationFn: (input: KpisEditKpiEntryInput) => defaultApiClient.apiNamespaceKpis.editKpiEntry(input),
       }),
 
     addKpiAnnotation: (input: KpisAddKpiAnnotationInput) => defaultApiClient.apiNamespaceKpis.addKpiAnnotation(input),

--- a/app/assets/js/features/activities/KpiEntryEdited/index.test.tsx
+++ b/app/assets/js/features/activities/KpiEntryEdited/index.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ActivityHandler, { DISPLAYED_IN_FEED } from "..";
+
+jest.mock("turboui", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+jest.mock("@/routes/paths", () => ({
+  usePaths: () => ({
+    spacePath: (id: string) => `/spaces/${id}`,
+    spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+    spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+  }),
+}));
+
+const paths: any = {
+  homePath: () => "/acme",
+  spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+  spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+};
+
+describe("kpi_entry_edited activities", () => {
+  const activity: any = {
+    action: "kpi_entry_edited",
+    author: { fullName: "Jo Smith" },
+    content: {
+      space: { id: "space-1", name: "General" },
+      kpi: { id: "kpi-1", name: "Monthly Recurring Revenue" },
+      oldValue: 40,
+      newValue: 42,
+    },
+  };
+
+  it("renders and includes the activity in the feed", () => {
+    const title = renderToStaticMarkup(<>{ActivityHandler.FeedItemTitle({ activity, page: "feed" })}</>);
+    const content = renderToStaticMarkup(<>{ActivityHandler.FeedItemContent({ activity, page: "feed" })}</>);
+
+    expect(DISPLAYED_IN_FEED).toContain("kpi_entry_edited");
+    expect(title).toContain("Jo edited a KPI update in the");
+    expect(title).toContain('href="/spaces/space-1"');
+    expect(content).toContain("Monthly Recurring Revenue: 40 → 42");
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationTitle({ activity })}</>)).toBe(
+      "Updated Monthly Recurring Revenue: 40 → 42",
+    );
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationLocation({ activity })}</>)).toBe("General");
+  });
+
+  it("links to the KPI's own page", () => {
+    expect(ActivityHandler.pagePath(paths, activity)).toBe("/spaces/space-1/kpis/kpi-1");
+  });
+});

--- a/app/assets/js/features/activities/KpiEntryEdited/index.tsx
+++ b/app/assets/js/features/activities/KpiEntryEdited/index.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+import type { ActivityContentKpiEntryEdited } from "@/api";
+import type { Activity } from "@/models/activities";
+import type { ActivityHandler } from "../interfaces";
+
+import { feedTitle, spaceLink } from "../feedItemLinks";
+
+const KpiEntryEdited: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, activity: Activity) {
+    const data = content(activity);
+    const spaceId = data.space?.id;
+    const kpiId = data.kpi?.id;
+
+    if (!spaceId) return paths.homePath();
+    return kpiId ? paths.spaceKpiPath(spaceId, kpiId) : paths.spaceKpisPath(spaceId);
+  },
+
+  PageTitle(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const data = content(activity);
+
+    if (page === "space") {
+      return feedTitle(activity, "edited a KPI update");
+    }
+
+    return feedTitle(activity, "edited a KPI update in the", spaceLink(data.space), "space");
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const data = content(activity);
+    const kpiName = data.kpi?.name ?? "KPI";
+
+    return (
+      <>
+        {kpiName}: {data.oldValue} → {data.newValue}
+      </>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const data = content(activity);
+    const kpiName = data.kpi?.name ?? "KPI";
+    return `Updated ${kpiName}: ${data.oldValue} → ${data.newValue}`;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).space?.name ?? null;
+  },
+};
+
+function content(activity: Activity): ActivityContentKpiEntryEdited {
+  return activity.content as ActivityContentKpiEntryEdited;
+}
+
+export default KpiEntryEdited;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -66,6 +66,7 @@ export default ActivityHandler;
 export const DISPLAYED_IN_FEED = [
   "kpi_created",
   "kpi_entry_commented",
+  "kpi_entry_edited",
   "kpi_annotation_added",
   "goal_check_toggled",
   "goal_check_removing",
@@ -211,6 +212,7 @@ import GoalClosing from "@/features/activities/GoalClosing";
 import GoalCreated from "@/features/activities/GoalCreated";
 import KpiCreated from "@/features/activities/KpiCreated";
 import KpiEntryCommented from "@/features/activities/KpiEntryCommented";
+import KpiEntryEdited from "@/features/activities/KpiEntryEdited";
 import KpiAnnotationAdded from "@/features/activities/KpiAnnotationAdded";
 import KpiAnnotationEdited from "@/features/activities/KpiAnnotationEdited";
 import KpiAnnotationDeleted from "@/features/activities/KpiAnnotationDeleted";
@@ -331,6 +333,7 @@ function handler(activity: Activity) {
     .with("goal_created", () => GoalCreated)
     .with("kpi_created", () => KpiCreated)
     .with("kpi_entry_commented", () => KpiEntryCommented)
+    .with("kpi_entry_edited", () => KpiEntryEdited)
     .with("kpi_annotation_added", () => KpiAnnotationAdded)
     .with("kpi_annotation_edited", () => KpiAnnotationEdited)
     .with("kpi_annotation_deleted", () => KpiAnnotationDeleted)

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -1,4 +1,4 @@
-import Api, { Kpi as ApiKpi, KpiAnnotation as ApiKpiAnnotation, KpiEntry as ApiKpiEntry } from "@/api";
+import { Kpi as ApiKpi, KpiAnnotation as ApiKpiAnnotation, KpiEntry as ApiKpiEntry } from "@/api";
 import { Paths } from "@/routes/paths";
 import { parsePersonForTurboUi } from "@/models/people";
 import type { SpaceKpisPage } from "turboui/SpaceKpisPage/types";

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -5,16 +5,16 @@ import type { SpaceKpisPage } from "turboui/SpaceKpisPage/types";
 import { fromIsoDate } from "turboui/SpaceKpisPage/utils";
 
 export type { Kpi } from "@/api";
-
-export const listKpis = Api.kpis.listKpis;
-export const getKpi = Api.kpis.getKpi;
-export const useCreateKpi = Api.kpis.useCreateKpi;
-export const useEditKpi = Api.kpis.useEditKpi;
-export const useDeleteKpi = Api.kpis.useDeleteKpi;
-export const useLogKpiEntry = Api.kpis.useLogKpiEntry;
-export const useAddKpiAnnotation = Api.kpis.useAddKpiAnnotation;
-export const useEditKpiAnnotation = Api.kpis.useEditKpiAnnotation;
-export const useDeleteKpiAnnotation = Api.kpis.useDeleteKpiAnnotation;
+export {
+  useAddKpiAnnotation,
+  useCreateKpi,
+  useDeleteKpi,
+  useDeleteKpiAnnotation,
+  useEditKpi,
+  useEditKpiAnnotation,
+  useEditKpiEntry,
+  useLogKpiEntry,
+} from "./kpiLifecycle";
 
 // Map the API KPI shape onto the presentational turboui shape. Date-only
 // `period` / annotation values arrive as `YYYY-MM-DD` and are parsed as local
@@ -42,6 +42,13 @@ function parseKpiEntryForTurboUi(paths: Paths, entry: ApiKpiEntry): SpaceKpisPag
     recordedAt: fromIsoDate(entry.period),
     recordedBy: parsePersonForTurboUi(paths, entry.recordedBy),
     commentsCount: entry.commentsCount ?? 0,
+    edits: (entry.edits ?? []).map((edit) => ({
+      id: edit.id,
+      previousValue: edit.previousValue,
+      previousPeriod: fromIsoDate(edit.previousPeriod),
+      editedBy: parsePersonForTurboUi(paths, edit.editedBy),
+      editedAt: edit.insertedAt ? new Date(edit.insertedAt) : new Date(),
+    })),
   };
 }
 

--- a/app/assets/js/models/kpis/kpiLifecycle.test.ts
+++ b/app/assets/js/models/kpis/kpiLifecycle.test.ts
@@ -1,0 +1,31 @@
+import Api from "@/api";
+import { QueryClient } from "@tanstack/react-query";
+import { invalidateKpiQueries } from "./kpiLifecycle";
+
+describe("KPI lifecycle queries", () => {
+  beforeAll(() => {
+    Api.default.setBasePath("/api/v2");
+    Api.default.setHeaders({ "x-company-id": "company-1" });
+  });
+
+  it("invalidates KPI detail and list queries", async () => {
+    const queryClient = createQueryClient();
+    const getKpiKey = Api.kpis.getKpiQueryKey({ kpiId: "kpi-1" });
+    const listKpisKey = Api.kpis.listKpisQueryKey({ spaceId: "space-1" });
+    const spacesKey = Api.spaces.getQueryKey({ id: "space-1" });
+
+    [getKpiKey, listKpisKey, spacesKey].forEach((queryKey) => {
+      queryClient.setQueryData(queryKey, {});
+    });
+
+    await invalidateKpiQueries(queryClient);
+
+    expect(queryClient.getQueryState(getKpiKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(listKpisKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(spacesKey)?.isInvalidated).toBe(false);
+  });
+});
+
+function createQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}

--- a/app/assets/js/models/kpis/kpiLifecycle.ts
+++ b/app/assets/js/models/kpis/kpiLifecycle.ts
@@ -1,0 +1,97 @@
+import Api from "@/api";
+import { QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
+
+export async function invalidateKpiQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: Api.kpis.getKpiQueryKeyPrefix() }),
+    queryClient.invalidateQueries({ queryKey: Api.kpis.listKpisQueryKeyPrefix() }),
+  ]);
+}
+
+export function useCreateKpi() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.createKpiMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useEditKpi() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.editKpiMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useDeleteKpi() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.deleteKpiMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useLogKpiEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.logKpiEntryMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useEditKpiEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.editKpiEntryMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useAddKpiAnnotation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.addKpiAnnotationMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useEditKpiAnnotation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.editKpiAnnotationMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
+export function useDeleteKpiAnnotation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.deleteKpiAnnotationMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}

--- a/app/assets/js/pages/SpaceKpisPage/loader.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/loader.tsx
@@ -1,31 +1,55 @@
+import Api, { Kpi, Space } from "@/api";
+import { useLoadedQuery } from "@/api/queryClient";
 import * as Pages from "@/components/Pages";
-import * as Spaces from "@/models/spaces";
-import { getKpi, listKpis } from "@/models/kpis";
-import { Kpi } from "@/api";
+import { useQueryClient } from "@tanstack/react-query";
 
-interface LoadedData {
-  space: Spaces.Space;
-  kpis: Kpi[];
+const DISABLED_KPI_INPUT = { kpiId: "" };
 
-  // The KPI addressed by the route (/spaces/:id/kpis/:kpiId), loaded with its
-  // entries for the chart. Null on the list route.
-  kpi: Kpi | null;
-}
+export async function loader({ params }) {
+  const spaceInput = { id: params.id, includePermissions: true };
+  const listInput = { spaceId: params.id };
+  const kpiInput = params.kpiId ? { kpiId: params.kpiId } : null;
 
-export async function loader({ params }): Promise<LoadedData> {
-  const [space, kpis, kpi] = await Promise.all([
-    Spaces.getSpace({ id: params.id, includePermissions: true }),
-    listKpis({ spaceId: params.id }).then((d) => d.kpis),
-    params.kpiId ? getKpi({ kpiId: params.kpiId }).then((d) => d.kpi) : null,
+  await Promise.all([
+    Api.spaces.getQuery(spaceInput),
+    Api.kpis.listKpisQuery(listInput),
+    kpiInput ? Api.kpis.getKpiQuery(kpiInput) : Promise.resolve(),
   ]);
 
-  return { space, kpis, kpi };
+  return { spaceInput, listInput, kpiInput };
 }
 
-export function useLoadedData(): LoadedData {
-  return Pages.useLoadedData() as LoadedData;
+type LoaderResult = Awaited<ReturnType<typeof loader>>;
+
+export function useLoadedData(): { space: Space; kpis: Kpi[]; kpi: Kpi | null } {
+  const { spaceInput, listInput, kpiInput } = Pages.useLoadedData<LoaderResult>();
+  const { data: spaceData } = useLoadedQuery(Api.spaces.getQueryOptions(spaceInput));
+  const { data: kpisData } = useLoadedQuery(Api.kpis.listKpisQueryOptions(listInput));
+  const { data: kpiData } = useLoadedQuery({
+    ...Api.kpis.getKpiQueryOptions(kpiInput ?? DISABLED_KPI_INPUT),
+    enabled: kpiInput != null,
+  });
+
+  if (!spaceData?.space || !kpisData) {
+    throw new Error(`KPI data is unavailable for space "${spaceInput.id}"`);
+  }
+
+  return {
+    space: spaceData.space,
+    kpis: kpisData.kpis,
+    kpi: kpiInput ? (kpiData?.kpi ?? null) : null,
+  };
 }
 
-export function useRefresh() {
-  return Pages.useRefresh();
+export function useRefresh(): () => Promise<void> {
+  const queryClient = useQueryClient();
+  const { spaceInput, listInput, kpiInput } = Pages.useLoadedData<LoaderResult>();
+
+  return async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: Api.spaces.getQueryKey(spaceInput) }),
+      queryClient.invalidateQueries({ queryKey: Api.kpis.listKpisQueryKey(listInput) }),
+      kpiInput ? queryClient.invalidateQueries({ queryKey: Api.kpis.getKpiQueryKey(kpiInput) }) : Promise.resolve(),
+    ]);
+  };
 }

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -1,13 +1,16 @@
 import * as React from "react";
 import { Navigate, useNavigate } from "react-router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { showErrorToast, SpaceKpisPage } from "turboui";
 import type { SpaceKpisPage as SpaceKpisPageTypes } from "turboui/SpaceKpisPage/types";
 
+import Api from "@/api";
 import * as Comments from "@/models/comments";
 import * as Companies from "@/models/companies";
 import * as People from "@/models/people";
 import * as Kpis from "@/models/kpis";
+import { invalidateKpiQueries } from "@/models/kpis/kpiLifecycle";
 import { useSubscription } from "@/models/subscriptions";
 
 import { useRichEditorHandlers } from "@/hooks/useRichEditorHandlers";
@@ -20,20 +23,27 @@ export function Page() {
   const paths = usePaths();
   const navigate = useNavigate();
   const refresh = useRefresh();
+  const queryClient = useQueryClient();
   const { company } = useCompanyLoaderData();
   const { space, kpis, kpi } = useLoadedData();
 
   const peopleSearch = People.usePeopleSearch({ type: "space", id: space.id! });
   const richTextHandlers = useRichEditorHandlers({ scope: { type: "space", id: space.id! } });
 
-  const [createKpi] = Kpis.useCreateKpi();
-  const [editKpi] = Kpis.useEditKpi();
-  const [deleteKpi] = Kpis.useDeleteKpi();
-  const [logKpiEntry] = Kpis.useLogKpiEntry();
-  const [addKpiAnnotation] = Kpis.useAddKpiAnnotation();
-  const [editKpiAnnotation] = Kpis.useEditKpiAnnotation();
-  const [deleteKpiAnnotation] = Kpis.useDeleteKpiAnnotation();
-  const [createComment] = Comments.useCreateComment();
+  const createKpi = Kpis.useCreateKpi();
+  const editKpi = Kpis.useEditKpi();
+  const deleteKpi = Kpis.useDeleteKpi();
+  const logKpiEntry = Kpis.useLogKpiEntry();
+  const editKpiEntry = Kpis.useEditKpiEntry();
+  const addKpiAnnotation = Kpis.useAddKpiAnnotation();
+  const editKpiAnnotation = Kpis.useEditKpiAnnotation();
+  const deleteKpiAnnotation = Kpis.useDeleteKpiAnnotation();
+  const createComment = useMutation({
+    ...Api.comments.createMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
 
   const kpisLink = paths.spaceKpisPath(space.id!);
   const parsedKpis = React.useMemo(() => kpis.map((k) => Kpis.parseKpiForTurboUi(paths, k)), [kpis, paths]);
@@ -60,34 +70,34 @@ export function Page() {
 
   const onCreateKpi = async (input: SpaceKpisPageTypes.NewKpiInput) =>
     run(async () => {
-      const res = await createKpi({
+      const res = await createKpi.mutateAsync({
         spaceId: space.id!,
         name: input.name,
         unit: input.unit,
         cadence: input.cadence,
         championId: input.championId,
       });
-      refresh();
+      await refresh();
       return res.kpi.id;
     });
 
   const onEditKpi = async (input: SpaceKpisPageTypes.EditKpiInput) =>
     run(async () => {
-      await editKpi({
+      await editKpi.mutateAsync({
         kpiId: input.id,
         name: input.name,
         unit: input.unit,
         cadence: input.cadence,
         championId: input.championId,
       });
-      refresh();
+      await refresh();
       return input.id;
     });
 
   const onDescriptionChange = async (kpiId: string, description: Record<string, unknown>) => {
     const result = await run(async () => {
-      await editKpi({ kpiId, description: JSON.stringify(description) });
-      refresh();
+      await editKpi.mutateAsync({ kpiId, description: JSON.stringify(description) });
+      await refresh();
       return kpiId;
     });
 
@@ -102,9 +112,9 @@ export function Page() {
   // to the list instead of refreshing into a missing KPI.
   const onDeleteKpi = async (kpiId: string) =>
     run(async () => {
-      await deleteKpi({ kpiId });
+      await deleteKpi.mutateAsync({ kpiId });
       if (kpiId === selectedKpi?.id) navigate(kpisLink);
-      else refresh();
+      else await refresh();
     });
 
   // The value is recorded first and the note is a comment on it, so a failed
@@ -112,11 +122,11 @@ export function Page() {
   // same value twice.
   const onRecordEntry = async (input: SpaceKpisPageTypes.RecordEntryInput) =>
     run(async () => {
-      const res = await logKpiEntry({ kpiId: input.kpiId, value: input.value, period: input.period });
+      const res = await logKpiEntry.mutateAsync({ kpiId: input.kpiId, value: input.value, period: input.period });
 
       if (input.comment) {
         try {
-          await createComment({
+          await createComment.mutateAsync({
             entityId: res.entry.id,
             entityType: "kpi_entry",
             content: Comments.stringifyCommentContent(input.comment),
@@ -126,33 +136,44 @@ export function Page() {
         }
       }
 
-      refresh();
+      await refresh();
+    });
+
+  const onEditEntry = async (input: SpaceKpisPageTypes.EditEntryInput) =>
+    run(async () => {
+      await editKpiEntry.mutateAsync({
+        entryId: input.entryId,
+        value: input.value,
+        period: input.period,
+      });
+      await refresh();
+      return input.entryId;
     });
 
   const onAddAnnotation = async (input: SpaceKpisPageTypes.AnnotationInput) =>
     run(async () => {
-      await addKpiAnnotation({
+      await addKpiAnnotation.mutateAsync({
         kpiId: input.kpiId,
         date: input.date,
         title: input.title,
       });
-      refresh();
+      await refresh();
     });
 
   const onEditAnnotation = async (input: SpaceKpisPageTypes.EditAnnotationInput) =>
     run(async () => {
-      await editKpiAnnotation({
+      await editKpiAnnotation.mutateAsync({
         annotationId: input.id,
         date: input.date,
         title: input.title,
       });
-      refresh();
+      await refresh();
     });
 
   const onDeleteAnnotation = async (annotationId: string) =>
     run(async () => {
-      await deleteKpiAnnotation({ annotationId });
-      refresh();
+      await deleteKpiAnnotation.mutateAsync({ annotationId });
+      await refresh();
     });
 
   return (
@@ -172,6 +193,7 @@ export function Page() {
       onDescriptionChange={onDescriptionChange}
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
+      onEditEntry={onEditEntry}
       onAddAnnotation={onAddAnnotation}
       onEditAnnotation={onEditAnnotation}
       onDeleteAnnotation={onDeleteAnnotation}

--- a/app/lib/operately/activities/content/kpi_entry_edited.ex
+++ b/app/lib/operately/activities/content/kpi_entry_edited.ex
@@ -1,0 +1,25 @@
+defmodule Operately.Activities.Content.KpiEntryEdited do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :kpi, Operately.Kpis.Kpi
+    belongs_to :entry, Operately.Kpis.KpiEntry
+
+    field :old_value, :float
+    field :new_value, :float
+    field :old_period, :date
+    field :new_period, :date
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required([:company_id, :space_id, :kpi_id, :entry_id, :old_value, :new_value, :old_period, :new_period])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/notifications/kpi_entry_edited.ex
+++ b/app/lib/operately/activities/notifications/kpi_entry_edited.ex
@@ -1,0 +1,5 @@
+defmodule Operately.Activities.Notifications.KpiEntryEdited do
+  def dispatch(activity) do
+    Operately.Kpis.Notifications.notify_subscribers(activity)
+  end
+end

--- a/app/lib/operately/company_transfers/schema/policy_registry.ex
+++ b/app/lib/operately/company_transfers/schema/policy_registry.ex
@@ -167,6 +167,7 @@ defmodule Operately.CompanyTransfers.Schema.PolicyRegistry do
     "groups",
     "kpi_annotations",
     "kpi_entries",
+    "kpi_entry_edits",
     "kpis",
     "members",
     "messages",

--- a/app/lib/operately/kpis.ex
+++ b/app/lib/operately/kpis.ex
@@ -2,13 +2,14 @@ defmodule Operately.Kpis do
   import Ecto.Query, warn: false
 
   alias Operately.Repo
-  alias Operately.Kpis.{Kpi, KpiAnnotation, KpiEntry}
+  alias Operately.Kpis.{Kpi, KpiAnnotation, KpiEntry, KpiEntryEdit}
 
   @kpi_actions [
     "kpi_created",
     "kpi_edited",
     "kpi_deleted",
     "kpi_entry_logged",
+    "kpi_entry_edited",
     "kpi_entry_commented",
     "kpi_annotation_added",
     "kpi_annotation_edited",
@@ -36,9 +37,19 @@ defmodule Operately.Kpis do
   def get_kpi(id), do: Repo.get(Kpi, id)
   def get_kpi!(id), do: Repo.get!(Kpi, id)
 
+  def get_entry(id), do: Repo.get(KpiEntry, id)
+
   def list_entries(kpi_id) do
     from(e in KpiEntry, where: e.kpi_id == ^kpi_id, order_by: e.period)
     |> Repo.all()
+  end
+
+  def preload_entry_history(entries) when is_list(entries) do
+    edits_query = from(edit in KpiEntryEdit, order_by: [desc: edit.inserted_at])
+
+    entries
+    |> Repo.preload(:recorded_by)
+    |> Repo.preload(edits: {edits_query, [:edited_by]})
   end
 
   def list_annotations(kpi_id) do
@@ -94,6 +105,7 @@ defmodule Operately.Kpis do
   defdelegate edit_kpi(author, kpi, attrs), to: Operately.Operations.KpiEditing, as: :run
   defdelegate delete_kpi(author, kpi), to: Operately.Operations.KpiDeleting, as: :run
   defdelegate log_entry(author, kpi, attrs), to: Operately.Operations.KpiEntryLogging, as: :run
+  defdelegate edit_entry(author, kpi, entry, attrs), to: Operately.Operations.KpiEntryEditing, as: :run
   defdelegate add_annotation(author, kpi, attrs), to: Operately.Operations.KpiAnnotationAdding, as: :run
   defdelegate edit_annotation(author, kpi, annotation, attrs), to: Operately.Operations.KpiAnnotationEditing, as: :run
   defdelegate delete_annotation(author, kpi, annotation), to: Operately.Operations.KpiAnnotationDeleting, as: :run

--- a/app/lib/operately/kpis/kpi_entry.ex
+++ b/app/lib/operately/kpis/kpi_entry.ex
@@ -8,6 +8,7 @@ defmodule Operately.Kpis.KpiEntry do
 
     has_one(:access_context, through: [:kpi, :access_context])
     has_many(:comments, Operately.Updates.Comment, where: [entity_type: :kpi_entry], foreign_key: :entity_id)
+    has_many(:edits, Operately.Kpis.KpiEntryEdit)
 
     field(:value, :float)
     field(:period, :date)

--- a/app/lib/operately/kpis/kpi_entry_edit.ex
+++ b/app/lib/operately/kpis/kpi_entry_edit.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Kpis.KpiEntryEdit do
+  use Operately.Schema
+
+  schema "kpi_entry_edits" do
+    belongs_to(:kpi_entry, Operately.Kpis.KpiEntry, foreign_key: :kpi_entry_id)
+    belongs_to(:edited_by, Operately.People.Person, foreign_key: :edited_by_id)
+
+    field(:previous_value, :float)
+    field(:previous_period, :date)
+
+    timestamps()
+  end
+
+  def changeset(attrs = %{}) do
+    changeset(%__MODULE__{}, attrs)
+  end
+
+  def changeset(edit, attrs) do
+    edit
+    |> cast(attrs, [:kpi_entry_id, :edited_by_id, :previous_value, :previous_period])
+    |> validate_required([:kpi_entry_id, :edited_by_id, :previous_value, :previous_period])
+  end
+end

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -101,6 +101,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     "kpi_edited",
     "kpi_deleted",
     "kpi_entry_logged",
+    "kpi_entry_edited",
     "kpi_annotation_added",
     "kpi_annotation_edited",
     "kpi_annotation_deleted",

--- a/app/lib/operately/operations/kpi_entry_editing.ex
+++ b/app/lib/operately/operations/kpi_entry_editing.ex
@@ -1,0 +1,66 @@
+defmodule Operately.Operations.KpiEntryEditing do
+  alias Ecto.Multi
+  alias Operately.Repo
+  alias Operately.Kpis.{Kpi, KpiEntry, KpiEntryEdit}
+  alias Operately.Activities
+
+  def run(author, %Kpi{} = kpi, %KpiEntry{} = entry, attrs) do
+    value = Map.get(attrs, :value, entry.value)
+    period = Map.get(attrs, :period, entry.period)
+
+    if unchanged?(entry, value, period) do
+      {:ok, entry}
+    else
+      Multi.new()
+      |> insert_edit(author, entry)
+      |> update_entry(entry, value, period)
+      |> insert_activity(author, kpi, entry)
+      |> Repo.transaction()
+      |> Repo.extract_result(:entry)
+      |> broadcast_assignments_count(kpi)
+    end
+  end
+
+  defp unchanged?(entry, value, period) do
+    entry.value == value and entry.period == period
+  end
+
+  defp insert_edit(multi, author, entry) do
+    Multi.insert(
+      multi,
+      :edit,
+      KpiEntryEdit.changeset(%{
+        kpi_entry_id: entry.id,
+        edited_by_id: author.id,
+        previous_value: entry.value,
+        previous_period: entry.period
+      })
+    )
+  end
+
+  defp update_entry(multi, entry, value, period) do
+    Multi.update(multi, :entry, KpiEntry.changeset(entry, %{value: value, period: period}))
+  end
+
+  defp insert_activity(multi, author, kpi, entry) do
+    Activities.insert_sync(multi, author.id, :kpi_entry_edited, fn changes ->
+      %{
+        company_id: author.company_id,
+        space_id: kpi.space_id,
+        kpi_id: kpi.id,
+        entry_id: entry.id,
+        old_value: entry.value,
+        new_value: changes.entry.value,
+        old_period: entry.period,
+        new_period: changes.entry.period
+      }
+    end)
+  end
+
+  defp broadcast_assignments_count({:ok, _entry} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do
+    OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+    result
+  end
+
+  defp broadcast_assignments_count(result, _kpi), do: result
+end

--- a/app/lib/operately/operations/kpi_entry_editing.ex
+++ b/app/lib/operately/operations/kpi_entry_editing.ex
@@ -1,60 +1,71 @@
 defmodule Operately.Operations.KpiEntryEditing do
   alias Ecto.Multi
-  alias Operately.Repo
-  alias Operately.Kpis.{Kpi, KpiEntry, KpiEntryEdit}
   alias Operately.Activities
+  alias Operately.Kpis.{Kpi, KpiEntry, KpiEntryEdit}
+  alias Operately.Repo
+  alias Operately.Repo.Locking
 
+  @doc """
+  Corrects an already logged KPI value, keeping a record of what it replaced.
+
+  The entry row is locked for the duration of the transaction, so overlapping
+  corrections are serialized and each edit record captures the value it
+  actually replaced instead of one a concurrent editor had already overwritten.
+  """
   def run(author, %Kpi{} = kpi, %KpiEntry{} = entry, attrs) do
-    value = Map.get(attrs, :value, entry.value)
-    period = Map.get(attrs, :period, entry.period)
+    Multi.new()
+    |> Multi.run(:current, fn repo, _ -> Locking.lock_for_update(repo, entry) end)
+    |> Multi.run(:requested, fn _repo, ctx -> requested_changes(ctx.current, attrs) end)
+    |> Multi.insert(:edit, fn ctx -> previous_values_changeset(author, ctx.current) end)
+    |> Multi.update(:entry, fn ctx -> KpiEntry.changeset(ctx.current, ctx.requested) end)
+    |> insert_activity(author, kpi)
+    |> Repo.transaction()
+    |> handle_result(kpi)
+  end
 
-    if unchanged?(entry, value, period) do
-      {:ok, entry}
+  defp requested_changes(current, attrs) do
+    value = Map.get(attrs, :value, current.value)
+    period = Map.get(attrs, :period, current.period)
+
+    if current.value == value and current.period == period do
+      {:error, :unchanged}
     else
-      Multi.new()
-      |> insert_edit(author, entry)
-      |> update_entry(entry, value, period)
-      |> insert_activity(author, kpi, entry)
-      |> Repo.transaction()
-      |> Repo.extract_result(:entry)
-      |> broadcast_assignments_count(kpi)
+      {:ok, %{value: value, period: period}}
     end
   end
 
-  defp unchanged?(entry, value, period) do
-    entry.value == value and entry.period == period
+  defp previous_values_changeset(author, current) do
+    KpiEntryEdit.changeset(%{
+      kpi_entry_id: current.id,
+      edited_by_id: author.id,
+      previous_value: current.value,
+      previous_period: current.period
+    })
   end
 
-  defp insert_edit(multi, author, entry) do
-    Multi.insert(
-      multi,
-      :edit,
-      KpiEntryEdit.changeset(%{
-        kpi_entry_id: entry.id,
-        edited_by_id: author.id,
-        previous_value: entry.value,
-        previous_period: entry.period
-      })
-    )
-  end
-
-  defp update_entry(multi, entry, value, period) do
-    Multi.update(multi, :entry, KpiEntry.changeset(entry, %{value: value, period: period}))
-  end
-
-  defp insert_activity(multi, author, kpi, entry) do
+  defp insert_activity(multi, author, kpi) do
     Activities.insert_sync(multi, author.id, :kpi_entry_edited, fn changes ->
       %{
         company_id: author.company_id,
         space_id: kpi.space_id,
         kpi_id: kpi.id,
-        entry_id: entry.id,
-        old_value: entry.value,
+        entry_id: changes.entry.id,
+        old_value: changes.current.value,
         new_value: changes.entry.value,
-        old_period: entry.period,
+        old_period: changes.current.period,
         new_period: changes.entry.period
       }
     end)
+  end
+
+  # Editing to the values the entry already holds is a no-op, not a failure:
+  # no edit record and no activity, and the caller still gets the entry back.
+  defp handle_result({:error, :requested, :unchanged, changes}, _kpi), do: {:ok, changes.current}
+
+  defp handle_result(result, kpi) do
+    result
+    |> Repo.extract_result(:entry)
+    |> broadcast_assignments_count(kpi)
   end
 
   defp broadcast_assignments_count({:ok, _entry} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -219,6 +219,7 @@ defmodule OperatelyWeb.Api do
         mutation(:edit_kpi, OperatelyWeb.Api.Kpis.EditKpi)
         mutation(:delete_kpi, OperatelyWeb.Api.Kpis.DeleteKpi)
         mutation(:log_kpi_entry, OperatelyWeb.Api.Kpis.LogKpiEntry)
+        mutation(:edit_kpi_entry, OperatelyWeb.Api.Kpis.EditKpiEntry)
         mutation(:add_kpi_annotation, OperatelyWeb.Api.Kpis.AddKpiAnnotation)
         mutation(:edit_kpi_annotation, OperatelyWeb.Api.Kpis.EditKpiAnnotation)
         mutation(:delete_kpi_annotation, OperatelyWeb.Api.Kpis.DeleteKpiAnnotation)

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -77,7 +77,7 @@ defmodule OperatelyWeb.Api.Kpis do
 
         kpi ->
           # Entries are ordered by period so the chart renders history in order.
-          entries = Kpis.list_entries(kpi_id) |> Repo.preload(:recorded_by) |> Operately.Updates.Comment.load_comments_count()
+          entries = Kpis.list_entries(kpi_id) |> Kpis.preload_entry_history() |> Operately.Updates.Comment.load_comments_count()
           annotations = Kpis.list_annotations(kpi_id) |> Repo.preload(:created_by)
 
           {:ok,
@@ -288,6 +288,64 @@ defmodule OperatelyWeb.Api.Kpis do
       case result do
         {:ok, ctx} -> {:ok, ctx.serialized}
         {:error, :kpi, _} -> {:error, :not_found}
+        {:error, :space, _} -> {:error, :not_found}
+        {:error, :check_permissions, _} -> {:error, :forbidden}
+        {:error, :operation, _} -> {:error, :bad_request}
+        _ -> {:error, :internal_server_error}
+      end
+    end
+  end
+
+  defmodule EditKpiEntry do
+    @moduledoc "Edits a logged KPI value. Previous values are kept so the change is visible."
+
+    use TurboConnect.Mutation
+    use OperatelyWeb.Api.Helpers
+
+    alias Operately.Kpis.KpiEntry
+
+    inputs do
+      field :entry_id, :id, null: false
+      field? :value, :float, null: true
+      field? :period, :date, null: true
+    end
+
+    outputs do
+      field :entry, :kpi_entry, null: false
+    end
+
+    def call(conn, inputs) do
+      Action.new()
+      |> run(:me, fn -> find_me(conn) end)
+      |> run(:entry, fn -> load_entry(inputs.entry_id) end)
+      |> run(:kpi, fn ctx -> {:ok, ctx.entry.kpi} end)
+      |> run(:space, fn ctx -> Group.get(ctx.me, id: ctx.kpi.space_id) end)
+      |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.request_info.access_level, :can_edit, company_read_only: company_read_only(conn)) end)
+      |> run(:operation, fn ctx -> Kpis.edit_entry(ctx.me, ctx.kpi, ctx.entry, edit_attrs(inputs)) end)
+      |> run(:serialized, fn ctx ->
+        [entry] = Kpis.preload_entry_history([ctx.operation])
+        {:ok, %{entry: Serializer.serialize(entry, level: :essential)}}
+      end)
+      |> respond()
+    end
+
+    defp load_entry(entry_id) do
+      case Kpis.get_entry(entry_id) do
+        nil -> {:error, :not_found}
+        %KpiEntry{} = entry -> {:ok, Repo.preload(entry, :kpi)}
+      end
+    end
+
+    defp edit_attrs(inputs) do
+      [:value, :period]
+      |> Enum.filter(&Map.has_key?(inputs, &1))
+      |> Map.new(fn key -> {key, inputs[key]} end)
+    end
+
+    defp respond(result) do
+      case result do
+        {:ok, ctx} -> {:ok, ctx.serialized}
+        {:error, :entry, _} -> {:error, :not_found}
         {:error, :space, _} -> {:error, :not_found}
         {:error, :check_permissions, _} -> {:error, :forbidden}
         {:error, :operation, _} -> {:error, :bad_request}

--- a/app/lib/operately_web/api/serializers/activity_content/kpi_entry_edited.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/kpi_entry_edited.ex
@@ -1,0 +1,15 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.KpiEntryEdited do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      space: Serializer.serialize(content.space, level: :essential),
+      kpi: Serializer.serialize(content.kpi, level: :essential),
+      entry: Serializer.serialize(content.entry, level: :essential),
+      old_value: content.old_value,
+      new_value: content.new_value,
+      old_period: Serializer.serialize(content.old_period),
+      new_period: Serializer.serialize(content.new_period)
+    }
+  end
+end

--- a/app/lib/operately_web/api/serializers/kpi_entry.ex
+++ b/app/lib/operately_web/api/serializers/kpi_entry.ex
@@ -8,8 +8,12 @@ defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.KpiEntry do
       period: Serializer.serialize(entry.period),
       recorded_by: Serializer.serialize(entry.recorded_by),
       comments_count: Map.get(entry, :comments_count) || 0,
+      edits: Serializer.serialize(loaded_edits(entry)),
       inserted_at: Serializer.serialize(entry.inserted_at),
       updated_at: Serializer.serialize(entry.updated_at)
     }
   end
+
+  defp loaded_edits(%{edits: %Ecto.Association.NotLoaded{}}), do: []
+  defp loaded_edits(%{edits: edits}) when is_list(edits), do: edits
 end

--- a/app/lib/operately_web/api/serializers/kpi_entry_edit.ex
+++ b/app/lib/operately_web/api/serializers/kpi_entry_edit.ex
@@ -1,0 +1,13 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Kpis.KpiEntryEdit do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(edit, level: :essential) do
+    %{
+      id: OperatelyWeb.Paths.kpi_entry_edit_id(edit),
+      previous_value: edit.previous_value,
+      previous_period: Serializer.serialize(edit.previous_period),
+      edited_by: Serializer.serialize(edit.edited_by),
+      inserted_at: Serializer.serialize(edit.inserted_at)
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -260,6 +260,16 @@ defmodule OperatelyWeb.Api.Types do
     field :comment, :comment, null: true
   end
 
+  object :activity_content_kpi_entry_edited, for: Operately.Activities.Content.KpiEntryEdited do
+    field :space, :space, null: false
+    field :kpi, :kpi, null: true
+    field :entry, :kpi_entry, null: true
+    field :old_value, :float, null: false
+    field :new_value, :float, null: false
+    field :old_period, :date, null: false
+    field :new_period, :date, null: false
+  end
+
   object :activity_content_kpi_annotation_added, for: Operately.Activities.Content.KpiAnnotationAdded do
     field :space, :space, null: false
     field :kpi, :kpi, null: true
@@ -731,17 +741,20 @@ defmodule OperatelyWeb.Api.Types do
     field? :new_name, :string, null: true
   end
 
-  enum :project_template_archive_status, values: Operately.ProjectTemplates.archive_statuses()
-  enum :project_template_person_role, values: Operately.ProjectTemplates.Person.roles()
+  enum(:project_template_archive_status, values: Operately.ProjectTemplates.archive_statuses())
+  enum(:project_template_person_role, values: Operately.ProjectTemplates.Person.roles())
 
-  enum :project_template_schedule_resource_type,
+  enum(:project_template_schedule_resource_type,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.resource_types()
+  )
 
-  enum :project_template_schedule_field,
+  enum(:project_template_schedule_field,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.fields()
+  )
 
-  enum :project_template_schedule_reason,
+  enum(:project_template_schedule_reason,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.reasons()
+  )
 
   object :project_template_schedule_issue do
     field :resource_type, :project_template_schedule_resource_type, null: false
@@ -855,7 +868,7 @@ defmodule OperatelyWeb.Api.Types do
     field :updated_at, :datetime, null: false
   end
 
-  enum :project_template_comment_parent_type, values: Operately.ProjectTemplates.Comment.parent_types()
+  enum(:project_template_comment_parent_type, values: Operately.ProjectTemplates.Comment.parent_types())
 
   object :project_template_comment, for: Operately.ProjectTemplates.Comment do
     field :id, :string, null: false
@@ -1102,8 +1115,17 @@ defmodule OperatelyWeb.Api.Types do
     field :period, :date, null: false
     field? :recorded_by, :person, null: true
     field? :comments_count, :integer, null: true
+    field? :edits, list_of(:kpi_entry_edit), null: true
     field? :inserted_at, :datetime, null: true
     field? :updated_at, :datetime, null: true
+  end
+
+  object :kpi_entry_edit, for: Operately.Kpis.KpiEntryEdit do
+    field :id, :id, null: false
+    field :previous_value, :float, null: false
+    field :previous_period, :date, null: false
+    field? :edited_by, :person, null: true
+    field? :inserted_at, :datetime, null: true
   end
 
   object :kpi_annotation, for: Operately.Kpis.KpiAnnotation do
@@ -1121,7 +1143,7 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   enum(:milestone_comment_action, values: Operately.Comments.MilestoneComment.valid_actions())
-  enum :milestone_open_tasks_resolution_action, values: Operately.Projects.Milestone.valid_open_tasks_resolution_actions()
+  enum(:milestone_open_tasks_resolution_action, values: Operately.Projects.Milestone.valid_open_tasks_resolution_actions())
 
   object :milestone_open_tasks_resolution_input do
     field :action, :milestone_open_tasks_resolution_action, null: false
@@ -1180,6 +1202,7 @@ defmodule OperatelyWeb.Api.Types do
       :activity_content_discussion_posting,
       :activity_content_kpi_created,
       :activity_content_kpi_entry_commented,
+      :activity_content_kpi_entry_edited,
       :activity_content_kpi_annotation_added,
       :activity_content_kpi_annotation_edited,
       :activity_content_kpi_annotation_deleted,
@@ -1846,7 +1869,7 @@ defmodule OperatelyWeb.Api.Types do
     field? :url, :string
   end
 
-  enum :search_result_type,
+  enum(:search_result_type,
     values: [
       :resource_hub_folder,
       :resource_hub_document,
@@ -1862,11 +1885,12 @@ defmodule OperatelyWeb.Api.Types do
       :goal_check_in,
       :project_retrospective
     ]
+  )
 
-  enum :search_matched_field, values: [:title, :name, :content, :description, :message]
-  enum :search_result_state, values: [:closed, :completed, :archived, :paused]
-  enum :search_time_range, values: Operately.Search.CompanyQuery.Filters.time_ranges()
-  enum :search_sort, values: Operately.Search.CompanyQuery.Filters.sorts()
+  enum(:search_matched_field, values: [:title, :name, :content, :description, :message])
+  enum(:search_result_state, values: [:closed, :completed, :archived, :paused])
+  enum(:search_time_range, values: Operately.Search.CompanyQuery.Filters.time_ranges())
+  enum(:search_sort, values: Operately.Search.CompanyQuery.Filters.sorts())
 
   object :search_navigation_target do
     field? :resource_hub_id, :string, null: true

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -741,20 +741,17 @@ defmodule OperatelyWeb.Api.Types do
     field? :new_name, :string, null: true
   end
 
-  enum(:project_template_archive_status, values: Operately.ProjectTemplates.archive_statuses())
-  enum(:project_template_person_role, values: Operately.ProjectTemplates.Person.roles())
+  enum :project_template_archive_status, values: Operately.ProjectTemplates.archive_statuses()
+  enum :project_template_person_role, values: Operately.ProjectTemplates.Person.roles()
 
-  enum(:project_template_schedule_resource_type,
+  enum :project_template_schedule_resource_type,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.resource_types()
-  )
 
-  enum(:project_template_schedule_field,
+  enum :project_template_schedule_field,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.fields()
-  )
 
-  enum(:project_template_schedule_reason,
+  enum :project_template_schedule_reason,
     values: Operately.Operations.ProjectTemplateCreationFromProject.ScheduleValidator.reasons()
-  )
 
   object :project_template_schedule_issue do
     field :resource_type, :project_template_schedule_resource_type, null: false
@@ -868,7 +865,7 @@ defmodule OperatelyWeb.Api.Types do
     field :updated_at, :datetime, null: false
   end
 
-  enum(:project_template_comment_parent_type, values: Operately.ProjectTemplates.Comment.parent_types())
+  enum :project_template_comment_parent_type, values: Operately.ProjectTemplates.Comment.parent_types()
 
   object :project_template_comment, for: Operately.ProjectTemplates.Comment do
     field :id, :string, null: false
@@ -1143,7 +1140,7 @@ defmodule OperatelyWeb.Api.Types do
   end
 
   enum(:milestone_comment_action, values: Operately.Comments.MilestoneComment.valid_actions())
-  enum(:milestone_open_tasks_resolution_action, values: Operately.Projects.Milestone.valid_open_tasks_resolution_actions())
+  enum :milestone_open_tasks_resolution_action, values: Operately.Projects.Milestone.valid_open_tasks_resolution_actions()
 
   object :milestone_open_tasks_resolution_input do
     field :action, :milestone_open_tasks_resolution_action, null: false
@@ -1869,7 +1866,7 @@ defmodule OperatelyWeb.Api.Types do
     field? :url, :string
   end
 
-  enum(:search_result_type,
+  enum :search_result_type,
     values: [
       :resource_hub_folder,
       :resource_hub_document,
@@ -1885,12 +1882,11 @@ defmodule OperatelyWeb.Api.Types do
       :goal_check_in,
       :project_retrospective
     ]
-  )
 
-  enum(:search_matched_field, values: [:title, :name, :content, :description, :message])
-  enum(:search_result_state, values: [:closed, :completed, :archived, :paused])
-  enum(:search_time_range, values: Operately.Search.CompanyQuery.Filters.time_ranges())
-  enum(:search_sort, values: Operately.Search.CompanyQuery.Filters.sorts())
+  enum :search_matched_field, values: [:title, :name, :content, :description, :message]
+  enum :search_result_state, values: [:closed, :completed, :archived, :paused]
+  enum :search_time_range, values: Operately.Search.CompanyQuery.Filters.time_ranges()
+  enum :search_sort, values: Operately.Search.CompanyQuery.Filters.sorts()
 
   object :search_navigation_target do
     field? :resource_hub_id, :string, null: true

--- a/app/lib/operately_web/paths.ex
+++ b/app/lib/operately_web/paths.ex
@@ -532,6 +532,14 @@ defmodule OperatelyWeb.Paths do
     Operately.ShortUuid.encode!(entry_id)
   end
 
+  def kpi_entry_edit_id(%Operately.Kpis.KpiEntryEdit{id: id}) do
+    Operately.ShortUuid.encode!(id)
+  end
+
+  def kpi_entry_edit_id(edit_id) when is_binary(edit_id) do
+    Operately.ShortUuid.encode!(edit_id)
+  end
+
   def kpi_annotation_id(%Operately.Kpis.KpiAnnotation{id: id}) do
     Operately.ShortUuid.encode!(id)
   end

--- a/app/priv/repo/migrations/20260907071121_create_kpi_entry_edits.exs
+++ b/app/priv/repo/migrations/20260907071121_create_kpi_entry_edits.exs
@@ -1,0 +1,21 @@
+defmodule Operately.Repo.Migrations.CreateKpiEntryEdits do
+  use Ecto.Migration
+
+  def change do
+    create table(:kpi_entry_edits, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :kpi_entry_id, references(:kpi_entries, on_delete: :delete_all, type: :binary_id),
+        null: false
+
+      add :edited_by_id, references(:people, on_delete: :nilify_all, type: :binary_id)
+      add :previous_value, :float, null: false
+      add :previous_period, :date, null: false
+
+      timestamps()
+    end
+
+    create index(:kpi_entry_edits, [:kpi_entry_id])
+    create index(:kpi_entry_edits, [:edited_by_id])
+  end
+end

--- a/app/test/features/kpi_entries_test.exs
+++ b/app/test/features/kpi_entries_test.exs
@@ -1,0 +1,15 @@
+defmodule Operately.Features.KpiEntriesTest do
+  use Operately.FeatureCase
+
+  alias Operately.Support.Features.KpiEntriesSteps, as: Steps
+
+  setup ctx, do: Steps.setup(ctx)
+
+  feature "edit a logged KPI update and see the previous value", ctx do
+    ctx
+    |> Steps.visit_kpi_page()
+    |> Steps.edit_latest_update(value: "50")
+    |> Steps.assert_latest_value("50")
+    |> Steps.assert_previous_value_visible("42")
+  end
+end

--- a/app/test/operately/operations/kpi_entry_editing_test.exs
+++ b/app/test/operately/operations/kpi_entry_editing_test.exs
@@ -1,0 +1,66 @@
+defmodule Operately.Operations.KpiEntryEditingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.PeopleFixtures
+  import Operately.GroupsFixtures
+  import Operately.KpisFixtures
+
+  alias Operately.Kpis
+  alias Operately.Kpis.KpiEntryEdit
+  alias Operately.Activities.Activity
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+    kpi = kpi_fixture(creator, %{space_id: space.id})
+    entry = kpi_entry_fixture(creator, kpi, %{value: 40.0, period: ~D[2026-01-01]})
+
+    {:ok, creator: creator, space: space, kpi: kpi, entry: entry}
+  end
+
+  test "updates the logged value and keeps the previous value", ctx do
+    {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
+
+    assert entry.value == 42.0
+    assert entry.period == ~D[2026-01-01]
+    assert entry.recorded_by_id == ctx.creator.id
+
+    [edit] = Repo.all(from(e in KpiEntryEdit, where: e.kpi_entry_id == ^entry.id))
+    assert edit.previous_value == 40.0
+    assert edit.previous_period == ~D[2026-01-01]
+    assert edit.edited_by_id == ctx.creator.id
+  end
+
+  test "updates the period and keeps the previous period", ctx do
+    {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{period: ~D[2026-01-15]})
+
+    assert entry.value == 40.0
+    assert entry.period == ~D[2026-01-15]
+
+    [edit] = Repo.all(from(e in KpiEntryEdit, where: e.kpi_entry_id == ^entry.id))
+    assert edit.previous_period == ~D[2026-01-01]
+  end
+
+  test "does nothing when the value and period are unchanged", ctx do
+    {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 40.0, period: ~D[2026-01-01]})
+
+    assert entry.value == 40.0
+    assert Repo.all(from(e in KpiEntryEdit, where: e.kpi_entry_id == ^entry.id)) == []
+    refute Repo.one(from(a in Activity, where: a.action == "kpi_entry_edited" and a.content["entry_id"] == ^entry.id))
+  end
+
+  test "records a kpi_entry_edited activity", ctx do
+    {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
+
+    activity =
+      from(a in Activity, where: a.action == "kpi_entry_edited" and a.content["entry_id"] == ^entry.id)
+      |> Repo.one()
+
+    assert activity
+    assert activity.content["old_value"] == 40.0
+    assert activity.content["new_value"] == 42.0
+    assert activity.access_context_id
+  end
+end

--- a/app/test/operately/operations/kpi_entry_editing_test.exs
+++ b/app/test/operately/operations/kpi_entry_editing_test.exs
@@ -51,6 +51,22 @@ defmodule Operately.Operations.KpiEntryEditingTest do
     refute Repo.one(from(a in Activity, where: a.action == "kpi_entry_edited" and a.content["entry_id"] == ^entry.id))
   end
 
+  test "records the value it actually replaced when the caller's entry is stale", ctx do
+    {:ok, _} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 41.0})
+
+    # ctx.entry still carries the original 40.0, as an overlapping request would.
+    {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
+
+    assert entry.value == 42.0
+
+    previous_values =
+      from(e in KpiEntryEdit, where: e.kpi_entry_id == ^entry.id, order_by: e.previous_value)
+      |> Repo.all()
+      |> Enum.map(& &1.previous_value)
+
+    assert previous_values == [40.0, 41.0]
+  end
+
   test "records a kpi_entry_edited activity", ctx do
     {:ok, entry} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
 

--- a/app/test/operately_web/api/external_mutations/mutations.ex
+++ b/app/test/operately_web/api/external_mutations/mutations.ex
@@ -51,6 +51,7 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations do
       Mutations.Kpis.EditKpi,
       Mutations.Kpis.DeleteKpi,
       Mutations.Kpis.LogKpiEntry,
+      Mutations.Kpis.EditKpiEntry,
       Mutations.Kpis.AddKpiAnnotation,
       Mutations.Kpis.EditKpiAnnotation,
       Mutations.Kpis.DeleteKpiAnnotation,

--- a/app/test/operately_web/api/external_mutations/mutations/kpis/edit_kpi_entry.ex
+++ b/app/test/operately_web/api/external_mutations/mutations/kpis/edit_kpi_entry.ex
@@ -1,0 +1,38 @@
+defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.EditKpiEntry do
+  use Operately.Support.ExternalApi.MutationSpec
+  use OperatelyWeb.TurboCase
+
+  import Operately.KpisFixtures
+
+  @impl true
+  def mutation_name, do: "kpis/edit_kpi_entry"
+
+  @impl true
+  def setup(ctx) do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+
+    kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+    entry = kpi_entry_fixture(ctx.creator, kpi, value: 40.0, period: ~D[2026-01-01])
+
+    ctx
+    |> Map.put(:kpi, kpi)
+    |> Map.put(:entry, entry)
+  end
+
+  @impl true
+  def inputs(ctx) do
+    %{
+      entry_id: Paths.kpi_entry_id(ctx.entry),
+      value: 42.0
+    }
+  end
+
+  @impl true
+  def assert(response, _ctx) do
+    assert response.entry.value == 42.0
+    refute Map.has_key?(response, :error)
+  end
+end

--- a/app/test/operately_web/api/kpis/edit_kpi_entry_test.exs
+++ b/app/test/operately_web/api/kpis/edit_kpi_entry_test.exs
@@ -1,0 +1,65 @@
+defmodule OperatelyWeb.Api.Kpis.EditKpiEntryTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.KpisFixtures
+
+  alias Operately.Kpis
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, [:kpis, :edit_kpi_entry], %{})
+    end
+  end
+
+  describe "edit_kpi_entry" do
+    setup ctx do
+      ctx =
+        ctx
+        |> Factory.setup()
+        |> Factory.add_space(:space)
+        |> Factory.add_space_member(:member, :space)
+        |> Factory.add_company_member(:outsider)
+
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+      entry = kpi_entry_fixture(ctx.creator, kpi, value: 40.0, period: ~D[2026-01-01])
+      ctx |> Map.put(:kpi, kpi) |> Map.put(:entry, entry)
+    end
+
+    test "any space member can edit a logged value", ctx do
+      ctx = Factory.log_in_person(ctx, :member)
+
+      inputs = %{entry_id: Paths.kpi_entry_id(ctx.entry), value: 42.0}
+      assert {200, res} = mutation(ctx.conn, [:kpis, :edit_kpi_entry], inputs)
+
+      assert res.entry.value == 42.0
+      assert res.entry.period == "2026-01-01"
+      assert [edit] = res.entry.edits
+      assert edit.previous_value == 40.0
+      assert edit.previous_period == "2026-01-01"
+      assert edit.edited_by.id == Paths.person_id(ctx.member)
+
+      loaded = Kpis.get_entry(ctx.entry.id)
+      assert loaded.value == 42.0
+    end
+
+    test "returns the previous values on the KPI detail payload", ctx do
+      ctx = Factory.log_in_person(ctx, :member)
+
+      assert {200, _} = mutation(ctx.conn, [:kpis, :edit_kpi_entry], %{entry_id: Paths.kpi_entry_id(ctx.entry), value: 42.0})
+      assert {200, res} = query(ctx.conn, [:kpis, :get_kpi], %{kpi_id: Paths.kpi_id(ctx.kpi)})
+
+      [entry] = res.kpi.entries
+      assert entry.value == 42.0
+      assert [edit] = entry.edits
+      assert edit.previous_value == 40.0
+    end
+
+    test "a non-space-member cannot edit a logged value", ctx do
+      ctx = Factory.log_in_person(ctx, :outsider)
+
+      inputs = %{entry_id: Paths.kpi_entry_id(ctx.entry), value: 42.0}
+      assert {404, _} = mutation(ctx.conn, [:kpis, :edit_kpi_entry], inputs)
+      assert Kpis.get_entry(ctx.entry.id).value == 40.0
+    end
+  end
+end

--- a/app/test/support/features/kpi_entries_steps.ex
+++ b/app/test/support/features/kpi_entries_steps.ex
@@ -24,6 +24,7 @@ defmodule Operately.Support.Features.KpiEntriesSteps do
   step :edit_latest_update, ctx, opts do
     ctx
     |> UI.assert_has(testid: "kpi-detail")
+    |> UI.click(testid: "entry-menu-#{Paths.kpi_entry_id(ctx.entry)}")
     |> UI.click(testid: "edit-entry-#{Paths.kpi_entry_id(ctx.entry)}")
     |> UI.assert_has(testid: "edit-entry-modal")
     |> UI.fill(testid: "value", with: opts[:value])

--- a/app/test/support/features/kpi_entries_steps.ex
+++ b/app/test/support/features/kpi_entries_steps.ex
@@ -1,0 +1,43 @@
+defmodule Operately.Support.Features.KpiEntriesSteps do
+  use Operately.FeatureCase
+
+  import Operately.KpisFixtures
+
+  def setup(ctx) do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.enable_feature("space_kpis")
+      |> Factory.add_space(:space)
+      |> Factory.log_in_person(:creator)
+
+    kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+    entry = kpi_entry_fixture(ctx.creator, kpi, value: 42.0, period: ~D[2026-01-15])
+
+    Map.merge(ctx, %{kpi: kpi, entry: entry})
+  end
+
+  step :visit_kpi_page, ctx do
+    UI.visit(ctx, Paths.space_kpi_path(ctx.company, ctx.space, ctx.kpi))
+  end
+
+  step :edit_latest_update, ctx, opts do
+    ctx
+    |> UI.assert_has(testid: "kpi-detail")
+    |> UI.click(testid: "edit-entry-#{Paths.kpi_entry_id(ctx.entry)}")
+    |> UI.assert_has(testid: "edit-entry-modal")
+    |> UI.fill(testid: "value", with: opts[:value])
+    |> UI.click(testid: "submit")
+    |> UI.refute_has(testid: "edit-entry-modal")
+  end
+
+  step :assert_latest_value, ctx, value do
+    UI.assert_text(ctx, value, testid: "kpi-current-value")
+  end
+
+  step :assert_previous_value_visible, ctx, previous do
+    ctx
+    |> UI.click(testid: "entry-edited-#{Paths.kpi_entry_id(ctx.entry)}")
+    |> UI.assert_text(previous, testid: "entry-edit-history-#{Paths.kpi_entry_id(ctx.entry)}")
+  end
+end

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -465,6 +465,10 @@
           "kind": "named"
         },
         {
+          "name": "activity_content_kpi_entry_edited",
+          "kind": "named"
+        },
+        {
           "name": "activity_content_kpi_annotation_added",
           "kind": "named"
         },
@@ -14182,6 +14186,20 @@
           },
           {
             "default": null,
+            "name": "edits",
+            "type": {
+              "item": {
+                "name": "kpi_entry_edit",
+                "kind": "named"
+              },
+              "kind": "list"
+            },
+            "optional": true,
+            "nullable": true,
+            "has_default": false
+          },
+          {
+            "default": null,
             "name": "inserted_at",
             "type": {
               "name": "datetime",
@@ -22959,6 +22977,168 @@
             "has_default": false
           }
         ]
+      },
+      "activity_content_kpi_entry_edited": {
+        "fields": [
+          {
+            "default": null,
+            "name": "__typename",
+            "type": {
+              "name": "string",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "space",
+            "type": {
+              "name": "space",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "kpi",
+            "type": {
+              "name": "kpi",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": true,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "entry",
+            "type": {
+              "name": "kpi_entry",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": true,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "old_value",
+            "type": {
+              "name": "float",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "new_value",
+            "type": {
+              "name": "float",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "old_period",
+            "type": {
+              "name": "date",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "new_period",
+            "type": {
+              "name": "date",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          }
+        ]
+      },
+      "kpi_entry_edit": {
+        "fields": [
+          {
+            "default": null,
+            "name": "__typename",
+            "type": {
+              "name": "string",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "id",
+            "type": {
+              "name": "id",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "previous_value",
+            "type": {
+              "name": "float",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "previous_period",
+            "type": {
+              "name": "date",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "edited_by",
+            "type": {
+              "name": "person",
+              "kind": "named"
+            },
+            "optional": true,
+            "nullable": true,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "inserted_at",
+            "type": {
+              "name": "datetime",
+              "kind": "named"
+            },
+            "optional": true,
+            "nullable": true,
+            "has_default": false
+          }
+        ]
       }
     }
   },
@@ -22980,7 +23160,7 @@
     "tasks": "Get, list, create and manage tasks across projects and spaces"
   },
   "api_base_path": "/api/external/v1",
-  "endpoint_count": 252,
+  "endpoint_count": 253,
   "endpoints": [
     {
       "name": "create",
@@ -29901,6 +30081,65 @@
       "method": "POST",
       "namespace": "kpis",
       "docstring": "Edits a KPI chart annotation's date or title.",
+      "hidden": true
+    },
+    {
+      "name": "edit_kpi_entry",
+      "type": "mutation",
+      "path": "/api/external/v1/kpis/edit_kpi_entry",
+      "handler": "OperatelyWeb.Api.Kpis.EditKpiEntry",
+      "outputs": [
+        {
+          "default": null,
+          "name": "entry",
+          "type": {
+            "name": "kpi_entry",
+            "kind": "named"
+          },
+          "optional": false,
+          "nullable": false,
+          "has_default": false
+        }
+      ],
+      "inputs": [
+        {
+          "default": null,
+          "name": "entry_id",
+          "type": {
+            "name": "id",
+            "kind": "named"
+          },
+          "optional": false,
+          "nullable": false,
+          "has_default": false
+        },
+        {
+          "default": null,
+          "name": "value",
+          "type": {
+            "name": "float",
+            "kind": "named"
+          },
+          "optional": true,
+          "nullable": true,
+          "has_default": false
+        },
+        {
+          "default": null,
+          "name": "period",
+          "type": {
+            "name": "date",
+            "kind": "named"
+          },
+          "optional": true,
+          "nullable": true,
+          "has_default": false
+        }
+      ],
+      "full_name": "kpis/edit_kpi_entry",
+      "method": "POST",
+      "namespace": "kpis",
+      "docstring": "Edits a logged KPI value. Previous values are kept so the change is visible.",
       "hidden": true
     },
     {
@@ -39945,6 +40184,6 @@
     }
   ],
   "query_count": 75,
-  "mutation_count": 177,
+  "mutation_count": 178,
   "schema_version": 1
 }

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -432,6 +432,17 @@ export interface ActivityContentKpiEntryCommented {
   comment: Comment | null;
 }
 
+export interface ActivityContentKpiEntryEdited {
+  __typename: "activity_content_kpi_entry_edited";
+  space: Space;
+  kpi: Kpi | null;
+  entry: KpiEntry | null;
+  oldValue: number;
+  newValue: number;
+  oldPeriod: string;
+  newPeriod: string;
+}
+
 export interface ActivityContentMessageArchiving {
   __typename: "activity_content_message_archiving";
   companyId?: string | null;
@@ -1695,8 +1706,18 @@ export interface KpiEntry {
   period: string;
   recordedBy?: Person | null;
   commentsCount?: number | null;
+  edits?: KpiEntryEdit[] | null;
   insertedAt?: string | null;
   updatedAt?: string | null;
+}
+
+export interface KpiEntryEdit {
+  __typename: "kpi_entry_edit";
+  id: Id;
+  previousValue: number;
+  previousPeriod: string;
+  editedBy?: Person | null;
+  insertedAt?: string | null;
 }
 
 export interface McpGrant {
@@ -2724,6 +2745,7 @@ export type ActivityContent =
   | ActivityContentDiscussionPosting
   | ActivityContentKpiCreated
   | ActivityContentKpiEntryCommented
+  | ActivityContentKpiEntryEdited
   | ActivityContentKpiAnnotationAdded
   | ActivityContentKpiAnnotationEdited
   | ActivityContentKpiAnnotationDeleted

--- a/turboui/src/SpaceKpisPage/EditEntryForm.tsx
+++ b/turboui/src/SpaceKpisPage/EditEntryForm.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+
+import { Form, NumberInput, Submit, useForm } from "../Forms";
+import { Modal } from "../Modal";
+import type { SpaceKpisPage } from "./types";
+import { formatShortDate, toIsoDate } from "./utils";
+
+interface EditEntryFormProps {
+  kpi: SpaceKpisPage.Kpi | null;
+  entry: SpaceKpisPage.KpiEntry | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: (input: SpaceKpisPage.EditEntryInput) => Promise<SpaceKpisPage.MutationResult>;
+}
+
+export function EditEntryForm({ kpi, entry, isOpen, onClose, onEdit }: EditEntryFormProps) {
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
+  const form = useForm<{ value: string; period: string }>({
+    fields: {
+      value: entry ? String(entry.value) : "",
+      period: entry ? toIsoDate(entry.recordedAt) : "",
+    },
+    validate: (addError) => {
+      if (form.values.value.trim() === "" || Number.isNaN(Number(form.values.value))) {
+        addError("value", "Enter a value");
+      }
+      if (!form.values.period) {
+        addError("period", "Choose a date");
+      }
+    },
+    submit: async () => {
+      if (!entry) return;
+      setSubmitError(null);
+
+      const result = await onEdit({
+        entryId: entry.id,
+        value: Number(form.values.value),
+        period: form.values.period,
+      });
+
+      if (result.success) {
+        onClose();
+      } else {
+        setSubmitError(result.error ?? "Something went wrong. Please try again.");
+      }
+    },
+    cancel: onClose,
+  });
+
+  React.useEffect(() => {
+    if (!isOpen || !entry) return;
+
+    form.actions.setValue("value", String(entry.value));
+    form.actions.setValue("period", toIsoDate(entry.recordedAt));
+    setSubmitError(null);
+    // The form identity is stable for the open entry; reset only when that entry or the modal changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, entry?.id]);
+
+  if (!kpi || !entry) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={`Edit update — ${kpi.name}`}
+      size="x-small"
+      testId="edit-entry-modal"
+    >
+      <Form form={form}>
+        <p className="mb-4 text-sm text-content-dimmed">
+          Correct the value recorded on{" "}
+          <span className="font-medium text-content-base">{formatShortDate(entry.recordedAt)}</span>. The previous
+          number stays visible on this update.
+        </p>
+
+        <div className="space-y-2">
+          <NumberInput field="value" label={`Value (${kpi.unit})`} placeholder="0" autoFocus required />
+
+          <div>
+            <label htmlFor="edit-kpi-entry-period" className="mb-1 block text-sm font-medium text-content-accent">
+              Date
+            </label>
+            <input
+              id="edit-kpi-entry-period"
+              type="date"
+              value={form.values.period}
+              onChange={(event) => form.actions.setValue("period", event.target.value)}
+              className="w-full rounded-lg border border-surface-outline bg-surface-base px-3 py-1.5 text-sm text-content-accent"
+              data-test-id="edit-entry-period"
+            />
+            {form.errors["period"] && <div className="mt-1 text-sm text-content-error">{form.errors["period"]}</div>}
+          </div>
+        </div>
+
+        {submitError && (
+          <div className="mt-4 text-sm text-content-error" data-test-id="edit-entry-error">
+            {submitError}
+          </div>
+        )}
+
+        <Submit saveText="Save changes" cancelText="Cancel" />
+      </Form>
+    </Modal>
+  );
+}

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -516,16 +516,21 @@ function EntryEditedHistory({ entry, unit }: { entry: SpaceKpisPage.KpiEntry; un
         <Popover.Content
           align="start"
           sideOffset={6}
-          className="z-[100] w-72 rounded-lg border border-stroke-base bg-surface-base p-3 shadow-xl"
+          className="z-[100] w-80 rounded-lg border border-stroke-base bg-surface-base p-3 shadow-xl"
         >
           <div className="text-xs font-medium uppercase tracking-wide text-content-dimmed">Previous values</div>
           <ol className="mt-2 space-y-2" data-test-id={`entry-edit-history-${entry.id}`}>
             {entry.edits.map((edit) => (
               <li key={edit.id} className="text-sm text-content-base" data-test-id={`entry-edit-${edit.id}`}>
-                <div className="font-medium text-content-accent">{formatValue(edit.previousValue, unit)}</div>
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="font-medium text-content-accent">{formatValue(edit.previousValue, unit)}</span>
+                  <span className="whitespace-nowrap text-xs text-content-dimmed">
+                    {formatShortDate(edit.previousPeriod)}
+                  </span>
+                </div>
                 <div className="mt-0.5 text-xs text-content-dimmed">
-                  on {formatShortDate(edit.previousPeriod)}
-                  {edit.editedBy ? `, replaced by ${edit.editedBy.fullName}` : ""} on {formatShortDate(edit.editedAt)}
+                  {edit.editedBy ? `Replaced by ${edit.editedBy.fullName} on ` : "Replaced on "}
+                  <span className="whitespace-nowrap">{formatShortDate(edit.editedAt)}</span>
                 </div>
               </li>
             ))}

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -1,3 +1,4 @@
+import * as Popover from "@radix-ui/react-popover";
 import React from "react";
 
 import { ActionList } from "../ActionList";
@@ -11,7 +12,7 @@ import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { TextField } from "../TextField";
 import { SlideIn } from "../SlideIn";
 import { showErrorToast, showSuccessToast } from "../Toasts";
-import { IconFlag, IconLink, IconMessage, IconTrash } from "../icons";
+import { IconFlag, IconLink, IconMessage, IconPencil, IconTrash } from "../icons";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
@@ -27,6 +28,7 @@ interface KpiDetailProps {
   onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPage.KpiAnnotation) => void;
+  onEditEntry: (entry: SpaceKpisPage.KpiEntry) => void;
   onDelete: () => void;
   richTextHandlers: RichEditorHandlers;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
@@ -46,6 +48,7 @@ export function KpiDetail({
   onDescriptionChange,
   onOpenNewAnnotation,
   onOpenAnnotation,
+  onEditEntry,
   onDelete,
   richTextHandlers,
   renderEntryComments,
@@ -107,7 +110,9 @@ export function KpiDetail({
           entries={kpi.entries}
           unit={fields.unit}
           kpiName={fields.name}
+          canManage={canManage}
           canComment={canComment}
+          onEditEntry={onEditEntry}
           renderEntryComments={renderEntryComments}
         />
       </div>
@@ -356,13 +361,17 @@ function EntriesTable({
   entries,
   unit,
   kpiName,
+  canManage,
   canComment,
+  onEditEntry,
   renderEntryComments,
 }: {
   entries: SpaceKpisPage.KpiEntry[];
   unit: string;
   kpiName: string;
+  canManage: boolean;
   canComment: boolean;
+  onEditEntry: (entry: SpaceKpisPage.KpiEntry) => void;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
 }) {
   const [openEntryId, setOpenEntryId] = React.useState<string | null>(null);
@@ -398,7 +407,10 @@ function EntriesTable({
                   data-test-id={`entry-row-${entry.id}`}
                 >
                   <td className="whitespace-nowrap px-4 py-2.5 text-content-base">
-                    {formatShortDate(entry.recordedAt)}
+                    <div className="flex items-center gap-1.5">
+                      <span>{formatShortDate(entry.recordedAt)}</span>
+                      <EntryEditedHistory entry={entry} unit={unit} />
+                    </div>
                   </td>
                   <td className="px-4 py-2.5">
                     {entry.recordedBy ? (
@@ -411,7 +423,21 @@ function EntriesTable({
                     )}
                   </td>
                   <td className="whitespace-nowrap px-4 py-2.5 text-right font-medium text-content-accent">
-                    {formatValue(entry.value, unit)}
+                    <div className="flex items-center justify-end gap-2">
+                      <span>{formatValue(entry.value, unit)}</span>
+                      {canManage && (
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+                          onClick={() => onEditEntry(entry)}
+                          data-test-id={`edit-entry-${entry.id}`}
+                          aria-label="Edit this update"
+                        >
+                          <IconPencil size={14} />
+                          Edit
+                        </button>
+                      )}
+                    </div>
                   </td>
                   <td className="px-4 py-2.5 text-right">
                     {canOpenComments ? (
@@ -454,6 +480,45 @@ function EntriesTable({
         )}
       </SlideIn>
     </Section>
+  );
+}
+
+function EntryEditedHistory({ entry, unit }: { entry: SpaceKpisPage.KpiEntry; unit: string }) {
+  if (entry.edits.length === 0) return null;
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <button
+          type="button"
+          className="rounded px-1 py-0.5 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
+          data-test-id={`entry-edited-${entry.id}`}
+        >
+          Edited
+        </button>
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={6}
+          className="z-[100] w-72 rounded-lg border border-stroke-base bg-surface-base p-3 shadow-xl"
+        >
+          <div className="text-xs font-medium uppercase tracking-wide text-content-dimmed">Previous values</div>
+          <ol className="mt-2 space-y-2" data-test-id={`entry-edit-history-${entry.id}`}>
+            {entry.edits.map((edit) => (
+              <li key={edit.id} className="text-sm text-content-base" data-test-id={`entry-edit-${edit.id}`}>
+                <div className="font-medium text-content-accent">{formatValue(edit.previousValue, unit)}</div>
+                <div className="mt-0.5 text-xs text-content-dimmed">
+                  on {formatShortDate(edit.previousPeriod)}
+                  {edit.editedBy ? `, replaced by ${edit.editedBy.fullName}` : ""} on {formatShortDate(edit.editedAt)}
+                </div>
+              </li>
+            ))}
+          </ol>
+          <Popover.Arrow className="fill-surface-outline" />
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -12,7 +12,7 @@ import { SidebarNotificationSection, SidebarSection } from "../SidebarSection";
 import { TextField } from "../TextField";
 import { SlideIn } from "../SlideIn";
 import { showErrorToast, showSuccessToast } from "../Toasts";
-import { IconFlag, IconLink, IconMessage, IconPencil, IconTrash } from "../icons";
+import { IconDotsVertical, IconFlag, IconLink, IconMessage, IconPencil, IconTrash } from "../icons";
 import { KpiLineChart } from "./KpiLineChart";
 import { TrendIndicator } from "./TrendIndicator";
 import type { SpaceKpisPage } from "./types";
@@ -392,6 +392,9 @@ function EntriesTable({
               <th className="px-4 py-2 font-medium">Recorded by</th>
               <th className="px-4 py-2 text-right font-medium">Value</th>
               <th className="px-4 py-2 text-right font-medium">Comments</th>
+              <th className="w-10 px-2 py-2">
+                <span className="sr-only">Actions</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -423,21 +426,7 @@ function EntriesTable({
                     )}
                   </td>
                   <td className="whitespace-nowrap px-4 py-2.5 text-right font-medium text-content-accent">
-                    <div className="flex items-center justify-end gap-2">
-                      <span>{formatValue(entry.value, unit)}</span>
-                      {canManage && (
-                        <button
-                          type="button"
-                          className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-xs font-medium text-content-dimmed hover:bg-surface-dimmed hover:text-content-base"
-                          onClick={() => onEditEntry(entry)}
-                          data-test-id={`edit-entry-${entry.id}`}
-                          aria-label="Edit this update"
-                        >
-                          <IconPencil size={14} />
-                          Edit
-                        </button>
-                      )}
-                    </div>
+                    {formatValue(entry.value, unit)}
                   </td>
                   <td className="px-4 py-2.5 text-right">
                     {canOpenComments ? (
@@ -458,6 +447,32 @@ function EntriesTable({
                         {commentsCount}
                       </span>
                     ) : null}
+                  </td>
+                  <td className="px-2 py-2.5 text-right">
+                    {canManage && (
+                      <Menu
+                        size="tiny"
+                        align="end"
+                        testId={`entry-menu-${entry.id}`}
+                        customTrigger={
+                          <button
+                            type="button"
+                            className="rounded p-1 text-content-dimmed hover:bg-surface-dimmed hover:text-content-base focus:outline-none focus:ring-2 focus:ring-primary-base"
+                            aria-label="Update options"
+                          >
+                            <IconDotsVertical size={16} />
+                          </button>
+                        }
+                      >
+                        <MenuActionItem
+                          icon={IconPencil}
+                          onClick={() => onEditEntry(entry)}
+                          testId={`edit-entry-${entry.id}`}
+                        >
+                          Edit
+                        </MenuActionItem>
+                      </Menu>
+                    )}
                   </td>
                 </tr>
               );

--- a/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
+++ b/turboui/src/SpaceKpisPage/KpiLineChart.test.tsx
@@ -7,7 +7,7 @@ import type { SpaceKpisPage } from "./types";
 import { formatShortDate } from "./utils";
 
 function entry(id: string, value: number): SpaceKpisPage.KpiEntry {
-  return { id, value, recordedAt: new Date(`2026-01-0${id}`), recordedBy: null, commentsCount: 0 };
+  return { id, value, recordedAt: new Date(`2026-01-0${id}`), recordedBy: null, commentsCount: 0, edits: [] };
 }
 
 describe("KpiLineChart y-axis", () => {
@@ -42,7 +42,7 @@ describe("KpiLineChart y-axis", () => {
 
 describe("KpiLineChart x-axis", () => {
   function entryOn(id: string, date: Date): SpaceKpisPage.KpiEntry {
-    return { id, value: 100, recordedAt: date, recordedBy: null, commentsCount: 0 };
+    return { id, value: 100, recordedAt: date, recordedBy: null, commentsCount: 0, edits: [] };
   }
 
   function axisLabels(entries: SpaceKpisPage.KpiEntry[]): string[] {

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -64,7 +64,7 @@ type Story = StoryObj<HarnessArgs>;
 function clone(kpis: SpaceKpisPageNS.Kpi[]): SpaceKpisPageNS.Kpi[] {
   return kpis.map((kpi) => ({
     ...kpi,
-    entries: kpi.entries.map((e) => ({ ...e })),
+    entries: kpi.entries.map((e) => ({ ...e, edits: e.edits.map((edit) => ({ ...edit })) })),
     annotations: kpi.annotations.map((a) => ({ ...a })),
   }));
 }
@@ -163,6 +163,7 @@ function Harness(args: HarnessArgs) {
                 recordedBy: mockCurrentUser,
                 // The app posts the note as the update's first comment.
                 commentsCount: input.comment ? 1 : 0,
+                edits: [],
               };
               return { ...kpi, latestEntry: entry, entries: [...kpi.entries, entry] };
             })()
@@ -171,6 +172,48 @@ function Harness(args: HarnessArgs) {
     );
 
     return { success: true };
+  };
+
+  const onEditEntry = async (input: SpaceKpisPageNS.EditEntryInput): Promise<SpaceKpisPageNS.MutationResult> => {
+    console.log("editKpiEntry", input);
+    await delay(400);
+
+    if (args.failMutations) {
+      return { success: false, error: "You don't have permission to edit this update." };
+    }
+
+    setKpis((prev) =>
+      prev
+        .map((kpi) => ({
+          ...kpi,
+          entries: kpi.entries.map((entry) => {
+            if (entry.id !== input.entryId) return entry;
+
+            const edit: SpaceKpisPageNS.KpiEntryEdit = {
+              id: `edit-${crypto.randomUUID()}`,
+              previousValue: entry.value,
+              previousPeriod: entry.recordedAt,
+              editedBy: mockCurrentUser,
+              editedAt: new Date(),
+            };
+
+            const next = {
+              ...entry,
+              value: input.value,
+              recordedAt: new Date(`${input.period}T12:00:00`),
+              edits: [edit, ...entry.edits],
+            };
+
+            return next;
+          }),
+        }))
+        .map((kpi) => ({
+          ...kpi,
+          latestEntry: kpi.entries.length > 0 ? kpi.entries[kpi.entries.length - 1]! : null,
+        })),
+    );
+
+    return { success: true, id: input.entryId };
   };
 
   const onAddAnnotation = async (input: SpaceKpisPageNS.AnnotationInput): Promise<SpaceKpisPageNS.MutationResult> => {
@@ -255,6 +298,7 @@ function Harness(args: HarnessArgs) {
       onDescriptionChange={onDescriptionChange}
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
+      onEditEntry={onEditEntry}
       onAddAnnotation={onAddAnnotation}
       onEditAnnotation={onEditAnnotation}
       onDeleteAnnotation={onDeleteAnnotation}

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -47,6 +47,7 @@ function pageProps(overrides: Partial<SpaceKpisPageNS.Props> = {}): SpaceKpisPag
     onDescriptionChange: async () => true,
     onDeleteKpi: async () => ({ success: true }),
     onRecordEntry: async () => ({ success: true }),
+    onEditEntry: async () => ({ success: true }),
     onAddAnnotation: async () => ({ success: true }),
     onEditAnnotation: async () => ({ success: true }),
     onDeleteAnnotation: async () => ({ success: true }),
@@ -369,7 +370,7 @@ describe("SpaceKpisPage list latest value", () => {
       champion: null,
       insertedAt: new Date(),
       link: `${kpisLink}/kpi-throughput`,
-      latestEntry: { id: "e1", value: 123, recordedAt: new Date(), recordedBy: null, commentsCount: 0 },
+      latestEntry: { id: "e1", value: 123, recordedAt: new Date(), recordedBy: null, commentsCount: 0, edits: [] },
       entries: [],
       annotations: [],
     };
@@ -586,6 +587,7 @@ describe("SpaceKpisPage create & log", () => {
           recordedAt: new Date(),
           recordedBy: null,
           commentsCount: 0,
+          edits: [],
         };
         setKpi((current) => ({ ...current, entries: [...current.entries, entry] }));
 
@@ -704,5 +706,48 @@ describe("SpaceKpisPage annotations", () => {
 
     const modal = await findByTestId("kpi-annotation-modal");
     expect(modal).toHaveTextContent("Edit annotation");
+  });
+});
+
+describe("SpaceKpisPage edit logged updates", () => {
+  test("editors can open a recorded update and submit a corrected value", async () => {
+    const user = userEvent.setup();
+    const onEditEntry = jest.fn().mockResolvedValue({ success: true });
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({ selectedKpi: target, onEditEntry });
+
+    await user.click(await findByTestId(`edit-entry-${entry.id}`));
+    await findByTestId("edit-entry-modal");
+
+    fireEvent.change(await findByTestId("value"), { target: { value: "1500000" } });
+    await user.click(await findByTestId("submit"));
+
+    await waitFor(() =>
+      expect(onEditEntry).toHaveBeenCalledWith(expect.objectContaining({ entryId: entry.id, value: 1500000 })),
+    );
+  });
+
+  test("an edited update shows the previous value when Edited is opened", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({ selectedKpi: target });
+
+    await user.click(await findByTestId(`entry-edited-${entry.id}`));
+
+    const history = await findByTestId(`entry-edit-history-${entry.id}`);
+    expect(history).toHaveTextContent("1.3M USD");
+  });
+
+  test("read-only viewers cannot edit a recorded update", () => {
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+    const { container } = renderPage({ selectedKpi: target, canManage: false });
+
+    expect(container.querySelector(`[data-test-id="edit-entry-${entry.id}"]`)).not.toBeInTheDocument();
+    expect(container.querySelector(`[data-test-id="entry-edited-${entry.id}"]`)).toBeInTheDocument();
   });
 });

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -718,6 +718,7 @@ describe("SpaceKpisPage edit logged updates", () => {
 
     renderPage({ selectedKpi: target, onEditEntry });
 
+    await user.click(await findByTestId(`entry-menu-${entry.id}`));
     await user.click(await findByTestId(`edit-entry-${entry.id}`));
     await findByTestId("edit-entry-modal");
 
@@ -747,7 +748,7 @@ describe("SpaceKpisPage edit logged updates", () => {
     const entry = target.entries[target.entries.length - 1]!;
     const { container } = renderPage({ selectedKpi: target, canManage: false });
 
-    expect(container.querySelector(`[data-test-id="edit-entry-${entry.id}"]`)).not.toBeInTheDocument();
+    expect(container.querySelector(`[data-test-id="entry-menu-${entry.id}"]`)).not.toBeInTheDocument();
     expect(container.querySelector(`[data-test-id="entry-edited-${entry.id}"]`)).toBeInTheDocument();
   });
 });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -8,6 +8,7 @@ import { IconChartColumn, IconChevronRight } from "../icons";
 
 import { AnnotationForm } from "./AnnotationForm";
 import { DeleteKpiModal } from "./DeleteKpiModal";
+import { EditEntryForm } from "./EditEntryForm";
 import { KpiDetail } from "./KpiDetail";
 import { KpiList } from "./KpiList";
 import { LogUpdateForm } from "./LogUpdateForm";
@@ -24,6 +25,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   const [isNewOpen, setIsNewOpen] = React.useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
   const [logKpiId, setLogKpiId] = React.useState<string | null>(null);
+  const [editingEntry, setEditingEntry] = React.useState<SpaceKpisPageNS.KpiEntry | null>(null);
   const [annotationState, setAnnotationState] = React.useState<{
     kpi: SpaceKpisPageNS.Kpi;
     annotation: SpaceKpisPageNS.KpiAnnotation | null;
@@ -87,6 +89,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
             onOpenDelete={() => setIsDeleteOpen(true)}
             onOpenNewAnnotation={() => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation: null })}
             onOpenAnnotation={(annotation) => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation })}
+            onOpenEditEntry={setEditingEntry}
           />
         </div>
       </div>
@@ -111,6 +114,14 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         onClose={() => setLogKpiId(null)}
         onRecord={props.onRecordEntry}
         richTextHandlers={props.richTextHandlers}
+      />
+
+      <EditEntryForm
+        kpi={selectedKpi}
+        entry={editingEntry}
+        isOpen={editingEntry !== null}
+        onClose={() => setEditingEntry(null)}
+        onEdit={props.onEditEntry}
       />
 
       <AnnotationForm
@@ -230,6 +241,7 @@ interface KpisContentProps extends SpaceKpisPageNS.Props {
   onOpenDelete: () => void;
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPageNS.KpiAnnotation) => void;
+  onOpenEditEntry: (entry: SpaceKpisPageNS.KpiEntry) => void;
 }
 
 function KpisContent(props: KpisContentProps) {
@@ -254,6 +266,7 @@ function KpisContent(props: KpisContentProps) {
         onDescriptionChange={props.onDescriptionChange}
         onOpenNewAnnotation={props.onOpenNewAnnotation}
         onOpenAnnotation={props.onOpenAnnotation}
+        onEditEntry={props.onOpenEditEntry}
         onDelete={props.onOpenDelete}
         richTextHandlers={props.richTextHandlers}
         renderEntryComments={props.renderEntryComments}

--- a/turboui/src/SpaceKpisPage/mockData.tsx
+++ b/turboui/src/SpaceKpisPage/mockData.tsx
@@ -41,7 +41,12 @@ function daysAgo(n: number): Date {
 }
 
 function makeEntries(
-  samples: { value: number; daysAgo: number; by: SpaceKpisPage.Person | null }[],
+  samples: {
+    value: number;
+    daysAgo: number;
+    by: SpaceKpisPage.Person | null;
+    edits?: SpaceKpisPage.KpiEntryEdit[];
+  }[],
 ): SpaceKpisPage.KpiEntry[] {
   return samples
     .map((sample, index) => ({
@@ -50,6 +55,7 @@ function makeEntries(
       recordedAt: daysAgo(sample.daysAgo),
       recordedBy: sample.by,
       commentsCount: 0,
+      edits: sample.edits ?? [],
     }))
     .sort((a, b) => a.recordedAt.getTime() - b.recordedAt.getTime());
 }
@@ -96,7 +102,20 @@ export const mockKpis: SpaceKpisPage.Kpi[] = (
         { value: 985000, daysAgo: 90, by: bob! },
         { value: 1120000, daysAgo: 60, by: carol! },
         { value: 1240000, daysAgo: 30, by: bob! },
-        { value: 1385000, daysAgo: 2, by: bob! },
+        {
+          value: 1385000,
+          daysAgo: 2,
+          by: bob!,
+          edits: [
+            {
+              id: "edit-mrr-latest",
+              previousValue: 1320000,
+              previousPeriod: daysAgo(2),
+              editedBy: bob!,
+              editedAt: daysAgo(1),
+            },
+          ],
+        },
       ]),
       annotations: makeAnnotations([
         { title: "Launched enterprise plan", daysAgo: 90, by: bob! },

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -3,7 +3,8 @@
 //
 // This mirrors the backend bounded context `Operately.Kpis` described in the POC:
 //   - Kpi:      company_id + group_id scoped, name, unit, cadence, champion, creator
-//   - KpiEntry: append-only value samples (value + recorded_at + recorded_by)
+//   - KpiEntry: recorded values (value + period + recorded_by), with an edit
+//     history when a logged value is corrected
 //
 // Intentionally simpler than Goals/Targets: raw value + unit only, no
 // target/threshold fields.
@@ -31,13 +32,24 @@ export namespace SpaceKpisPage {
     link: string;
   }
 
-  // Append-only sample of a KPI's value at a point in time.
+  // A recorded sample of a KPI's value at a point in time. Editing keeps the
+  // previous values on `edits` so a correction is visible, the way a GitHub
+  // comment still shows what was there before.
+  export interface KpiEntryEdit {
+    id: string;
+    previousValue: number;
+    previousPeriod: Date;
+    editedBy: Person | null;
+    editedAt: Date;
+  }
+
   export interface KpiEntry {
     id: string;
     value: number;
     recordedAt: Date;
     recordedBy: Person | null;
     commentsCount: number;
+    edits: KpiEntryEdit[];
   }
 
   // A date marked on the KPI chart, typically a launch, pricing change, or
@@ -84,8 +96,7 @@ export namespace SpaceKpisPage {
   }
 
   // Payload for the `updateKpi` mutation / `KpiUpdating` operation. Same shape
-  // as NewKpiInput plus the id of the KPI being edited. Entries are never edited
-  // here — they are append-only samples managed via recordKpiEntry.
+  // as NewKpiInput plus the id of the KPI being edited.
   export interface EditKpiInput {
     id: string;
     name: string;
@@ -105,6 +116,12 @@ export namespace SpaceKpisPage {
     // Optional note explaining the value, posted as the update's first comment.
     // Absent when the author left the note blank.
     comment?: Record<string, unknown>;
+  }
+
+  export interface EditEntryInput {
+    entryId: string;
+    value: number;
+    period: string;
   }
 
   export interface AnnotationInput {
@@ -151,6 +168,7 @@ export namespace SpaceKpisPage {
     onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
     onDeleteKpi: (kpiId: string) => Promise<MutationResult>;
     onRecordEntry: (input: RecordEntryInput) => Promise<MutationResult>;
+    onEditEntry: (input: EditEntryInput) => Promise<MutationResult>;
     onAddAnnotation: (input: AnnotationInput) => Promise<MutationResult>;
     onEditAnnotation: (input: EditAnnotationInput) => Promise<MutationResult>;
     onDeleteAnnotation: (annotationId: string) => Promise<MutationResult>;

--- a/turboui/src/icons/index.tsx
+++ b/turboui/src/icons/index.tsx
@@ -57,6 +57,7 @@ import IconCopy from "@tabler/icons-react/dist/esm/icons/IconCopy.mjs";
 import IconDeviceLaptop from "@tabler/icons-react/dist/esm/icons/IconDeviceLaptop.mjs";
 import IconDoorExit from "@tabler/icons-react/dist/esm/icons/IconDoorExit.mjs";
 import IconDots from "@tabler/icons-react/dist/esm/icons/IconDots.mjs";
+import IconDotsVertical from "@tabler/icons-react/dist/esm/icons/IconDotsVertical.mjs";
 import IconDownload from "@tabler/icons-react/dist/esm/icons/IconDownload.mjs";
 import IconEdit from "@tabler/icons-react/dist/esm/icons/IconEdit.mjs";
 import IconExchange from "@tabler/icons-react/dist/esm/icons/IconExchange.mjs";
@@ -221,6 +222,7 @@ export {
   IconDeviceLaptop,
   IconDoorExit,
   IconDots,
+  IconDotsVertical,
   IconDownload,
   IconEdit,
   IconExchange,


### PR DESCRIPTION
## Summary

A value logged against a KPI could not be corrected. A typo left the chart and the trend permanently wrong, and the only workarounds were logging a second value for the same period (which distorts the series) or asking someone with database access to fix it.

Logged values are now editable, and every correction keeps a record of what it replaced:

- New `kpi_entry_edits` table stores the previous value, previous period, editor, and timestamp for each correction.
- The recorded-updates log marks a corrected value as **Edited**; clicking it reveals the previous values, so a correction stays auditable the way an edited GitHub comment does instead of silently rewriting history.
- Editing requires the same space edit access as logging a value, and a no-op edit is a no-op (no edit record, no activity).
- Emits a `kpi_entry_edited` activity so the change shows up in the feed and in notifications for KPI subscribers.
- Exposed as `kpis/edit_kpi_entry` on the internal and external APIs; the CLI catalog is regenerated accordingly.

TurboUI primitives reused: `Modal`, `Form` / `useForm` / `NumberInput` / `Submit` from `Forms`, and the `icons` set. The edit form deliberately mirrors its sibling `LogUpdateForm` in the same directory, including its raw `<input type="date">` for the period; `DateField` is a click-to-open calendar popover built for inline page fields and does not fit a stacked modal form, so matching the existing form keeps the two dialogs consistent. The "Edited" disclosure uses Radix `Popover` directly, which is how every other popover in TurboUI is built.

MCP: no existing MCP tool wraps KPI entry logging, so no MCP wrapper needed updating for this change.

## Test plan

- [ ] `make test FILE=app/test/operately/operations/kpi_entry_editing_test.exs`
- [ ] `make test FILE=app/test/operately_web/api/kpis/edit_kpi_entry_test.exs`
- [ ] `make test FILE=app/test/features/kpi_entries_test.exs`
- [ ] `make test FILE=app/test/operately/company_transfers/schema_graph_test.exs`
- [ ] `make test FILE=assets/js/models/kpis/kpiLifecycle.test.ts`
- [ ] `make test FILE=assets/js/features/activities/KpiEntryEdited/index.test.tsx`
- [ ] `make turboui.test` (`SpaceKpisPage/index.test.tsx`, `KpiLineChart.test.tsx`)
- [ ] `make test.cli.catalog.sync`
- [ ] Manual: log a KPI value, edit it via the pencil in the recorded-updates log, confirm the chart updates and the **Edited** marker shows the previous value; confirm a viewer without edit access sees no pencil.

## Migration notes

Adds `kpi_entry_edits` (`priv/repo/migrations/20260907071121_create_kpi_entry_edits.exs`). Additive only, no backfill needed; existing entries simply have no edit history.

Made with [Cursor](https://cursor.com)
