### PR TITLE
feat: Allow deleting a logged KPI value

### DIFF
--- a/app/assets/js/api/index.tsx
+++ b/app/assets/js/api/index.tsx
@@ -554,6 +554,14 @@ export interface ActivityContentKpiEntryCommented {
   comment: Comment | null;
 }
 
+export interface ActivityContentKpiEntryDeleted {
+  __typename: "activity_content_kpi_entry_deleted";
+  space: Space;
+  kpi: Kpi | null;
+  value: number;
+  period: string;
+}
+
 export interface ActivityContentKpiEntryEdited {
   __typename: "activity_content_kpi_entry_edited";
   space: Space;
@@ -2868,6 +2876,7 @@ export type ActivityContent =
   | ActivityContentKpiCreated
   | ActivityContentKpiEntryCommented
   | ActivityContentKpiEntryEdited
+  | ActivityContentKpiEntryDeleted
   | ActivityContentKpiAnnotationAdded
   | ActivityContentKpiAnnotationEdited
   | ActivityContentKpiAnnotationDeleted
@@ -5209,6 +5218,14 @@ export interface KpisDeleteKpiAnnotationResult {
   annotation: KpiAnnotation;
 }
 
+export interface KpisDeleteKpiEntryInput {
+  entryId: Id;
+}
+
+export interface KpisDeleteKpiEntryResult {
+  entry: KpiEntry;
+}
+
 export interface KpisEditKpiInput {
   kpiId: Id;
   name?: string | null;
@@ -7158,6 +7175,10 @@ class ApiNamespaceKpis {
 
   async deleteKpiAnnotation(input: KpisDeleteKpiAnnotationInput): Promise<KpisDeleteKpiAnnotationResult> {
     return this.client.post("/kpis/delete_kpi_annotation", input);
+  }
+
+  async deleteKpiEntry(input: KpisDeleteKpiEntryInput): Promise<KpisDeleteKpiEntryResult> {
+    return this.client.post("/kpis/delete_kpi_entry", input);
   }
 
   async editKpi(input: KpisEditKpiInput): Promise<KpisEditKpiResult> {
@@ -10135,6 +10156,16 @@ export default {
     addKpiAnnotationMutationOptions: () =>
       mutationOptions({
         mutationFn: (input: KpisAddKpiAnnotationInput) => defaultApiClient.apiNamespaceKpis.addKpiAnnotation(input),
+      }),
+
+    deleteKpiEntry: (input: KpisDeleteKpiEntryInput) => defaultApiClient.apiNamespaceKpis.deleteKpiEntry(input),
+    useDeleteKpiEntry: () =>
+      useMutation<KpisDeleteKpiEntryInput, KpisDeleteKpiEntryResult>((input) =>
+        defaultApiClient.apiNamespaceKpis.deleteKpiEntry(input),
+      ),
+    deleteKpiEntryMutationOptions: () =>
+      mutationOptions({
+        mutationFn: (input: KpisDeleteKpiEntryInput) => defaultApiClient.apiNamespaceKpis.deleteKpiEntry(input),
       }),
 
     createKpi: (input: KpisCreateKpiInput) => defaultApiClient.apiNamespaceKpis.createKpi(input),

--- a/app/assets/js/features/activities/KpiEntryDeleted/index.test.tsx
+++ b/app/assets/js/features/activities/KpiEntryDeleted/index.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import ActivityHandler, { DISPLAYED_IN_FEED } from "..";
+
+jest.mock("turboui", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => <a href={to}>{children}</a>,
+}));
+
+jest.mock("@/routes/paths", () => ({
+  usePaths: () => ({
+    spacePath: (id: string) => `/spaces/${id}`,
+    spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+    spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+  }),
+}));
+
+const paths: any = {
+  homePath: () => "/acme",
+  spaceKpisPath: (id: string) => `/spaces/${id}/kpis`,
+  spaceKpiPath: (spaceId: string, kpiId: string) => `/spaces/${spaceId}/kpis/${kpiId}`,
+};
+
+describe("kpi_entry_deleted activities", () => {
+  const activity: any = {
+    action: "kpi_entry_deleted",
+    author: { fullName: "Jo Smith" },
+    content: {
+      space: { id: "space-1", name: "General" },
+      kpi: { id: "kpi-1", name: "Monthly Recurring Revenue", unit: "USD" },
+      value: 42,
+    },
+  };
+
+  it("renders and includes the activity in the feed", () => {
+    const title = renderToStaticMarkup(<>{ActivityHandler.FeedItemTitle({ activity, page: "feed" })}</>);
+    const content = renderToStaticMarkup(<>{ActivityHandler.FeedItemContent({ activity, page: "feed" })}</>);
+
+    expect(DISPLAYED_IN_FEED).toContain("kpi_entry_deleted");
+    expect(title).toContain("Jo deleted a KPI update in the");
+    expect(title).toContain('href="/spaces/space-1"');
+    expect(content).toContain("Monthly Recurring Revenue: 42 USD");
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationTitle({ activity })}</>)).toBe(
+      "Deleted an update from Monthly Recurring Revenue: 42 USD",
+    );
+    expect(renderToStaticMarkup(<>{ActivityHandler.NotificationLocation({ activity })}</>)).toBe("General");
+  });
+
+  it("links to the KPI's own page", () => {
+    expect(ActivityHandler.pagePath(paths, activity)).toBe("/spaces/space-1/kpis/kpi-1");
+  });
+});

