### PR TITLE
feat: Add Log update button to the KPI chart

### DIFF
--- a/turboui/src/SpaceKpisPage/KpiDetail.tsx
+++ b/turboui/src/SpaceKpisPage/KpiDetail.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { ActionList } from "../ActionList";
 import { Avatar } from "../Avatar";
-import { SecondaryButton } from "../Button";
+import { PrimaryButton, SecondaryButton } from "../Button";
 import { Menu, MenuActionItem } from "../Menu";
 import { PageDescription } from "../PageDescription";
 import { PersonField } from "../PersonField";
@@ -26,6 +26,7 @@ interface KpiDetailProps {
   canComment?: boolean;
   championSearch: (query: string) => Promise<SpaceKpisPage.Person[]>;
   onDescriptionChange: (kpiId: string, description: Record<string, unknown>) => Promise<boolean>;
+  onLogUpdate: () => void;
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPage.KpiAnnotation) => void;
   onEditEntry: (entry: SpaceKpisPage.KpiEntry) => void;
@@ -39,7 +40,7 @@ interface KpiDetailProps {
 // The KPI's name leads its page, with the current reading beside it, so the two
 // questions a KPI answers — which metric is this, and where does it stand — are
 // answered before the description, chart and recorded-updates log below.
-// Back navigation and the "Log update" action live in the page header (index.tsx).
+// Back navigation lives in the page header (index.tsx).
 export function KpiDetail({
   kpi,
   fields,
@@ -47,6 +48,7 @@ export function KpiDetail({
   canComment = false,
   championSearch,
   onDescriptionChange,
+  onLogUpdate,
   onOpenNewAnnotation,
   onOpenAnnotation,
   onEditEntry,
@@ -94,10 +96,19 @@ export function KpiDetail({
         >
           <div className="flex items-start justify-between gap-4">
             <CurrentValue kpi={kpi} unit={fields.unit} />
+
             {canManage && (
-              <SecondaryButton size="xxs" icon={IconFlag} onClick={onOpenNewAnnotation} testId="add-kpi-annotation">
-                Add annotation
-              </SecondaryButton>
+              // Keep the chart's actions against its right edge even when there is
+              // no reading yet to sit opposite them.
+              <div className="ml-auto flex shrink-0 items-center gap-2">
+                <SecondaryButton size="xxs" icon={IconFlag} onClick={onOpenNewAnnotation} testId="add-kpi-annotation">
+                  Add annotation
+                </SecondaryButton>
+
+                <PrimaryButton size="xxs" onClick={onLogUpdate} testId="chart-log-update">
+                  Log update
+                </PrimaryButton>
+              </div>
             )}
           </div>
           <KpiLineChart

--- a/turboui/src/SpaceKpisPage/index.test.tsx
+++ b/turboui/src/SpaceKpisPage/index.test.tsx
@@ -210,6 +210,28 @@ describe("SpaceKpisPage layout", () => {
     expect(value).toHaveTextContent(formatShortDate(latest.recordedAt));
   });
 
+  // Logging an update is what the chart is for, so the action sits on the chart
+  // as well as in the page header.
+  test("logs an update from the chart's own action", async () => {
+    const user = userEvent.setup();
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target });
+    const history = container.querySelector<HTMLElement>('[data-test-id="kpi-history"]')!;
+
+    await user.click(history.querySelector('[data-test-id="chart-log-update"]')!);
+
+    expect(await findByTestId("log-update-modal")).toBeInTheDocument();
+  });
+
+  test("does not offer the chart's actions to read-only viewers", () => {
+    const target = mockKpis[0]!;
+    const { container } = renderPage({ selectedKpi: target, canManage: false });
+    const history = container.querySelector<HTMLElement>('[data-test-id="kpi-history"]')!;
+
+    expect(history.querySelector('[data-test-id="chart-log-update"]')).not.toBeInTheDocument();
+    expect(history.querySelector('[data-test-id="add-kpi-annotation"]')).not.toBeInTheDocument();
+  });
+
   // The value alone doesn't say whether the KPI is moving, so it carries the
   // signed change against the entry before it.
   test("shows the change against the previous entry beside the current value", () => {

--- a/turboui/src/SpaceKpisPage/index.tsx
+++ b/turboui/src/SpaceKpisPage/index.tsx
@@ -89,6 +89,7 @@ export function SpaceKpisPage(props: SpaceKpisPageNS.Props) {
             openKpi={openKpi}
             onOpenNew={() => setIsNewOpen(true)}
             onOpenDelete={() => setIsDeleteOpen(true)}
+            onLogUpdate={() => selectedKpi && setLogKpiId(selectedKpi.id)}
             onOpenNewAnnotation={() => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation: null })}
             onOpenAnnotation={(annotation) => selectedKpi && setAnnotationState({ kpi: selectedKpi, annotation })}
             onOpenEditEntry={setEditingEntry}
@@ -249,6 +250,7 @@ interface KpisContentProps extends SpaceKpisPageNS.Props {
   openKpi: KpiFields | null;
   onOpenNew: () => void;
   onOpenDelete: () => void;
+  onLogUpdate: () => void;
   onOpenNewAnnotation: () => void;
   onOpenAnnotation: (annotation: SpaceKpisPageNS.KpiAnnotation) => void;
   onOpenEditEntry: (entry: SpaceKpisPageNS.KpiEntry) => void;
@@ -275,6 +277,7 @@ function KpisContent(props: KpisContentProps) {
         canComment={props.canComment}
         championSearch={props.championSearch}
         onDescriptionChange={props.onDescriptionChange}
+        onLogUpdate={props.onLogUpdate}
         onOpenNewAnnotation={props.onOpenNewAnnotation}
         onOpenAnnotation={props.onOpenAnnotation}
         onEditEntry={props.onOpenEditEntry}


### PR DESCRIPTION
## Summary

Logging a value is what the KPI chart exists for, but the only way in was the action in the page header, away from the chart the reader is looking at. This adds a primary **Log update** button to the chart card itself, beside **Add annotation**, opening the same form as the header action.

Both actions are now grouped against the chart's right edge, so they stay put when a KPI has no entries yet and the current-value block renders nothing to sit opposite them.

TurboUI primitives reused: `PrimaryButton`, `SecondaryButton`. No raw interactive elements added.

## Test plan

- [ ] Open a space's KPIs tool and open a KPI. The chart card shows **Add annotation** and **Log update** on the right.
- [ ] Click **Log update** on the chart; the log-update form opens and records a value.
- [ ] Open a KPI with no entries yet; the two actions remain right-aligned.
- [ ] As a read-only viewer, neither chart action appears.
- [ ] `cd turboui && npx jest src/SpaceKpisPage` passes (added two tests covering the new action and its read-only case).

Made with [Cursor](https://cursor.com)