### PR TITLE
fix: show ctrl k as global shortcut on non-mac devices

### DIFF
--- a/turboui/src/GlobalSearch/SearchActivator.test.tsx
+++ b/turboui/src/GlobalSearch/SearchActivator.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { SearchActivator } from "./SearchActivator";
+
+describe("SearchActivator", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    ["macOS", "MacIntel", "⌘K"],
+    ["Windows", "Win32", "Ctrl K"],
+    ["Linux", "Linux x86_64", "Ctrl K"],
+  ])("shows the global search shortcut for %s", (_operatingSystem, platform, shortcut) => {
+    jest.spyOn(window.navigator, "platform", "get").mockReturnValue(platform);
+
+    render(<SearchActivator placeholder="Search..." onActivate={jest.fn()} />);
+
+    expect(screen.getByRole("button", { name: /search/i })).toHaveTextContent(shortcut);
+  });
+});

--- a/turboui/src/GlobalSearch/SearchActivator.tsx
+++ b/turboui/src/GlobalSearch/SearchActivator.tsx
@@ -9,6 +9,8 @@ interface SearchActivatorProps {
 }
 
 export function SearchActivator({ placeholder, onActivate, testId }: SearchActivatorProps) {
+  const shortcut = isMacPlatform() ? "⌘K" : "Ctrl K";
+
   return (
     <button
       type="button"
@@ -18,7 +20,11 @@ export function SearchActivator({ placeholder, onActivate, testId }: SearchActiv
     >
       <IconSearch size={14} className="text-content-dimmed" />
       <span className="flex-1 text-left truncate">{placeholder}</span>
-      <span className="text-xs">⌘K</span>
+      <span className="text-xs">{shortcut}</span>
     </button>
   );
+}
+
+function isMacPlatform(): boolean {
+  return window.navigator.platform.toLowerCase().includes("mac");
 }


### PR DESCRIPTION
fixes #5248 