--- a/app/assets/js/features/activities/KpiEntryDeleted/index.tsx
+++ b/app/assets/js/features/activities/KpiEntryDeleted/index.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+
+import type { ActivityContentKpiEntryDeleted } from "@/api";
+import type { Activity } from "@/models/activities";
+import type { ActivityHandler } from "../interfaces";
+import { formatValue } from "turboui/SpaceKpisPage/utils";
+
+import { feedTitle, spaceLink } from "../feedItemLinks";
+
+const KpiEntryDeleted: ActivityHandler = {
+  pageHtmlTitle(_activity: Activity) {
+    throw new Error("Not implemented");
+  },
+
+  pagePath(paths, activity: Activity) {
+    const data = content(activity);
+    const spaceId = data.space?.id;
+    const kpiId = data.kpi?.id;
+
+    if (!spaceId) return paths.homePath();
+    return kpiId ? paths.spaceKpiPath(spaceId, kpiId) : paths.spaceKpisPath(spaceId);
+  },
+
+  PageTitle(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageContent(_props: { activity: Activity }) {
+    throw new Error("Not implemented");
+  },
+
+  PageOptions(_props: { activity: Activity }) {
+    return null;
+  },
+
+  FeedItemTitle({ activity, page }: { activity: Activity; page: any }) {
+    const data = content(activity);
+
+    if (page === "space") {
+      return feedTitle(activity, "deleted a KPI update");
+    }
+
+    return feedTitle(activity, "deleted a KPI update in the", spaceLink(data.space), "space");
+  },
+
+  FeedItemContent({ activity }: { activity: Activity }) {
+    const data = content(activity);
+    const kpiName = data.kpi?.name ?? "KPI";
+
+    return (
+      <>
+        {kpiName}: {formatValue(data.value, data.kpi?.unit)}
+      </>
+    );
+  },
+
+  feedItemAlignment(_activity: Activity): "items-start" | "items-center" {
+    return "items-start";
+  },
+
+  commentCount(_activity: Activity): number {
+    throw new Error("Not implemented");
+  },
+
+  hasComments(_activity: Activity): boolean {
+    throw new Error("Not implemented");
+  },
+
+  NotificationTitle({ activity }: { activity: Activity }) {
+    const data = content(activity);
+    const kpiName = data.kpi?.name ?? "KPI";
+    return `Deleted an update from ${kpiName}: ${formatValue(data.value, data.kpi?.unit)}`;
+  },
+
+  NotificationLocation({ activity }: { activity: Activity }) {
+    return content(activity).space?.name ?? null;
+  },
+};
+
+function content(activity: Activity): ActivityContentKpiEntryDeleted {
+  return activity.content as ActivityContentKpiEntryDeleted;
+}
+
+export default KpiEntryDeleted;

--- a/app/assets/js/features/activities/index.tsx
+++ b/app/assets/js/features/activities/index.tsx
@@ -67,6 +67,7 @@ export const DISPLAYED_IN_FEED = [
   "kpi_created",
   "kpi_entry_commented",
   "kpi_entry_edited",
+  "kpi_entry_deleted",
   "kpi_annotation_added",
   "goal_check_toggled",
   "goal_check_removing",
@@ -213,6 +214,7 @@ import GoalCreated from "@/features/activities/GoalCreated";
 import KpiCreated from "@/features/activities/KpiCreated";
 import KpiEntryCommented from "@/features/activities/KpiEntryCommented";
 import KpiEntryEdited from "@/features/activities/KpiEntryEdited";
+import KpiEntryDeleted from "@/features/activities/KpiEntryDeleted";
 import KpiAnnotationAdded from "@/features/activities/KpiAnnotationAdded";
 import KpiAnnotationEdited from "@/features/activities/KpiAnnotationEdited";
 import KpiAnnotationDeleted from "@/features/activities/KpiAnnotationDeleted";
@@ -334,6 +336,7 @@ function handler(activity: Activity) {
     .with("kpi_created", () => KpiCreated)
     .with("kpi_entry_commented", () => KpiEntryCommented)
     .with("kpi_entry_edited", () => KpiEntryEdited)
+    .with("kpi_entry_deleted", () => KpiEntryDeleted)
     .with("kpi_annotation_added", () => KpiAnnotationAdded)
     .with("kpi_annotation_edited", () => KpiAnnotationEdited)
     .with("kpi_annotation_deleted", () => KpiAnnotationDeleted)

--- a/app/assets/js/models/kpis/index.tsx
+++ b/app/assets/js/models/kpis/index.tsx
@@ -10,6 +10,7 @@ export {
   useCreateKpi,
   useDeleteKpi,
   useDeleteKpiAnnotation,
+  useDeleteKpiEntry,
   useEditKpi,
   useEditKpiAnnotation,
   useEditKpiEntry,

--- a/app/assets/js/models/kpis/kpiLifecycle.ts
+++ b/app/assets/js/models/kpis/kpiLifecycle.ts
@@ -63,6 +63,17 @@ export function useEditKpiEntry() {
   });
 }
 
+export function useDeleteKpiEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    ...Api.kpis.deleteKpiEntryMutationOptions(),
+    onSuccess: () => {
+      void invalidateKpiQueries(queryClient);
+    },
+  });
+}
+
 export function useAddKpiAnnotation() {
   const queryClient = useQueryClient();
 

--- a/app/assets/js/pages/SpaceKpisPage/page.tsx
+++ b/app/assets/js/pages/SpaceKpisPage/page.tsx
@@ -35,6 +35,7 @@ export function Page() {
   const deleteKpi = Kpis.useDeleteKpi();
   const logKpiEntry = Kpis.useLogKpiEntry();
   const editKpiEntry = Kpis.useEditKpiEntry();
+  const deleteKpiEntry = Kpis.useDeleteKpiEntry();
   const addKpiAnnotation = Kpis.useAddKpiAnnotation();
   const editKpiAnnotation = Kpis.useEditKpiAnnotation();
   const deleteKpiAnnotation = Kpis.useDeleteKpiAnnotation();
@@ -150,6 +151,13 @@ export function Page() {
       return input.entryId;
     });
 
+  const onDeleteEntry = async (entryId: string) =>
+    run(async () => {
+      await deleteKpiEntry.mutateAsync({ entryId });
+      await refresh();
+      return entryId;
+    });
+
   const onAddAnnotation = async (input: SpaceKpisPageTypes.AnnotationInput) =>
     run(async () => {
       await addKpiAnnotation.mutateAsync({
@@ -194,6 +202,7 @@ export function Page() {
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
       onEditEntry={onEditEntry}
+      onDeleteEntry={onDeleteEntry}
       onAddAnnotation={onAddAnnotation}
       onEditAnnotation={onEditAnnotation}
       onDeleteAnnotation={onDeleteAnnotation}

--- a/app/lib/operately/activities/content/kpi_entry_deleted.ex
+++ b/app/lib/operately/activities/content/kpi_entry_deleted.ex
@@ -1,0 +1,23 @@
+defmodule Operately.Activities.Content.KpiEntryDeleted do
+  use Operately.Activities.Content
+
+  embedded_schema do
+    belongs_to :company, Operately.Companies.Company
+    belongs_to :space, Operately.Groups.Group
+    belongs_to :kpi, Operately.Kpis.Kpi
+    belongs_to :entry, Operately.Kpis.KpiEntry
+
+    field :value, :float
+    field :period, :date
+  end
+
+  def changeset(attrs) do
+    %__MODULE__{}
+    |> cast(attrs, __schema__(:fields))
+    |> validate_required([:company_id, :space_id, :kpi_id, :entry_id, :value, :period])
+  end
+
+  def build(params) do
+    changeset(params)
+  end
+end

--- a/app/lib/operately/activities/notifications/kpi_entry_deleted.ex
+++ b/app/lib/operately/activities/notifications/kpi_entry_deleted.ex
@@ -1,0 +1,5 @@
+defmodule Operately.Activities.Notifications.KpiEntryDeleted do
+  def dispatch(activity) do
+    Operately.Kpis.Notifications.notify_subscribers(activity)
+  end
+end

--- a/app/lib/operately/kpis.ex
+++ b/app/lib/operately/kpis.ex
@@ -10,6 +10,7 @@ defmodule Operately.Kpis do
     "kpi_deleted",
     "kpi_entry_logged",
     "kpi_entry_edited",
+    "kpi_entry_deleted",
     "kpi_entry_commented",
     "kpi_annotation_added",
     "kpi_annotation_edited",
@@ -106,6 +107,7 @@ defmodule Operately.Kpis do
   defdelegate delete_kpi(author, kpi), to: Operately.Operations.KpiDeleting, as: :run
   defdelegate log_entry(author, kpi, attrs), to: Operately.Operations.KpiEntryLogging, as: :run
   defdelegate edit_entry(author, kpi, entry, attrs), to: Operately.Operations.KpiEntryEditing, as: :run
+  defdelegate delete_entry(author, kpi, entry), to: Operately.Operations.KpiEntryDeleting, as: :run
   defdelegate add_annotation(author, kpi, attrs), to: Operately.Operations.KpiAnnotationAdding, as: :run
   defdelegate edit_annotation(author, kpi, annotation, attrs), to: Operately.Operations.KpiAnnotationEditing, as: :run
   defdelegate delete_annotation(author, kpi, annotation), to: Operately.Operations.KpiAnnotationDeleting, as: :run

--- a/app/lib/operately/notifications/direct_mention_classifier.ex
+++ b/app/lib/operately/notifications/direct_mention_classifier.ex
@@ -102,6 +102,7 @@ defmodule Operately.Notifications.DirectMentionClassifier do
     "kpi_deleted",
     "kpi_entry_logged",
     "kpi_entry_edited",
+    "kpi_entry_deleted",
     "kpi_annotation_added",
     "kpi_annotation_edited",
     "kpi_annotation_deleted",

--- a/app/lib/operately/operations/kpi_entry_deleting.ex
+++ b/app/lib/operately/operations/kpi_entry_deleting.ex
@@ -1,0 +1,64 @@
+defmodule Operately.Operations.KpiEntryDeleting do
+  import Ecto.Query, only: [from: 2]
+
+  alias Ecto.Multi
+  alias Operately.Activities
+  alias Operately.Kpis.{Kpi, KpiEntry}
+  alias Operately.Repo
+  alias Operately.Updates.{Comment, Reaction}
+
+  def run(author, %Kpi{} = kpi, %KpiEntry{} = entry) do
+    Multi.new()
+    |> delete_reactions(entry)
+    |> delete_comments(entry)
+    |> insert_activity(author, kpi, entry)
+    |> Multi.delete(:entry, entry)
+    |> Repo.transaction()
+    |> Repo.extract_result(:entry)
+    |> broadcast_assignments_count(kpi)
+  end
+
+  defp delete_reactions(multi, entry) do
+    comment_ids =
+      from(comment in Comment,
+        where: comment.entity_type == :kpi_entry and comment.entity_id == ^entry.id,
+        select: comment.id
+      )
+
+    Multi.delete_all(
+      multi,
+      :reactions,
+      from(reaction in Reaction,
+        where: reaction.entity_type == :comment and reaction.entity_id in subquery(comment_ids)
+      )
+    )
+  end
+
+  defp delete_comments(multi, entry) do
+    Multi.delete_all(
+      multi,
+      :comments,
+      from(comment in Comment, where: comment.entity_type == :kpi_entry and comment.entity_id == ^entry.id)
+    )
+  end
+
+  defp insert_activity(multi, author, kpi, entry) do
+    Activities.insert_sync(multi, author.id, :kpi_entry_deleted, fn _changes ->
+      %{
+        company_id: author.company_id,
+        space_id: kpi.space_id,
+        kpi_id: kpi.id,
+        entry_id: entry.id,
+        value: entry.value,
+        period: entry.period
+      }
+    end)
+  end
+
+  defp broadcast_assignments_count({:ok, _entry} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do
+    OperatelyWeb.Api.Subscriptions.AssignmentsCount.broadcast(person_id: champion_id)
+    result
+  end
+
+  defp broadcast_assignments_count(result, _kpi), do: result
+end

--- a/app/lib/operately/operations/kpi_entry_deleting.ex
+++ b/app/lib/operately/operations/kpi_entry_deleting.ex
@@ -5,17 +5,28 @@ defmodule Operately.Operations.KpiEntryDeleting do
   alias Operately.Activities
   alias Operately.Kpis.{Kpi, KpiEntry}
   alias Operately.Repo
+  alias Operately.Repo.Locking
   alias Operately.Updates.{Comment, Reaction}
 
+  @doc """
+  Removes an already logged KPI value, along with its edit history, comments
+  and reactions.
+
+  The entry row is locked for the duration of the transaction. Overlapping
+  requests are therefore serialized, so the second one finds the row gone and
+  reports it as missing rather than raising on a stale delete, and the activity
+  records the value the entry held at deletion time even if it was edited in
+  between.
+  """
   def run(author, %Kpi{} = kpi, %KpiEntry{} = entry) do
     Multi.new()
+    |> Multi.run(:current, fn repo, _ -> Locking.lock_for_update(repo, entry) end)
     |> delete_reactions(entry)
     |> delete_comments(entry)
-    |> insert_activity(author, kpi, entry)
-    |> Multi.delete(:entry, entry)
+    |> insert_activity(author, kpi)
+    |> Multi.delete(:entry, fn ctx -> ctx.current end)
     |> Repo.transaction()
-    |> Repo.extract_result(:entry)
-    |> broadcast_assignments_count(kpi)
+    |> handle_result(kpi)
   end
 
   defp delete_reactions(multi, entry) do
@@ -42,17 +53,28 @@ defmodule Operately.Operations.KpiEntryDeleting do
     )
   end
 
-  defp insert_activity(multi, author, kpi, entry) do
-    Activities.insert_sync(multi, author.id, :kpi_entry_deleted, fn _changes ->
+  defp insert_activity(multi, author, kpi) do
+    Activities.insert_sync(multi, author.id, :kpi_entry_deleted, fn changes ->
       %{
         company_id: author.company_id,
         space_id: kpi.space_id,
         kpi_id: kpi.id,
-        entry_id: entry.id,
-        value: entry.value,
-        period: entry.period
+        entry_id: changes.current.id,
+        value: changes.current.value,
+        period: changes.current.period
       }
     end)
+  end
+
+  # The entry may already be gone when two people confirm the same deletion, or
+  # when a stale page submits one. The end state is what the caller wanted, but
+  # there is no entry left to hand back, so report it as missing.
+  defp handle_result({:error, :current, :not_found, _changes}, _kpi), do: {:error, :not_found}
+
+  defp handle_result(result, kpi) do
+    result
+    |> Repo.extract_result(:entry)
+    |> broadcast_assignments_count(kpi)
   end
 
   defp broadcast_assignments_count({:ok, _entry} = result, %Kpi{champion_id: champion_id}) when not is_nil(champion_id) do

--- a/app/lib/operately_web/api.ex
+++ b/app/lib/operately_web/api.ex
@@ -220,6 +220,7 @@ defmodule OperatelyWeb.Api do
         mutation(:delete_kpi, OperatelyWeb.Api.Kpis.DeleteKpi)
         mutation(:log_kpi_entry, OperatelyWeb.Api.Kpis.LogKpiEntry)
         mutation(:edit_kpi_entry, OperatelyWeb.Api.Kpis.EditKpiEntry)
+        mutation(:delete_kpi_entry, OperatelyWeb.Api.Kpis.DeleteKpiEntry)
         mutation(:add_kpi_annotation, OperatelyWeb.Api.Kpis.AddKpiAnnotation)
         mutation(:edit_kpi_annotation, OperatelyWeb.Api.Kpis.EditKpiAnnotation)
         mutation(:delete_kpi_annotation, OperatelyWeb.Api.Kpis.DeleteKpiAnnotation)

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -395,6 +395,7 @@ defmodule OperatelyWeb.Api.Kpis do
         {:error, :entry, _} -> {:error, :not_found}
         {:error, :space, _} -> {:error, :not_found}
         {:error, :check_permissions, _} -> {:error, :forbidden}
+        {:error, :operation, :not_found} -> {:error, :not_found}
         {:error, :operation, _} -> {:error, :internal_server_error}
         _ -> {:error, :internal_server_error}
       end

--- a/app/lib/operately_web/api/kpis.ex
+++ b/app/lib/operately_web/api/kpis.ex
@@ -354,6 +354,53 @@ defmodule OperatelyWeb.Api.Kpis do
     end
   end
 
+  defmodule DeleteKpiEntry do
+    @moduledoc "Deletes a logged KPI value. Any space member with edit access may delete one."
+
+    use TurboConnect.Mutation
+    use OperatelyWeb.Api.Helpers
+
+    alias Operately.Kpis.KpiEntry
+
+    inputs do
+      field :entry_id, :id, null: false
+    end
+
+    outputs do
+      field :entry, :kpi_entry, null: false
+    end
+
+    def call(conn, inputs) do
+      Action.new()
+      |> run(:me, fn -> find_me(conn) end)
+      |> run(:entry, fn -> load_entry(inputs.entry_id) end)
+      |> run(:kpi, fn ctx -> {:ok, ctx.entry.kpi} end)
+      |> run(:space, fn ctx -> Group.get(ctx.me, id: ctx.kpi.space_id) end)
+      |> run(:check_permissions, fn ctx -> Permissions.check(ctx.space.request_info.access_level, :can_edit, company_read_only: company_read_only(conn)) end)
+      |> run(:operation, fn ctx -> Kpis.delete_entry(ctx.me, ctx.kpi, ctx.entry) end)
+      |> run(:serialized, fn ctx -> {:ok, %{entry: Serializer.serialize(ctx.operation, level: :essential)}} end)
+      |> respond()
+    end
+
+    defp load_entry(entry_id) do
+      case Kpis.get_entry(entry_id) do
+        nil -> {:error, :not_found}
+        %KpiEntry{} = entry -> {:ok, Repo.preload(entry, :kpi)}
+      end
+    end
+
+    defp respond(result) do
+      case result do
+        {:ok, ctx} -> {:ok, ctx.serialized}
+        {:error, :entry, _} -> {:error, :not_found}
+        {:error, :space, _} -> {:error, :not_found}
+        {:error, :check_permissions, _} -> {:error, :forbidden}
+        {:error, :operation, _} -> {:error, :internal_server_error}
+        _ -> {:error, :internal_server_error}
+      end
+    end
+  end
+
   defmodule AddKpiAnnotation do
     @moduledoc "Marks a date on a KPI chart with a short event title."
 

--- a/app/lib/operately_web/api/serializers/activity_content/kpi_entry_deleted.ex
+++ b/app/lib/operately_web/api/serializers/activity_content/kpi_entry_deleted.ex
@@ -1,0 +1,12 @@
+defimpl OperatelyWeb.Api.Serializable, for: Operately.Activities.Content.KpiEntryDeleted do
+  alias OperatelyWeb.Api.Serializer
+
+  def serialize(content, level: :essential) do
+    %{
+      space: Serializer.serialize(content.space, level: :essential),
+      kpi: Serializer.serialize(content.kpi, level: :essential),
+      value: content.value,
+      period: Serializer.serialize(content.period)
+    }
+  end
+end

--- a/app/lib/operately_web/api/types.ex
+++ b/app/lib/operately_web/api/types.ex
@@ -270,6 +270,13 @@ defmodule OperatelyWeb.Api.Types do
     field :new_period, :date, null: false
   end
 
+  object :activity_content_kpi_entry_deleted, for: Operately.Activities.Content.KpiEntryDeleted do
+    field :space, :space, null: false
+    field :kpi, :kpi, null: true
+    field :value, :float, null: false
+    field :period, :date, null: false
+  end
+
   object :activity_content_kpi_annotation_added, for: Operately.Activities.Content.KpiAnnotationAdded do
     field :space, :space, null: false
     field :kpi, :kpi, null: true
@@ -1200,6 +1207,7 @@ defmodule OperatelyWeb.Api.Types do
       :activity_content_kpi_created,
       :activity_content_kpi_entry_commented,
       :activity_content_kpi_entry_edited,
+      :activity_content_kpi_entry_deleted,
       :activity_content_kpi_annotation_added,
       :activity_content_kpi_annotation_edited,
       :activity_content_kpi_annotation_deleted,

--- a/app/test/features/kpi_entries_test.exs
+++ b/app/test/features/kpi_entries_test.exs
@@ -12,4 +12,11 @@ defmodule Operately.Features.KpiEntriesTest do
     |> Steps.assert_latest_value("50")
     |> Steps.assert_previous_value_visible("42")
   end
+
+  feature "delete a logged KPI update", ctx do
+    ctx
+    |> Steps.visit_kpi_page()
+    |> Steps.delete_latest_update()
+    |> Steps.assert_update_deleted()
+  end
 end

--- a/app/test/operately/operations/kpi_entry_deleting_test.exs
+++ b/app/test/operately/operations/kpi_entry_deleting_test.exs
@@ -51,6 +51,26 @@ defmodule Operately.Operations.KpiEntryDeletingTest do
     assert Repo.get(Reaction, reaction.id) == nil
   end
 
+  test "reports the entry as missing when it is already gone", ctx do
+    assert {:ok, _} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+
+    # ctx.entry still points at the deleted row, as an overlapping request would.
+    assert {:error, :not_found} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+  end
+
+  test "records the value the entry held at deletion time", ctx do
+    {:ok, _} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
+
+    # ctx.entry still carries the original 40.0, as an overlapping request would.
+    assert {:ok, _} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+
+    activity =
+      from(a in Activity, where: a.action == "kpi_entry_deleted" and a.content["entry_id"] == ^ctx.entry.id)
+      |> Repo.one()
+
+    assert activity.content["value"] == 42.0
+  end
+
   test "records a kpi_entry_deleted activity", ctx do
     assert {:ok, _} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
 

--- a/app/test/operately/operations/kpi_entry_deleting_test.exs
+++ b/app/test/operately/operations/kpi_entry_deleting_test.exs
@@ -1,0 +1,66 @@
+defmodule Operately.Operations.KpiEntryDeletingTest do
+  use Operately.DataCase
+
+  import Operately.CompaniesFixtures
+  import Operately.GroupsFixtures
+  import Operately.KpisFixtures
+  import Operately.PeopleFixtures
+
+  alias Operately.Activities.Activity
+  alias Operately.Kpis
+  alias Operately.Kpis.KpiEntryEdit
+  alias Operately.Updates.{Comment, Reaction}
+
+  setup do
+    company = company_fixture()
+    creator = person_fixture_with_account(%{company_id: company.id})
+    space = group_fixture(creator)
+    kpi = kpi_fixture(creator, %{space_id: space.id})
+    entry = kpi_entry_fixture(creator, kpi, %{value: 40.0, period: ~D[2026-01-01]})
+
+    {:ok, creator: creator, kpi: kpi, entry: entry}
+  end
+
+  test "removes the entry and its edit history", ctx do
+    {:ok, _} = Kpis.edit_entry(ctx.creator, ctx.kpi, ctx.entry, %{value: 42.0})
+
+    assert {:ok, deleted_entry} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+    assert deleted_entry.id == ctx.entry.id
+    assert Kpis.get_entry(ctx.entry.id) == nil
+    refute Repo.exists?(from(edit in KpiEntryEdit, where: edit.kpi_entry_id == ^ctx.entry.id))
+  end
+
+  test "removes comments and their reactions", ctx do
+    {:ok, comment} =
+      %{
+        author_id: ctx.creator.id,
+        entity_id: ctx.entry.id,
+        entity_type: :kpi_entry,
+        content: %{"message" => "Context for this value"}
+      }
+      |> Comment.changeset()
+      |> Repo.insert()
+
+    {:ok, reaction} =
+      %{person_id: ctx.creator.id, entity_id: comment.id, entity_type: :comment, emoji: "👍"}
+      |> Reaction.changeset()
+      |> Repo.insert()
+
+    assert {:ok, _} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+    assert Repo.get(Comment, comment.id) == nil
+    assert Repo.get(Reaction, reaction.id) == nil
+  end
+
+  test "records a kpi_entry_deleted activity", ctx do
+    assert {:ok, _} = Kpis.delete_entry(ctx.creator, ctx.kpi, ctx.entry)
+
+    activity =
+      from(a in Activity, where: a.action == "kpi_entry_deleted" and a.content["entry_id"] == ^ctx.entry.id)
+      |> Repo.one()
+
+    assert activity
+    assert activity.content["value"] == 40.0
+    assert activity.content["period"] == "2026-01-01"
+    assert activity.access_context_id
+  end
+end

--- a/app/test/operately_web/api/external_mutations/mutations.ex
+++ b/app/test/operately_web/api/external_mutations/mutations.ex
@@ -52,6 +52,7 @@ defmodule OperatelyWeb.Api.ExternalMutations.Mutations do
       Mutations.Kpis.DeleteKpi,
       Mutations.Kpis.LogKpiEntry,
       Mutations.Kpis.EditKpiEntry,
+      Mutations.Kpis.DeleteKpiEntry,
       Mutations.Kpis.AddKpiAnnotation,
       Mutations.Kpis.EditKpiAnnotation,
       Mutations.Kpis.DeleteKpiAnnotation,

--- a/app/test/operately_web/api/external_mutations/mutations/kpis/delete_kpi_entry.ex
+++ b/app/test/operately_web/api/external_mutations/mutations/kpis/delete_kpi_entry.ex
@@ -1,0 +1,35 @@
+defmodule OperatelyWeb.Api.ExternalMutations.Mutations.Kpis.DeleteKpiEntry do
+  use Operately.Support.ExternalApi.MutationSpec
+  use OperatelyWeb.TurboCase
+
+  import Operately.KpisFixtures
+
+  @impl true
+  def mutation_name, do: "kpis/delete_kpi_entry"
+
+  @impl true
+  def setup(ctx) do
+    ctx =
+      ctx
+      |> Factory.setup()
+      |> Factory.add_space(:space)
+
+    kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+    entry = kpi_entry_fixture(ctx.creator, kpi)
+
+    ctx
+    |> Map.put(:kpi, kpi)
+    |> Map.put(:entry, entry)
+  end
+
+  @impl true
+  def inputs(ctx) do
+    %{entry_id: Paths.kpi_entry_id(ctx.entry)}
+  end
+
+  @impl true
+  def assert(response, ctx) do
+    assert response.entry.id == Paths.kpi_entry_id(ctx.entry)
+    refute Map.has_key?(response, :error)
+  end
+end

--- a/app/test/operately_web/api/kpis/delete_kpi_entry_test.exs
+++ b/app/test/operately_web/api/kpis/delete_kpi_entry_test.exs
@@ -1,0 +1,48 @@
+defmodule OperatelyWeb.Api.Kpis.DeleteKpiEntryTest do
+  use OperatelyWeb.TurboCase
+
+  import Operately.KpisFixtures
+
+  alias Operately.Kpis
+
+  describe "security" do
+    test "it requires authentication", ctx do
+      assert {401, _} = mutation(ctx.conn, [:kpis, :delete_kpi_entry], %{})
+    end
+  end
+
+  describe "delete_kpi_entry" do
+    setup ctx do
+      ctx =
+        ctx
+        |> Factory.setup()
+        |> Factory.add_space(:space)
+        |> Factory.add_space_member(:member, :space)
+        |> Factory.add_company_member(:outsider)
+
+      kpi = kpi_fixture(ctx.creator, space_id: ctx.space.id)
+      entry = kpi_entry_fixture(ctx.creator, kpi)
+
+      ctx
+      |> Map.put(:kpi, kpi)
+      |> Map.put(:entry, entry)
+    end
+
+    test "any space member with edit access can delete an entry", ctx do
+      ctx = Factory.log_in_person(ctx, :member)
+
+      inputs = %{entry_id: Paths.kpi_entry_id(ctx.entry)}
+      assert {200, res} = mutation(ctx.conn, [:kpis, :delete_kpi_entry], inputs)
+      assert res.entry.id == Paths.kpi_entry_id(ctx.entry)
+      assert Kpis.get_entry(ctx.entry.id) == nil
+    end
+
+    test "a non-space-member cannot delete an entry", ctx do
+      ctx = Factory.log_in_person(ctx, :outsider)
+
+      inputs = %{entry_id: Paths.kpi_entry_id(ctx.entry)}
+      assert {404, _} = mutation(ctx.conn, [:kpis, :delete_kpi_entry], inputs)
+      assert Kpis.get_entry(ctx.entry.id)
+    end
+  end
+end

--- a/app/test/support/features/kpi_entries_steps.ex
+++ b/app/test/support/features/kpi_entries_steps.ex
@@ -32,6 +32,22 @@ defmodule Operately.Support.Features.KpiEntriesSteps do
     |> UI.refute_has(testid: "edit-entry-modal")
   end
 
+  step :delete_latest_update, ctx do
+    entry_id = Paths.kpi_entry_id(ctx.entry)
+
+    ctx
+    |> UI.assert_has(testid: "kpi-detail")
+    |> UI.click(testid: "entry-menu-#{entry_id}")
+    |> UI.click(testid: "delete-entry-#{entry_id}")
+    |> UI.assert_has(testid: "delete-entry-dialog")
+    |> UI.click_button("Delete update")
+    |> UI.refute_has(testid: "delete-entry-dialog")
+  end
+
+  step :assert_update_deleted, ctx do
+    UI.refute_has(ctx, testid: "entry-row-#{Paths.kpi_entry_id(ctx.entry)}")
+  end
+
   step :assert_latest_value, ctx, value do
     UI.assert_text(ctx, value, testid: "kpi-current-value")
   end

--- a/cli/src/generated/api-catalog.json
+++ b/cli/src/generated/api-catalog.json
@@ -469,6 +469,10 @@
           "kind": "named"
         },
         {
+          "name": "activity_content_kpi_entry_deleted",
+          "kind": "named"
+        },
+        {
           "name": "activity_content_kpi_annotation_added",
           "kind": "named"
         },
@@ -23139,6 +23143,65 @@
             "has_default": false
           }
         ]
+      },
+      "activity_content_kpi_entry_deleted": {
+        "fields": [
+          {
+            "default": null,
+            "name": "__typename",
+            "type": {
+              "name": "string",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "space",
+            "type": {
+              "name": "space",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "kpi",
+            "type": {
+              "name": "kpi",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": true,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "value",
+            "type": {
+              "name": "float",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          },
+          {
+            "default": null,
+            "name": "period",
+            "type": {
+              "name": "date",
+              "kind": "named"
+            },
+            "optional": false,
+            "nullable": false,
+            "has_default": false
+          }
+        ]
       }
     }
   },
@@ -23160,7 +23223,7 @@
     "tasks": "Get, list, create and manage tasks across projects and spaces"
   },
   "api_base_path": "/api/external/v1",
-  "endpoint_count": 253,
+  "endpoint_count": 254,
   "endpoints": [
     {
       "name": "create",
@@ -29930,6 +29993,43 @@
       "method": "POST",
       "namespace": "kpis",
       "docstring": "Removes a KPI chart annotation.",
+      "hidden": true
+    },
+    {
+      "name": "delete_kpi_entry",
+      "type": "mutation",
+      "path": "/api/external/v1/kpis/delete_kpi_entry",
+      "handler": "OperatelyWeb.Api.Kpis.DeleteKpiEntry",
+      "outputs": [
+        {
+          "default": null,
+          "name": "entry",
+          "type": {
+            "name": "kpi_entry",
+            "kind": "named"
+          },
+          "optional": false,
+          "nullable": false,
+          "has_default": false
+        }
+      ],
+      "inputs": [
+        {
+          "default": null,
+          "name": "entry_id",
+          "type": {
+            "name": "id",
+            "kind": "named"
+          },
+          "optional": false,
+          "nullable": false,
+          "has_default": false
+        }
+      ],
+      "full_name": "kpis/delete_kpi_entry",
+      "method": "POST",
+      "namespace": "kpis",
+      "docstring": "Deletes a logged KPI value. Any space member with edit access may delete one.",
       "hidden": true
     },
     {
@@ -40184,6 +40284,6 @@
     }
   ],
   "query_count": 75,
-  "mutation_count": 178,
+  "mutation_count": 179,
   "schema_version": 1
 }

--- a/turboui/src/ApiTypes/index.ts
+++ b/turboui/src/ApiTypes/index.ts
@@ -432,6 +432,14 @@ export interface ActivityContentKpiEntryCommented {
   comment: Comment | null;
 }
 
+export interface ActivityContentKpiEntryDeleted {
+  __typename: "activity_content_kpi_entry_deleted";
+  space: Space;
+  kpi: Kpi | null;
+  value: number;
+  period: string;
+}
+
 export interface ActivityContentKpiEntryEdited {
   __typename: "activity_content_kpi_entry_edited";
   space: Space;
@@ -2746,6 +2754,7 @@ export type ActivityContent =
   | ActivityContentKpiCreated
   | ActivityContentKpiEntryCommented
   | ActivityContentKpiEntryEdited
+  | ActivityContentKpiEntryDeleted
   | ActivityContentKpiAnnotationAdded
   | ActivityContentKpiAnnotationEdited
   | ActivityContentKpiAnnotationDeleted

--- a/turboui/src/SpaceKpisPage/DeleteEntryDialog.tsx
+++ b/turboui/src/SpaceKpisPage/DeleteEntryDialog.tsx
@@ -41,7 +41,7 @@ export function DeleteEntryDialog({ entry, unit, onClose, onDelete }: DeleteEntr
       title="Delete this update?"
       message={
         entry
-          ? `Delete ${formatValue(entry.value, unit)} recorded on ${formatShortDate(entry.recordedAt)}? This permanently removes its edit history and comments.`
+          ? `${formatValue(entry.value, unit)} recorded on ${formatShortDate(entry.recordedAt)} will be permanently removed.`
           : ""
       }
       confirmText="Delete update"

--- a/turboui/src/SpaceKpisPage/DeleteEntryDialog.tsx
+++ b/turboui/src/SpaceKpisPage/DeleteEntryDialog.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+
+import { ConfirmDialog } from "../ConfirmDialog";
+import { showErrorToast } from "../Toasts";
+import type { SpaceKpisPage } from "./types";
+import { formatShortDate, formatValue } from "./utils";
+
+interface DeleteEntryDialogProps {
+  entry: SpaceKpisPage.KpiEntry | null;
+  unit: string;
+  onClose: () => void;
+  onDelete: (entryId: string) => Promise<SpaceKpisPage.MutationResult>;
+}
+
+export function DeleteEntryDialog({ entry, unit, onClose, onDelete }: DeleteEntryDialogProps) {
+  const [isDeleting, setIsDeleting] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!entry) setIsDeleting(false);
+  }, [entry]);
+
+  const confirmDelete = async () => {
+    if (!entry || isDeleting) return;
+
+    setIsDeleting(true);
+    const result = await onDelete(entry.id);
+    setIsDeleting(false);
+
+    if (result.success) {
+      onClose();
+    } else {
+      showErrorToast("Update not deleted", result.error ?? "Something went wrong. Please try again.");
+    }
+  };
+
+  return (
+    <ConfirmDialog
+      isOpen={entry !== null}
+      onConfirm={() => void confirmDelete()}
+      onCancel={onClose}
+      title="Delete this update?"
+      message={
+        entry
+          ? `Delete ${formatValue(entry.value, unit)} recorded on ${formatShortDate(entry.recordedAt)}? This permanently removes its edit history and comments.`
+          : ""
+      }
+      confirmText="Delete update"
+      cancelText="Keep update"
+      variant="danger"
+      size="x-small"
+      testId="delete-entry-dialog"
+      confirming={isDeleting}
+    />
+  );
+}

--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -29,6 +29,7 @@ interface KpiDetailProps {
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPage.KpiAnnotation) => void;
   onEditEntry: (entry: SpaceKpisPage.KpiEntry) => void;
+  onDeleteEntry: (entry: SpaceKpisPage.KpiEntry) => void;
   onDelete: () => void;
   richTextHandlers: RichEditorHandlers;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
@@ -49,6 +50,7 @@ export function KpiDetail({
   onOpenNewAnnotation,
   onOpenAnnotation,
   onEditEntry,
+  onDeleteEntry,
   onDelete,
   richTextHandlers,
   renderEntryComments,
@@ -113,6 +115,7 @@ export function KpiDetail({
           canManage={canManage}
           canComment={canComment}
           onEditEntry={onEditEntry}
+          onDeleteEntry={onDeleteEntry}
           renderEntryComments={renderEntryComments}
         />
       </div>
@@ -364,6 +367,7 @@ function EntriesTable({
   canManage,
   canComment,
   onEditEntry,
+  onDeleteEntry,
   renderEntryComments,
 }: {
   entries: SpaceKpisPage.KpiEntry[];
@@ -372,6 +376,7 @@ function EntriesTable({
   canManage: boolean;
   canComment: boolean;
   onEditEntry: (entry: SpaceKpisPage.KpiEntry) => void;
+  onDeleteEntry: (entry: SpaceKpisPage.KpiEntry) => void;
   renderEntryComments?: SpaceKpisPage.Props["renderEntryComments"];
 }) {
   const [openEntryId, setOpenEntryId] = React.useState<string | null>(null);
@@ -470,6 +475,14 @@ function EntriesTable({
                           testId={`edit-entry-${entry.id}`}
                         >
                           Edit
+                        </MenuActionItem>
+                        <MenuActionItem
+                          icon={IconTrash}
+                          onClick={() => onDeleteEntry(entry)}
+                          testId={`delete-entry-${entry.id}`}
+                          danger
+                        >
+                          Delete
                         </MenuActionItem>
                       </Menu>
                     )}

--- a/turboui/src/SpaceKpisPage/index.stories.tsx
+++ b/turboui/src/SpaceKpisPage/index.stories.tsx
@@ -216,6 +216,29 @@ function Harness(args: HarnessArgs) {
     return { success: true, id: input.entryId };
   };
 
+  const onDeleteEntry = async (entryId: string): Promise<SpaceKpisPageNS.MutationResult> => {
+    console.log("deleteKpiEntry", entryId);
+    await delay(400);
+
+    if (args.failMutations) {
+      return { success: false, error: "You don't have permission to delete this update." };
+    }
+
+    setKpis((prev) =>
+      prev.map((kpi) => {
+        const entries = kpi.entries.filter((entry) => entry.id !== entryId);
+
+        return {
+          ...kpi,
+          entries,
+          latestEntry: entries.length > 0 ? entries[entries.length - 1]! : null,
+        };
+      }),
+    );
+
+    return { success: true, id: entryId };
+  };
+
   const onAddAnnotation = async (input: SpaceKpisPageNS.AnnotationInput): Promise<SpaceKpisPageNS.MutationResult> => {
     console.log("addKpiAnnotation", input);
     await delay(400);
@@ -299,6 +322,7 @@ function Harness(args: HarnessArgs) {
       onDeleteKpi={onDeleteKpi}
       onRecordEntry={onRecordEntry}
       onEditEntry={onEditEntry}
+      onDeleteEntry={onDeleteEntry}
       onAddAnnotation={onAddAnnotation}
       onEditAnnotation={onEditAnnotation}
       onDeleteAnnotation={onDeleteAnnotation}

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -48,6 +48,7 @@ function pageProps(overrides: Partial<SpaceKpisPageNS.Props> = {}): SpaceKpisPag
     onDeleteKpi: async () => ({ success: true }),
     onRecordEntry: async () => ({ success: true }),
     onEditEntry: async () => ({ success: true }),
+    onDeleteEntry: async () => ({ success: true }),
     onAddAnnotation: async () => ({ success: true }),
     onEditAnnotation: async () => ({ success: true }),
     onDeleteAnnotation: async () => ({ success: true }),
@@ -750,5 +751,22 @@ describe("SpaceKpisPage edit logged updates", () => {
 
     expect(container.querySelector(`[data-test-id="entry-menu-${entry.id}"]`)).not.toBeInTheDocument();
     expect(container.querySelector(`[data-test-id="entry-edited-${entry.id}"]`)).toBeInTheDocument();
+  });
+
+  test("editors can confirm deleting a recorded update", async () => {
+    const user = userEvent.setup();
+    const onDeleteEntry = jest.fn().mockResolvedValue({ success: true });
+    const target = mockKpis[0]!;
+    const entry = target.entries[target.entries.length - 1]!;
+
+    renderPage({ selectedKpi: target, onDeleteEntry });
+
+    await user.click(await findByTestId(`entry-menu-${entry.id}`));
+    await user.click(await findByTestId(`delete-entry-${entry.id}`));
+
+    const dialog = await findByTestId("delete-entry-dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Delete update" }));
+
+    await waitFor(() => expect(onDeleteEntry).toHaveBeenCalledWith(entry.id));
   });
 });

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -7,6 +7,7 @@ import type { Navigation } from "../Page/Navigation";
 import { IconChartColumn, IconChevronRight } from "../icons";
 
 import { AnnotationForm } from "./AnnotationForm";
+import { DeleteEntryDialog } from "./DeleteEntryDialog";
 import { DeleteKpiModal } from "./DeleteKpiModal";
 import { EditEntryForm } from "./EditEntryForm";
 import { KpiDetail } from "./KpiDetail";
@@ -26,6 +27,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
   const [logKpiId, setLogKpiId] = React.useState<string | null>(null);
   const [editingEntry, setEditingEntry] = React.useState<SpaceKpisPageNS.KpiEntry | null>(null);
+  const [deletingEntry, setDeletingEntry] = React.useState<SpaceKpisPageNS.KpiEntry | null>(null);
   const [annotationState, setAnnotationState] = React.useState<{
     kpi: SpaceKpisPageNS.Kpi;
     annotation: SpaceKpisPageNS.KpiAnnotation | null;
@@ -90,6 +92,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
             onOpenNewAnnotation={() => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation: null })}
             onOpenAnnotation={(annotation) => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation })}
             onOpenEditEntry={setEditingEntry}
+            onOpenDeleteEntry={setDeletingEntry}
           />
         </div>
       </div>
@@ -122,6 +125,13 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
         isOpen={editingEntry !== null}
         onClose={() => setEditingEntry(null)}
         onEdit={props.onEditEntry}
+      />
+
+      <DeleteEntryDialog
+        entry={deletingEntry}
+        unit={selectedKpi?.unit ?? ""}
+        onClose={() => setDeletingEntry(null)}
+        onDelete={props.onDeleteEntry}
       />
 
       <AnnotationForm
@@ -242,6 +252,7 @@ interface KpisContentProps extends SpaceKpisPageNS.Props {
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPageNS.KpiAnnotation) => void;
   onOpenEditEntry: (entry: SpaceKpisPageNS.KpiEntry) => void;
+  onOpenDeleteEntry: (entry: SpaceKpisPageNS.KpiEntry) => void;
 }
 
 function KpisContent(props: KpisContentProps) {
@@ -267,6 +278,7 @@ function KpisContent(props: KpisContentProps) {
         onOpenNewAnnotation={props.onOpenNewAnnotation}
         onOpenAnnotation={props.onOpenAnnotation}
         onEditEntry={props.onOpenEditEntry}
+        onDeleteEntry={props.onOpenDeleteEntry}
         onDelete={props.onOpenDelete}
         richTextHandlers={props.richTextHandlers}
         renderEntryComments={props.renderEntryComments}

--- a/turboui/src/SpaceKpisPage/types.ts
+++ b/turboui/src/SpaceKpisPage/types.ts
@@ -169,6 +169,7 @@ export namespace SpaceKpisPage {
     onDeleteKpi: (kpiId: string) => Promise<MutationResult>;
     onRecordEntry: (input: RecordEntryInput) => Promise<MutationResult>;
     onEditEntry: (input: EditEntryInput) => Promise<MutationResult>;
+    onDeleteEntry: (entryId: string) => Promise<MutationResult>;
     onAddAnnotation: (input: AnnotationInput) => Promise<MutationResult>;
     onEditAnnotation: (input: EditAnnotationInput) => Promise<MutationResult>;
     onDeleteAnnotation: (annotationId: string) => Promise<MutationResult>;


### PR DESCRIPTION
## Summary

A value logged against the wrong KPI, or duplicated by logging twice for the same period, could only be corrected by editing it into something plausible. That left a phantom point on the chart and an edit history describing a correction that never happened; the only real fix was database access.

Logged values can now be deleted:

- **Delete** joins **Edit** in the per-row actions menu on the recorded-updates log, as a danger item.
- Deleting asks for confirmation first, naming the value and its date and warning that the edit history and comments go with it.
- Deletion cleans up what the database cannot cascade on its own. `kpi_entries` cascades to `kpi_entry_edits`, but KPI entry comments are polymorphic (`entity_type` / `entity_id`, no FK), so the transaction removes those comments and their reactions alongside the entry.
- Emits a `kpi_entry_deleted` activity so the removal shows up in the feed and in notifications for KPI subscribers.
- Requires the same space edit access as logging a value; read-only viewers get no actions menu at all.
- Exposed as `kpis/delete_kpi_entry` on the internal and external APIs, with the CLI catalog regenerated.

TurboUI primitives reused: `ConfirmDialog` (with its `danger` variant) for the confirmation, and `Menu` / `MenuActionItem` for the new menu entry — both already used elsewhere on this page. No raw interactive elements were added.

MCP: no MCP tool wraps KPI entry logging or editing, so there is no MCP wrapper to update for this change.

## Test plan

- [ ] `make test FILE=app/test/operately/operations/kpi_entry_deleting_test.exs` — covers entry + edit history removal, comment/reaction cleanup, and the activity
- [ ] `make test FILE=app/test/operately_web/api/kpis/delete_kpi_entry_test.exs` — auth, space-member success, non-member 404
- [ ] `make test FILE=app/test/operately_web/api/external_mutations/auth_test.exs` — external token coverage for the new mutation
- [ ] `make test FILE=app/test/features/kpi_entries_test.exs` — browser flow: open the menu, confirm, row disappears
- [ ] `make test FILE=assets/js/features/activities/KpiEntryDeleted/index.test.tsx`
- [ ] `make test FILE=assets/js/models/kpis/kpiLifecycle.test.ts`
- [ ] `make turboui.test` (`SpaceKpisPage/index.test.tsx`)
- [ ] `make test.tsc.lint` and `make test.cli.catalog.sync`
- [ ] Manual: log a value, delete it from the row menu, confirm the chart and latest value update; confirm a viewer without edit access sees no menu.

## Migration notes

No schema changes. Existing `kpi_entries` → `kpi_entry_edits` cascade handles edit history; comment and reaction cleanup is explicit in `Operately.Operations.KpiEntryDeleting` because those associations are polymorphic.

Made with [Cursor](https://cursor.com)